### PR TITLE
Prevent board dialog submission from logging session

### DIFF
--- a/components/add-board-dialog.tsx
+++ b/components/add-board-dialog.tsx
@@ -167,7 +167,10 @@ export function AddBoardDialog({
       </DialogHeader>
       <Form {...form}>
         <form
-          onSubmit={form.handleSubmit(handleAddBoard)}
+          onSubmit={(e) => {
+            e.stopPropagation();
+            form.handleSubmit(handleAddBoard)(e);
+          }}
           className="space-y-4"
         >
           <FormField


### PR DESCRIPTION
## Summary
- stop event propagation when submitting new board form

## Testing
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c60d4d38c83229da0396a3962d97d