### PR TITLE
fix: remove deprecated schema-only flag from backups

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -34,12 +34,8 @@ jobs:
           # Link non-interactively via env token
           supabase link --project-ref "$PROJECT_REF" --password "$SUPABASE_DB_PASSWORD"
 
-          # Dump schema & data
-          supabase db dump --schema-only > "backups/schema_${DATE}.sql"
-          supabase db dump --data-only   > "backups/data_${DATE}.sql"
-
-          # Combine & compress
-          cat "backups/schema_${DATE}.sql" "backups/data_${DATE}.sql" > "backups/full_backup_${DATE}.sql"
+          # Dump schema & data into a single file
+          supabase db dump --file "backups/full_backup_${DATE}.sql"
           gzip "backups/full_backup_${DATE}.sql"
 
           # Keep only last 30 days

--- a/backup_script.sh
+++ b/backup_script.sh
@@ -16,12 +16,7 @@ echo "📁 Created backup directory: $BACKUP_DIR"
 
 # Backup all data using supabase CLI
 echo "💾 Backing up database schema and data..."
-supabase db dump --linked --data-only > "$BACKUP_DIR/quiver_data_backup_$DATE.sql"
-supabase db dump --linked --schema-only > "$BACKUP_DIR/quiver_schema_backup_$DATE.sql"
-
-# Create a combined backup file
-echo "🔗 Creating combined backup..."
-cat "$BACKUP_DIR/quiver_schema_backup_$DATE.sql" "$BACKUP_DIR/quiver_data_backup_$DATE.sql" > "$BACKUP_DIR/quiver_full_backup_$DATE.sql"
+supabase db dump --linked --file "$BACKUP_DIR/quiver_full_backup_$DATE.sql"
 
 # Compress the backup
 echo "🗜️ Compressing backup..."


### PR DESCRIPTION
## Summary
- remove unsupported `--schema-only` flag from backup workflow
- dump full database snapshot directly in backup script

## Testing
- `npm test` *(fails: use-forecast-calibration.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b08bbb9b2c832290dd206fa63dda7b