### PR TITLE
feat: rideable waves per hour metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Rideable waves per hour metric on beach detail page — predicts catchable wave frequency from swell, break type, and conditions; displayed in ConditionsTicker as "~N waves/hr"
+
+### Fixed
+- Landing page "Popular surf spots" no longer shows CA-only beaches for non-CA users — progressively expands search radius (300→500→1000mi) before falling back to global list
+
 ### Changed
 - SEO: state browse pages (`/beaches/usa/ca`) now show Beginner/Tides/Water Temp intent pill links per city for crawler discovery of city intent pages
 - SEO: `getTopCitiesInState` default limit raised from 8 to 100 so all qualifying cities are returned for crawl discovery (backwards-compatible — pass a lower value when a small subset is needed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Rideable waves per hour metric on beach detail page — predicts catchable wave frequency from swell, break type, and conditions; displayed in ConditionsTicker as "~N waves/hr"
+- Landing page "Show spots near me" button — contextual geolocation prompt in surf highlights section upgrades IP-based location to precise browser coordinates for regionally relevant beach results
 
 ### Fixed
 - Landing page "Popular surf spots" no longer shows CA-only beaches for non-CA users — progressively expands search radius (300→500→1000mi) before falling back to global list

--- a/__tests__/components/landing-page/surf-highlights-location-prompt.test.tsx
+++ b/__tests__/components/landing-page/surf-highlights-location-prompt.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { SurfHighlightsSection } from "@/components/landing-page/surf-highlights-section";
+
+const mockRequestPreciseLocation = jest.fn();
+const mockClearError = jest.fn();
+
+let mockLocationCtx: Record<string, unknown> | null = {};
+
+jest.mock("@/context/location-context", () => ({
+  useLocationSafe: () => mockLocationCtx,
+}));
+
+jest.mock("@/hooks/use-data-fetcher", () => ({
+  useDataFetcher: () => ({
+    data: { spots: [], isNearby: false },
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("framer-motion", () => ({
+  motion: {
+    h2: ({ children, initial, animate, transition, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <h2 {...props}>{children}</h2>
+    ),
+    div: ({ children, initial, animate, transition, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+  useInView: () => true,
+  useReducedMotion: () => false,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+jest.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ className }: { className?: string }) => <div className={className} />,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLocationCtx = {
+    location: {
+      displayName: "Unknown",
+      coordinates: { lat: 38.9, lon: -77.0 },
+      source: "ip" as const,
+      isLoading: false,
+    },
+    hasPreciseLocation: false,
+    requestPreciseLocation: mockRequestPreciseLocation,
+    locationError: null,
+    clearError: mockClearError,
+  };
+});
+
+describe("SurfHighlightsSection location prompt", () => {
+  it("shows 'Show spots near me' button when precise location not granted", () => {
+    render(<SurfHighlightsSection />);
+    expect(screen.getByRole("button", { name: /show spots near me/i })).toBeInTheDocument();
+  });
+
+  it("hides the button when precise location is already granted", () => {
+    mockLocationCtx!.hasPreciseLocation = true;
+    render(<SurfHighlightsSection />);
+    expect(screen.queryByRole("button", { name: /show spots near me/i })).not.toBeInTheDocument();
+  });
+
+  it("calls requestPreciseLocation when button is clicked", async () => {
+    mockRequestPreciseLocation.mockResolvedValue(undefined);
+    render(<SurfHighlightsSection />);
+    fireEvent.click(screen.getByRole("button", { name: /show spots near me/i }));
+    expect(mockRequestPreciseLocation).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows error message when location is denied", () => {
+    mockLocationCtx!.locationError = "Location access was denied";
+    render(<SurfHighlightsSection />);
+    expect(screen.getByText(/location access was denied/i)).toBeInTheDocument();
+  });
+
+  it("shows 'Locating...' text while requesting", async () => {
+    mockRequestPreciseLocation.mockReturnValue(new Promise(() => {}));
+    render(<SurfHighlightsSection />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /show spots near me/i }));
+    });
+    expect(screen.getByRole("button", { name: /locating/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /locating/i })).toBeDisabled();
+  });
+
+  it("hides button when location context is unavailable", () => {
+    mockLocationCtx = null;
+    render(<SurfHighlightsSection />);
+    expect(screen.queryByRole("button", { name: /show spots near me/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/domains/wave-frequency/calculator.test.ts
+++ b/__tests__/lib/domains/wave-frequency/calculator.test.ts
@@ -1,0 +1,726 @@
+/**
+ * Unit tests for the rideable wave frequency calculator.
+ *
+ * Covers all seven algorithm steps plus integration scenarios and edge cases.
+ */
+
+import { calculateRideableWaves } from "@/lib/domains/wave-frequency/calculator";
+import type { WaveFrequencyInput } from "@/lib/domains/wave-frequency/types";
+import {
+  BREAK_TYPE_FACTORS,
+  DEFAULT_BREAK_TYPE_FACTOR,
+  DEFAULT_RIDEABLE_THRESHOLD,
+  DEFAULT_SWELL_ACCESS_FACTOR,
+  MAX_RIDEABLE_WAVES_PER_HOUR,
+  WIND_PENALTY_FLOOR,
+  WIND_PENALTY_DIVISOR,
+  WIND_SWELL_PERIOD_THRESHOLD,
+  MIN_SET_INTERVAL_S,
+  MAX_SET_INTERVAL_S,
+  MIN_WAVES_PER_SET,
+  MAX_WAVES_PER_SET,
+} from "@/lib/domains/wave-frequency/constants";
+
+/** Baseline input with sane defaults — override fields per test */
+function makeInput(overrides: Partial<WaveFrequencyInput> = {}): WaveFrequencyInput {
+  return {
+    dominantPeriodS: 12,
+    swell1PeriodS: null,
+    swell2PeriodS: null,
+    swell1DirectionDeg: null,
+    waveHeightFt: 4,
+    windSpeedKts: 0,
+    windDirectionDeg: null,
+    breakType: "beach",
+    aspectDeg: 270,
+    swellAccessFactors: null,
+    ...overrides,
+  };
+}
+
+describe("calculateRideableWaves", () => {
+  // ───────────────────────────────────────────────────────────────
+  // Step 0: Period guard
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 0: Period guard", () => {
+    it("returns 0 when dominant period is null", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: null }));
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("returns 0 when dominant period is zero", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 0 }));
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("returns 0 when dominant period is negative", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: -5 }));
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("returns zero factors when period is invalid", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: null }));
+      expect(result.factors.baseFrequency).toBe(0);
+      expect(result.factors.breakTypeFactor).toBe(0);
+      expect(result.factors.shortPeriodPenalty).toBe(0);
+      expect(result.factors.swellAccessFactor).toBe(0);
+      expect(result.factors.windPenalty).toBe(0);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 1: Height gate
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 1: Height gate", () => {
+    it("returns 0 when wave height is below beach threshold (2.0ft)", () => {
+      const result = calculateRideableWaves(
+        makeInput({ breakType: "beach", waveHeightFt: 1.5 }),
+      );
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("returns 0 when wave height is below reef threshold (2.5ft)", () => {
+      const result = calculateRideableWaves(
+        makeInput({ breakType: "reef", waveHeightFt: 2.0 }),
+      );
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("returns non-zero when wave height meets beach threshold", () => {
+      const result = calculateRideableWaves(
+        makeInput({ breakType: "beach", waveHeightFt: 2.0 }),
+      );
+      expect(result.rideableWavesPerHour).toBeGreaterThan(0);
+    });
+
+    it("returns non-zero when wave height meets reef threshold", () => {
+      const result = calculateRideableWaves(
+        makeInput({ breakType: "reef", waveHeightFt: 2.5 }),
+      );
+      expect(result.rideableWavesPerHour).toBeGreaterThan(0);
+    });
+
+    it("returns 0 when wave height is null", () => {
+      const result = calculateRideableWaves(makeInput({ waveHeightFt: null }));
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("uses default threshold (2.0) for unknown break type", () => {
+      // 1.9ft is below the default 2.0 threshold
+      const below = calculateRideableWaves(
+        makeInput({ breakType: "jetty", waveHeightFt: 1.9 }),
+      );
+      expect(below.rideableWavesPerHour).toBe(0);
+
+      // 2.0ft meets the default threshold
+      const at = calculateRideableWaves(
+        makeInput({ breakType: "jetty", waveHeightFt: 2.0 }),
+      );
+      expect(at.rideableWavesPerHour).toBeGreaterThan(0);
+    });
+
+    it("uses default threshold when break type is null", () => {
+      const below = calculateRideableWaves(
+        makeInput({ breakType: null, waveHeightFt: 1.9 }),
+      );
+      expect(below.rideableWavesPerHour).toBe(0);
+
+      const at = calculateRideableWaves(
+        makeInput({ breakType: null, waveHeightFt: 2.0 }),
+      );
+      expect(at.rideableWavesPerHour).toBeGreaterThan(0);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 2: Base frequency
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 2: Base frequency", () => {
+    it("single swell: base = 3600 / period (e.g., 10s -> 360)", () => {
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 10, swell1PeriodS: null, swell2PeriodS: null }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 10);
+    });
+
+    it("single swell: base = 3600 / period (e.g., 12s -> 300)", () => {
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 12, swell1PeriodS: null, swell2PeriodS: null }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 12);
+    });
+
+    it("multi-swell: uses beat frequency formula with known values", () => {
+      // T1=14, T2=9, |T1-T2|=5 >= 1.0 (MIN_PERIOD_DIFFERENCE)
+      // setInterval = clamp((14*9)/5, 60, 600) = clamp(25.2, 60, 600) = 60
+      // wavesPerSet = clamp(round(14/9), 2, 7) = clamp(round(1.556), 2, 7) = clamp(2, 2, 7) = 2
+      // baseFrequency = (3600/60) * 2 = 120
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 12, swell1PeriodS: 14, swell2PeriodS: 9 }),
+      );
+      expect(result.factors.baseFrequency).toBe(120);
+    });
+
+    it("multi-swell: falls back to single swell when periods within 1.0s", () => {
+      // T1=12, T2=11.5, |T1-T2|=0.5 < 1.0 (MIN_PERIOD_DIFFERENCE)
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 12, swell1PeriodS: 12, swell2PeriodS: 11.5 }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 12);
+    });
+
+    it("multi-swell: falls back to single swell when periods are equal", () => {
+      // T1=10, T2=10, |T1-T2|=0 < 1.0 (MIN_PERIOD_DIFFERENCE)
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 10, swell1PeriodS: 10, swell2PeriodS: 10 }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 10);
+    });
+
+    it("multi-swell: falls back to single when swell2 is null", () => {
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 10, swell1PeriodS: 14, swell2PeriodS: null }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 10);
+    });
+
+    it("multi-swell: falls back to single when swell1 is null", () => {
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 10, swell1PeriodS: null, swell2PeriodS: 9 }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 10);
+    });
+
+    it("multi-swell: falls back to single when swell1 is zero", () => {
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 10, swell1PeriodS: 0, swell2PeriodS: 9 }),
+      );
+      expect(result.factors.baseFrequency).toBe(3600 / 10);
+    });
+
+    it("multi-swell: set interval is clamped to MIN_SET_INTERVAL_S", () => {
+      // T1=14, T2=9: raw setInterval = (14*9)/5 = 25.2 -> clamped to 60
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 12, swell1PeriodS: 14, swell2PeriodS: 9 }),
+      );
+      // If setInterval were unclamped (25.2), base would be (3600/25.2)*2 = 285.7
+      // With clamping to 60, base = (3600/60)*2 = 120
+      expect(result.factors.baseFrequency).toBe(120);
+    });
+
+    it("multi-swell: large period difference produces higher set interval", () => {
+      // T1=18, T2=8, diff=10
+      // setInterval = clamp((18*8)/10, 60, 600) = clamp(14.4, 60, 600) = 60
+      // wavesPerSet = clamp(round(18/8), 2, 7) = clamp(round(2.25), 2, 7) = clamp(2, 2, 7) = 2
+      // baseFrequency = (3600/60) * 2 = 120
+      const result = calculateRideableWaves(
+        makeInput({ dominantPeriodS: 14, swell1PeriodS: 18, swell2PeriodS: 8 }),
+      );
+      expect(result.factors.baseFrequency).toBe(120);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 3: Break type factor
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 3: Break type factor", () => {
+    it("beach break uses 0.15 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: "beach" }));
+      expect(result.factors.breakTypeFactor).toBe(BREAK_TYPE_FACTORS["beach"]);
+      expect(result.factors.breakTypeFactor).toBe(0.15);
+    });
+
+    it("point break uses 0.08 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: "point" }));
+      expect(result.factors.breakTypeFactor).toBe(BREAK_TYPE_FACTORS["point"]);
+      expect(result.factors.breakTypeFactor).toBe(0.08);
+    });
+
+    it("reef break uses 0.10 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: "reef" }));
+      expect(result.factors.breakTypeFactor).toBe(BREAK_TYPE_FACTORS["reef"]);
+      expect(result.factors.breakTypeFactor).toBe(0.1);
+    });
+
+    it("river break uses 0.08 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: "river" }));
+      expect(result.factors.breakTypeFactor).toBe(BREAK_TYPE_FACTORS["river"]);
+      expect(result.factors.breakTypeFactor).toBe(0.08);
+    });
+
+    it("null break type uses default 0.12 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: null }));
+      expect(result.factors.breakTypeFactor).toBe(DEFAULT_BREAK_TYPE_FACTOR);
+      expect(result.factors.breakTypeFactor).toBe(0.12);
+    });
+
+    it("unknown break type ('jetty') uses default 0.12 factor", () => {
+      const result = calculateRideableWaves(makeInput({ breakType: "jetty" }));
+      expect(result.factors.breakTypeFactor).toBe(DEFAULT_BREAK_TYPE_FACTOR);
+      expect(result.factors.breakTypeFactor).toBe(0.12);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 4: Short period penalty
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 4: Short period penalty", () => {
+    it("period 6s produces penalty of 0.75 (6/8)", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 6 }));
+      expect(result.factors.shortPeriodPenalty).toBeCloseTo(6 / WIND_SWELL_PERIOD_THRESHOLD, 10);
+      expect(result.factors.shortPeriodPenalty).toBeCloseTo(0.75, 10);
+    });
+
+    it("period 4s produces penalty of 0.50 (4/8)", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 4 }));
+      expect(result.factors.shortPeriodPenalty).toBeCloseTo(0.5, 10);
+    });
+
+    it("period 8s produces penalty of 1.0 (threshold boundary, no penalty)", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 8 }));
+      expect(result.factors.shortPeriodPenalty).toBe(1.0);
+    });
+
+    it("period 12s produces penalty of 1.0 (above threshold)", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 12 }));
+      expect(result.factors.shortPeriodPenalty).toBe(1.0);
+    });
+
+    it("period 7s produces penalty of 0.875 (7/8)", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: 7 }));
+      expect(result.factors.shortPeriodPenalty).toBeCloseTo(0.875, 10);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 5: Swell access
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 5: Swell access factor", () => {
+    it("uses bin lookup with valid 72-element access factors array", () => {
+      // swell1DirectionDeg=270 => bin = round(270/5) % 72 = 54
+      const accessFactors = new Array(72).fill(0.5);
+      accessFactors[54] = 0.95;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+      expect(result.factors.swellAccessFactor).toBe(0.95);
+    });
+
+    it("falls back to default 0.7 when access factors is null", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: 270,
+          swellAccessFactors: null,
+        }),
+      );
+      expect(result.factors.swellAccessFactor).toBe(DEFAULT_SWELL_ACCESS_FACTOR);
+      expect(result.factors.swellAccessFactor).toBe(0.7);
+    });
+
+    it("falls back to default 0.7 when access factors has wrong length", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: 270,
+          swellAccessFactors: [0.9, 0.8, 0.7], // only 3 elements, not 72
+        }),
+      );
+      expect(result.factors.swellAccessFactor).toBe(DEFAULT_SWELL_ACCESS_FACTOR);
+    });
+
+    it("falls back to default 0.7 when swell1DirectionDeg is null", () => {
+      const accessFactors = new Array(72).fill(0.95);
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: null,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+      expect(result.factors.swellAccessFactor).toBe(DEFAULT_SWELL_ACCESS_FACTOR);
+    });
+
+    it("handles direction at 0 degrees (bin 0)", () => {
+      const accessFactors = new Array(72).fill(0.5);
+      accessFactors[0] = 0.88;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: 0,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+      expect(result.factors.swellAccessFactor).toBe(0.88);
+    });
+
+    it("handles direction at 360 degrees (wraps to bin 0)", () => {
+      const accessFactors = new Array(72).fill(0.5);
+      accessFactors[0] = 0.88;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          swell1DirectionDeg: 360,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+      // round(360/5) % 72 = 72 % 72 = 0
+      expect(result.factors.swellAccessFactor).toBe(0.88);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 6: Wind penalty
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 6: Wind penalty", () => {
+    it("offshore wind has no penalty (windPenalty = 1.0)", () => {
+      // Wind from 90 (east), aspect 270 (facing west)
+      // cos(toRad(90 - 270)) = cos(toRad(-180)) = cos(pi) = -1 (offshore)
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 10,
+          windDirectionDeg: 90,
+          aspectDeg: 270,
+        }),
+      );
+      expect(result.factors.windPenalty).toBe(1.0);
+    });
+
+    it("light onshore produces moderate penalty", () => {
+      // Wind from 270 (west), aspect 270 (facing west)
+      // cos(toRad(270 - 270)) = cos(0) = 1 (directly onshore)
+      // windPenalty = max(0.3, 1 - (5 * 1) / 30) = max(0.3, 0.833) = 0.833
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 5,
+          windDirectionDeg: 270,
+          aspectDeg: 270,
+        }),
+      );
+      const expected = Math.max(WIND_PENALTY_FLOOR, 1 - (5 * 1) / WIND_PENALTY_DIVISOR);
+      expect(result.factors.windPenalty).toBeCloseTo(expected, 10);
+      expect(result.factors.windPenalty).toBeCloseTo(1 - 5 / 30, 10);
+    });
+
+    it("strong onshore (15kt+) produces heavy penalty clamped to floor", () => {
+      // Wind from 270 (west), aspect 270 (facing west)
+      // cos(0) = 1, penalty = max(0.3, 1 - (25 * 1) / 30) = max(0.3, -0.167) = 0.3
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 25,
+          windDirectionDeg: 270,
+          aspectDeg: 270,
+        }),
+      );
+      expect(result.factors.windPenalty).toBe(WIND_PENALTY_FLOOR);
+      expect(result.factors.windPenalty).toBe(0.3);
+    });
+
+    it("15kt onshore exactly", () => {
+      // cos(0) = 1, penalty = max(0.3, 1 - (15 * 1)/30) = max(0.3, 0.5) = 0.5
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 15,
+          windDirectionDeg: 270,
+          aspectDeg: 270,
+        }),
+      );
+      expect(result.factors.windPenalty).toBeCloseTo(0.5, 10);
+    });
+
+    it("null wind direction has no penalty (windPenalty = 1.0)", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 20,
+          windDirectionDeg: null,
+          aspectDeg: 270,
+        }),
+      );
+      expect(result.factors.windPenalty).toBe(1.0);
+    });
+
+    it("zero wind speed has no penalty (windPenalty = 1.0)", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 0,
+          windDirectionDeg: 270,
+          aspectDeg: 270,
+        }),
+      );
+      expect(result.factors.windPenalty).toBe(1.0);
+    });
+
+    it("null aspect has no penalty (windPenalty = 1.0)", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 15,
+          windDirectionDeg: 270,
+          aspectDeg: null,
+        }),
+      );
+      expect(result.factors.windPenalty).toBe(1.0);
+    });
+
+    it("crossshore wind (90 degrees off) has no penalty", () => {
+      // Wind from 0 (north), aspect 270 (facing west)
+      // cos(toRad(0 - 270)) = cos(toRad(-270)) = cos(-3pi/2) ~= 0
+      // Cosine of -270 deg is ~0, so onshoreComponent ~= 0, no penalty applied
+      const result = calculateRideableWaves(
+        makeInput({
+          windSpeedKts: 15,
+          windDirectionDeg: 0,
+          aspectDeg: 270,
+        }),
+      );
+      // cos(-270 deg) = cos(-3*pi/2) = 0 (actually ~6.12e-17 due to float)
+      // Since it's effectively 0, no penalty branch entered
+      expect(result.factors.windPenalty).toBeCloseTo(1.0, 5);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Step 7: Output clamping
+  // ───────────────────────────────────────────────────────────────
+  describe("Step 7: Output clamping", () => {
+    it("result is clamped to MAX_RIDEABLE_WAVES_PER_HOUR (60)", () => {
+      // Engineer a scenario that would produce > 60 without clamping:
+      // Very short period (2s) with beach break:
+      // base = 3600/2 = 1800, breakType = 0.15, shortPeriod = 2/8 = 0.25
+      // swellAccess = 0.7 (default), windPenalty = 1.0
+      // raw = 1800 * 0.15 * 0.25 * 0.7 * 1.0 = 47.25 — not enough
+      // Use access factor of 1.0 to push it:
+      // raw = 1800 * 0.15 * 0.25 * 1.0 * 1.0 = 67.5 > 60
+      const accessFactors = new Array(72).fill(1.0);
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 2,
+          waveHeightFt: 5,
+          breakType: "beach",
+          windSpeedKts: 0,
+          swell1DirectionDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+      expect(result.rideableWavesPerHour).toBe(MAX_RIDEABLE_WAVES_PER_HOUR);
+      expect(result.rideableWavesPerHour).toBe(60);
+    });
+
+    it("zero result stays 0", () => {
+      const result = calculateRideableWaves(makeInput({ waveHeightFt: 0 }));
+      expect(result.rideableWavesPerHour).toBe(0);
+    });
+
+    it("result is never negative", () => {
+      const result = calculateRideableWaves(makeInput({ waveHeightFt: null }));
+      expect(result.rideableWavesPerHour).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Spec example verification — realistic scenarios
+  // ───────────────────────────────────────────────────────────────
+  describe("Spec example verification", () => {
+    it("Ocean Beach Pier (beach): 4ft @ 10s, access 0.85, light offshore", () => {
+      // base = 3600/10 = 360
+      // breakType = 0.15 (beach)
+      // shortPeriod = 1.0 (10s >= 8s)
+      // swellAccess = 0.85 (from bin lookup)
+      // windPenalty = 1.0 (offshore)
+      // raw = 360 * 0.15 * 1.0 * 0.85 * 1.0 = 45.9
+      // clamped = round(45.9) = 46
+      const accessFactors = new Array(72).fill(0.5);
+      const bin = Math.round(270 / 5) % 72; // 54
+      accessFactors[bin] = 0.85;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 10,
+          swell1PeriodS: null,
+          swell2PeriodS: null,
+          swell1DirectionDeg: 270,
+          waveHeightFt: 4,
+          windSpeedKts: 5,
+          windDirectionDeg: 90, // offshore (opposite of aspect)
+          breakType: "beach",
+          aspectDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+
+      expect(result.rideableWavesPerHour).toBe(46);
+      expect(result.factors.baseFrequency).toBe(360);
+      expect(result.factors.breakTypeFactor).toBe(0.15);
+      expect(result.factors.shortPeriodPenalty).toBe(1.0);
+      expect(result.factors.swellAccessFactor).toBe(0.85);
+      expect(result.factors.windPenalty).toBe(1.0);
+    });
+
+    it("Scripps (reef): 4ft @ 12s, glassy, access 0.90", () => {
+      // base = 3600/12 = 300
+      // breakType = 0.10 (reef)
+      // shortPeriod = 1.0 (12s >= 8s)
+      // swellAccess = 0.90 (from bin lookup)
+      // windPenalty = 1.0 (0kt wind)
+      // raw = 300 * 0.10 * 1.0 * 0.90 * 1.0 = 27.0
+      // clamped = round(27) = 27
+      const accessFactors = new Array(72).fill(0.5);
+      const bin = Math.round(270 / 5) % 72;
+      accessFactors[bin] = 0.90;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 12,
+          swell1DirectionDeg: 270,
+          waveHeightFt: 4,
+          windSpeedKts: 0,
+          breakType: "reef",
+          aspectDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+
+      expect(result.rideableWavesPerHour).toBe(27);
+      expect(result.factors.baseFrequency).toBe(300);
+      expect(result.factors.breakTypeFactor).toBe(0.1);
+      expect(result.factors.swellAccessFactor).toBe(0.9);
+    });
+
+    it("Scripps (reef): 4ft @ 12s, 15kt onshore reduces count", () => {
+      // base = 300, breakType = 0.10, shortPeriod = 1.0, swellAccess = 0.90
+      // windPenalty: cos(toRad(270 - 270)) = cos(0) = 1.0 (directly onshore)
+      // penalty = max(0.3, 1 - (15 * 1.0) / 30) = max(0.3, 0.5) = 0.5
+      // raw = 300 * 0.10 * 1.0 * 0.90 * 0.5 = 13.5
+      // clamped = round(13.5) = 14
+      const accessFactors = new Array(72).fill(0.5);
+      const bin = Math.round(270 / 5) % 72;
+      accessFactors[bin] = 0.90;
+
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 12,
+          swell1DirectionDeg: 270,
+          waveHeightFt: 4,
+          windSpeedKts: 15,
+          windDirectionDeg: 270, // onshore (same as aspect)
+          breakType: "reef",
+          aspectDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+
+      expect(result.rideableWavesPerHour).toBe(14);
+      expect(result.factors.windPenalty).toBeCloseTo(0.5, 10);
+
+      // Should be less than the glassy scenario
+      expect(result.rideableWavesPerHour).toBeLessThan(27);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────
+  // Edge cases
+  // ───────────────────────────────────────────────────────────────
+  describe("Edge cases", () => {
+    it("all factors at minimum produce very low result", () => {
+      // Short period (3s), reef (high threshold), strong onshore, low access
+      const accessFactors = new Array(72).fill(0.05);
+
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 3,
+          swell1DirectionDeg: 270,
+          waveHeightFt: 2.5, // just at reef threshold
+          windSpeedKts: 25,
+          windDirectionDeg: 270,
+          breakType: "reef",
+          aspectDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+
+      // base = 3600/3 = 1200
+      // breakType = 0.10
+      // shortPeriod = 3/8 = 0.375
+      // swellAccess = 0.05
+      // windPenalty = 0.3 (floor)
+      // raw = 1200 * 0.10 * 0.375 * 0.05 * 0.3 = 0.675
+      // clamped = round(0.675) = 1
+      expect(result.rideableWavesPerHour).toBeLessThanOrEqual(2);
+      expect(result.rideableWavesPerHour).toBeGreaterThanOrEqual(0);
+    });
+
+    it("perfect conditions produce high result approaching cap", () => {
+      const accessFactors = new Array(72).fill(1.0);
+
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 8, // at threshold, no period penalty
+          swell1DirectionDeg: 270,
+          waveHeightFt: 8,
+          windSpeedKts: 0, // glassy
+          breakType: "beach", // highest factor (0.15)
+          aspectDeg: 270,
+          swellAccessFactors: accessFactors,
+        }),
+      );
+
+      // base = 3600/8 = 450
+      // breakType = 0.15
+      // shortPeriod = 1.0
+      // swellAccess = 1.0
+      // windPenalty = 1.0
+      // raw = 450 * 0.15 * 1.0 * 1.0 * 1.0 = 67.5
+      // clamped to 60
+      expect(result.rideableWavesPerHour).toBe(MAX_RIDEABLE_WAVES_PER_HOUR);
+    });
+
+    it("confidence is always 'medium' from the calculator", () => {
+      const result = calculateRideableWaves(makeInput());
+      expect(result.confidence).toBe("medium");
+    });
+
+    it("confidence is 'medium' even for zero result", () => {
+      const result = calculateRideableWaves(makeInput({ dominantPeriodS: null }));
+      expect(result.confidence).toBe("medium");
+    });
+
+    it("result is deterministic — same input always produces same output", () => {
+      const input = makeInput({
+        dominantPeriodS: 10,
+        waveHeightFt: 4,
+        windSpeedKts: 8,
+        windDirectionDeg: 200,
+        aspectDeg: 270,
+      });
+
+      const r1 = calculateRideableWaves(input);
+      const r2 = calculateRideableWaves(input);
+      const r3 = calculateRideableWaves(input);
+
+      expect(r1).toEqual(r2);
+      expect(r2).toEqual(r3);
+    });
+
+    it("result is an integer (rounded)", () => {
+      const result = calculateRideableWaves(
+        makeInput({
+          dominantPeriodS: 11,
+          waveHeightFt: 3.5,
+          windSpeedKts: 3,
+          windDirectionDeg: 250,
+          aspectDeg: 270,
+        }),
+      );
+      expect(Number.isInteger(result.rideableWavesPerHour)).toBe(true);
+    });
+
+    it("break type matching is case-insensitive", () => {
+      const lower = calculateRideableWaves(makeInput({ breakType: "beach" }));
+      const upper = calculateRideableWaves(makeInput({ breakType: "Beach" }));
+      const mixed = calculateRideableWaves(makeInput({ breakType: "BEACH" }));
+
+      expect(lower.factors.breakTypeFactor).toBe(upper.factors.breakTypeFactor);
+      expect(lower.factors.breakTypeFactor).toBe(mixed.factors.breakTypeFactor);
+    });
+  });
+});

--- a/__tests__/lib/mappers/conditions-mappers.test.ts
+++ b/__tests__/lib/mappers/conditions-mappers.test.ts
@@ -1,4 +1,4 @@
-import { forecastToConditionsData } from "@/lib/mappers/conditions-mappers";
+import { forecastToConditionsData, BeachForWaveFrequency } from "@/lib/mappers/conditions-mappers";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 
 /** Helper to create a minimal valid EnhancedForecastEntity with optional overrides. */
@@ -80,6 +80,13 @@ describe("forecastToConditionsData", () => {
     expect(withWindOnly.waveHeight).toBeNull();
   });
 
+  it("normalizes numeric wind direction to cardinal", () => {
+    const result = forecastToConditionsData(
+      makeForecast({ wind_direction: "109" })
+    );
+    expect(result.windDirection).toBe("ESE");
+  });
+
   it("converts undefined optional fields to null", () => {
     // wave_period, wave_direction, etc. are optional on EnhancedForecastEntity
     // and may be undefined rather than null — the mapper should normalize to null
@@ -92,5 +99,86 @@ describe("forecastToConditionsData", () => {
 
     expect(result.waveHeight).toBe("2-3ft");
     expect(result.wavePeriod).toBeNull();
+  });
+});
+
+const testBeach: BeachForWaveFrequency = {
+  break_type: "beach",
+  aspect_deg: 180,
+  swell_access_factors: null,
+};
+
+describe("forecastToConditionsData with beach (wave frequency)", () => {
+  it("computes rideableWavesPerHour using RSS of swell components", () => {
+    // Rockaway-like scenario: 2.7 + 2.2 + 1.3 ft swells = ~3.7ft combined
+    const forecast = makeForecast({
+      wave_height: "1.8 ft",
+      wave_period: "10s",
+      swell_1_height: "2.7 ft",
+      swell_1_period: "10s",
+      swell_1_direction: "SE",
+      swell_2_height: "2.2 ft",
+      swell_2_period: "9s",
+      wind_wave_height: "1.3 ft",
+    });
+    const result = forecastToConditionsData(forecast, testBeach);
+    // RSS ≈ 3.7ft, well above 2.0ft beach threshold → should produce waves
+    expect(result.rideableWavesPerHour).toBeGreaterThan(0);
+  });
+
+  it("uses single swell component when others are null", () => {
+    const forecast = makeForecast({
+      wave_height: "1.5 ft",
+      wave_period: "12s",
+      swell_1_height: "3 ft",
+      swell_1_period: "12s",
+      swell_1_direction: "S",
+    });
+    const result = forecastToConditionsData(forecast, testBeach);
+    // Single component 3ft > 2.0ft threshold → should produce waves
+    expect(result.rideableWavesPerHour).toBeGreaterThan(0);
+  });
+
+  it("falls back to wave_height when all swell components are null", () => {
+    const forecast = makeForecast({
+      wave_height: "4-5ft",
+      wave_period: "10s",
+    });
+    const result = forecastToConditionsData(forecast, testBeach);
+    // wave_height lower bound 4ft > 2.0ft threshold → should produce waves
+    expect(result.rideableWavesPerHour).toBeGreaterThan(0);
+  });
+
+  it("returns 0 waves/hr when all components are flat", () => {
+    const forecast = makeForecast({
+      wave_height: "Flat",
+      wave_period: "8s",
+    });
+    const result = forecastToConditionsData(forecast, testBeach);
+    expect(result.rideableWavesPerHour).toBe(0);
+  });
+
+  it("returns null rideableWavesPerHour when no beach provided", () => {
+    const forecast = makeForecast({
+      wave_height: "4-5ft",
+      wave_period: "10s",
+      swell_1_height: "3 ft",
+    });
+    const result = forecastToConditionsData(forecast);
+    expect(result.rideableWavesPerHour).toBeUndefined();
+  });
+
+  it("filters flat sentinel from swell components, uses wave_height fallback", () => {
+    // All swell fields null/missing but wave_height has a real value
+    const forecast = makeForecast({
+      wave_height: "3 ft",
+      wave_period: "10s",
+      swell_1_height: null,
+      swell_2_height: null,
+      wind_wave_height: null,
+    });
+    const result = forecastToConditionsData(forecast, testBeach);
+    // Falls back to wave_height 3ft > 2.0ft → produces waves
+    expect(result.rideableWavesPerHour).toBeGreaterThan(0);
   });
 });

--- a/app/embed/ticker/[slug]/embed-ticker-widget.tsx
+++ b/app/embed/ticker/[slug]/embed-ticker-widget.tsx
@@ -132,11 +132,30 @@ function QuiverLogoIcon() {
 }
 
 // Embed-specific icon map keyed by ConditionsIconType
+function ActivityIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  );
+}
+
 const EMBED_ICONS: Record<string, React.ReactNode> = {
   waves: <WaveIcon />,
   swell: <ArrowIcon />,
   wind: <WindIcon />,
   water: <ThermometerIcon />,
+  frequency: <ActivityIcon />,
 };
 
 interface TickerCard {

--- a/components/beach-detail.tsx
+++ b/components/beach-detail.tsx
@@ -544,9 +544,10 @@ function BeachDetailContent({
               />
               {currentForecast && (
                 <ConditionsTicker
-                  data={forecastToConditionsData(currentForecast)}
+                  data={forecastToConditionsData(currentForecast, beach)}
                   theme="dark"
                   beachName={beach.name}
+                  showFrequency
                 />
               )}
             </div>

--- a/components/conditions/conditions-ticker.tsx
+++ b/components/conditions/conditions-ticker.tsx
@@ -47,7 +47,7 @@ function CardIcon({
 
 function TickerCard({ card, isDark }: { card: ConditionsCard; isDark: boolean }) {
   return (
-    <div className="flex items-center gap-1.5 shrink-0">
+    <div className="flex items-center gap-1.5 shrink-0" aria-label={card.ariaLabel}>
       <span className={isDark ? "text-gray-400" : "text-gray-500"}>
         <CardIcon iconType={card.iconType} tideRising={card.tideRising} />
       </span>

--- a/components/conditions/conditions-ticker.tsx
+++ b/components/conditions/conditions-ticker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { Compass, Wind, Thermometer, ChevronUp, ChevronDown } from "lucide-react";
+import { Compass, Wind, Thermometer, ChevronUp, ChevronDown, Activity } from "lucide-react";
 import { AnimatedWaveIcon } from "@/components/ui/animated-wave-icon";
 import type { ConditionsData } from "@/types/conditions";
 import {
@@ -15,6 +15,7 @@ interface ConditionsTickerProps {
   theme?: "light" | "dark";
   loading?: boolean;
   beachName?: string;
+  showFrequency?: boolean;
   className?: string;
 }
 
@@ -39,6 +40,8 @@ function CardIcon({
       return <Thermometer {...props} />;
     case "tide":
       return tideRising ? <ChevronUp {...props} /> : <ChevronDown {...props} />;
+    case "frequency":
+      return <Activity {...props} />;
   }
 }
 
@@ -95,10 +98,11 @@ export function ConditionsTicker({
   theme = "light",
   loading = false,
   beachName,
+  showFrequency,
   className,
 }: ConditionsTickerProps) {
   const isDark = theme === "dark";
-  const cards = loading ? [] : buildConditionsCards(data);
+  const cards = loading ? [] : buildConditionsCards(data, { showFrequency });
 
   if (!loading && cards.length === 0) return null;
 

--- a/components/landing-page/surf-highlights-section.tsx
+++ b/components/landing-page/surf-highlights-section.tsx
@@ -80,7 +80,7 @@ export function SurfHighlightsSection() {
             location:
               beach.city && beach.state
                 ? `${beach.city}, ${beach.state}`
-                : beach.city || beach.state || "California",
+                : beach.city || beach.state || "USA",
             slug: beach.slug,
             city: beach.city,
             state: beach.state,

--- a/components/landing-page/surf-highlights-section.tsx
+++ b/components/landing-page/surf-highlights-section.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { motion, useInView, useReducedMotion } from "framer-motion";
 import { SurfSpotCard, SurfSpotCardProps } from "./surf-spot-card";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, MapPin } from "lucide-react";
 import { useDataFetcher } from "@/hooks/use-data-fetcher";
 import { getProxiedImageUrl } from "@/lib/utils/image-utils";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -38,6 +38,11 @@ export function SurfHighlightsSection() {
   const pageSize = 4;
   const locationCtx = useLocationSafe();
   const location = locationCtx?.location;
+  const hasPreciseLocation = locationCtx?.hasPreciseLocation ?? false;
+  const requestPreciseLocation = locationCtx?.requestPreciseLocation;
+  const locationError = locationCtx?.locationError ?? null;
+  const clearError = locationCtx?.clearError;
+  const [requesting, setRequesting] = useState(false);
   // Don't use coordinates until location has resolved (avoids race with default SD coords)
   const coordinates = location && !location.isLoading ? location.coordinates : null;
 
@@ -139,6 +144,17 @@ export function SurfHighlightsSection() {
 
   const easeOutQuart: [number, number, number, number] = [0.25, 1, 0.5, 1];
 
+  const handleRequestLocation = async () => {
+    if (!requestPreciseLocation) return;
+    clearError?.();
+    setRequesting(true);
+    try {
+      await requestPreciseLocation();
+    } finally {
+      setRequesting(false);
+    }
+  };
+
   return (
     <section
       ref={sectionRef}
@@ -146,18 +162,44 @@ export function SurfHighlightsSection() {
     >
       <div className="max-w-7xl mx-auto px-6">
         {/* Section header */}
-        <motion.h2
-          className="text-3xl sm:text-4xl md:text-5xl font-heading font-bold text-white mb-10 md:mb-12 text-left"
-          initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
-          animate={
-            shouldReduceMotion
-              ? {}
-              : { opacity: isInView ? 1 : 0, y: isInView ? 0 : 16 }
-          }
-          transition={{ duration: 0.5, ease: easeOutQuart }}
-        >
-          {isNearby ? "Local surf favorites near you" : "Popular surf spots"}
-        </motion.h2>
+        <div className="mb-10 md:mb-12">
+          <motion.h2
+            className="text-3xl sm:text-4xl md:text-5xl font-heading font-bold text-white text-left"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
+            animate={
+              shouldReduceMotion
+                ? {}
+                : { opacity: isInView ? 1 : 0, y: isInView ? 0 : 16 }
+            }
+            transition={{ duration: 0.5, ease: easeOutQuart }}
+          >
+            {isNearby ? "Local surf favorites near you" : "Popular surf spots"}
+          </motion.h2>
+
+          {!hasPreciseLocation && requestPreciseLocation && !loading && !locationLoading && (
+            <motion.div
+              className="mt-3 flex items-center gap-3 flex-wrap"
+              initial={shouldReduceMotion ? false : { opacity: 0 }}
+              animate={shouldReduceMotion ? {} : { opacity: isInView ? 1 : 0 }}
+              transition={{ duration: 0.4, ease: easeOutQuart, delay: 0.2 }}
+            >
+              <button
+                type="button"
+                onClick={handleRequestLocation}
+                disabled={requesting}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-white/[0.08] text-[#9AABC6] hover:bg-white/[0.14] hover:text-white border border-white/[0.1] transition-all duration-200 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 focus-visible:ring-offset-2 focus-visible:ring-offset-[#252D6B]"
+              >
+                <MapPin size={14} />
+                {requesting ? "Locating\u2026" : "Show spots near me"}
+              </button>
+              {locationError && (
+                <span role="alert" className="text-sm text-amber-400/80">
+                  {locationError}
+                </span>
+              )}
+            </motion.div>
+          )}
+        </div>
 
         {loading || locationLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/lib/constants/featured-beaches-config.ts
+++ b/lib/constants/featured-beaches-config.ts
@@ -48,11 +48,18 @@ export const FEATURED_BEACHES_LIMIT = 50;
 export const FEATURED_BEACHES_RADIUS_MILES = 150;
 
 /**
- * Minimum number of nearby beaches required before proximity filtering kicks in.
- * If fewer than this many beaches are within the radius, fall back to the global list
- * to prevent showing an empty or near-empty section.
+ * Minimum number of nearby beaches (with photos) required before proximity filtering kicks in.
+ * If fewer than this many displayable beaches are within the radius, fall back to the global list
+ * to prevent a sparse grid. Matches the desktop grid column count (lg:grid-cols-4).
  */
 export const MIN_NEARBY_RESULTS = 4;
+
+/**
+ * Progressive search radii (miles) used when the default radius finds too few nearby beaches.
+ * Expands outward until enough beaches with photos are found.
+ * Capped at 1000 miles to avoid showing irrelevant results (e.g., Hawaii for Minnesota).
+ */
+export const EXPANDED_SEARCH_RADII = [300, 500, 1000] as const;
 
 /**
  * Mapping of beach names to curated fallback imagery.

--- a/lib/data/server/featured-beaches.ts
+++ b/lib/data/server/featured-beaches.ts
@@ -20,6 +20,7 @@ import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { withApprovedPhotos } from "@/lib/supabase/query-builders";
 import {
   EXCLUDED_BEACH_IDS,
+  EXPANDED_SEARCH_RADII,
   FEATURED_BEACHES_LIMIT,
   FEATURED_BEACHES_RADIUS_MILES,
   MIN_NEARBY_RESULTS,
@@ -394,11 +395,27 @@ async function _getFeaturedBeaches(options?: FeaturedBeachesOptions): Promise<Fe
       FEATURED_BEACHES_LIMIT
     );
 
-    // Fall back to global list if too few nearby results
-    if (nearby.length < MIN_NEARBY_RESULTS) {
-      return { beaches: globalList, isNearby: false };
+    // If initial radius finds enough beaches with photos, use them
+    const nearbyWithPhotos = nearby.filter((b) => b.has_real_photo);
+    if (nearbyWithPhotos.length >= MIN_NEARBY_RESULTS) {
+      return { beaches: nearby, isNearby: true };
     }
-    return { beaches: nearby, isNearby: true };
+
+    // Expand radius progressively to find closest beaches
+    // (e.g., DC → OBX at ~300mi, Atlanta → FL at ~500mi)
+    for (const expandedRadius of EXPANDED_SEARCH_RADII) {
+      if (expandedRadius <= radiusMiles) continue; // skip radii we've already covered
+      const expanded = filterByProximity(
+        allDeduped, coordinatesById, userCoords, expandedRadius, FEATURED_BEACHES_LIMIT
+      );
+      const expandedWithPhotos = expanded.filter((b) => b.has_real_photo);
+      if (expandedWithPhotos.length >= MIN_NEARBY_RESULTS) {
+        return { beaches: expanded, isNearby: true };
+      }
+    }
+
+    // Only fall back to global list if even max radius finds nothing (e.g., landlocked midwest)
+    return { beaches: globalList, isNearby: false };
   } catch (error) {
     console.error("Error fetching featured beaches:", error);
     return { beaches: [], isNearby: false };

--- a/lib/domains/scoring/discovery-adapter.ts
+++ b/lib/domains/scoring/discovery-adapter.ts
@@ -15,6 +15,7 @@ import type { Beach } from '@/types/database';
 import type { EnhancedForecastEntity } from '@/types/forecast';
 import type { DetailedScore } from '@/types/personalization';
 import type { ScorerInput, CompositeScore } from './types';
+import { getDirectionDegrees } from '@/lib/utils/number-parsing';
 import { trackFallback } from '@/lib/monitoring/fallback-tracker';
 import { resolveConfidence } from '@/lib/monitoring/fallback-helpers';
 import type { SpotProfile } from '../spot-profile/types';
@@ -548,46 +549,6 @@ function applyPreferredWaveSizeAdjustment(
 // =============================================================================
 // Helper Functions
 // =============================================================================
-
-/**
- * Get direction in degrees from either numeric or string direction.
- */
-function getDirectionDegrees(
-  deg: number | string | null | undefined,
-  cardinal: string | null | undefined
-): number | null {
-  // If we have numeric degrees
-  if (deg !== null && deg !== undefined) {
-    const numDeg = typeof deg === 'string' ? parseFloat(deg) : deg;
-    if (!isNaN(numDeg)) {
-      return numDeg;
-    }
-  }
-
-  // Fall back to cardinal direction
-  if (!cardinal) return null;
-
-  const cardinalMap: Record<string, number> = {
-    N: 0,
-    NNE: 22.5,
-    NE: 45,
-    ENE: 67.5,
-    E: 90,
-    ESE: 112.5,
-    SE: 135,
-    SSE: 157.5,
-    S: 180,
-    SSW: 202.5,
-    SW: 225,
-    WSW: 247.5,
-    W: 270,
-    WNW: 292.5,
-    NW: 315,
-    NNW: 337.5,
-  };
-
-  return cardinalMap[cardinal.toUpperCase()] ?? null;
-}
 
 /**
  * Parse tide status from string.

--- a/lib/domains/wave-frequency/calculator.ts
+++ b/lib/domains/wave-frequency/calculator.ts
@@ -1,0 +1,199 @@
+/**
+ * Rideable Waves Per Hour Calculator
+ *
+ * Estimates how many rideable waves a surfer can expect per hour
+ * at a given spot, based on swell, wind, and break characteristics.
+ *
+ * Algorithm steps:
+ *   0. Period guard — no period means no waves
+ *   1. Height gate — below threshold is flat
+ *   2. Base frequency — single swell or multi-swell beat frequency
+ *   3. Break type factor — what fraction of waves are rideable
+ *   4. Short period penalty — wind swell degrades quality
+ *   5. Swell access — directional exposure of the break
+ *   6. Wind penalty — onshore wind chops up the lineup
+ *   7. Clamp and return
+ */
+
+import type { WaveFrequencyInput, WaveFrequencyResult } from './types';
+import {
+  BREAK_TYPE_FACTORS,
+  DEFAULT_BREAK_TYPE_FACTOR,
+  RIDEABLE_THRESHOLDS,
+  DEFAULT_RIDEABLE_THRESHOLD,
+  MAX_RIDEABLE_WAVES_PER_HOUR,
+  MIN_SET_INTERVAL_S,
+  MAX_SET_INTERVAL_S,
+  MIN_WAVES_PER_SET,
+  MAX_WAVES_PER_SET,
+  WIND_SWELL_PERIOD_THRESHOLD,
+  MIN_PERIOD_DIFFERENCE,
+  DEFAULT_SWELL_ACCESS_FACTOR,
+  WIND_PENALTY_FLOOR,
+  WIND_PENALTY_DIVISOR,
+} from './constants';
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Calculates the estimated number of rideable waves per hour.
+ *
+ * Pure function — no side effects, deterministic output for the same input.
+ *
+ * @param input - Forecast, wind, and break characteristics
+ * @returns Rideable wave count, confidence level, and intermediate factors
+ *
+ * @example
+ * const result = calculateRideableWaves({
+ *   dominantPeriodS: 12,
+ *   swell1PeriodS: 14,
+ *   swell2PeriodS: 9,
+ *   swell1DirectionDeg: 270,
+ *   waveHeightFt: 4,
+ *   windSpeedKts: 5,
+ *   windDirectionDeg: 90,
+ *   breakType: 'beach',
+ *   aspectDeg: 270,
+ *   swellAccessFactors: null,
+ * });
+ * // result.rideableWavesPerHour → number between 0-60
+ */
+export function calculateRideableWaves(
+  input: WaveFrequencyInput,
+): WaveFrequencyResult {
+  const {
+    dominantPeriodS,
+    swell1PeriodS,
+    swell2PeriodS,
+    swell1DirectionDeg,
+    waveHeightFt,
+    windSpeedKts,
+    windDirectionDeg,
+    breakType,
+    aspectDeg,
+    swellAccessFactors,
+  } = input;
+
+  const zeroResult = (
+    confidence: 'high' | 'medium' | 'low' = 'medium',
+  ): WaveFrequencyResult => ({
+    rideableWavesPerHour: 0,
+    confidence,
+    factors: {
+      baseFrequency: 0,
+      breakTypeFactor: 0,
+      shortPeriodPenalty: 0,
+      swellAccessFactor: 0,
+      windPenalty: 0,
+    },
+  });
+
+  // Step 0: Period guard — cannot estimate without a dominant period
+  if (!dominantPeriodS || dominantPeriodS <= 0) return zeroResult();
+
+  // Step 1: Height gate — below the rideable threshold for this break type
+  const breakTypeKey = breakType?.toLowerCase() ?? '';
+  const threshold =
+    RIDEABLE_THRESHOLDS[breakTypeKey] ?? DEFAULT_RIDEABLE_THRESHOLD;
+  if (!waveHeightFt || waveHeightFt < threshold) return zeroResult();
+
+  // Step 2: Base wave frequency
+  let baseFrequency: number;
+
+  if (
+    swell1PeriodS != null &&
+    swell1PeriodS > 0 &&
+    swell2PeriodS != null &&
+    swell2PeriodS > 0 &&
+    Math.abs(swell1PeriodS - swell2PeriodS) >= MIN_PERIOD_DIFFERENCE
+  ) {
+    // Multi-swell: beat frequency formula
+    // Set interval = (T1 * T2) / |T1 - T2|, clamped to sane bounds
+    const t1 = swell1PeriodS;
+    const t2 = swell2PeriodS;
+    const setInterval = clamp(
+      (t1 * t2) / Math.abs(t1 - t2),
+      MIN_SET_INTERVAL_S,
+      MAX_SET_INTERVAL_S,
+    );
+    const wavesPerSet = clamp(
+      Math.round(Math.max(t1, t2) / Math.min(t1, t2)),
+      MIN_WAVES_PER_SET,
+      MAX_WAVES_PER_SET,
+    );
+    baseFrequency = (3600 / setInterval) * wavesPerSet;
+  } else {
+    // Single swell: one wave per period
+    baseFrequency = 3600 / dominantPeriodS;
+  }
+
+  // Step 3: Break type factor — what fraction of incoming waves are rideable
+  const breakTypeFactor =
+    BREAK_TYPE_FACTORS[breakTypeKey] ?? DEFAULT_BREAK_TYPE_FACTOR;
+
+  // Step 4: Short period penalty — wind swell produces less organized waves
+  const shortPeriodPenalty =
+    dominantPeriodS < WIND_SWELL_PERIOD_THRESHOLD
+      ? dominantPeriodS / WIND_SWELL_PERIOD_THRESHOLD
+      : 1.0;
+
+  // Step 5: Swell direction access — how exposed is this break to the swell
+  let swellAccessFactor = DEFAULT_SWELL_ACCESS_FACTOR;
+  if (
+    swell1DirectionDeg != null &&
+    swellAccessFactors != null &&
+    swellAccessFactors.length === 72
+  ) {
+    const bin = Math.round(swell1DirectionDeg / 5) % 72;
+    const factor = swellAccessFactors[bin];
+    if (factor != null && factor >= 0) {
+      swellAccessFactor = factor;
+    }
+  }
+
+  // Step 6: Wind penalty — onshore wind degrades wave quality
+  let windPenalty = 1.0;
+  if (windDirectionDeg != null && aspectDeg != null && windSpeedKts > 0) {
+    // Positive cosine = onshore component (wind blowing toward shore)
+    const onshoreComponent = Math.cos(
+      toRadians(windDirectionDeg - aspectDeg),
+    );
+    if (onshoreComponent > 0) {
+      windPenalty = Math.max(
+        WIND_PENALTY_FLOOR,
+        1 - (windSpeedKts * onshoreComponent) / WIND_PENALTY_DIVISOR,
+      );
+    }
+  }
+
+  // Step 7: Final calculation — multiply all factors and clamp
+  const raw =
+    baseFrequency *
+    breakTypeFactor *
+    shortPeriodPenalty *
+    swellAccessFactor *
+    windPenalty;
+  const rideableWavesPerHour = clamp(
+    Math.round(raw),
+    0,
+    MAX_RIDEABLE_WAVES_PER_HOUR,
+  );
+
+  return {
+    rideableWavesPerHour,
+    confidence: 'medium', // Confidence will be set by the caller with forecast metadata
+    factors: {
+      baseFrequency,
+      breakTypeFactor,
+      shortPeriodPenalty,
+      swellAccessFactor,
+      windPenalty,
+    },
+  };
+}

--- a/lib/domains/wave-frequency/constants.ts
+++ b/lib/domains/wave-frequency/constants.ts
@@ -1,0 +1,46 @@
+/**
+ * Wave Frequency Domain Constants
+ *
+ * Configuration values for the rideable wave frequency calculator.
+ * Tuned from empirical surf observation data.
+ */
+
+/** Break type factor: fraction of total waves that are rideable */
+export const BREAK_TYPE_FACTORS: Record<string, number> = {
+  beach: 0.15,
+  point: 0.08,
+  reef: 0.1,
+  river: 0.08,
+};
+export const DEFAULT_BREAK_TYPE_FACTOR = 0.12;
+
+/** Minimum wave height (ft) considered rideable per break type */
+export const RIDEABLE_THRESHOLDS: Record<string, number> = {
+  beach: 2.0,
+  point: 2.5,
+  reef: 2.5,
+  river: 2.5,
+};
+export const DEFAULT_RIDEABLE_THRESHOLD = 2.0;
+
+/** Clamp bounds */
+export const MAX_RIDEABLE_WAVES_PER_HOUR = 60;
+export const MIN_SET_INTERVAL_S = 60;
+export const MAX_SET_INTERVAL_S = 600;
+export const MIN_WAVES_PER_SET = 2;
+export const MAX_WAVES_PER_SET = 7;
+
+/** Below this period (seconds), apply wind swell degradation penalty */
+export const WIND_SWELL_PERIOD_THRESHOLD = 8;
+
+/** Minimum period difference (seconds) to use multi-swell formula */
+export const MIN_PERIOD_DIFFERENCE = 1.0;
+
+/** Default swell access factor when beach has no directional data */
+export const DEFAULT_SWELL_ACCESS_FACTOR = 0.7;
+
+/** Wind penalty floor (worst case for strong onshore) */
+export const WIND_PENALTY_FLOOR = 0.3;
+
+/** Wind speed divisor for penalty calculation */
+export const WIND_PENALTY_DIVISOR = 30;

--- a/lib/domains/wave-frequency/index.ts
+++ b/lib/domains/wave-frequency/index.ts
@@ -1,0 +1,3 @@
+export { calculateRideableWaves } from './calculator';
+export type { WaveFrequencyInput, WaveFrequencyResult } from './types';
+export * from './constants';

--- a/lib/domains/wave-frequency/types.ts
+++ b/lib/domains/wave-frequency/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Wave Frequency Domain Types
+ *
+ * Input and output types for the rideable waves per hour calculator.
+ * Pure data structures with no external dependencies.
+ */
+
+/**
+ * Input data required to estimate rideable wave frequency at a spot.
+ */
+export interface WaveFrequencyInput {
+  /** Dominant wave period in seconds (overall forecast period) */
+  readonly dominantPeriodS: number | null;
+  /** Primary swell period in seconds */
+  readonly swell1PeriodS: number | null;
+  /** Secondary swell period in seconds */
+  readonly swell2PeriodS: number | null;
+  /** Primary swell direction in degrees (0-360, direction waves come FROM) */
+  readonly swell1DirectionDeg: number | null;
+  /** Combined wave height in feet */
+  readonly waveHeightFt: number | null;
+  /** Wind speed in knots */
+  readonly windSpeedKts: number;
+  /** Wind direction in degrees (0-360, direction wind comes FROM) */
+  readonly windDirectionDeg: number | null;
+  /** Break type of the spot (beach, point, reef, river) */
+  readonly breakType: string | null;
+  /** Shore-facing aspect of the break in degrees (perpendicular to shore) */
+  readonly aspectDeg: number | null;
+  /** 72-bin swell access factors (one per 5-degree bin, 0-360), or null if unavailable */
+  readonly swellAccessFactors: number[] | null;
+}
+
+/**
+ * Result of the rideable wave frequency calculation.
+ */
+export interface WaveFrequencyResult {
+  /** Estimated number of rideable waves per hour (0-60) */
+  readonly rideableWavesPerHour: number;
+  /** Confidence level based on input data completeness */
+  readonly confidence: 'high' | 'medium' | 'low';
+  /** Intermediate factors used in the calculation (useful for debugging / UI) */
+  readonly factors: {
+    /** Raw waves per hour before filtering (from period or beat frequency) */
+    readonly baseFrequency: number;
+    /** Fraction of total waves that are rideable for this break type (0-1) */
+    readonly breakTypeFactor: number;
+    /** Penalty for short-period wind swell (0-1, 1 = no penalty) */
+    readonly shortPeriodPenalty: number;
+    /** Swell direction access for this break (0-1) */
+    readonly swellAccessFactor: number;
+    /** Wind quality penalty (0-1, 1 = no penalty) */
+    readonly windPenalty: number;
+  };
+}

--- a/lib/mappers/conditions-mappers.ts
+++ b/lib/mappers/conditions-mappers.ts
@@ -8,6 +8,32 @@ import { degreeToCardinal } from "@/lib/utils/geo-utils";
 const METERS_TO_FEET = 1 / 0.3048;
 const MPH_TO_KTS = 1 / 1.151;
 
+/**
+ * Compute combined surf height (ft) from swell components using root-sum-of-squares.
+ * Falls back to wave_height if no individual components are available.
+ *
+ * RSS combines independent swell trains: sqrt(h1² + h2² + h3²)
+ * This matches how Surfline and NOAA compute "surf height" from swell components.
+ */
+function getCombinedHeightFt(forecast: EnhancedForecastEntity): number | null {
+  const components: number[] = [];
+
+  for (const field of [forecast.swell_1_height, forecast.swell_2_height, forecast.wind_wave_height]) {
+    const meters = parseWaveHeight(field, { useLowerBound: true });
+    if (meters != null && meters > 0.15) { // 0.15m is the "flat" sentinel from parseWaveHeight
+      components.push(meters * METERS_TO_FEET);
+    }
+  }
+
+  if (components.length > 0) {
+    return Math.sqrt(components.reduce((sum, h) => sum + h * h, 0));
+  }
+
+  // Fall back to wave_height field
+  const meters = parseWaveHeight(forecast.wave_height, { useLowerBound: true });
+  return meters != null ? meters * METERS_TO_FEET : null;
+}
+
 /** Convert numeric degree strings (e.g. "109") to cardinal (e.g. "ESE"), pass through existing cardinals. */
 function normalizeDirection(value: string | null | undefined): string | null {
   if (!value) return null;
@@ -49,8 +75,10 @@ export function forecastToConditionsData(
   };
 
   if (beach) {
-    const heightMeters = parseWaveHeight(forecast.wave_height, { useLowerBound: true });
-    const heightFt = heightMeters != null ? heightMeters * METERS_TO_FEET : null;
+    // Use combined swell height (RSS) for the calculator — individual swell components
+    // give a better estimate of actual surf height than the raw wave_height field,
+    // which may represent a single offshore swell component.
+    const heightFt = getCombinedHeightFt(forecast);
 
     // parseWindSpeed (number-parsing) returns raw number (units stripped).
     // Forecast wind_speed is typically "X mph". Calculator expects knots, so convert.

--- a/lib/mappers/conditions-mappers.ts
+++ b/lib/mappers/conditions-mappers.ts
@@ -2,7 +2,7 @@ import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { ConditionsData } from "@/types/conditions";
 import { calculateRideableWaves } from "@/lib/domains/wave-frequency";
 import { parseWavePeriod, parseWindSpeed, getDirectionDegrees } from "@/lib/utils/number-parsing";
-import { parseWaveHeight } from "@/lib/ml/parse-wave-height";
+import { parseWaveHeight, FLAT_HEIGHT_METERS } from "@/lib/ml/parse-wave-height";
 import { degreeToCardinal } from "@/lib/utils/geo-utils";
 
 const METERS_TO_FEET = 1 / 0.3048;
@@ -20,7 +20,7 @@ function getCombinedHeightFt(forecast: EnhancedForecastEntity): number | null {
 
   for (const field of [forecast.swell_1_height, forecast.swell_2_height, forecast.wind_wave_height]) {
     const meters = parseWaveHeight(field, { useLowerBound: true });
-    if (meters != null && meters > 0.15) { // 0.15m is the "flat" sentinel from parseWaveHeight
+    if (meters != null && meters > FLAT_HEIGHT_METERS) {
       components.push(meters * METERS_TO_FEET);
     }
   }
@@ -29,9 +29,12 @@ function getCombinedHeightFt(forecast: EnhancedForecastEntity): number | null {
     return Math.sqrt(components.reduce((sum, h) => sum + h * h, 0));
   }
 
-  // Fall back to wave_height field
+  // Fall back to wave_height field when no swell components available
   const meters = parseWaveHeight(forecast.wave_height, { useLowerBound: true });
-  return meters != null ? meters * METERS_TO_FEET : null;
+  if (meters != null && meters > FLAT_HEIGHT_METERS) {
+    return meters * METERS_TO_FEET;
+  }
+  return null;
 }
 
 /** Convert numeric degree strings (e.g. "109") to cardinal (e.g. "ESE"), pass through existing cardinals. */

--- a/lib/mappers/conditions-mappers.ts
+++ b/lib/mappers/conditions-mappers.ts
@@ -3,9 +3,22 @@ import type { ConditionsData } from "@/types/conditions";
 import { calculateRideableWaves } from "@/lib/domains/wave-frequency";
 import { parseWavePeriod, parseWindSpeed, getDirectionDegrees } from "@/lib/utils/number-parsing";
 import { parseWaveHeight } from "@/lib/ml/parse-wave-height";
+import { degreeToCardinal } from "@/lib/utils/geo-utils";
 
 const METERS_TO_FEET = 1 / 0.3048;
 const MPH_TO_KTS = 1 / 1.151;
+
+/** Convert numeric degree strings (e.g. "109") to cardinal (e.g. "ESE"), pass through existing cardinals. */
+function normalizeDirection(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const num = parseFloat(trimmed);
+  if (!isNaN(num) && /^\d+(\.\d+)?$/.test(trimmed)) {
+    return degreeToCardinal(num);
+  }
+  return trimmed;
+}
 
 /** Minimal beach shape needed for wave frequency calculation */
 export interface BeachForWaveFrequency {
@@ -27,9 +40,9 @@ export function forecastToConditionsData(
   const base: ConditionsData = {
     waveHeight: forecast.wave_height ?? null,
     wavePeriod: forecast.wave_period ?? null,
-    waveDirection: forecast.wave_direction ?? null,
+    waveDirection: normalizeDirection(forecast.wave_direction),
     windSpeed: forecast.wind_speed ?? null,
-    windDirection: forecast.wind_direction ?? null,
+    windDirection: normalizeDirection(forecast.wind_direction),
     waterTemp: forecast.water_temp ?? null,
     tideStatus: forecast.tide_status ?? null,
     tideHeight: forecast.tide_height ?? null,

--- a/lib/mappers/conditions-mappers.ts
+++ b/lib/mappers/conditions-mappers.ts
@@ -1,14 +1,30 @@
 import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { ConditionsData } from "@/types/conditions";
+import { calculateRideableWaves } from "@/lib/domains/wave-frequency";
+import { parseWavePeriod, parseWindSpeed, getDirectionDegrees } from "@/lib/utils/number-parsing";
+import { parseWaveHeight } from "@/lib/ml/parse-wave-height";
+
+const METERS_TO_FEET = 1 / 0.3048;
+const MPH_TO_KTS = 1 / 1.151;
+
+/** Minimal beach shape needed for wave frequency calculation */
+export interface BeachForWaveFrequency {
+  break_type: string | null;
+  aspect_deg: number | null;
+  swell_access_factors: number[] | null;
+}
 
 /**
  * Maps an EnhancedForecastEntity (snake_case DB row) to the
  * shared ConditionsData shape (camelCase) used by ticker components.
+ *
+ * When `beach` is provided, also calculates rideable waves per hour.
  */
 export function forecastToConditionsData(
-  forecast: EnhancedForecastEntity
+  forecast: EnhancedForecastEntity,
+  beach?: BeachForWaveFrequency | null,
 ): ConditionsData {
-  return {
+  const base: ConditionsData = {
     waveHeight: forecast.wave_height ?? null,
     wavePeriod: forecast.wave_period ?? null,
     waveDirection: forecast.wave_direction ?? null,
@@ -18,4 +34,31 @@ export function forecastToConditionsData(
     tideStatus: forecast.tide_status ?? null,
     tideHeight: forecast.tide_height ?? null,
   };
+
+  if (beach) {
+    const heightMeters = parseWaveHeight(forecast.wave_height, { useLowerBound: true });
+    const heightFt = heightMeters != null ? heightMeters * METERS_TO_FEET : null;
+
+    // parseWindSpeed (number-parsing) returns raw number (units stripped).
+    // Forecast wind_speed is typically "X mph". Calculator expects knots, so convert.
+    const windSpeedRaw = parseWindSpeed(forecast.wind_speed);
+    const windSpeedKts = windSpeedRaw * MPH_TO_KTS;
+
+    const result = calculateRideableWaves({
+      dominantPeriodS: parseWavePeriod(forecast.wave_period) || null,
+      swell1PeriodS: parseWavePeriod(forecast.swell_1_period) || null,
+      swell2PeriodS: parseWavePeriod(forecast.swell_2_period) || null,
+      swell1DirectionDeg: getDirectionDegrees(forecast.swell_1_direction),
+      waveHeightFt: heightFt,
+      windSpeedKts,
+      windDirectionDeg: forecast.wind_direction_deg ?? getDirectionDegrees(forecast.wind_direction),
+      breakType: beach.break_type,
+      aspectDeg: beach.aspect_deg,
+      swellAccessFactors: beach.swell_access_factors,
+    });
+
+    base.rideableWavesPerHour = result.rideableWavesPerHour;
+  }
+
+  return base;
 }

--- a/lib/ml/parse-wave-height.ts
+++ b/lib/ml/parse-wave-height.ts
@@ -2,6 +2,9 @@
  * Parse NOAA forecast text fields to numeric values.
  */
 
+/** Returned by parseWaveHeight for flat/null/empty inputs (~6 inches, negligible surf). */
+export const FLAT_HEIGHT_METERS = 0.15;
+
 const FEET_TO_METERS = 0.3048;
 const MPH_TO_MS = 0.44704;
 const KTS_TO_MS = 0.514444;
@@ -19,7 +22,7 @@ export function parseWaveHeight(
   options?: { useLowerBound?: boolean }
 ): number | null {
   if (!text || text.toLowerCase().includes('flat')) {
-    return 0.15;
+    return FLAT_HEIGHT_METERS;
   }
 
   // Clean text: remove non-digits except hyphens and dots

--- a/lib/ml/parse-wave-height.ts
+++ b/lib/ml/parse-wave-height.ts
@@ -14,7 +14,10 @@ const KTS_TO_MS = 0.514444;
  * - "3ft", "3 ft"
  * - "Flat", "flat"
  */
-export function parseWaveHeight(text: string | null | undefined): number | null {
+export function parseWaveHeight(
+  text: string | null | undefined,
+  options?: { useLowerBound?: boolean }
+): number | null {
   if (!text || text.toLowerCase().includes('flat')) {
     return 0.15;
   }
@@ -33,7 +36,8 @@ export function parseWaveHeight(text: string | null | undefined): number | null 
 
   if (values.length === 2) {
     // Range: take midpoint
-    return ((values[0] + values[1]) / 2) * FEET_TO_METERS;
+    const value = options?.useLowerBound ? values[0] : (values[0] + values[1]) / 2;
+    return value * FEET_TO_METERS;
   } else if (values.length === 1) {
     return values[0] * FEET_TO_METERS;
   }

--- a/lib/utils/conditions-card-builder.ts
+++ b/lib/utils/conditions-card-builder.ts
@@ -1,6 +1,6 @@
 import type { ConditionsData } from "@/types/conditions";
 
-export type ConditionsIconType = "waves" | "swell" | "wind" | "water" | "tide";
+export type ConditionsIconType = "waves" | "swell" | "wind" | "water" | "tide" | "frequency";
 
 export interface ConditionsCard {
   id: string;
@@ -10,11 +10,18 @@ export interface ConditionsCard {
   tideRising?: boolean;
 }
 
+export interface BuildConditionsCardsOptions {
+  showFrequency?: boolean;
+}
+
 /**
  * Builds an array of conditions cards from ConditionsData.
  * Pure function — no React dependency, fully testable.
  */
-export function buildConditionsCards(data: ConditionsData): ConditionsCard[] {
+export function buildConditionsCards(
+  data: ConditionsData,
+  options?: BuildConditionsCardsOptions
+): ConditionsCard[] {
   const cards: ConditionsCard[] = [];
 
   if (data.waveHeight != null && data.waveHeight !== "") {
@@ -84,6 +91,30 @@ export function buildConditionsCards(data: ConditionsData): ConditionsCard[] {
         tideRising: isRising,
       });
     }
+  }
+
+  if (
+    options?.showFrequency &&
+    data.rideableWavesPerHour != null &&
+    data.rideableWavesPerHour > 0
+  ) {
+    cards.push({
+      id: "frequency",
+      label: "Waves/hr",
+      value: `~${data.rideableWavesPerHour}`,
+      iconType: "frequency",
+    });
+  } else if (
+    options?.showFrequency &&
+    data.rideableWavesPerHour === 0 &&
+    data.waveHeight != null
+  ) {
+    cards.push({
+      id: "frequency",
+      label: "Waves/hr",
+      value: "Flat",
+      iconType: "frequency",
+    });
   }
 
   return cards;

--- a/lib/utils/conditions-card-builder.ts
+++ b/lib/utils/conditions-card-builder.ts
@@ -8,6 +8,7 @@ export interface ConditionsCard {
   value: string;
   iconType: ConditionsIconType;
   tideRising?: boolean;
+  ariaLabel?: string;
 }
 
 export interface BuildConditionsCardsOptions {
@@ -103,6 +104,7 @@ export function buildConditionsCards(
       label: "Waves/hr",
       value: `~${data.rideableWavesPerHour}`,
       iconType: "frequency",
+      ariaLabel: `approximately ${data.rideableWavesPerHour} rideable waves per hour`,
     });
   } else if (
     options?.showFrequency &&
@@ -114,6 +116,7 @@ export function buildConditionsCards(
       label: "Waves/hr",
       value: "Flat",
       iconType: "frequency",
+      ariaLabel: "flat, no rideable waves",
     });
   }
 

--- a/lib/utils/number-parsing.ts
+++ b/lib/utils/number-parsing.ts
@@ -70,3 +70,43 @@ export function parseWavePeriod(value: unknown, fallback: number = 0): number {
   const parsed = parseFloat(cleaned);
   return Number.isNaN(parsed) ? fallback : parsed;
 }
+
+const CARDINAL_TO_DEGREES: Record<string, number> = {
+  N: 0,
+  NNE: 22.5,
+  NE: 45,
+  ENE: 67.5,
+  E: 90,
+  ESE: 112.5,
+  SE: 135,
+  SSE: 157.5,
+  S: 180,
+  SSW: 202.5,
+  SW: 225,
+  WSW: 247.5,
+  W: 270,
+  WNW: 292.5,
+  NW: 315,
+  NNW: 337.5,
+};
+
+/**
+ * Convert a direction value to degrees. Accepts numeric degrees or cardinal strings ("SW", "WNW", etc.).
+ * Returns null if the input cannot be parsed.
+ */
+export function getDirectionDegrees(
+  deg: number | string | null | undefined,
+  cardinal?: string | null | undefined
+): number | null {
+  if (deg !== null && deg !== undefined) {
+    const numDeg = typeof deg === 'string' ? parseFloat(deg) : deg;
+    if (!isNaN(numDeg)) return numDeg;
+    // First param is a non-numeric string — try cardinal lookup
+    if (typeof deg === 'string') {
+      const fromCardinal = CARDINAL_TO_DEGREES[deg.toUpperCase()];
+      if (fromCardinal !== undefined) return fromCardinal;
+    }
+  }
+  if (!cardinal) return null;
+  return CARDINAL_TO_DEGREES[cardinal.toUpperCase()] ?? null;
+}

--- a/types/conditions.ts
+++ b/types/conditions.ts
@@ -8,4 +8,5 @@ export interface ConditionsData {
   waterTemp?: string | null;
   tideStatus?: string | null;
   tideHeight?: string | null;
+  rideableWavesPerHour?: number | null;
 }


### PR DESCRIPTION
## Summary

- Adds a new surfer-facing "Waves/hr" metric predicting rideable wave frequency at each beach
- Pure TypeScript calculator using swell period, break type, wind conditions, and directional exposure
- No new data sources — uses existing forecast + beach metadata
- Displayed in the ConditionsTicker on beach detail pages only (gated by `showFrequency` prop)
- **No competitor offers this metric** — genuine whitespace in surf forecasting

## Changes

- **New domain:** `lib/domains/wave-frequency/` — calculator, constants, types, barrel export
- **Utility mods:** Moved `getDirectionDegrees` to shared `number-parsing.ts`, added `useLowerBound` option to `parseWaveHeight`
- **Integration:** `forecastToConditionsData` accepts optional beach param, calls calculator, populates `rideableWavesPerHour`
- **UI:** Frequency card in `buildConditionsCards` (gated), `Activity` icon in ticker, `showFrequency` prop on `ConditionsTicker`

## Test plan

- [x] 59 unit tests covering all 7 algorithm steps, edge cases, and spec examples
- [x] 4 existing mapper tests passing
- [x] 20 existing card builder tests passing
- [x] TypeScript compiles with 0 errors
- [ ] Visual verification on beach detail page (Ocean Beach Pier, Scripps)
- [ ] Confirm ticker card does NOT appear on embed/landing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)