### PR TITLE
fix(api/devices): accept Bearer auth so native push registration lands

### DIFF
--- a/__tests__/api/devices-upsert.test.ts
+++ b/__tests__/api/devices-upsert.test.ts
@@ -8,22 +8,29 @@ jest.mock("next/server", () => require("@/__tests__/setup/mock-next-server"));
 import { NextRequest } from "next/server";
 import { POST, DELETE } from "@/app/api/devices/upsert/route";
 
-// Mock API utilities
+// Mock API utilities — match real signatures in lib/api-utils.ts
 jest.mock("@/lib/api-utils", () => ({
   createSuccessResponse: jest.fn((data) => ({
     status: 200,
     json: async () => ({ success: true, data }),
   })),
-  handleApiError: jest.fn((error, status = 500) => ({
-    status,
+  handleApiError: jest.fn((error, _errorMessage?: string) => ({
+    status: 500,
     json: async () => ({
       success: false,
       error: error instanceof Error ? error.message : String(error),
     }),
   })),
+  createAuthError: jest.fn((message = "Authentication required") => ({
+    status: 401,
+    json: async () => ({
+      success: false,
+      error: message,
+    }),
+  })),
 }));
 
-// Mock Supabase client
+// Mock Supabase client — shared by bearer and cookie auth paths in withAuth
 const mockUpsert = jest.fn();
 const mockDelete = jest.fn();
 const mockSupabase = {
@@ -43,6 +50,9 @@ const mockSupabase = {
 
 jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: jest.fn(() => mockSupabase),
+}));
+jest.mock("@/lib/supabase/bearer-client", () => ({
+  createBearerTokenClient: jest.fn(() => mockSupabase),
 }));
 
 describe("Device Token API", () => {

--- a/__tests__/api/devices/device-upsert.test.ts
+++ b/__tests__/api/devices/device-upsert.test.ts
@@ -22,27 +22,41 @@ import {
   type MockSupabaseClient,
 } from "@/test-utils/api-test-helpers";
 
-// Mock API utilities
+// Mock API utilities — signatures must match real ones in lib/api-utils.ts:
+// - handleApiError(error, errorMessage?) always returns 500
+// - createAuthError(message?) returns 401
+// - createSuccessResponse(data) returns 200
 jest.mock("@/lib/api-utils", () => ({
   createSuccessResponse: jest.fn((data) => ({
     status: 200,
     json: async () => ({ success: true, data, timestamp: new Date().toISOString() }),
   })),
-  handleApiError: jest.fn((error, status = 500) => ({
-    status,
+  handleApiError: jest.fn((error, _errorMessage?: string) => ({
+    status: 500,
     json: async () => ({
       success: false,
       error: error instanceof Error ? error.message : String(error),
       timestamp: new Date().toISOString(),
     }),
   })),
+  createAuthError: jest.fn((message = "Authentication required") => ({
+    status: 401,
+    json: async () => ({
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+    }),
+  })),
 }));
 
-// Mock Supabase client
+// Mock Supabase client — used by both bearer and cookie auth paths in withAuth
 let mockSupabase: MockSupabaseClient;
 
 jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: jest.fn(() => mockSupabase),
+}));
+jest.mock("@/lib/supabase/bearer-client", () => ({
+  createBearerTokenClient: jest.fn(() => mockSupabase),
 }));
 
 describe("Device Token API - POST /api/devices/upsert", () => {

--- a/app/api/devices/upsert/route.ts
+++ b/app/api/devices/upsert/route.ts
@@ -1,202 +1,121 @@
 /**
  * Device Token Management API
- * Handles registration and removal of FCM device tokens
- * Following patterns from app/api/session-planner/invitations/route.ts
+ * Handles registration and removal of FCM device tokens.
+ *
+ * Accepts both cookie-based SSR auth (web) and Authorization: Bearer <jwt>
+ * (native clients) via withAuth — the previous createSupabaseServerClient()
+ * path only read cookies, causing all native device registrations to 401.
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createSuccessResponse, handleApiError } from "@/lib/api-utils";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { withAuth, createSuccessResponse } from "@/lib/middleware/api-wrappers";
 
 /**
  * POST /api/devices/upsert
  * Register or update a device token for push notifications
  */
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { platform, device_token } = body;
+export const POST = withAuth(async (request: NextRequest, { user, supabase }) => {
+  const body = await request.json();
+  const { platform, device_token } = body;
 
-    // Validate input
-    if (!platform || !device_token) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Platform and device_token are required",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 400 }
-      );
-    }
-
-    // Validate device token length (max 512 characters)
-    if (device_token.length > 512) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Device token exceeds maximum length of 512 characters",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 400 }
-      );
-    }
-
-    // Validate device token is not empty string
-    if (device_token.trim().length === 0) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Device token cannot be empty",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 400 }
-      );
-    }
-
-    if (!["ios", "android", "web"].includes(platform)) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Invalid platform. Must be "ios", "android", or "web"',
-          timestamp: new Date().toISOString(),
-        },
-        { status: 400 }
-      );
-    }
-
-    // Authenticate user
-    const supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Authentication required",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 }
-      );
-    }
-
-    // Upsert device token (insert or update if exists)
-    const { error: upsertError } = await supabase
-      .from("user_devices")
-      .upsert(
-        {
-          user_id: user.id,
-          platform,
-          device_token,
-          updated_at: new Date().toISOString(),
-        },
-        {
-          onConflict: "user_id,device_token",
-        }
-      );
-
-    if (upsertError) {
-      console.error("Device token upsert failed:", upsertError);
-      throw upsertError;
-    }
-
-    return createSuccessResponse({
-      message: "Device registered successfully",
-      platform,
-    });
-  } catch (error) {
-    console.error("Device upsert error:", error);
-    return handleApiError(error);
+  if (!platform || !device_token) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Platform and device_token are required",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
   }
-}
+
+  if (device_token.length > 512) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Device token exceeds maximum length of 512 characters",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  if (device_token.trim().length === 0) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Device token cannot be empty",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  if (!["ios", "android", "web"].includes(platform)) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Invalid platform. Must be "ios", "android", or "web"',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  const { error: upsertError } = await supabase
+    .from("user_devices")
+    .upsert(
+      {
+        user_id: user.id,
+        platform,
+        device_token,
+        updated_at: new Date().toISOString(),
+      },
+      {
+        onConflict: "user_id,device_token",
+      }
+    );
+
+  if (upsertError) {
+    console.error("Device token upsert failed:", upsertError);
+    throw upsertError;
+  }
+
+  return createSuccessResponse({
+    message: "Device registered successfully",
+    platform,
+  });
+}, { errorMessage: "Failed to register device" });
 
 /**
  * DELETE /api/devices/upsert
  * Remove a device token (e.g., on logout or token refresh)
  */
-export async function DELETE(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const { device_token } = body;
+export const DELETE = withAuth(async (request: NextRequest, { user, supabase }) => {
+  const body = await request.json();
+  const { device_token } = body;
 
-    if (!device_token) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "device_token is required",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 400 }
-      );
-    }
-
-    // Authenticate user
-    const supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: "Authentication required",
-          timestamp: new Date().toISOString(),
-        },
-        { status: 401 }
-      );
-    }
-
-    // Delete device token
-    const { error: deleteError } = await supabase
-      .from("user_devices")
-      .delete()
-      .eq("user_id", user.id)
-      .eq("device_token", device_token);
-
-    if (deleteError) {
-      console.error("Device token deletion failed:", deleteError);
-      throw deleteError;
-    }
-
-    return createSuccessResponse({ message: "Device removed successfully" });
-  } catch (error) {
-    console.error("Device deletion error:", error);
-    return handleApiError(error);
+  if (!device_token) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "device_token is required",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
   }
-}
 
+  const { error: deleteError } = await supabase
+    .from("user_devices")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("device_token", device_token);
 
+  if (deleteError) {
+    console.error("Device token deletion failed:", deleteError);
+    throw deleteError;
+  }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  return createSuccessResponse({ message: "Device removed successfully" });
+}, { errorMessage: "Failed to remove device" });


### PR DESCRIPTION
## Summary
Hotfix to prod: \`/api/devices/upsert\` now accepts \`Authorization: Bearer <jwt>\` from native clients. Before this, the route used cookie-only \`createSupabaseServerClient()\` and silently 401'd every native push registration. Confirmed live via trace events on a Quiver Native Android build.

## Evidence
Live user_events trace from stcha0004 on v1.0.0(3) debug APK:
\`\`\`
start              is_device: true
permission_checked granted
token_acquired     fcm token len=142, type=android, prefix=cmsjMOGITJmha_NtIgcu
upsert_failed      Request failed with status 401  ← blocker
\`\`\`

Root cause: \`createSupabaseServerClient()\` reads session from cookies. Native HTTP (\`okhttp/4.12.0\`) sends \`Authorization: Bearer\` headers. The cookie reader ignores the header; \`supabase.auth.getUser()\` returns null; route returns 401.

## Fix
Migrate POST + DELETE handlers to \`withAuth\` from \`lib/middleware/api-wrappers/auth-wrapper.ts\`, which resolves auth from Bearer first, then falls back to cookie SSR. Same \`{ user, supabase }\` context shape — no caller changes, no schema changes.

## Test plan
- [x] \`yarn test:unit devices\` — all 31 pass (test mocks updated for new auth path)
- [x] \`yarn typecheck\` clean
- [ ] Prod Gate CI green
- [ ] After deploy: Quiver Native Android retries \`getDevicePushTokenAsync()\` registration → \`user_devices\` gets a fresh row with raw FCM token (platform=android) → admin test-push sends successfully to the device

## Rollback
Single file behavior change. Revert the commit; \`vercel promote\` prior deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)