### PR TITLE
test+chore: Bearer path invariants and prod push-upsert smoke diagnostics

### DIFF
--- a/__tests__/api/devices-upsert.test.ts
+++ b/__tests__/api/devices-upsert.test.ts
@@ -162,6 +162,69 @@ describe("Device Token API", () => {
     });
   });
 
+  describe("Bearer token auth path", () => {
+    // These tests pin the invariant that a native Authorization: Bearer request
+    // goes through createBearerTokenClient + supabase.auth.getUser(token), NOT
+    // the cookie-based createSupabaseServerClient. Without this pin, the PR #199
+    // hotfix could silently regress because the existing "should require
+    // authentication" test passes regardless of which path runs.
+    it("routes Authorization: Bearer requests through createBearerTokenClient with the token", async () => {
+      const { createBearerTokenClient } = require("@/lib/supabase/bearer-client");
+      const { createSupabaseServerClient } = require("@/lib/supabase/server");
+
+      (mockSupabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-bearer-42" } },
+        error: null,
+      });
+      mockUpsert.mockResolvedValue({ error: null });
+
+      const request = new NextRequest("http://localhost:3000/api/devices/upsert", {
+        method: "POST",
+        headers: { authorization: "Bearer fake-native-jwt-xyz" },
+        body: JSON.stringify({ platform: "android", device_token: "fcm-abc-123" }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(createBearerTokenClient).toHaveBeenCalledWith("fake-native-jwt-xyz");
+      expect(createSupabaseServerClient).not.toHaveBeenCalled();
+      expect(mockSupabase.auth.getUser).toHaveBeenCalledWith("fake-native-jwt-xyz");
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({ user_id: "user-bearer-42", platform: "android" }),
+        { onConflict: "user_id,device_token" }
+      );
+    });
+
+    it("returns 401 with { success, error } shape when Bearer token is rejected", async () => {
+      // Simulates Supabase auth.getUser rejecting an expired/invalid JWT.
+      // The response body must carry an `error` field so the native client's
+      // ApiError.message is informative (see quiver-native api-client.ts).
+      (mockSupabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { name: "AuthApiError", message: "JWT expired" },
+      });
+
+      const request = new NextRequest("http://localhost:3000/api/devices/upsert", {
+        method: "POST",
+        headers: { authorization: "Bearer expired-jwt" },
+        body: JSON.stringify({ platform: "android", device_token: "fcm-abc-123" }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: expect.any(String),
+        })
+      );
+      expect(mockUpsert).not.toHaveBeenCalled();
+    });
+  });
+
   describe("DELETE /api/devices/upsert", () => {
     it("should delete a device token", async () => {
       const mockUser = { id: "user-123" };

--- a/scripts/prod-push-upsert-smoke-local-validate.mjs
+++ b/scripts/prod-push-upsert-smoke-local-validate.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Follow-up diagnostic: takes the SAME access token flow as the prod server
+// and calls it from this machine. If Supabase accepts the JWT here but Vercel
+// rejects it, the bug is on Vercel (env/config). If both reject, the bug is
+// somewhere in lib/supabase/bearer-client.ts or lib/middleware/api-wrappers/
+// auth-wrapper.ts.
+
+import { config as loadEnv } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: path.join(__dirname, "..", ".env") });
+loadEnv({ path: path.join(__dirname, "..", ".env.local"), override: true });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
+console.log("[local-validate] NEXT_PUBLIC_SUPABASE_URL:", SUPABASE_URL);
+console.log("[local-validate] NEXT_PUBLIC_SUPABASE_ANON_KEY:", SUPABASE_ANON_KEY?.slice(0, 40) + "...");
+
+const authClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+const { data, error } = await authClient.auth.signInWithPassword({
+  email: process.env.TEST_USER_EMAIL,
+  password: process.env.TEST_USER_PASSWORD,
+});
+if (error || !data.session?.access_token) {
+  console.error("[local-validate] sign-in failed:", error?.message);
+  process.exit(1);
+}
+const jwt = data.session.access_token;
+console.log("[local-validate] obtained JWT, len=", jwt.length);
+
+// Exact replica of createBearerTokenClient
+const bearerClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  global: { headers: { Authorization: `Bearer ${jwt}` } },
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const { data: userData, error: userErr } = await bearerClient.auth.getUser(jwt);
+if (userErr) {
+  console.error("[local-validate] ❌ Supabase rejected the JWT:", userErr.name, "-", userErr.message);
+  console.error("[local-validate]    → server code bug OR Supabase auth issue.");
+  process.exit(1);
+}
+if (!userData.user) {
+  console.error("[local-validate] ❌ no user in response but no error either.");
+  process.exit(1);
+}
+console.log("[local-validate] ✅ Supabase accepted the JWT.");
+console.log("[local-validate]    user.id:", userData.user.id);
+console.log("[local-validate]    user.email:", userData.user.email);
+console.log("[local-validate] ");
+console.log("[local-validate] Conclusion: the server-side code path works when given this env.");
+console.log("[local-validate] The bug is in VERCEL PRODUCTION ENV, not the code.");
+console.log("[local-validate] Check: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY in Vercel prod.");
+process.exit(0);

--- a/scripts/prod-push-upsert-smoke.mjs
+++ b/scripts/prod-push-upsert-smoke.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Phase 3 smoke: reproduce the native Android upsert_failed: 401 against prod.
+//
+// Why: mocks can't catch env-var misconfig, Supabase auth-service rejection of
+// real JWTs, or Vercel infra stripping the Authorization header. This exercises
+// the real /api/devices/upsert endpoint with a real Bearer token.
+//
+// Usage (two supported paths):
+//
+//   1) With a known test user's email/password:
+//      TEST_USER_EMAIL=stcha0004@gmail.com \
+//      TEST_USER_PASSWORD=... \
+//      node scripts/prod-push-upsert-smoke.mjs
+//
+//   2) With an access_token already in hand (paste from device):
+//      TEST_USER_ACCESS_TOKEN=eyJhbGciOi... \
+//      node scripts/prod-push-upsert-smoke.mjs
+//
+// Outputs on non-200:
+//   - Full response body
+//   - Decoded JWT claims (iss, aud, exp, sub)
+//   - Whether Authorization header was present on the request
+
+import { config as loadEnv } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: path.join(__dirname, "..", ".env") });
+loadEnv({ path: path.join(__dirname, "..", ".env.local"), override: true });
+
+const API_BASE = process.env.SMOKE_API_BASE || "https://www.quiversurf.app";
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  process.exit(1);
+}
+
+function decodeJwtPayload(jwt) {
+  try {
+    const [, payload] = jwt.split(".");
+    const json = Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+async function getAccessToken() {
+  if (process.env.TEST_USER_ACCESS_TOKEN) {
+    return process.env.TEST_USER_ACCESS_TOKEN.trim();
+  }
+  const email = process.env.TEST_USER_EMAIL;
+  const password = process.env.TEST_USER_PASSWORD;
+  if (!email || !password) {
+    console.error(
+      "Need TEST_USER_ACCESS_TOKEN, OR TEST_USER_EMAIL + TEST_USER_PASSWORD. See file header."
+    );
+    process.exit(1);
+  }
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error || !data.session?.access_token) {
+    console.error("Sign-in failed:", error?.message ?? "no session");
+    process.exit(1);
+  }
+  return data.session.access_token;
+}
+
+const accessToken = await getAccessToken();
+const claims = decodeJwtPayload(accessToken);
+console.log("[smoke] JWT claims:", {
+  iss: claims?.iss,
+  aud: claims?.aud,
+  sub: claims?.sub,
+  exp: claims?.exp ? new Date(claims.exp * 1000).toISOString() : null,
+  role: claims?.role,
+});
+const expired = claims?.exp && claims.exp * 1000 < Date.now();
+if (expired) console.warn("[smoke] WARNING: JWT is already expired");
+
+const url = `${API_BASE}/api/devices/upsert`;
+const body = JSON.stringify({
+  platform: "android",
+  device_token: `smoke-diagnostic-${Date.now()}`,
+});
+console.log(`[smoke] POST ${url}`);
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+  },
+  body,
+});
+const text = await response.text();
+let parsed = null;
+try {
+  parsed = JSON.parse(text);
+} catch {
+  // non-JSON body; keep raw text
+}
+console.log(`[smoke] status=${response.status}`);
+console.log("[smoke] response-body:", parsed ?? text);
+
+if (response.status === 200) {
+  console.log("[smoke] ✅ SERVER ACCEPTS BEARER — prod auth pipeline works end-to-end.");
+  console.log("[smoke]    If native still 401s, look at the device/session side:");
+  console.log("[smoke]      - auth-provider.tsx session hydration timing");
+  console.log("[smoke]      - Zustand session.access_token at fetch time");
+  console.log("[smoke]      - Supabase client autoRefreshToken behavior after background resume");
+  process.exit(0);
+}
+
+console.log("[smoke] ❌ SERVER REJECTED BEARER — this is the real bug.");
+console.log("[smoke] Interpretation:");
+if (parsed?.error === "Authentication required") {
+  if (expired) {
+    console.log("[smoke]   -> Token was expired. Get a fresh one and re-run.");
+  } else {
+    console.log("[smoke]   -> Token looked valid but server's supabase.auth.getUser rejected it.");
+    console.log("[smoke]      Check Vercel env: NEXT_PUBLIC_SUPABASE_URL must match iss claim");
+    console.log(`[smoke]      Claim iss: ${claims?.iss ?? "<unset>"}`);
+    console.log("[smoke]      Also check that Vercel build is on the same Supabase project.");
+  }
+} else {
+  console.log("[smoke]   -> Unexpected response shape. Route may not be what we think.");
+}
+process.exit(1);


### PR DESCRIPTION
## Summary

Two follow-ups from the 2026-04-19 Android push registration 401 debug:

1. **Phase 2 — server test harness**: adds two tests to `__tests__/api/devices-upsert.test.ts` that differentiate the Bearer vs cookie auth path in `withAuth` (the existing mocks returned the same supabase for both, hiding which one ran). PR #199 passes; future regressions will fail.
2. **Phase 3 — diagnostic scripts**: two `.mjs` scripts under `scripts/` used to reproduce and triangulate the 401. Keeps them in-repo so the next diagnosis starts from real tools, not improvised ones.

No production code changes. The observability fix lives in quiver-native (separate PR).

## Test plan
- [ ] `yarn test:unit --testPathPattern=devices-upsert` green (was 6 → now 8 tests)
- [ ] Scripts parse (`node --check`) and usage documented inline