### PR TITLE
test(auth): mock trackLoginFormSubmitted in unified-auth-modal test

### DIFF
--- a/__tests__/components/auth/unified-auth-modal.test.tsx
+++ b/__tests__/components/auth/unified-auth-modal.test.tsx
@@ -36,6 +36,7 @@ jest.mock("@/lib/analytics/auth-events", () => ({
   trackSignupSuccess: jest.fn(),
   trackSignupFailed: jest.fn(),
   trackSignupFormSubmitted: jest.fn(),
+  trackLoginFormSubmitted: jest.fn(),
   trackMagicLinkSent: jest.fn(),
   categorizeAuthError: jest.fn(() => "unknown_error"),
   extractEmailDomain: jest.fn((email) => email.split("@")[1] || "unknown"),


### PR DESCRIPTION
## Summary

- One-line test fix: add missing `jest.fn()` mock for `trackLoginFormSubmitted` in `__tests__/components/auth/unified-auth-modal.test.tsx`

## Context

When `login_form_submitted` was split out of `signup_form_submitted` (prior PR — see `[Unreleased] › Fixed` in CHANGELOG), `components/auth/unified-auth-modal.tsx:480` started calling `trackLoginFormSubmitted(...)` on login submits. The test file at `__tests__/components/auth/unified-auth-modal.test.tsx:27` mocks the `@/lib/analytics/auth-events` module by listing each exported function, but that list wasn't updated to include `trackLoginFormSubmitted`. Result: the "should handle successful login" test has been failing on main with:

```
TypeError: (0 , _authevents.trackLoginFormSubmitted) is not a function
  at handleEmailPassword (components/auth/unified-auth-modal.tsx:480:32)
```

The real export exists at `lib/analytics/auth-events.ts:177` — this is purely a mock-completeness miss, not a missing production function.

## Test plan

- [x] `yarn test:unit --testPathPattern="unified-auth-modal"` — 52/52 pass
- [x] `yarn test:unit` full suite — 12,057/12,057 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)