### PR TITLE
fix(onboarding): don't force-reopen dialog for completed users on ?onboarding=required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`?onboarding=required` no longer re-opens dialog for already-completed users** (`components/onboarding/onboarding-dialog.tsx`). The force-open branch of `shouldRender` intentionally bypassed `hasCompletedOnboarding` to dodge a fresh-signup profile-materialization race — which meant a stale welcome-email link, bookmark, or browser autocomplete could land an activated user on `/?onboarding=required` and force the dialog open every visit. Observed in prod on `omg.its.thefuture@gmail.com` (user `73040cff-...`): three `dialog_opened` events in under 3 minutes after legitimate completion on Apr 20. Strip effect now checks `profile?.onboarding_completed_at` before calling `reopenFresh` — if profile has loaded and shows completion, the param is stripped without opening the dialog. The profile-race case (profile still `null` for fresh signups) falls through to the existing `reopenFresh` path, so the `/auth/callback` entry path is unaffected. 1 new unit test + 1 updated E2E test pin the invariant.
+
 ### Infrastructure
 - **Server-side Firebase Admin env vars added to Vercel production.** `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY` were only present in local `quiver/.env` (gitignored), so Vercel-deployed serverless functions had them undefined and `getFirebaseAdminMessaging()` returned `null` on every invocation. That silently no-op'd `POST /api/admin/test-push`, `sendPushNotification()` in `lib/services/push-notifications.ts`, and the FCM branch of `sendPushNotifications()` in `lib/alerts/push-sender.ts` used by `condition-alert-deliver`. PR #196 triggered a Vercel production redeploy so already-warm serverless instances are recycled and pick up the newly-added env vars.
 

--- a/__tests__/components/onboarding/onboarding-dialog.test.tsx
+++ b/__tests__/components/onboarding/onboarding-dialog.test.tsx
@@ -10,13 +10,14 @@ import { useSearchParams } from "next/navigation";
 jest.mock("@/context/auth-context");
 jest.mock("@/context/profile-context");
 jest.mock("@/store/onboarding-store");
+// Shared router-replace spy so tests can assert the param strip fires without
+// opening the dialog. Must be `mock`-prefixed for jest.mock hoisting.
+const mockRouterReplace = jest.fn();
 jest.mock("next/navigation", () => ({
   useSearchParams: jest.fn(),
-  // Added for plan abstract-exploring-phoenix (Commit B): the dialog now
-  // uses useRouter + usePathname to strip ?onboarding=required from the URL
-  // after opening. Tests don't assert the replace() call — the e2e spec
-  // covers that invariant — so lightweight jest.fn stubs are sufficient.
-  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), refresh: jest.fn() }),
+  // Added for plan abstract-exploring-phoenix (Commit B): the dialog uses
+  // useRouter + usePathname to strip ?onboarding=required from the URL.
+  useRouter: () => ({ replace: mockRouterReplace, push: jest.fn(), refresh: jest.fn() }),
   usePathname: () => "/",
 }));
 jest.mock("@/components/onboarding/steps/home-beach-step", () => ({
@@ -68,6 +69,7 @@ describe("OnboardingDialog Logic", () => {
   const mockOpenDialog = jest.fn();
   const mockReset = jest.fn();
   const mockCheckUserId = jest.fn();
+  const mockReopenFresh = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -86,10 +88,14 @@ describe("OnboardingDialog Logic", () => {
       openDialog: mockOpenDialog,
       reset: mockReset,
       checkUserId: mockCheckUserId,
+      reopenFresh: mockReopenFresh,
       closeDialog: jest.fn(),
       setCurrentStep: jest.fn(),
     });
-    (useSearchParams as jest.Mock).mockReturnValue({ get: jest.fn() });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: jest.fn(),
+      toString: () => "",
+    });
   });
 
   // Auto-open behaviour was removed in plan vast-dancing-whale. The dialog now
@@ -141,6 +147,30 @@ describe("OnboardingDialog Logic", () => {
 
     expect(mockOpenDialog).not.toHaveBeenCalled();
     jest.useRealTimers();
+  });
+
+  it("does NOT re-open when ?onboarding=required is set AND onboarding already completed", () => {
+    // Guards the activated-user case: a stale welcome-email link, bookmark,
+    // or browser autocomplete must not force-reopen the dialog for a user
+    // whose profile already shows onboarding_completed_at. The param must
+    // still be stripped so a refresh settles on a clean URL.
+    (useProfileContext as jest.Mock).mockReturnValue({
+      profile: {
+        onboarding_completed_at: "2026-04-20T18:42:44Z",
+        home_beach_id: "b1",
+      },
+      isLoading: false,
+    });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => (key === "onboarding" ? "required" : null),
+      toString: () => "onboarding=required",
+    });
+
+    render(<OnboardingDialog />);
+
+    expect(mockReopenFresh).not.toHaveBeenCalled();
+    expect(mockOpenDialog).not.toHaveBeenCalled();
+    expect(mockRouterReplace).toHaveBeenCalledWith("/", { scroll: false });
   });
 
   it("opens dialog when ?showOnboarding=1 URL param is set", () => {

--- a/components/onboarding/onboarding-dialog.tsx
+++ b/components/onboarding/onboarding-dialog.tsx
@@ -242,6 +242,25 @@ export function OnboardingDialog() {
     if (hasProcessedRequiredParam.current) return;
     if (searchParams?.get("onboarding") !== "required") return;
     if (!user) return;
+
+    const stripParam = () => {
+      const next = new URLSearchParams(searchParams?.toString() ?? "");
+      next.delete("onboarding");
+      const qs = next.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    };
+
+    // Defense-in-depth against stale welcome-email links, bookmarks, and
+    // browser autocomplete: if the profile has loaded and already shows
+    // onboarding_completed_at, do NOT force-reopen the dialog. Still strip
+    // the param so refreshes settle on a clean URL. The profile-race case
+    // (profile still null for a fresh signup) falls through to reopenFresh.
+    if (profile?.onboarding_completed_at) {
+      hasProcessedRequiredParam.current = true;
+      stripParam();
+      return;
+    }
+
     hasProcessedRequiredParam.current = true;
 
     // Use `reopenFresh` instead of `reset() + openDialog()`. `reset()`
@@ -252,12 +271,8 @@ export function OnboardingDialog() {
     // store action's JSDoc and plan abstract-exploring-phoenix E1.
     reopenFresh(user.id);
 
-    // Strip the query param so a refresh doesn't re-trigger.
-    const next = new URLSearchParams(searchParams?.toString() ?? "");
-    next.delete("onboarding");
-    const qs = next.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [searchParams, user, reopenFresh, router, pathname]);
+    stripParam();
+  }, [searchParams, user, profile, reopenFresh, router, pathname]);
 
   // Keep store/UI consistent: if the store says "open" but render conditions
   // no longer allow onboarding (e.g., profile loads as complete), close it.

--- a/e2e/onboarding-entry-points.spec.ts
+++ b/e2e/onboarding-entry-points.spec.ts
@@ -143,31 +143,35 @@ test.describe("Onboarding dialog entry points (regression smoke)", () => {
     });
   });
 
-  test("?onboarding=required on a beach page opens dialog and strips the param", async ({
+  test("?onboarding=required for an already-activated user does NOT open the dialog, strips the param", async ({
     page,
   }) => {
-    // Plan F2: /auth/callback now appends ?onboarding=required to ANY
-    // fresh-signup redirect target (not just '/'), so a user who signs up
-    // via PublicContentGate on a beach page lands there with the dialog
-    // open instead of bypassing activation. The OnboardingDialog is mounted
-    // globally (components/providers.tsx → AuthOverlays) and its handler
-    // (onboarding-dialog.tsx:210-230) opens once then strips the param via
-    // router.replace, preserving other query params (UTM survival).
+    // The standard auth fixture (`e2e/.auth/state.json`) has
+    // `onboarding_completed_at` set. A stale welcome-email link, bookmark,
+    // or browser autocomplete can still land an activated user on
+    // /?onboarding=required — the dialog must NOT re-open for them, and
+    // the param must still be stripped so a subsequent refresh settles on
+    // a clean URL. Plan: in-quiverweb-app-on-prod-happy-nebula (2026-04-21).
     await page.goto(
       "/ca/oceanside/the-rock-oceanside?onboarding=required&foo=bar"
     );
     await waitForPageLoad(page);
 
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible({ timeout: TIMEOUTS.long });
-    await expect(page.getByText(/where do you surf/i)).toBeVisible({
-      timeout: TIMEOUTS.long,
-    });
-
+    // Param strip: URL settles with ?foo=bar preserved but no onboarding=required.
     await expect(page).toHaveURL(
       /^https?:\/\/[^/]+\/ca\/oceanside\/the-rock-oceanside\?foo=bar$/,
       { timeout: TIMEOUTS.long }
     );
+
+    // Dialog invariant: the onboarding dialog (aria-label "Set up your surf
+    // profile") must NOT appear for the already-completed fixture user.
+    const onboardingDialog = page.getByRole("dialog", {
+      name: /set up your surf profile/i,
+    });
+    const dialogVisible = await isVisibleSafe(onboardingDialog, {
+      timeout: 2000,
+    });
+    expect(dialogVisible).toBe(false);
   });
 
   test("HomeBeachStep does NOT render a Maybe later button (required step)", async ({


### PR DESCRIPTION
## Summary

Prod hotfix — cherry-pick of `b665a8ad` from main (already live on dev.quiversurf.app).

The force-open branch of `shouldRender` in the onboarding dialog was bypassing `hasCompletedOnboarding` unconditionally to dodge a fresh-signup profile-materialization race. Result: any authenticated user landing on `/?onboarding=required` — stale welcome-email link, bookmark, browser autocomplete — got the dialog re-opened regardless of their completion state.

Observed in prod on `omg.its.thefuture@gmail.com` (`73040cff-...`): three `dialog_opened` events in <3 minutes today after a legitimate completion yesterday, each triggered by re-landing on `/?onboarding=required`.

- `components/onboarding/onboarding-dialog.tsx` — strip effect now checks `profile?.onboarding_completed_at` before calling `reopenFresh`. If profile has loaded and shows completion, strip the param without opening the dialog. The profile-race case (profile still `null` for fresh signups) falls through to the existing `reopenFresh` path, so `/auth/callback` is unaffected.
- `__tests__/components/onboarding/onboarding-dialog.test.tsx` — 1 new unit test pinning the invariant.
- `e2e/onboarding-entry-points.spec.ts` — existing beach-page test updated: was pinning the buggy "dialog opens for any ?onboarding=required" behavior, now pins the corrected "does NOT open for already-activated fixture user, param is stripped."

Verified end-to-end on dev.quiversurf.app against `omg.its.thefuture@gmail.com` — 4/5 tests pass, 1 expected skip.

## Test plan
- [x] Unit tests green locally (8/8 dialog tests, 65/65 onboarding+store+callback suites)
- [x] Typecheck clean
- [x] Lint clean (changed files)
- [x] E2E verified on dev against the actual affected user account
- [ ] CI status checks (Unit Tests / Build / Lint / TypeScript / lighthouse) pass on this PR
- [ ] Post-merge: confirm fix live by visiting https://www.quiversurf.app/?onboarding=required signed in as the affected user — dialog should NOT appear, URL should strip to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)