### PR TITLE
fix(discovery): unbreak post-sunset recs + UI guard for empty state

### DIFF
--- a/components/oracle/oracle-home-screen.tsx
+++ b/components/oracle/oracle-home-screen.tsx
@@ -303,6 +303,41 @@ function LoadingSkeleton() {
 }
 
 // ============================================================================
+// Empty / error state — renders when discovery resolved with no usable data
+// ============================================================================
+
+function OracleHeroEmpty({
+  beachName,
+  reason,
+  onRetry,
+}: {
+  beachName: string;
+  reason: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-[#252D6B]">
+      <div className="mx-auto max-w-3xl md:max-w-6xl px-6 py-24">
+        <div className="rounded-2xl border border-white/10 bg-[#2D357D] p-8 text-center">
+          <h1 className="font-space-grotesk text-2xl text-white mb-2">
+            {beachName}
+          </h1>
+          <p className="text-white/60 text-sm mb-6">{reason}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex items-center gap-2 rounded-full border border-[#F78E42] bg-[#F78E42]/10 px-5 py-2 text-sm font-semibold text-[#F78E42] hover:bg-[#F78E42]/20 transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+      <BottomNav />
+    </div>
+  );
+}
+
+// ============================================================================
 // OracleHomeScreen
 // ============================================================================
 
@@ -524,6 +559,22 @@ export function OracleHomeScreen() {
   // ------------------------------------------------------------------
   if (oracle.discoveryLoading && !heroRec) {
     return <LoadingSkeleton />;
+  }
+
+  // Empty / error state — discovery resolved but returned no usable data.
+  // Render an honest empty card with a retry affordance instead of letting
+  // `parseNumeric(undefined) → 0` leak phantom zeros into the hero UI.
+  if (!heroRec) {
+    const reason = oracle.discovery
+      ? "We couldn't find any surf spots near you right now."
+      : "We couldn't load conditions for your area.";
+    return (
+      <OracleHeroEmpty
+        beachName={homeBeach?.name ?? "Your Surf"}
+        reason={reason}
+        onRetry={() => window.location.reload()}
+      />
+    );
   }
 
   // ------------------------------------------------------------------

--- a/components/oracle/oracle-home-screen.tsx
+++ b/components/oracle/oracle-home-screen.tsx
@@ -572,7 +572,7 @@ export function OracleHomeScreen() {
       <OracleHeroEmpty
         beachName={homeBeach?.name ?? "Your Surf"}
         reason={reason}
-        onRetry={() => window.location.reload()}
+        onRetry={() => globalThis.location.reload()}
       />
     );
   }

--- a/hooks/use-surf-discovery.ts
+++ b/hooks/use-surf-discovery.ts
@@ -239,9 +239,18 @@ export function useSurfDiscovery(
 
     const discoveryData = result.data as SurfDiscoveryResponse;
 
-    // Save to localStorage cache using shared utility
-    if (cacheKey) {
+    // Save to localStorage cache using shared utility.
+    // Don't cache empty responses — otherwise a transient empty result
+    // (cold start, auth blip, deploy flip) poisons the cache for up to
+    // 30 min and the UI keeps rendering phantom zeros even after the
+    // server recovers.
+    const hasResults = (discoveryData?.recommendations?.length ?? 0) > 0;
+    if (cacheKey && hasResults) {
       writeToCache(cacheKey, discoveryData, optionsHash);
+    } else if (!hasResults) {
+      console.warn(
+        "[useSurfDiscovery] empty recommendations — skipping cache write"
+      );
     }
 
     setIsCached(false);

--- a/lib/services/discovery/surf-discovery-orchestrator.ts
+++ b/lib/services/discovery/surf-discovery-orchestrator.ts
@@ -567,17 +567,21 @@ async function discoverSurfSpotsInner(
       getLocalDateStr(new Date(f.forecast_at), beachTz) === todayStr
     );
 
-    // If today has any forecasts, trust selectBestWindow's internal fallback to
-    // return today's best remaining window. Only reach into tomorrow's data when
-    // today is actually gone (e.g. post-sunset, todayForecasts empty) — otherwise
-    // we flip the hero to "Tomorrow's dawn patrol" while today's dawn is still
-    // minutes away.
+    // Try today's forecasts first so we don't flip the hero to "Tomorrow's
+    // dawn patrol" while today's dawn is still minutes away. If today has
+    // no viable window (e.g. post-sunset when all remaining today rows are
+    // nighttime/pre-dawn), fall through to the full forecast set so tomorrow
+    // morning still surfaces — otherwise every beach returns null on post-
+    // sunset traffic and the UI shows a phantom empty state.
     let bestWindow = todayForecasts.length > 0
       ? selectBestWindow(todayForecasts, beach, userPrefs, horizonHours, sunTimesCache, timeSlot)
-      : selectBestWindow(forecasts, beach, userPrefs, horizonHours, sunTimesCache, timeSlot);
+      : null;
 
-    if (!bestWindow && todayForecasts.length === 0) {
-      log.warn(`[discoverSurfSpots] ${beach.name}: no today forecasts (total=${forecasts.length}), tomorrow fallback returned null`);
+    if (!bestWindow) {
+      bestWindow = selectBestWindow(forecasts, beach, userPrefs, horizonHours, sunTimesCache, timeSlot);
+      if (!bestWindow) {
+        log.warn(`[discoverSurfSpots] ${beach.name}: no viable window in today (${todayForecasts.length}) or full set (${forecasts.length})`);
+      }
     }
 
     if (!bestWindow) {


### PR DESCRIPTION
## Summary

- **Root cause**: After sunset, the today-first guard in `surf-discovery-orchestrator.ts` runs `selectBestWindow` on today-only forecasts. All remaining today rows (8pm/11pm/2am/5am local) fail night-hour filters, the internal fallback can't salvage them either, and the beach returns null. With 20 beaches hitting this simultaneously, `/api/surf/discover` returns `recommendations: []` → Oracle hero renders phantom zeros ("Ocean Beach Pier 0.0/10, W 0s, 0°F"). This is what the user was seeing on prod tonight.
- **Fix**: If today-only returns null, retry with full forecasts (tomorrow's dawn patrol surfaces). Today still wins when viable — this only kicks in when today is genuinely unusable.
- **Two defense-in-depth hardenings** so this class of regression never silently lands again:
  1. `OracleHeroEmpty` component renders when `heroRec === null` (replaces zero-leak hero)
  2. `useSurfDiscovery` skips cache write when `recommendations.length === 0` (prevents localStorage poisoning for 30 min)

## Test plan

- [ ] Typecheck + unit passes on CI
- [ ] Playwright smoke on `/` (authed)
- [ ] Manual: load home at ~8pm PDT → hero shows tomorrow's dawn, not zero state
- [ ] Manual: simulate empty recs (block `/api/surf/discover` in DevTools) → OracleHeroEmpty card renders with "Try again"
- [ ] Manual: clear localStorage + reload after empty response → does not re-poison cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)