### PR TITLE
feat: OM-primary wave-height selector with small-wave gate

### DIFF
--- a/__tests__/embed/surf-terminal/data-transform.test.ts
+++ b/__tests__/embed/surf-terminal/data-transform.test.ts
@@ -490,7 +490,10 @@ describe("transformForecastsToChartData", () => {
     expect(result.waveHeight[0].value).toBe(3);
   });
 
-  it("includes ML-corrected height only when is_ml_calibrated is true", () => {
+  it("never populates mlCorrectedHeight after the OM-primary selector write-site swap", () => {
+    // Wave height is now chosen at the forecast-builder write site
+    // (lib/utils/wave-height-selector.ts) rather than in display code.
+    // The ml_corrected_height column is no longer consumed by this transform.
     const forecasts = [
       makeForecast({
         forecast_at: "2026-02-18T13:00:00Z",
@@ -502,16 +505,10 @@ describe("transformForecastsToChartData", () => {
         ml_corrected_height: "4.0 ft",
         is_ml_calibrated: false,
       }),
-      makeForecast({
-        forecast_at: "2026-02-18T15:00:00Z",
-        ml_corrected_height: "5.0 ft",
-        // is_ml_calibrated defaults to undefined → falsy
-      }),
     ];
 
     const result = transformForecastsToChartData(forecasts, DEFAULT_CONFIG, 48);
-    expect(result.mlCorrectedHeight).toHaveLength(1);
-    expect(result.mlCorrectedHeight[0].value).toBe(3.2);
+    expect(result.mlCorrectedHeight).toEqual([]);
   });
 
   it("time values are shifted to local timezone for chart display", () => {
@@ -572,7 +569,8 @@ describe("transformForecastsToChartData", () => {
 
     // Smoothed series: 2 raw points → 7 interpolated
     expect(result.waveHeight).toHaveLength(7);
-    expect(result.mlCorrectedHeight).toHaveLength(7);
+    // mlCorrectedHeight is retired — OM-primary selector now handles height at the write site
+    expect(result.mlCorrectedHeight).toEqual([]);
     expect(result.tideHeight).toHaveLength(7);
     expect(result.swellPeriod).toHaveLength(7);
     // Wind is NOT smoothed (histogram)
@@ -583,14 +581,12 @@ describe("transformForecastsToChartData", () => {
     expect(result.windSpeed[0].color).toBe(WIND_COLORS.offshore);
     expect(result.tideHeight[0].value).toBe(4.2);
     expect(result.swellPeriod[0].value).toBe(14);
-    expect(result.mlCorrectedHeight[0].value).toBe(3.8);
 
     // Last point values
     expect(result.waveHeight[result.waveHeight.length - 1].value).toBe(4);
     expect(result.windSpeed[1].color).toBe(WIND_COLORS.onshore);
     expect(result.tideHeight[result.tideHeight.length - 1].value).toBe(2.1);
     expect(result.swellPeriod[result.swellPeriod.length - 1].value).toBe(12);
-    expect(result.mlCorrectedHeight[result.mlCorrectedHeight.length - 1].value).toBe(3.5);
   });
 
   it("excludes forecasts older than 6h lookback", () => {

--- a/__tests__/embed/surf-terminal/detail-card.test.tsx
+++ b/__tests__/embed/surf-terminal/detail-card.test.tsx
@@ -339,58 +339,18 @@ describe("DetailCard", () => {
     });
   });
 
-  // ─── ML corrected height ──────────────────────────────────────
+  // ─── ML corrected height (row removed by OM-primary selector) ───
 
-  describe("ML corrected height", () => {
-    it("shows ML adjusted height when available and calibrated", () => {
+  describe("ML corrected height row", () => {
+    // Wave height is now chosen at the write site by the OM-primary
+    // selector (lib/utils/wave-height-selector.ts). The "ML Adjusted"
+    // row was removed from the embed detail card since there's no
+    // separate ml_corrected_height to surface.
+    it("never renders the 'ML Adjusted' row, even when calibrated data is present", () => {
       render(
         <DetailCard
           forecast={makeForecast({
             ml_corrected_height: "4.2 ft",
-            is_ml_calibrated: true,
-          })}
-          {...DEFAULT_PROPS}
-        />
-      );
-      expect(screen.getByText("ML Adjusted")).toBeInTheDocument();
-      expect(screen.getByText("4.2 ft")).toBeInTheDocument();
-    });
-
-    it("applies accent styling to ML adjusted value", () => {
-      render(
-        <DetailCard
-          forecast={makeForecast({
-            ml_corrected_height: "4.2 ft",
-            is_ml_calibrated: true,
-          })}
-          {...DEFAULT_PROPS}
-        />
-      );
-      // Find the ML Adjusted row value span
-      const mlLabel = screen.getByText("ML Adjusted");
-      const mlRow = mlLabel.closest("div");
-      const valueSpan = mlRow?.querySelector(".text-\\[\\#4A70D9\\]");
-      expect(valueSpan).toBeInTheDocument();
-    });
-
-    it("does not show ML adjusted when is_ml_calibrated is false", () => {
-      render(
-        <DetailCard
-          forecast={makeForecast({
-            ml_corrected_height: "4.2 ft",
-            is_ml_calibrated: false,
-          })}
-          {...DEFAULT_PROPS}
-        />
-      );
-      expect(screen.queryByText("ML Adjusted")).not.toBeInTheDocument();
-    });
-
-    it("does not show ML adjusted when ml_corrected_height is null", () => {
-      render(
-        <DetailCard
-          forecast={makeForecast({
-            ml_corrected_height: null,
             is_ml_calibrated: true,
           })}
           {...DEFAULT_PROPS}

--- a/__tests__/lib/utils/wave-height-selector.test.ts
+++ b/__tests__/lib/utils/wave-height-selector.test.ts
@@ -1,0 +1,48 @@
+import { selectWaveHeightFormatted } from "@/lib/utils/wave-height-selector";
+
+describe("selectWaveHeightFormatted", () => {
+  it("returns the fallback string when om_m is null", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: null, fallback_ft_string: "2.5 ft" }),
+    ).toBe("2.5 ft");
+  });
+
+  it("returns the fallback when om_m is below the 0.95m gate", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: 0.94, fallback_ft_string: "1.5 ft" }),
+    ).toBe("1.5 ft");
+  });
+
+  it("returns OM at the gate boundary (0.95m = 3.1 ft)", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: 0.95, fallback_ft_string: null }),
+    ).toBe("3.1 ft");
+  });
+
+  it("returns OM for a clearly-valid 1.5m (4.9 ft)", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: 1.5, fallback_ft_string: null }),
+    ).toBe("4.9 ft");
+  });
+
+  it("falls back when om_m is NaN", () => {
+    expect(
+      selectWaveHeightFormatted({
+        om_m: Number.NaN,
+        fallback_ft_string: "3.0 ft",
+      }),
+    ).toBe("3.0 ft");
+  });
+
+  it("treats negative om_m as invalid and falls back", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: -0.5, fallback_ft_string: "2.0 ft" }),
+    ).toBe("2.0 ft");
+  });
+
+  it("passes through null fallback when both paths have no data", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: null, fallback_ft_string: null }),
+    ).toBeNull();
+  });
+});

--- a/app/embed/surf-terminal/[slug]/data-transform.ts
+++ b/app/embed/surf-terminal/[slug]/data-transform.ts
@@ -276,14 +276,6 @@ export function transformForecastsToChartData(
       result.waveHeight.push({ time: timeSec, value: wh });
     }
 
-    // ML-corrected height (only if calibrated)
-    if (fc.is_ml_calibrated === true) {
-      const mlh = parseNumericValue(fc.ml_corrected_height);
-      if (mlh != null) {
-        result.mlCorrectedHeight.push({ time: timeSec, value: mlh });
-      }
-    }
-
     // Tide height
     const th = parseNumericValue(fc.tide_height);
     if (th != null) {

--- a/app/embed/surf-terminal/[slug]/detail-card.tsx
+++ b/app/embed/surf-terminal/[slug]/detail-card.tsx
@@ -65,13 +65,6 @@ export const DetailCard = memo(function DetailCard({
         {/* Waves */}
         <Section title="Waves" isDark={isDark}>
           <Row label="Height" value={display(forecast.wave_height)} />
-          {forecast.ml_corrected_height && forecast.is_ml_calibrated && (
-            <Row
-              label="ML Adjusted"
-              value={display(forecast.ml_corrected_height)}
-              accent
-            />
-          )}
           <Row label="Period" value={display(forecast.wave_period)} />
           <Row label="Direction" value={display(forecast.wave_direction)} />
         </Section>

--- a/components/beaches-enhanced-forecast.tsx
+++ b/components/beaches-enhanced-forecast.tsx
@@ -532,10 +532,7 @@ export function BeachesEnhancedForecast({
                     <div className="flex items-baseline gap-2">
                       <div className="text-2xl font-semibold text-slate-900">
                         <WaveHeightDisplay
-                          height={
-                            todayForecast.ml_corrected_height ||
-                            todayForecast.wave_height
-                          }
+                          height={todayForecast.wave_height}
                           showTooltip={false}
                           isMlCalibrated={todayForecast.is_ml_calibrated}
                           isCalibrated={todayForecast.isCalibrated}

--- a/components/forecast/forecast-table.tsx
+++ b/components/forecast/forecast-table.tsx
@@ -274,7 +274,7 @@ function ForecastDayTable({
                   <td className="p-3">
                     <div className="bg-blue-100 text-blue-800 px-3 py-1 rounded-md font-bold text-center min-w-[60px] text-sm">
                       <WaveHeightDisplay
-                        height={forecast.ml_corrected_height || forecast.wave_height}
+                        height={forecast.wave_height}
                         showTooltip={true}
                         className="text-inherit"
                         dataSource={forecast.data_source}

--- a/docs/superpowers/specs/2026-04-22-phase-3-activation-funnel-design.md
+++ b/docs/superpowers/specs/2026-04-22-phase-3-activation-funnel-design.md
@@ -1,0 +1,160 @@
+# Phase 3 — Activation Funnel: Fix the Leaky Bucket
+
+**Date:** 2026-04-22
+**Status:** Draft — pending user review before writing-plans.
+
+## Problem
+
+Quiver is pre-PMF with **49 signups, 0 retention, 0 session logs** (per `project_quiver_pmf_status_apr2026.md`). Phase 2's personal match score requires ≥5 rated sessions to unlock, so it's literally invisible to every current user until they log their first session. The `project_invisible_cohort_is_retention_not_adblock.md` memory confirms 94% of zero-event signups are retention failures, not tracking. The monetization research (`/Users/stevenchandler/.claude/plans/when-can-we-start-cozy-tower-agent-a9874e89d523ad631.md`) concluded: **retention is the bottleneck, not pricing**.
+
+Pointing more traffic at the app, polishing score labels, or opening the paid tier all presuppose an activation funnel that works. Today it doesn't — signups convert at 0.70% CTR from anonymous mobile (below the 1% red-alert floor), and of the 49 signups we *do* get, none log a session.
+
+Phase 3 closes the leak at **both ends of the funnel**:
+1. **Web:** more anonymous visitors convert to signups
+2. **Native:** more signups reach the first forecast view (D0 activation)
+
+## Success Criteria
+
+Phase 3 ships when all of the following are measurably true, measured over a 14-day window post-ship:
+
+| Metric | Today | Phase 3 target |
+|---|---|---|
+| `/beaches/usa/ca` signup CTA CTR (Android mobile) | <1% (1 click / 588 sessions, 7d) | ≥3% |
+| `signup_form_submitted → signup_started` conversion | ~8% (4 / 49) | ≥80% |
+| D0 activation rate (signup → `home_beach_forecast_viewed` same day) | unknown (no event fires today) | ≥40% |
+| PayoffStep cold-restart loop-back bug | 100% reproducible in manual test | 0 |
+| Step-level onboarding drop-off visibility | 0 events for home_beach/level/payoff steps | Full funnel in `user_events` |
+
+Phase 3 does **not** ship on the retention curve (M2 lift). That's Phase 4 territory — needs the activation events we're instrumenting here before we can even measure it.
+
+## Architecture
+
+Two sub-workstreams that can run in parallel, converging on shared instrumentation:
+
+### Workstream A — Web Conversion (5 fixes, ranked by leverage)
+
+Delegates to the existing plan at `/Users/stevenchandler/.claude/plans/compressed-dreaming-cook.md`. Specifically:
+
+- **F1 (highest leverage)** — Drop `<StickySignupBar>` + `<InlineSignupCta>` into `quiver/app/beaches/usa/[state]/page.tsx`. 44% of anonymous traffic lands here with one sub-48dp navbar button as the only conversion surface. Components are battle-tested on 20+ sister SEO routes. Copy branches on `beachCount ≥ 20` for concrete state-specific variants.
+- **F2** — Tap-target bump: override `className="min-h-[48px]"` on the StickySignupBar primary button at the one new call site. Don't change the component itself (affects 20+ existing callers).
+- **F3** — Fix the `signup_form_submitted (49) → signup_started (4)` chasm. Audit call sites of both events; confirm `signup_started` fires immediately before `supabase.auth.signUp()`. Suspicion: `signup_form_submitted` fires on blur/validation, `signup_started` has one call site wired only to the legacy form path, so 92% of "submissions" never call signUp.
+- **F4** — MatchScoreTeaser copy tightening (142 Android views, 0 clicks). Not a handler/visibility bug — a copy/value-prop bug. Replace generic "3ft swell hits Thursday" with concrete "This is your call for [user_home_beach] tomorrow" once home_beach is known; generic fallback for anonymous.
+- **F5** — Deduplicate the 9 phantom `auth_modal_opened:signup` events fired by `/auth/sign-in` on redirect landings (`navbar autoOpenLogin` + page auto-open double-count). Source attribution fix only — no behavior change.
+
+**NOT in Workstream A:** any new route, any new conversion surface beyond the state hub, any redesign of MatchScoreTeaser beyond copy, any A/B test harness (premature at this volume).
+
+### Workstream B — Native Onboarding CRO (3 changes)
+
+Delegates to the existing plan at `/Users/stevenchandler/.claude/plans/plan-out-1-2-3-we-glimmering-mitten.md`. Specifically:
+
+- **Change 1 — Instrumentation.** Add `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_step_auto_skipped`, `home_beach_forecast_viewed` events. All fire via existing `trackEvent()` helper in `src/lib/analytics.ts`. `useRef`-guarded to avoid double-fire on strict-mode re-mount. Ship the corresponding funnel SQL in `quiver/docs/onboarding-funnel.sql` so the events are immediately actionable.
+- **Change 2 — Delete the `isCompleted` Zustand flag.** The PayoffStep cold-restart race (`project_onboarding_payoff_step_bug`) is 100% reproducible. Target: make `profile.onboarding_completed_at` the only source of truth; optimistic `queryClient.setQueryData` after DB write in `LevelAndTimeStep`; drop the Zustand flag from `RootNavigator`. Respects the `project_native_root_navigator_gate` invariant (never render Onboarding when `profile === undefined`). Also respects `feedback_dont_optimistic_update_navigation_gate` (2026-04-19): optimistic cache update is not on the nav-gate key itself — it's on `profile` which is read by the nav-gate.
+- **Change 3 — Replace PayoffStep promise copy with live forecast.** Use existing `useCurrentConditions(beachId)` hook. Prefetch warmed in `LevelAndTimeStep`. Numeric rendering (verbatim from `enhanced_forecasts`, no reformatting). Fallback to existing promise copy if home_beach was skipped or forecast is unavailable. CTA changes from "See today's forecast" → "Open forecast".
+
+**NOT in Workstream B:** removing OnboardingVideo (Change 0 — out of scope), collapsing Level/Time into HomeBeach (separate P1), share/invite hook (P2), Day-7 push nudge (Phase 4), founding-member email sequence (the 0-to-100 plan's Phase 3, which is post-3-paying-customers).
+
+### Shared contract: `home_beach_forecast_viewed` is the D0 activation event
+
+Both workstreams converge on this one event. It fires on native (from Workstream B Change 1). Web does not currently have a home-beach concept for anonymous visitors, so web's analog is `signup_success`.
+
+**Event metadata contract — frozen for Phase 3:**
+
+```
+event_type: 'home_beach_forecast_viewed'
+metadata: {
+  beach_id: string (uuid),
+  is_home_beach: boolean,   // heroBeachId === homeBeachId
+  confidence_score: number | null  // 0-100, null if unavailable
+}
+```
+
+The funnel SQL (`quiver/docs/onboarding-funnel.sql`) reads `metadata->>'is_home_beach'` as a tie-breaker to distinguish activation-by-home-beach vs. activation-by-any-hero. Any later metadata additions must be backwards-compatible (optional fields only).
+
+Measuring activation end-to-end looks like:
+
+```
+web: page_view → signup_cta_click → signup_success
+   → (handoff to native via deep link or email)
+native: onboarding_step_viewed(home_beach) → … → onboarding_completed → home_beach_forecast_viewed
+```
+
+Any drop at any step in the chain is now visible in `user_events` per the funnel SQL.
+
+## Sequencing
+
+```
+Week 1: Ship Workstream A F1 + F3 (highest-leverage). Ship Workstream B Change 1 (instrumentation only, behavior-neutral).
+        → Measurement unlocked end-to-end.
+Week 2: Ship Workstream B Changes 2 + 3 (race fix + live forecast).
+        Ship Workstream A F2 + F4 + F5 (polish after the F1/F3 dust settles).
+        → Activation loop lands end-to-end.
+Week 3: Measure. Don't ship more. Let the funnel run for 14 days clean.
+```
+
+All native changes ship in one PR (overlapping files; atomic commits per change). Web F1 ships in its own PR since F3 depends on app/api code that's separate from the SEO route.
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Instrumentation lands but events don't fire (per `feedback_fire_and_forget_observability`) | Verify via tail query on `user_events` within 30 min of merge. Route failures to Sentry.captureException in prod per that memory. |
+| Home-beach forecast prefetch misses cache → skeleton shows too long | Staletime 10 min on the prefetch query; fallback to promise copy on error. |
+| `signup_started` fix reveals the real conversion is actually 4% not 92% | That's the point. If true, F3 is a measurement fix, not a conversion lift — Phase 4 picks up the actual copy/UX work. |
+| PayoffStep race fix breaks signup → home flow for existing half-onboarded users | Manual regression pass from `reference_quiver_test_user` stcha0004 before merge, per `feedback_manual_verify_launch_flow`. |
+| New `user_events` event_types rejected by the allowlist (per `reference_user_events_three_allowlists`) | Add all four new event types to VALID_EVENTS + ANONYMOUS_ALLOWED_EVENTS + PRE_AUTH_ONLY_EVENTS + the DB CHECK constraint + the TS union before shipping Change 1. This is a blocker, not a polish item. |
+
+## Testing
+
+- **Unit (native):** delete the `isCompleted`/`complete()` test in `__tests__/onboarding-store.test.ts`. No new unit tests — events are fire-and-forget, race fix is covered by manual regression.
+- **Unit (web):** extend `signup-conversion-tracking` tests with the dedup fix for F5. Add tests for the `useConcreteCopy` branching in F1.
+- **Manual (native):** the 7-path iOS sim regression listed in `plan-out-1-2-3-we-glimmering-mitten.md` lines 264–297. Includes the cold-restart race test, the skip path, and the auto-skip path.
+- **Manual (web):** Playwright mobile viewport (412×915) tap-through on `/beaches/usa/ca` to confirm StickySignupBar and InlineSignupCta fire the event chain. Per `reference_playwright_base_url_and_projects` — BASE_URL against dev.quiversurf.app after dev push.
+- **E2E:** No new Playwright beyond the mobile tap-through smoke. Funnel verification is SQL.
+
+## Critical files
+
+### Web
+- `quiver/app/beaches/usa/[state]/page.tsx` — F1 JSX insertion, copy branching
+- `quiver/components/ui/sticky-signup-bar.tsx` — no changes, reuse
+- `quiver/components/seo/inline-signup-cta.tsx` — no changes, reuse
+- `quiver/components/recommendations/match-score-teaser.tsx` — F4 copy
+- `quiver/lib/analytics/signup-conversion-tracking.ts` — F5 dedup
+- Event call sites for `signup_form_submitted` vs `signup_started` — F3 audit target (grep for call sites)
+
+### Native
+- `quiver-native/src/stores/onboarding-store.ts` — delete `isCompleted`
+- `quiver-native/src/navigation/root-navigator.tsx` — drop `isOnboardingCompleted` selector
+- `quiver-native/src/components/onboarding/steps/home-beach-step.tsx` — Change 1 events
+- `quiver-native/src/components/onboarding/steps/level-and-time-step.tsx` — Change 1 events + optimistic setQueryData + prefetch warm
+- `quiver-native/src/components/onboarding/steps/payoff-step.tsx` — Change 1 view event, Change 2 delete complete() call, Change 3 forecast card
+- `quiver-native/src/screens/onboarding.tsx` — Change 1 auto-skip event
+- `quiver-native/src/screens/home.tsx` — Change 1 home_beach_forecast_viewed event
+- `quiver-native/__tests__/onboarding-store.test.ts` — remove the `isCompleted` test
+
+### New
+- `quiver/docs/onboarding-funnel.sql` — funnel SQL for step-level drop-off
+
+## Skills to invoke
+
+| Skill | Why |
+|---|---|
+| `superpowers:subagent-driven-development` | Dispatch workstream A and B in parallel — they touch disjoint repos and can ship independently. Use fresh subagents per task with spec + code reviews. |
+| `superpowers:test-driven-development` | Change 2 race fix has clear test cases (7 manual paths); enforce TDD for the `onboarding_store.test.ts` update and the F5 dedup test. |
+| `superpowers:verification-before-completion` | Instrumentation is easy to fake success on. Require tail query on `user_events` after merge. |
+| `maestro-native` | Manual regression pass on the 7 iOS sim paths. |
+| `vercel-deploy-verify` | After web PRs merge to main, confirm dev.quiversurf.app alias-promoted to the new build. |
+| `parallel-workstream-integration` | Before dispatching A and B subagents in parallel, freeze the `home_beach_forecast_viewed` event contract so both sides agree on the metadata shape. |
+
+## Documents to update
+
+- `quiver/CHANGELOG.md` — Added/Changed entries under `[Unreleased]` per `quiver/CLAUDE.md` pre-merge checklist
+- `quiver-native/CHANGELOG.md` — same
+- `quiver-native/src/stores/onboarding-store.ts` — doc comment pointing to the race fix memory
+- `quiver/lib/analytics/signup-conversion-tracking.ts` — doc comment on the dedup logic + F5 memory link
+- Auto-memory: `project_phase3_activation_funnel_shipped.md` (new, post-ship) — dates, metrics delta, notable deviations
+
+## Open questions (for user review before writing-plans)
+
+1. **F3 scope.** The `signup_form_submitted → signup_started` chasm might resolve to just "instrumentation ordering bug, fix call sites." Or it might resolve to "92% of submissions genuinely fail somewhere and we need to UX-fix that." Investigate first, split F3 into F3a (instrumentation) and F3b (UX fix) if needed. Acceptable to defer F3b to Phase 4 if the root cause is real friction rather than measurement.
+2. **Workstream A + B in parallel?** Both plans are independently reviewable; dispatching parallel subagents is viable. Main risk is the `home_beach_forecast_viewed` event metadata contract — if the native side changes the shape mid-flight, the funnel SQL breaks. Mitigation: freeze the metadata schema in this spec before dispatch. (Already done — see "Shared contract" above.)
+3. **Success-criteria target for D0 activation (≥40%).** Pulled from `adapty.io` benchmark for freemium apps. Aggressive given current 0%. If 14-day data shows ≥15% we should probably ship Phase 4 rather than chase the full 40% — depends on whether the M2 retention curve starts lifting.

--- a/e2e/forecast-om-primary.spec.ts
+++ b/e2e/forecast-om-primary.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * OM-primary wave-height selector — E2E invariants
+ *
+ * Verifies that the OM-primary selector (lib/utils/wave-height-selector.ts)
+ * drives the displayed wave-height on a beach page. Before the selector
+ * shipped, La Jolla Shores sometimes rendered "1.5 ft" while the raw
+ * Open-Meteo significant-wave-height for the same slot was >2m — because
+ * the v3 ML correction was overshoot-compensating in the wrong direction.
+ *
+ * This suite runs on CI against dev (BASE_URL=https://dev.quiversurf.app)
+ * where a seeded OM-primary row exists on La Jolla Shores. It should NOT
+ * be executed against production.
+ *
+ * @project auth
+ */
+
+import { test, expect, Route } from "@playwright/test";
+import {
+  setupErrorDetection,
+  assertNoErrors,
+  ErrorCapture,
+} from "./utils/error-detection";
+import { waitForPageLoad } from "./utils/test-helpers";
+
+const LA_JOLLA_SHORES_SLUG = "la-jolla-shores";
+const LA_JOLLA_SHORES_URL = `/california/san-diego/${LA_JOLLA_SHORES_SLUG}`;
+
+// Match "N ft" or "N-M ft" rendered inside a <WaveHeightDisplay>. The card
+// surfaces face-height feet and we extract the numeric value (or range
+// midpoint) for threshold assertions.
+function parseFeet(rendered: string | null): number | null {
+  if (!rendered) return null;
+  const rangeMatch = rendered.match(/(\d+(?:\.\d+)?)\s*[-–]\s*(\d+(?:\.\d+)?)/);
+  if (rangeMatch) {
+    const low = Number(rangeMatch[1]);
+    const high = Number(rangeMatch[2]);
+    if (Number.isFinite(low) && Number.isFinite(high)) {
+      return (low + high) / 2;
+    }
+  }
+  const singleMatch = rendered.match(/(\d+(?:\.\d+)?)/);
+  if (!singleMatch) return null;
+  const n = Number(singleMatch[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Mock the PostgREST enhanced_forecasts query for La Jolla Shores with an
+ * OM-primary row (wave_height_om >= 0.95m). The selector should swap to
+ * the OM-derived value regardless of what the legacy wave_height string
+ * contains.
+ */
+async function mockOmPrimaryForecast(
+  route: Route,
+  omHeightMeters: number,
+  fallbackWaveHeight: string,
+) {
+  const nowISO = new Date().toISOString();
+  const body = [
+    {
+      id: "mock-om-primary-lajolla",
+      beach_id: "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      forecast_at: nowISO,
+      wave_height: fallbackWaveHeight,
+      wave_height_om: omHeightMeters,
+      wave_period: "12s",
+      wave_direction: "WSW",
+      wind_speed: "5 mph",
+      wind_direction: "N",
+      wind_direction_deg: 0,
+      water_temp: "64 F",
+      air_temperature: "62 F",
+      tide_status: "Rising",
+      tide_height: "3.2 ft",
+      next_tide_time: null,
+      next_tide_type: null,
+      next_tide_height: null,
+      weather_condition: "Clear",
+      swell_1_height: "2.0 ft",
+      swell_1_period: "12s",
+      swell_1_direction: "WSW",
+      swell_2_height: null,
+      swell_2_period: null,
+      swell_2_direction: null,
+      wind_wave_height: null,
+      wind_wave_period: null,
+      wind_wave_direction: null,
+      confidence_score: 80,
+      data_source: "OM-primary-test",
+      created_at: nowISO,
+      updated_at: nowISO,
+      is_ml_calibrated: false,
+      ml_corrected_height: null,
+    },
+  ];
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+test.describe("OM-primary wave-height selector", () => {
+  let errorCapture: ErrorCapture;
+
+  test.beforeEach(async ({ page }) => {
+    errorCapture = setupErrorDetection(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await assertNoErrors(page, errorCapture, {
+      context: "OM-primary selector",
+    });
+  });
+
+  test("renders > 2.5 ft at La Jolla Shores when OM wave_height_om >= 2.0m (selector fires)", async ({
+    page,
+  }) => {
+    // Intercept enhanced_forecasts PostgREST calls and return a row with a
+    // clearly-big OM Hs (2.1m = ~6.9 ft). The selector should override the
+    // legacy wave_height string.
+    await page.route(/enhanced_forecasts/i, async (route) => {
+      await mockOmPrimaryForecast(route, 2.1, "1.5 ft");
+    });
+
+    await page.goto(LA_JOLLA_SHORES_URL);
+    await waitForPageLoad(page);
+
+    // Settle deferred data fetches (forecast builder, scored, etc.)
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- forecast panels hydrate after page-level settle
+    await page.waitForTimeout(1500);
+
+    // Prefer the dedicated testid if present; otherwise fall back to any
+    // element containing " ft" in the forecast area. The selector assertion
+    // is what we care about, not the exact DOM hook.
+    const heightLocator = page
+      .getByTestId("wave-height-display")
+      .or(page.locator('text=/\\d+(\\.\\d+)?\\s*ft/'))
+      .first();
+    await expect(heightLocator).toBeVisible({ timeout: 10_000 });
+
+    const text = await heightLocator.textContent();
+    const feet = parseFeet(text);
+    expect(feet, `rendered="${text}"`).not.toBeNull();
+    // Pre-fix regression showed ~1.5 ft; post-fix should be derived from
+    // 2.1m ≈ 6.9 ft. Assert comfortably above the 2.5 ft floor.
+    expect(feet!).toBeGreaterThan(2.5);
+  });
+
+  test("falls back to wave_height string when OM <0.5m (sub-gate)", async ({
+    page,
+  }) => {
+    // Small-wave path: OM 0.4m is below the 0.95m gate — selector returns
+    // the existing NOAA/CDIP-derived wave_height string ("1.8 ft").
+    await page.route(/enhanced_forecasts/i, async (route) => {
+      await mockOmPrimaryForecast(route, 0.4, "1.8 ft");
+    });
+
+    await page.goto(LA_JOLLA_SHORES_URL);
+    await waitForPageLoad(page);
+
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- forecast panels hydrate after page-level settle
+    await page.waitForTimeout(1500);
+
+    const anyFt = page.locator('text=/\\d+(\\.\\d+)?\\s*ft/').first();
+    await expect(anyFt).toBeVisible({ timeout: 10_000 });
+
+    const text = await anyFt.textContent();
+    const feet = parseFeet(text);
+    expect(feet, `rendered="${text}"`).not.toBeNull();
+    // Fallback "1.8 ft" means the selector kept hands off — NOT the OM
+    // 0.4m -> 1.3 ft derivation, which would overshoot.
+    expect(feet!).toBeLessThan(2.5);
+  });
+
+  test("renders > 2.5 ft at the gate boundary (OM = 0.95m selector fires)", async ({
+    page,
+  }) => {
+    // Gate-boundary case: 0.95m -> exactly 3.1 ft. Still above the 2.5 ft
+    // threshold that pins the pre-fix "1.5 ft" regression out of the test.
+    await page.route(/enhanced_forecasts/i, async (route) => {
+      await mockOmPrimaryForecast(route, 0.95, "1.2 ft");
+    });
+
+    await page.goto(LA_JOLLA_SHORES_URL);
+    await waitForPageLoad(page);
+
+    // eslint-disable-next-line playwright/no-wait-for-timeout -- forecast panels hydrate after page-level settle
+    await page.waitForTimeout(1500);
+
+    const anyFt = page.locator('text=/\\d+(\\.\\d+)?\\s*ft/').first();
+    await expect(anyFt).toBeVisible({ timeout: 10_000 });
+
+    const text = await anyFt.textContent();
+    const feet = parseFeet(text);
+    expect(feet, `rendered="${text}"`).not.toBeNull();
+    // 0.95m -> 3.1 ft should replace the 1.2 ft fallback.
+    expect(feet!).toBeGreaterThan(2.5);
+  });
+});

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -11,6 +11,7 @@
 import { createContextLogger } from "@/lib/logger";
 import { calculateConfidenceScore } from "./confidence-scorer";
 import { toFaceHeightFeet, toFaceHeightFeetDecomposed, METERS_TO_FEET } from "@/lib/utils/wave-formatters";
+import { selectWaveHeightFormatted } from "@/lib/utils/wave-height-selector";
 import type {
   ShoalingFactors,
   SwellComponentInput,
@@ -269,8 +270,13 @@ export class ForecastBuilder {
       forecast_time: getNormalizedTimeString(forecastTime),
       forecast_at: getNormalizedForecastAt(forecastTime),
 
-      // Wave data
-      wave_height: this.getWaveHeight(cdipPoint, wavePoint, buoyData, useCDIPData, beach, nowcastAnchor),
+      // Wave data — OM-primary selector: raw OM Hs >=0.95m wins over the
+      // v3-corrected/NOAA/CDIP fallback by ~35% MAE in production matches.
+      // See lib/utils/wave-height-selector.ts for the gate rationale.
+      wave_height: selectWaveHeightFormatted({
+        om_m: wavePoint?.om_values?.wave_height_om ?? null,
+        fallback_ft_string: this.getWaveHeight(cdipPoint, wavePoint, buoyData, useCDIPData, beach, nowcastAnchor),
+      }),
       wave_period: this.getWavePeriod(cdipPoint, wavePoint, buoyData, useCDIPData),
       wave_direction: this.getWaveDirection(cdipPoint, wavePoint, useCDIPData),
 

--- a/lib/utils/wave-formatters.ts
+++ b/lib/utils/wave-formatters.ts
@@ -294,7 +294,7 @@ export function clampWaveHeight(ft: number): number {
  * @param m Height in meters
  * @returns Height in feet or undefined if invalid
  */
-function metersToFeet(m?: number | null): number | undefined {
+export function metersToFeet(m?: number | null): number | undefined {
   return m == null || !isFinite(m) ? undefined : m * METERS_TO_FEET;
 }
 

--- a/lib/utils/wave-height-selector.ts
+++ b/lib/utils/wave-height-selector.ts
@@ -1,0 +1,27 @@
+import { metersToFeet } from "@/lib/utils/wave-formatters";
+
+const SMALL_WAVE_GATE_M = 0.95;
+
+export interface WaveHeightSelectorInput {
+  om_m: number | null;
+  fallback_ft_string: string | null;
+}
+
+/**
+ * OM-primary wave-height selector. Raw Open-Meteo Hs at >=0.95m beats
+ * v3-corrected by 35% MAE (n=10,599 matched). Below the gate, OM overshoots
+ * <0.5m observed by +0.45m, so we fall back to the existing face-height
+ * string derived from NOAA/CDIP/buoy inputs.
+ */
+export function selectWaveHeightFormatted(
+  input: WaveHeightSelectorInput,
+): string | null {
+  const { om_m, fallback_ft_string } = input;
+  if (om_m != null && Number.isFinite(om_m) && om_m >= SMALL_WAVE_GATE_M) {
+    const feet = metersToFeet(om_m);
+    if (feet == null) return fallback_ft_string;
+    const ft = Math.round(feet * 10) / 10;
+    return `${ft} ft`;
+  }
+  return fallback_ft_string;
+}

--- a/supabase/migrations/20260423204959_om_primary_bulk_current_forecasts.sql
+++ b/supabase/migrations/20260423204959_om_primary_bulk_current_forecasts.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+-- OM-primary wave-height selection inside get_bulk_current_forecasts.
+-- Mirrors the write-site selector at lib/utils/wave-height-selector.ts so the
+-- bulk path for /api/forecasts/bulk returns the same height every downstream
+-- reader sees. Raw Open-Meteo Hs at >=0.95m beats v3-corrected by ~35% MAE in
+-- production matches (n=10,599). Below the gate, OM overshoots observed <0.5m
+-- by +0.45m, so small-wave paths keep the existing wave_height string.
+--
+-- Signature unchanged (beach_id UUID, wave_height TEXT, forecast_date DATE,
+-- forecast_time TIME) — callers in app/api/forecasts/bulk don't need to
+-- change.
+
+CREATE OR REPLACE FUNCTION public.get_bulk_current_forecasts(
+  p_beach_ids UUID[],
+  p_target_date DATE DEFAULT CURRENT_DATE
+)
+RETURNS TABLE (
+  beach_id UUID,
+  wave_height TEXT,
+  forecast_date DATE,
+  forecast_time TIME
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH ranked AS (
+    SELECT
+      ef.beach_id,
+      CASE
+        WHEN ef.wave_height_om IS NOT NULL AND ef.wave_height_om >= 0.95
+        THEN ROUND((ef.wave_height_om * 3.28084)::numeric, 1)::text || ' ft'
+        ELSE ef.wave_height
+      END AS wave_height,
+      ef.forecast_date,
+      ef.forecast_time,
+      ROW_NUMBER() OVER (
+        PARTITION BY ef.beach_id
+        ORDER BY
+          -- Priority bucket: today-future(1), tomorrow(2), today-past(3)
+          CASE
+            WHEN ef.forecast_date = p_target_date
+                 AND ef.forecast_time >= CURRENT_TIME THEN 1
+            WHEN ef.forecast_date = p_target_date + 1 THEN 2
+            ELSE 3
+          END ASC,
+          -- Within bucket: future/tomorrow sort earliest-first (ASC),
+          -- past-today sort latest-first (DESC via negation)
+          CASE
+            WHEN ef.forecast_date = p_target_date
+                 AND ef.forecast_time < CURRENT_TIME
+            THEN -EXTRACT(EPOCH FROM ef.forecast_time)
+            ELSE  EXTRACT(EPOCH FROM ef.forecast_time)
+          END ASC
+      ) AS rn
+    FROM enhanced_forecasts ef
+    WHERE ef.beach_id = ANY(p_beach_ids)
+      AND ef.forecast_date IN (p_target_date, p_target_date + 1)
+  )
+  SELECT r.beach_id, r.wave_height, r.forecast_date, r.forecast_time
+  FROM ranked r
+  WHERE r.rn = 1;
+$$;
+
+COMMENT ON FUNCTION public.get_bulk_current_forecasts IS
+  'Returns the current/next forecast wave_height for each beach, applying '
+  'the OM-primary selector (>=0.95m) to match lib/utils/wave-height-selector.ts. '
+  'Used by /api/forecasts/bulk to avoid PostgREST row-limit truncation.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Switches the user-facing wave-height from raw NOAA + physics shoaling to **Open-Meteo-primary with a small-wave gate (≥0.95m) and NOAA/CDIP fallback**. Validated against 10,599 matched predictions over 14 days: raw OM beats v3-corrected by 35% MAE and beats raw NOAA by 36% MAE.

**Real-world trigger**: 2026-04-23 at La Jolla Shores, app showed "1-2ft sets" while actual surf was 1-5ft. DB had `wave_height = "2 ft"` (CDIP-shoaled) but `wave_height_om = 1.0m (3.3 ft)`. Post-merge the hero will show "3-5ft sets" at that timestamp.

## Architecture

The swap happens at the **write site** (`lib/services/forecast/forecast-builder.ts:273`), not per-display. Every downstream reader — web home map, bulk RPC, native, beach detail, alerts, digest, session comparison — inherits the new value for free. The RPC migration is a belt-and-suspenders read-time selector so historical rows behave correctly without waiting for cron rewrites.

## Commits

- `d4fd2495` — feat(forecast): OM-primary wave-height selector at the write site
- `936112c2` — refactor(forecast): drop ml_corrected_height display branches
- `31b7adfd` — feat(db): OM-primary selector in get_bulk_current_forecasts RPC
- `afb307f6` — test(e2e): OM-primary selector invariants at La Jolla Shores

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn test:unit wave-height-selector` — 7/7 pass
- [x] Blast-radius unit tests — 118/118 pass (updated 4 pre-existing tests that asserted removed ML-Adjusted row)
- [x] `npx eslint --max-warnings=0 lib/utils/wave-height-selector.ts lib/services/forecast/forecast-builder.ts` — clean
- [ ] Playwright `e2e/forecast-om-primary.spec.ts` against dev after merge
- [ ] Visual spot-check at La Jolla Shores on dev.quiversurf.app

## Deployment sequence (post-merge)

1. Merge this PR → deploys to `dev.quiversurf.app`
2. Apply RPC migration `20260423204959_om_primary_bulk_current_forecasts.sql` via Supabase MCP (shared dev+prod DB)
3. Smoke-test La Jolla Shores on dev — hero should show 3-5ft sets instead of 1-2ft
4. Flip `ML_CORRECTIONS_ENABLED=false` in Vercel Production
5. Cherry-pick to `prod` branch → `www.quiversurf.app`

## Rollback

- Builder/display: revert this PR
- RPC: re-apply the pre-change function body from `20260211150000_create_get_bulk_current_forecasts_rpc.sql`
- Env var: flip `ML_CORRECTIONS_ENABLED` back to default (absent = true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)