### PR TITLE
test(forecast-builder): add metersToFeet to wave-formatters mock

### DIFF
--- a/__tests__/lib/services/forecast/forecast-builder.test.ts
+++ b/__tests__/lib/services/forecast/forecast-builder.test.ts
@@ -19,6 +19,7 @@ jest.mock("@/lib/logger", () => ({
 jest.mock("@/lib/utils/wave-formatters", () => ({
   toFaceHeightFeet: jest.fn(() => "3.5 ft"),
   toFaceHeightFeetDecomposed: jest.fn(() => "3.5 ft"),
+  metersToFeet: jest.fn((m: number) => m * 3.28084),
   METERS_TO_FEET: 3.28084,
 }));
 


### PR DESCRIPTION
## Summary

One-line test-mock fix. PR #213 added `metersToFeet` as a call inside the new OM-primary selector, but `__tests__/lib/services/forecast/forecast-builder.test.ts` mocks the whole `wave-formatters` module and didn't include `metersToFeet` in its mock factory. Unit Tests CI failed on the main→prod release PR (#214) as a result.

## Fix

Adds `metersToFeet: jest.fn((m: number) => m * 3.28084),` to the existing `jest.mock("@/lib/utils/wave-formatters", ...)` block.

## Verified locally

All 17 tests in `forecast-builder.test.ts` now pass, including the three "Open-Meteo co-located values" tests that were failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)