### PR TITLE
feat(db): Surfline shadow-forecast table for MAE head-to-head

### DIFF
--- a/supabase/migrations/20260423180000_create_surfline_shadow_forecasts.sql
+++ b/supabase/migrations/20260423180000_create_surfline_shadow_forecasts.sql
@@ -1,0 +1,43 @@
+-- Shadow-capture Surfline's public wave forecast so we can compare MAE
+-- vs our OM/NOAA forecasts against IOOS buoy ground truth.
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS surfline_shadow_forecasts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  beach_id UUID NOT NULL REFERENCES beaches(id) ON DELETE CASCADE,
+  forecast_ts TIMESTAMPTZ NOT NULL,
+
+  -- Surfline wave height bounds, converted to METERS at ingest
+  wave_height_min_m NUMERIC(4,2),
+  wave_height_max_m NUMERIC(4,2),
+
+  -- Source traceability
+  surfline_spot_id TEXT NOT NULL,
+  fetched_at TIMESTAMPTZ DEFAULT now(),
+
+  CONSTRAINT unique_surfline_beach_forecast_ts UNIQUE (beach_id, forecast_ts)
+);
+
+CREATE INDEX idx_surfline_shadow_beach_ts
+  ON surfline_shadow_forecasts(beach_id, forecast_ts DESC);
+
+-- RLS: Public read, service role write
+ALTER TABLE surfline_shadow_forecasts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY surfline_shadow_select_all
+  ON surfline_shadow_forecasts FOR SELECT USING (true);
+
+CREATE POLICY surfline_shadow_service_role_insert
+  ON surfline_shadow_forecasts FOR INSERT
+  WITH CHECK (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY surfline_shadow_service_role_update
+  ON surfline_shadow_forecasts FOR UPDATE
+  USING (auth.jwt() ->> 'role' = 'service_role')
+  WITH CHECK (auth.jwt() ->> 'role' = 'service_role');
+
+CREATE POLICY surfline_shadow_service_role_delete
+  ON surfline_shadow_forecasts FOR DELETE
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+COMMIT;


### PR DESCRIPTION
## Summary

Adds the `surfline_shadow_forecasts` table that Seaside's `fetch-surfline-shadow` cron (separate PR) will populate with hourly Surfline public forecasts for 11 mapped SoCal / Central Coast beaches.

After 3-5 days of accumulation, we can compute a clean Surfline-vs-NOAA-vs-OM MAE comparison by joining `surfline_shadow_forecasts` to `ml_predictions_log` (which already has matched `observed_m` via the existing backfill-observations cron). This is the Option B validation that closes the "is Quiver actually more accurate than Surfline?" question — complementing the Option A (review synthesis) and Option C (JTBD) work already shipped.

## Schema

- `id` (uuid PK)
- `beach_id` (uuid FK → beaches.id, ON DELETE CASCADE)
- `forecast_ts` (timestamptz)
- `wave_height_min_m` / `wave_height_max_m` (numeric(4,2), converted from Surfline's feet at ingest)
- `surfline_spot_id` (text)
- `fetched_at` (timestamptz)
- `UNIQUE (beach_id, forecast_ts)` for upsert safety
- Index on `(beach_id, forecast_ts DESC)`
- RLS: public SELECT, service_role INSERT/UPDATE/DELETE

Mirrors the style of `20260113200200_create_corrected_forecasts.sql`.

## Deployment

- Migration will be applied via Supabase MCP `apply_migration` after merge (not via `supabase db push`).
- Paired Seaside PR registers the cron that writes into this table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)