### PR TITLE
fix(forecast): match SQL selector format with one-decimal feet

### DIFF
--- a/__tests__/lib/utils/wave-height-selector.test.ts
+++ b/__tests__/lib/utils/wave-height-selector.test.ts
@@ -25,6 +25,22 @@ describe("selectWaveHeightFormatted", () => {
     ).toBe("4.9 ft");
   });
 
+  // Format parity with SQL ROUND(..., 1)::text in supabase/migrations/
+  // 20260423204959_om_primary_bulk_current_forecasts.sql — JavaScript
+  // number→string drops trailing zeros ("5" vs "5.0"), so we must use
+  // toFixed(1) to match the bulk-RPC string exactly.
+  it("formats a whole-foot boundary with one decimal (1.524m = 5.0 ft)", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: 1.524, fallback_ft_string: null }),
+    ).toBe("5.0 ft");
+  });
+
+  it("formats just-under-boundary with one decimal (1.5m = 4.9 ft)", () => {
+    expect(
+      selectWaveHeightFormatted({ om_m: 1.5, fallback_ft_string: null }),
+    ).toBe("4.9 ft");
+  });
+
   it("falls back when om_m is NaN", () => {
     expect(
       selectWaveHeightFormatted({

--- a/lib/utils/wave-height-selector.ts
+++ b/lib/utils/wave-height-selector.ts
@@ -20,8 +20,7 @@ export function selectWaveHeightFormatted(
   if (om_m != null && Number.isFinite(om_m) && om_m >= SMALL_WAVE_GATE_M) {
     const feet = metersToFeet(om_m);
     if (feet == null) return fallback_ft_string;
-    const ft = Math.round(feet * 10) / 10;
-    return `${ft} ft`;
+    return `${feet.toFixed(1)} ft`;
   }
   return fallback_ft_string;
 }


### PR DESCRIPTION
## Summary

The OM-primary wave-height selector was shipped in two places that disagreed on format for whole-foot boundaries.

- **SQL path** (`/api/forecasts/bulk` RPC in `supabase/migrations/20260423204959_om_primary_bulk_current_forecasts.sql:34`):
  `ROUND((ef.wave_height_om * 3.28084)::numeric, 1)::text || ' ft'` -> `"5.0 ft"`
- **TS path** (web rendering in `lib/utils/wave-height-selector.ts`, called from `lib/services/forecast/forecast-builder.ts:273`):
  `Math.round(feet * 10) / 10` + template literal -> `"5 ft"` (JS `number`->`string` drops trailing `.0`)

For `om_m = 1.524` (exactly 5.0 ft), SQL returned `"5.0 ft"` and TS returned `"5 ft"` — same inputs, different UI between the bulk RPC and the render path.

**Fix**: Switch the TS path to `feet.toFixed(1)` so it always produces one decimal place, matching SQL `ROUND(..., 1)::text`.

The SQL migration already ran in prod, so changing TS is the one-way-safe fix.

Reference: Code Reviewer finding on the OM-primary selector work.

## Test plan

- [x] `yarn test:unit __tests__/lib/utils/wave-height-selector.test.ts` — 9/9 passing (includes new `1.524m -> "5.0 ft"` and `1.5m -> "4.9 ft"` cases that codify SQL parity)
- [x] `yarn test:unit __tests__/lib/services/forecast/forecast-builder.test.ts` — 17/17 still passing (mocks the selector)
- [ ] Manual: hit `/api/forecasts/bulk` and compare returned `wave_height_ft` string to the forecast-builder render for a beach where `om_m` rounds to a whole foot (e.g. any row with `ef.wave_height_om ≈ 1.524`) — both should read `"5.0 ft"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)