### PR TITLE
chore: migrate 8 cookie-only-auth routes to withAuth

### DIFF
--- a/__tests__/api/intel-route.test.ts
+++ b/__tests__/api/intel-route.test.ts
@@ -59,20 +59,31 @@ jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServiceRoleClient: jest.fn(() => mockServiceRoleClient),
 }));
 
-// Mock middleware wrappers to pass through and provide context
+// Mock middleware wrappers to pass through and provide context.
+// `withAuth` honours the current mockSupabaseClient.auth.getUser() result so
+// GET (optional auth) can see a null user, and POST (required auth) 401s
+// unless mockAuthenticatedUser() was called first.
 jest.mock("@/lib/middleware/api-wrappers", () => {
   const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  const { NextResponse } = require("next/server");
   return {
     ...actual,
-    withAuth: (handler: any, options: any) => async (request: any) => {
+    withAuth: (handler: any, options: any = {}) => async (request: any) => {
       try {
+        const { data, error } = await mockSupabaseClient.auth.getUser();
+        const user = error ? null : data?.user ?? null;
+        if (!options.optional && !user) {
+          return NextResponse.json(
+            { error: options.authErrorMessage ?? "Authentication required" },
+            { status: 401 },
+          );
+        }
         const context = {
-          user: { id: "test-user-123" },
+          user,
           supabase: mockSupabaseClient,
         };
         return await handler(request, context);
       } catch (error: any) {
-        // Mimic actual withAuth error handling
         const { handleApiError } = jest.requireActual("@/lib/api-utils");
         return handleApiError(error, options?.errorMessage || "Request failed");
       }
@@ -82,7 +93,6 @@ jest.mock("@/lib/middleware/api-wrappers", () => {
       try {
         return await handler(request);
       } catch (error: any) {
-        // Mimic actual withErrorHandler error handling
         const { handleApiError } = jest.requireActual("@/lib/api-utils");
         return handleApiError(error, options?.errorMessage || "Request failed");
       }
@@ -522,6 +532,9 @@ describe("POST /api/intel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.ALLOW_E2E_MUTATIONS_DEV;
+    // POST is withAuth(required). Default to authed; individual tests can
+    // override via mockUnauthenticatedUser() to assert 401 behavior.
+    mockAuthenticatedUser("test-user-123");
   });
 
   describe("Authentication", () => {

--- a/__tests__/api/profile/profile-by-id-homebeach.test.ts
+++ b/__tests__/api/profile/profile-by-id-homebeach.test.ts
@@ -11,9 +11,35 @@ import {
 
 const mockSupabaseClient = createMockSupabaseClient();
 
-jest.mock("@/lib/middleware/api-wrappers", () => ({
-  withBotBlockingAndRateLimit: (handler: any) => handler,
-}));
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  return {
+    ...actual,
+    withBotBlockingAndRateLimit: (handler: any) => handler,
+    withAuth:
+      (handler: any, options: any = {}) =>
+      async (request: any, context: any) => {
+        const { data, error } = await mockSupabaseClient.auth.getUser();
+        const user = error ? null : data?.user ?? null;
+        if (!options.optional && !user) {
+          const { createAuthError } = jest.requireActual("@/lib/api-utils");
+          return createAuthError(
+            options.authErrorMessage ?? "Authentication required"
+          );
+        }
+        const resolvedParams = context?.params
+          ? typeof context.params === "object" && "then" in context.params
+            ? await context.params
+            : context.params
+          : {};
+        return await handler(request, {
+          params: resolvedParams,
+          user,
+          supabase: mockSupabaseClient,
+        });
+      },
+  };
+});
 
 jest.mock("@/lib/supabase/api-server-client", () => ({
   createAPIServerClient: jest.fn(() => mockSupabaseClient),

--- a/__tests__/api/profile/profile-by-id.test.ts
+++ b/__tests__/api/profile/profile-by-id.test.ts
@@ -24,9 +24,38 @@ import {
 // Mock the Supabase API server client
 const mockSupabaseClient = createMockSupabaseClient();
 
-jest.mock("@/lib/middleware/api-wrappers", () => ({
-  withBotBlockingAndRateLimit: (handler: any) => handler,
-}));
+// withAuth is now optional-auth on this route. Mock it to inspect
+// `mockSupabaseClient.auth.getUser()` so the handler receives the user
+// exactly as the real wrapper would.
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  return {
+    ...actual,
+    withBotBlockingAndRateLimit: (handler: any) => handler,
+    withAuth:
+      (handler: any, options: any = {}) =>
+      async (request: any, context: any) => {
+        const { data, error } = await mockSupabaseClient.auth.getUser();
+        const user = error ? null : data?.user ?? null;
+        if (!options.optional && !user) {
+          const { createAuthError } = jest.requireActual("@/lib/api-utils");
+          return createAuthError(
+            options.authErrorMessage ?? "Authentication required"
+          );
+        }
+        const resolvedParams = context?.params
+          ? typeof context.params === "object" && "then" in context.params
+            ? await context.params
+            : context.params
+          : {};
+        return await handler(request, {
+          params: resolvedParams,
+          user,
+          supabase: mockSupabaseClient,
+        });
+      },
+  };
+});
 
 jest.mock("@/lib/supabase/api-server-client", () => ({
   createAPIServerClient: jest.fn(() => mockSupabaseClient),

--- a/__tests__/api/session-planner/invitations-create.test.ts
+++ b/__tests__/api/session-planner/invitations-create.test.ts
@@ -14,7 +14,8 @@ import {
   mockUnauthenticatedUser,
 } from "@/test-utils/api-test-helpers";
 
-// Mock the api-utils functions
+// Mock the api-utils functions. Must include handleApiError + createAuthError
+// because lib/middleware/api-wrappers (which wraps the route) imports them.
 jest.mock("@/lib/api-utils", () => ({
   createSuccessResponse: jest.fn((data, status = 200) => {
     return new Response(
@@ -37,6 +38,28 @@ jest.mock("@/lib/api-utils", () => ({
       { status }
     );
   }),
+  createAuthError: jest.fn((message = "Authentication required") => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: message,
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 401 }
+    );
+  }),
+  handleApiError: jest.fn((error: any, fallback?: string) => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: fallback ?? "Internal error",
+        details: error instanceof Error ? error.message : String(error),
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 500 }
+    );
+  }),
+  DEFAULT_SECURITY_HEADERS: {},
 }));
 
 // Mock the Supabase server client

--- a/__tests__/api/session-planner/invitations-list.test.ts
+++ b/__tests__/api/session-planner/invitations-list.test.ts
@@ -14,7 +14,8 @@ import {
   mockUnauthenticatedUser,
 } from "@/test-utils/api-test-helpers";
 
-// Mock the api-utils functions
+// Mock the api-utils functions. Must include handleApiError + createAuthError
+// because lib/middleware/api-wrappers (which wraps the route) imports them.
 jest.mock("@/lib/api-utils", () => ({
   createSuccessResponse: jest.fn((data, status = 200) => {
     return new Response(
@@ -37,6 +38,28 @@ jest.mock("@/lib/api-utils", () => ({
       { status }
     );
   }),
+  createAuthError: jest.fn((message = "Authentication required") => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: message,
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 401 }
+    );
+  }),
+  handleApiError: jest.fn((error: any, fallback?: string) => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: fallback ?? "Internal error",
+        details: error instanceof Error ? error.message : String(error),
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 500 }
+    );
+  }),
+  DEFAULT_SECURITY_HEADERS: {},
 }));
 
 // Mock the Supabase server client

--- a/__tests__/api/session-planner/invitations-respond.test.ts
+++ b/__tests__/api/session-planner/invitations-respond.test.ts
@@ -14,7 +14,8 @@ import {
   mockUnauthenticatedUser,
 } from "@/test-utils/api-test-helpers";
 
-// Mock the api-utils functions
+// Mock the api-utils functions. Must include handleApiError + createAuthError
+// because lib/middleware/api-wrappers (which wraps the route) imports them.
 jest.mock("@/lib/api-utils", () => ({
   createSuccessResponse: jest.fn((data, status = 200) => {
     return new Response(
@@ -37,6 +38,28 @@ jest.mock("@/lib/api-utils", () => ({
       { status }
     );
   }),
+  createAuthError: jest.fn((message = "Authentication required") => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: message,
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 401 }
+    );
+  }),
+  handleApiError: jest.fn((error: any, fallback?: string) => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: fallback ?? "Internal error",
+        details: error instanceof Error ? error.message : String(error),
+        timestamp: new Date().toISOString(),
+      }),
+      { status: 500 }
+    );
+  }),
+  DEFAULT_SECURITY_HEADERS: {},
 }));
 
 // Mock the Supabase server client

--- a/__tests__/api/sessions/session-photos.test.ts
+++ b/__tests__/api/sessions/session-photos.test.ts
@@ -26,6 +26,43 @@ jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: jest.fn(() => mockSupabaseClient),
 }));
 
+// Route is now withAuth({ optional: true }): auth.getUser() is consulted,
+// but a null user still reaches the handler. Private-session ownership
+// check is enforced inside the handler.
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  return {
+    ...actual,
+    withAuth:
+      (handler: any, options: any = {}) =>
+      async (request: any, context: any) => {
+        try {
+          const { data, error } = await mockSupabaseClient.auth.getUser();
+          const user = error ? null : data?.user ?? null;
+          if (!options.optional && !user) {
+            const { createAuthError } = jest.requireActual("@/lib/api-utils");
+            return createAuthError(
+              options.authErrorMessage ?? "Authentication required"
+            );
+          }
+          const resolvedParams = context?.params
+            ? typeof context.params === "object" && "then" in context.params
+              ? await context.params
+              : context.params
+            : {};
+          return await handler(request, {
+            params: resolvedParams,
+            user,
+            supabase: mockSupabaseClient,
+          });
+        } catch (err: any) {
+          const { handleApiError } = jest.requireActual("@/lib/api-utils");
+          return handleApiError(err, options?.errorMessage ?? "Internal error");
+        }
+      },
+  };
+});
+
 // Mock getSessionPhotos helper
 jest.mock("@/lib/supabase/storage", () => ({
   getSessionPhotos: jest.fn(),
@@ -119,11 +156,11 @@ describe("GET /api/sessions/[id]/photos", () => {
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
       expect(data.data.photos).toHaveLength(1);
-      // Critical: supabase.auth.getUser() must NOT be called for public
-      // sessions — the RLS policy "Public can view media from public sessions"
-      // handles authorization at the DB layer. Calling getUser would add
-      // unnecessary latency and block anonymous callers.
-      expect(mockAuthGetUser).not.toHaveBeenCalled();
+      // Route is now `withAuth({ optional: true })`, so auth.getUser() IS
+      // called to determine whether a Bearer/cookie session exists — but a
+      // null user still reaches the handler, and public sessions skip the
+      // ownership check. The assertion that matters is that an anonymous
+      // caller successfully reads photos from a public session.
     });
   });
 

--- a/__tests__/app/api/events/route.test.ts
+++ b/__tests__/app/api/events/route.test.ts
@@ -7,7 +7,10 @@
  * It respects user privacy settings (allow_implicit_tracking).
  */
 
-import { POST } from '@/app/api/events/route';
+import { POST as _POST } from '@/app/api/events/route';
+// Tests call POST with a plain Request for brevity; the real signature is
+// NextRequest. Cast to loosen for the test harness only.
+const POST = _POST as unknown as (req: Request, ctx?: any) => Promise<Response>;
 import { __clearTrackingCache } from '@/lib/services/tracking-cache';
 import { createServiceRoleClient } from '@/lib/supabase';
 

--- a/__tests__/app/api/events/route.test.ts
+++ b/__tests__/app/api/events/route.test.ts
@@ -9,17 +9,44 @@
 
 import { POST } from '@/app/api/events/route';
 import { __clearTrackingCache } from '@/lib/services/tracking-cache';
-import { createAPIServerClient } from '@/lib/supabase/api-server-client';
 import { createServiceRoleClient } from '@/lib/supabase';
-
-// Mock Supabase client
-jest.mock('@/lib/supabase/api-server-client', () => ({
-  createAPIServerClient: jest.fn(),
-}));
 
 jest.mock('@/lib/supabase', () => ({
   createServiceRoleClient: jest.fn(),
 }));
+
+// Route is now withAuth({ optional: true }). The wrapper reads the user
+// from `mockSupabaseClient.auth.getUser()` and passes the same client
+// into the handler as `supabase`. Insert/profile lookups go through this
+// client, matching the legacy createAPIServerClient-based test shape.
+jest.mock('@/lib/middleware/api-wrappers', () => {
+  const actual = jest.requireActual('@/lib/middleware/api-wrappers');
+  return {
+    ...actual,
+    withAuth:
+      (handler: any, options: any = {}) =>
+      async (request: any, context: any) => {
+        const { data, error } = await mockSupabase.auth.getUser();
+        const user = error ? null : data?.user ?? null;
+        if (!options.optional && !user) {
+          const { createAuthError } = jest.requireActual('@/lib/api-utils');
+          return createAuthError(
+            options.authErrorMessage ?? 'Authentication required'
+          );
+        }
+        const resolvedParams = context?.params
+          ? typeof context.params === 'object' && 'then' in context.params
+            ? await context.params
+            : context.params
+          : {};
+        return await handler(request, {
+          params: resolvedParams,
+          user,
+          supabase: mockSupabase,
+        });
+      },
+  };
+});
 
 const mockSupabase = {
   auth: {
@@ -52,7 +79,6 @@ describe('POST /api/events', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     __clearTrackingCache(); // Clear the in-memory cache between tests
-    (createAPIServerClient as jest.Mock).mockReturnValue(mockSupabase);
   });
 
   it('returns 401 for unauthenticated requests', async () => {

--- a/app/api/auth/email/update/route.ts
+++ b/app/api/auth/email/update/route.ts
@@ -1,27 +1,28 @@
 import { NextRequest } from "next/server";
 import {
+  withAuth,
+  withRateLimit,
   createSuccessResponse,
-  handleApiError,
   createValidationError,
-  createAuthError,
-} from "@/lib/api-utils";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+  type AuthenticatedContext,
+} from "@/lib/middleware/api-wrappers";
 
-export async function POST(request: NextRequest) {
-  try {
+/**
+ * POST /api/auth/email/update
+ *
+ * Initiates an email-change flow for the authenticated user. Supabase sends
+ * confirmation links to both current and new addresses.
+ *
+ * Authentication is REQUIRED (cookie or Bearer). Composition order matters:
+ * `withRateLimit(withAuth(handler))` — the outer rate-limit guards the
+ * inner auth-gated handler, matching the pattern used by other protected
+ * mutation routes.
+ */
+const emailUpdateHandler = withAuth(
+  async (request: NextRequest, { supabase }: AuthenticatedContext) => {
     const { newEmail } = await request.json().catch(() => ({}));
     if (!newEmail || typeof newEmail !== "string") {
       return createValidationError("newEmail is required");
-    }
-
-    const supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-      error,
-    } = await supabase.auth.getUser();
-
-    if (error || !user) {
-      return createAuthError();
     }
 
     const { error: updateError } = await supabase.auth.updateUser({
@@ -30,10 +31,12 @@ export async function POST(request: NextRequest) {
 
     if (updateError) throw updateError;
 
-    return createSuccessResponse({ message: "Email update process initiated. Please check your current and new email for confirmation links." });
-  } catch (error) {
-    return handleApiError(error, "Failed to update email");
-  }
-}
+    return createSuccessResponse({
+      message:
+        "Email update process initiated. Please check your current and new email for confirmation links.",
+    });
+  },
+  { errorMessage: "Failed to update email" }
+);
 
-
+export const POST = withRateLimit(emailUpdateHandler, "authenticated-default");

--- a/app/api/comments/[commentId]/route.ts
+++ b/app/api/comments/[commentId]/route.ts
@@ -1,24 +1,20 @@
 import { NextRequest } from "next/server";
-import { createSuccessResponse, handleApiError, createAuthError, createValidationError, methodNotAllowed, isValidUuid } from "@/lib/api-utils";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createValidationError, isValidUuid } from "@/lib/api-utils";
+import {
+  withAuth,
+  createSuccessResponse,
+  methodNotAllowed,
+  type AuthenticatedContext,
+} from "@/lib/middleware/api-wrappers";
 
-export async function DELETE(
-  _request: NextRequest,
-  context: { params: Promise<{ commentId: string }> }
-) {
-  try {
-    const { commentId } = (await context.params);
+export const DELETE = withAuth(
+  async (
+    _request: NextRequest,
+    { user, supabase, params }: AuthenticatedContext
+  ) => {
+    const commentId = params.commentId;
     if (!commentId || !isValidUuid(commentId)) {
       return createValidationError("Invalid comment id format");
-    }
-    const supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-      error,
-    } = await supabase.auth.getUser();
-
-    if (error || !user) {
-      return createAuthError();
     }
 
     const { error: deleteError } = await supabase
@@ -30,13 +26,10 @@ export async function DELETE(
     if (deleteError) throw deleteError;
 
     return createSuccessResponse({ message: "Comment deleted successfully" });
-  } catch (error) {
-    return handleApiError(error, "Failed to delete comment");
-  }
-}
+  },
+  { errorMessage: "Failed to delete comment" }
+);
 
 export function GET() {
   return methodNotAllowed(["DELETE"]);
 }
-
-

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -9,12 +9,15 @@
  * Response: { ok: boolean, status?: 'tracking_disabled' | 'rate_limited' }
  */
 
-import { createAPIServerClient } from '@/lib/supabase/api-server-client';
 import {
   createSuccessResponse,
   createAuthError,
   createErrorResponse,
 } from '@/lib/api-utils';
+import {
+  withAuth,
+  type OptionalAuthContext,
+} from '@/lib/middleware/api-wrappers';
 import type {
   ImplicitEventType,
   TrackEventRequest,
@@ -270,7 +273,7 @@ import { isValidUUID } from '@/lib/utils/validation';
  * Uses 5-minute in-memory cache to reduce database queries
  */
 async function isTrackingAllowed(
-  supabase: Awaited<ReturnType<typeof createAPIServerClient>>,
+  supabase: OptionalAuthContext['supabase'],
   userId: string
 ): Promise<boolean> {
   // Check cache first (using LRU-aware getter)
@@ -298,7 +301,21 @@ async function isTrackingAllowed(
   return allowed;
 }
 
-export async function POST(request: Request) {
+/**
+ * POST /api/events
+ *
+ * Authentication: OPTIONAL via withAuth({ optional: true }). Two flows:
+ *   • Authenticated (cookie OR Bearer) — writes user-scoped event via
+ *     request-scoped supabase client. Native Bearer callers previously
+ *     dropped silently because the route ignored Authorization headers.
+ *   • Anonymous — requires body.sessionId, writes nullable user_id event
+ *     via the service-role client (bypassing RLS). Unchanged.
+ */
+export const POST = withAuth(
+  async (
+    request,
+    { user, supabase }: OptionalAuthContext
+  ) => {
   // 1. Bot filtering — silent 200 OK so bots don't learn they're detected
   const ua = request.headers.get('user-agent') || '';
   const acceptLanguage = request.headers.get('accept-language');
@@ -321,7 +338,7 @@ export async function POST(request: Request) {
     return createSuccessResponse({ ok: true, status: 'bot_filtered' });
   }
 
-  // 2. Parse request body first (before auth check, needed for anonymous flow)
+  // 2. Parse request body (needed for anonymous flow + fingerprint check)
   let body: TrackEventRequest;
   try {
     body = await request.json();
@@ -343,16 +360,8 @@ export async function POST(request: Request) {
 
   const { eventType, beachId } = body;
 
-  // 4. Try auth
-  const supabase = await createAPIServerClient();
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (!authError && user) {
-    // Authenticated flow
-
+  // 4. Authenticated flow (user resolved by withAuth from cookie OR Bearer)
+  if (user) {
     // Rate limiting check
     const rateLimit = checkRateLimit(user.id);
     if (!rateLimit.allowed) {
@@ -502,4 +511,6 @@ export async function POST(request: Request) {
 
   // 6. Neither authenticated nor anonymous sessionId
   return createAuthError('Unauthorized');
-}
+  },
+  { optional: true, errorMessage: 'Failed to record event' }
+);

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -9,6 +9,7 @@
  * Response: { ok: boolean, status?: 'tracking_disabled' | 'rate_limited' }
  */
 
+import { NextResponse } from 'next/server';
 import {
   createSuccessResponse,
   createAuthError,
@@ -16,8 +17,8 @@ import {
 } from '@/lib/api-utils';
 import {
   withAuth,
-  type OptionalAuthContext,
 } from '@/lib/middleware/api-wrappers';
+import type { OptionalAuthContext } from '@/lib/middleware/api-wrappers/types';
 import type {
   ImplicitEventType,
   TrackEventRequest,
@@ -365,16 +366,15 @@ export const POST = withAuth(
     // Rate limiting check
     const rateLimit = checkRateLimit(user.id);
     if (!rateLimit.allowed) {
-      return new Response(
-        JSON.stringify({
+      return NextResponse.json(
+        {
           ok: false,
           status: 'rate_limited',
           error: 'Too many requests. Please try again later.',
-        }),
+        },
         {
           status: 429,
           headers: {
-            'Content-Type': 'application/json',
             'X-RateLimit-Limit': RATE_LIMIT.toString(),
             'X-RateLimit-Remaining': '0',
             'X-RateLimit-Reset': Math.ceil(rateLimit.resetAt / 1000).toString(),
@@ -405,7 +405,7 @@ export const POST = withAuth(
     }
 
     // Insert event
-    const { error: insertError } = await supabase.from('user_events').insert({
+    const { error: insertError } = await (supabase as any).from('user_events').insert({
       user_id: user.id,
       event_type: eventType,
       beach_id: beachId || null,
@@ -436,16 +436,15 @@ export const POST = withAuth(
 
     const anonRateLimit = checkRateLimit(`anon:${body.sessionId}`, ANON_RATE_LIMIT);
     if (!anonRateLimit.allowed) {
-      return new Response(
-        JSON.stringify({
+      return NextResponse.json(
+        {
           ok: false,
           status: 'rate_limited',
           error: 'Too many requests. Please try again later.',
-        }),
+        },
         {
           status: 429,
           headers: {
-            'Content-Type': 'application/json',
             'X-RateLimit-Limit': ANON_RATE_LIMIT.toString(),
             'X-RateLimit-Remaining': '0',
             'X-RateLimit-Reset': Math.ceil(anonRateLimit.resetAt / 1000).toString(),

--- a/app/api/intel/route.ts
+++ b/app/api/intel/route.ts
@@ -14,8 +14,8 @@ import { normalizeCoordinates } from "@/lib/types/coordinates";
 import {
   withAuth,
   type AuthenticatedContext,
-  type OptionalAuthContext,
 } from "@/lib/middleware/api-wrappers";
+import type { OptionalAuthContext } from "@/lib/middleware/api-wrappers/types";
 
 export const dynamic = "force-dynamic";
 
@@ -168,7 +168,9 @@ const intelGetHandler = withAuth(
     }
 
     // Combine data
-    const profilesMap = new Map(profiles?.map((p) => [p.id, p]) || []);
+    const profilesMap = new Map<string, { id: string; full_name: string | null; avatar_url: string | null }>(
+      profiles?.map((p: { id: string; full_name: string | null; avatar_url: string | null }) => [p.id, p]) || []
+    );
     const confirmationsSet = new Set(
       userConfirmations.map((c) => c.intel_post_id)
     );

--- a/app/api/intel/route.ts
+++ b/app/api/intel/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createSupabaseServerClient, createSupabaseServiceRoleClient } from "@/lib/supabase/server";
-import { createSuccessResponse, handleApiError, validateOrError, createValidationError } from "@/lib/api-utils";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+import { createSuccessResponse, validateOrError, createValidationError } from "@/lib/api-utils";
 import { INTEL_CONFIG } from "@/lib/constants/intel";
 import type { IntelPostTag, IntelPostWithUser } from "@/types/database";
 import {
@@ -9,9 +9,13 @@ import {
 } from "@/lib/utils/intel-dedupe";
 import { parseAndValidateJson } from "@/lib/validation/middleware";
 import { IntelPostCreateSchema } from "@/lib/validation/schemas";
-import { withBotBlockingAndRateLimit, withErrorHandler } from "@/lib/middleware/api-wrappers";
+import { withBotBlockingAndRateLimit } from "@/lib/middleware/api-wrappers";
 import { normalizeCoordinates } from "@/lib/types/coordinates";
-import { withAuth, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
+import {
+  withAuth,
+  type AuthenticatedContext,
+  type OptionalAuthContext,
+} from "@/lib/middleware/api-wrappers";
 
 export const dynamic = "force-dynamic";
 
@@ -52,79 +56,139 @@ interface CreateIntelPostData {
  * GET /api/intel
  * Returns nearby intel posts with user data and confirmation status
  * Query params: lat/lon (preferred), lat/lng (legacy), radius (miles), tag, limit
+ *
+ * Authentication: Optional. Anonymous callers still get the posts; the
+ * `user_confirmed` flag is only populated for authenticated viewers.
  */
-async function intelGetHandler(request: NextRequest): Promise<NextResponse> {
-  const { searchParams } = new URL(request.url);
+const intelGetHandler = withAuth(
+  async (
+    request: NextRequest,
+    { user, supabase }: OptionalAuthContext
+  ): Promise<NextResponse> => {
+    const { searchParams } = new URL(request.url);
 
-  const coords = normalizeCoordinates(
-    {
-      lat: searchParams.get("lat"),
-      lon: searchParams.get("lon"),
-      lng: searchParams.get("lng"),
-      latitude: searchParams.get("latitude"),
-      longitude: searchParams.get("longitude"),
-    },
-    { context: "GET /api/intel" }
-  );
-  const radius = parseFloat(
-    searchParams.get("radius") || INTEL_CONFIG.DEFAULT_RADIUS_MILES.toString()
-  );
-  const tag = searchParams.get("tag") as IntelPostTag | "all" | null;
-  const limit = Math.min(
-    parseInt(
-      searchParams.get("limit") || INTEL_CONFIG.DEFAULT_LIMIT.toString()
-    ),
-    INTEL_CONFIG.MAX_LIMIT
-  );
-
-  // Validate required parameters
-  if (!coords) {
-    return createValidationError("Latitude and longitude are required", {
-      required: ["lat", "lon"],
-      accepted_legacy: ["lng", "latitude", "longitude"],
-    });
-  }
-
-  // Validate radius
-  if (radius > INTEL_CONFIG.MAX_RADIUS_MILES) {
-    return createValidationError(
-      `Radius cannot exceed ${INTEL_CONFIG.MAX_RADIUS_MILES} miles`,
+    const coords = normalizeCoordinates(
       {
-        providedRadiusMiles: radius,
-        maxRadiusMiles: INTEL_CONFIG.MAX_RADIUS_MILES,
+        lat: searchParams.get("lat"),
+        lon: searchParams.get("lon"),
+        lng: searchParams.get("lng"),
+        latitude: searchParams.get("latitude"),
+        longitude: searchParams.get("longitude"),
+      },
+      { context: "GET /api/intel" }
+    );
+    const radius = parseFloat(
+      searchParams.get("radius") || INTEL_CONFIG.DEFAULT_RADIUS_MILES.toString()
+    );
+    const tag = searchParams.get("tag") as IntelPostTag | "all" | null;
+    const limit = Math.min(
+      parseInt(
+        searchParams.get("limit") || INTEL_CONFIG.DEFAULT_LIMIT.toString()
+      ),
+      INTEL_CONFIG.MAX_LIMIT
+    );
+
+    // Validate required parameters
+    if (!coords) {
+      return createValidationError("Latitude and longitude are required", {
+        required: ["lat", "lon"],
+        accepted_legacy: ["lng", "latitude", "longitude"],
+      });
+    }
+
+    // Validate radius
+    if (radius > INTEL_CONFIG.MAX_RADIUS_MILES) {
+      return createValidationError(
+        `Radius cannot exceed ${INTEL_CONFIG.MAX_RADIUS_MILES} miles`,
+        {
+          providedRadiusMiles: radius,
+          maxRadiusMiles: INTEL_CONFIG.MAX_RADIUS_MILES,
+        }
+      );
+    }
+
+    const currentUserId = user?.id;
+
+    // Use the database function for geo-query
+    const { data: intelPosts, error: intelError } = await supabase.rpc(
+      "get_nearby_intel_posts",
+      {
+        center_lat: coords.lat,
+        center_lng: coords.lon,
+        radius_miles: radius,
+        tag_filter: (tag === "all" || tag == null) ? undefined : tag,
+        limit_count: limit,
       }
     );
-  }
 
-  const supabase = await createSupabaseServerClient();
-
-  // Get current user for confirmation status
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  const currentUserId = user?.id;
-
-  // Use the database function for geo-query
-  const { data: intelPosts, error: intelError } = await supabase.rpc(
-    "get_nearby_intel_posts",
-    {
-      center_lat: coords.lat,
-      center_lng: coords.lon,
-      radius_miles: radius,
-      tag_filter: (tag === "all" || tag == null) ? undefined : tag,
-      limit_count: limit,
+    if (intelError) {
+      console.error("Error fetching intel posts:", intelError);
+      throw intelError;
     }
-  );
 
-  if (intelError) {
-    console.error("Error fetching intel posts:", intelError);
-    throw intelError;
-  }
+    if (!intelPosts || intelPosts.length === 0) {
+      return createSuccessResponse({
+        posts: [],
+        total: 0,
+        filters: {
+          latitude: coords.lat,
+          longitude: coords.lon,
+          radius,
+          tag: tag || "all",
+          limit,
+        },
+      });
+    }
 
-  if (!intelPosts || intelPosts.length === 0) {
+    // Get user details for posts
+    const userIds = [...new Set(intelPosts.map((post: any) => post.user_id))];
+    const { data: profiles, error: profilesError } = await supabase
+      .from("profiles")
+      .select("id, full_name, avatar_url")
+      .in("id", userIds);
+
+    // If profile lookup fails (RLS or other), continue with fallback names from RPC
+    if (profilesError) {
+      console.warn("Profiles lookup failed; continuing with fallback usernames from RPC", profilesError);
+    }
+
+    // Get user confirmations if authenticated
+    let userConfirmations: any[] = [];
+    if (currentUserId) {
+      const postIds = intelPosts.map((post: any) => post.id);
+      const { data: confirmations, error: confirmationsError } = await supabase
+        .from("intel_post_confirmations")
+        .select("intel_post_id")
+        .eq("user_id", currentUserId)
+        .in("intel_post_id", postIds);
+
+      if (!confirmationsError && confirmations) {
+        userConfirmations = confirmations;
+      }
+    }
+
+    // Combine data
+    const profilesMap = new Map(profiles?.map((p) => [p.id, p]) || []);
+    const confirmationsSet = new Set(
+      userConfirmations.map((c) => c.intel_post_id)
+    );
+
+    const enrichedPosts: IntelPostWithUser[] = intelPosts.map((post: any) => {
+      const profile = profilesMap.get(post.user_id);
+      return {
+        ...post,
+        user: {
+          id: post.user_id,
+          full_name: profile?.full_name || (post as any).user_name || "Anonymous",
+          avatar_url: profile?.avatar_url || null,
+        },
+        user_confirmed: confirmationsSet.has(post.id),
+      };
+    });
+
     return createSuccessResponse({
-      posts: [],
-      total: 0,
+      posts: enrichedPosts,
+      total: enrichedPosts.length,
       filters: {
         latitude: coords.lat,
         longitude: coords.lon,
@@ -133,70 +197,13 @@ async function intelGetHandler(request: NextRequest): Promise<NextResponse> {
         limit,
       },
     });
-  }
+  },
+  { optional: true, errorMessage: "Failed to fetch intel posts" }
+);
 
-  // Get user details for posts
-  const userIds = [...new Set(intelPosts.map((post: any) => post.user_id))];
-  const { data: profiles, error: profilesError } = await supabase
-    .from("profiles")
-    .select("id, full_name, avatar_url")
-    .in("id", userIds);
-
-  // If profile lookup fails (RLS or other), continue with fallback names from RPC
-  if (profilesError) {
-    console.warn("Profiles lookup failed; continuing with fallback usernames from RPC", profilesError);
-  }
-
-  // Get user confirmations if authenticated
-  let userConfirmations: any[] = [];
-  if (currentUserId) {
-    const postIds = intelPosts.map((post: any) => post.id);
-    const { data: confirmations, error: confirmationsError } = await supabase
-      .from("intel_post_confirmations")
-      .select("intel_post_id")
-      .eq("user_id", currentUserId)
-      .in("intel_post_id", postIds);
-
-    if (!confirmationsError && confirmations) {
-      userConfirmations = confirmations;
-    }
-  }
-
-  // Combine data
-  const profilesMap = new Map(profiles?.map((p) => [p.id, p]) || []);
-  const confirmationsSet = new Set(
-    userConfirmations.map((c) => c.intel_post_id)
-  );
-
-  const enrichedPosts: IntelPostWithUser[] = intelPosts.map((post: any) => {
-    const profile = profilesMap.get(post.user_id);
-    return {
-      ...post,
-      user: {
-        id: post.user_id,
-        full_name: profile?.full_name || (post as any).user_name || "Anonymous",
-        avatar_url: profile?.avatar_url || null,
-      },
-      user_confirmed: confirmationsSet.has(post.id),
-    };
-  });
-
-  return createSuccessResponse({
-    posts: enrichedPosts,
-    total: enrichedPosts.length,
-    filters: {
-      latitude: coords.lat,
-      longitude: coords.lon,
-      radius,
-      tag: tag || "all",
-      limit,
-    },
-  });
-}
-
-// Apply bot blocking, rate limiting, and error handling to public GET endpoint
+// Compose: bot blocking + rate limit → optional-auth handler.
 export const GET = withBotBlockingAndRateLimit(
-  withErrorHandler(intelGetHandler, { errorMessage: "Failed to fetch intel posts" }),
+  intelGetHandler,
   "public-default"
 );
 

--- a/app/api/internal/send-welcome-email/route.ts
+++ b/app/api/internal/send-welcome-email/route.ts
@@ -31,6 +31,8 @@ export const runtime = "nodejs";
 const CONTEXT_TAG = "[send-welcome-email]";
 const EMAIL_TYPE = "welcome" as const;
 
+// NOTE: cookie-only auth is intentional — called server-side right after
+// signup when cookies are the authoritative session. Native never calls this.
 async function handler(request: NextRequest) {
   try {
     // Verify the user is authenticated

--- a/app/api/profile/[id]/route.ts
+++ b/app/api/profile/[id]/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createAPIServerClient } from "@/lib/supabase/api-server-client";
 import { createSuccessResponse, handleApiError } from "@/lib/api-utils";
 import { getProfileDTOById, getProfileWithHomeBeachById } from "@/lib/profile/fetchers";
-import { withBotBlockingAndRateLimit } from "@/lib/middleware/api-wrappers";
+import {
+  withAuth,
+  withBotBlockingAndRateLimit,
+  type OptionalAuthContext,
+} from "@/lib/middleware/api-wrappers";
 import { PROFILE_FULL_SELECT } from "@/lib/profile/constants";
 import type { ProfileDTO } from "@/types/profile";
 
@@ -37,137 +40,122 @@ interface ProfileDetails {
 export const dynamic = 'force-dynamic';
 
 /**
- * Core handler for fetching user profile by ID
- */
-async function fetchProfileById(userId: string): Promise<NextResponse> {
-  try {
-    if (!userId) {
-      return createSuccessResponse(
-        { error: "User ID is required" },
-        400
-      );
-    }
-
-    const supabase = await createAPIServerClient();
-
-    // Get current user for authentication (optional for public profiles)
-    const { data: { user } } = await supabase.auth.getUser();
-
-    // Get user profile DTO via view; fallback to joined query if the view is missing in dev/test
-    let base: ProfileDTO | null = null;
-    try {
-      base = await getProfileDTOById(userId, supabase);
-    } catch (e) {
-      // Fallback path for environments without the materialized view
-      const { profile, homeBeachName } = await getProfileWithHomeBeachById(userId, supabase);
-      base = {
-        id: profile.id,
-        full_name: profile.full_name ?? null,
-        home_beach_id: profile.home_beach_id ?? null,
-        homeBeachName: homeBeachName,
-        home_beach: profile.home_beach ?? null,
-      } as ProfileDTO;
-    }
-
-    // Fetch additional profile details and counters expected by clients/tests
-    const { data: details } = await supabase
-      .from("profiles")
-      .select(PROFILE_FULL_SELECT)
-      .eq("id", userId)
-      .single<ProfileDetails>();
-
-    // Add session stats (only public sessions for privacy)
-    const { data: sessions, error: sessionsError } = await supabase
-      .from("sessions")
-      .select("id, rating, status")
-      .eq("user_id", userId)
-      .eq("is_public", true);
-
-    let sessionStats: { session_count: number; average_rating: number | null } = {
-      session_count: 0,
-      average_rating: null,
-    };
-
-    if (!sessionsError && sessions) {
-      const completedSessions = sessions.filter(s => s.status === "completed");
-      sessionStats.session_count = completedSessions.length;
-
-      if (completedSessions.length > 0) {
-        const totalRating = completedSessions.reduce((sum, s) => sum + (s.rating || 0), 0);
-        sessionStats.average_rating = Math.round((totalRating / completedSessions.length) * 10) / 10;
-      }
-    }
-
-    // Check if current user is following this user (if authenticated)
-    let isFollowingUser = false;
-    if (user && user.id !== userId) {
-      const { data: followData } = await supabase
-        .from("user_follows")
-        .select("id")
-        .eq("follower_id", user.id)
-        .eq("following_id", userId)
-        .single();
-
-      isFollowingUser = !!followData;
-    }
-
-    const profileWithStats = {
-      ...(base as ProfileDTO),
-      followers_count: details?.followers_count ?? 0,
-      following_count: details?.following_count ?? 0,
-      created_at: details?.created_at ?? null,
-      // Optional details for richer UI rendering
-      avatar_url: details?.avatar_url ?? null,
-      email: details?.email ?? null,
-      bio: details?.bio ?? null,
-      location: details?.location ?? null,
-      experience_level: details?.experience_level ?? null,
-      instagram: details?.instagram ?? null,
-      home_beach: details?.home_beach ?? null,
-      // Surf preferences
-      surf_styles: details?.surf_styles ?? null,
-      // Notification preferences
-      notif_push_enabled: details?.notif_push_enabled ?? true,
-      notif_forecast_alerts: details?.notif_forecast_alerts ?? true,
-      notif_email_enabled: details?.notif_email_enabled ?? true,
-      notif_inapp_enabled: details?.notif_inapp_enabled ?? true,
-      notif_session_invites: details?.notif_session_invites ?? true,
-      notif_likes: details?.notif_likes ?? true,
-      notif_follows: details?.notif_follows ?? true,
-      notif_reminders: details?.notif_reminders ?? true,
-      notif_xp_updates: details?.notif_xp_updates ?? true,
-      // Onboarding tracking
-      onboarding_completed_at: details?.onboarding_completed_at ?? null,
-      ...sessionStats,
-      isFollowing: isFollowingUser,
-      isOwnProfile: user?.id === userId,
-    };
-
-    return createSuccessResponse(profileWithStats);
-
-  } catch (error) {
-    console.error("Error fetching user profile:", error);
-    return handleApiError(error);
-  }
-}
-
-/**
  * Get user profile by ID
  * GET /api/profile/[id]
  *
- * Bot blocking and rate limiting applied to prevent abuse
+ * Authentication is OPTIONAL — profiles are public. `isFollowing` and
+ * `isOwnProfile` are populated only when a user is authenticated (cookie
+ * or Bearer). Bot blocking + rate limiting wrap the outside.
  */
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-): Promise<NextResponse> {
-  const { id } = await params;
+const profileHandler = withAuth(
+  async (
+    _request: NextRequest,
+    { user, supabase, params }: OptionalAuthContext
+  ): Promise<NextResponse> => {
+    try {
+      const userId = params.id;
+      if (!userId) {
+        return createSuccessResponse({ error: "User ID is required" }, 400);
+      }
 
-  // Wrap the handler with bot blocking and rate limiting
-  const wrappedHandler = withBotBlockingAndRateLimit(
-    async () => fetchProfileById(id),
-    "public-default"
-  );
+      // Get user profile DTO via view; fallback to joined query if the view is missing in dev/test
+      let base: ProfileDTO | null = null;
+      try {
+        base = await getProfileDTOById(userId, supabase);
+      } catch (e) {
+        // Fallback path for environments without the materialized view
+        const { profile, homeBeachName } = await getProfileWithHomeBeachById(userId, supabase);
+        base = {
+          id: profile.id,
+          full_name: profile.full_name ?? null,
+          home_beach_id: profile.home_beach_id ?? null,
+          homeBeachName: homeBeachName,
+          home_beach: profile.home_beach ?? null,
+        } as ProfileDTO;
+      }
 
-  return wrappedHandler(request);
-}
+      // Fetch additional profile details and counters expected by clients/tests
+      const { data: details } = await supabase
+        .from("profiles")
+        .select(PROFILE_FULL_SELECT)
+        .eq("id", userId)
+        .single<ProfileDetails>();
+
+      // Add session stats (only public sessions for privacy)
+      const { data: sessions, error: sessionsError } = await supabase
+        .from("sessions")
+        .select("id, rating, status")
+        .eq("user_id", userId)
+        .eq("is_public", true);
+
+      let sessionStats: { session_count: number; average_rating: number | null } = {
+        session_count: 0,
+        average_rating: null,
+      };
+
+      if (!sessionsError && sessions) {
+        const completedSessions = sessions.filter(s => s.status === "completed");
+        sessionStats.session_count = completedSessions.length;
+
+        if (completedSessions.length > 0) {
+          const totalRating = completedSessions.reduce((sum, s) => sum + (s.rating || 0), 0);
+          sessionStats.average_rating = Math.round((totalRating / completedSessions.length) * 10) / 10;
+        }
+      }
+
+      // Check if current user is following this user (if authenticated)
+      let isFollowingUser = false;
+      if (user && user.id !== userId) {
+        const { data: followData } = await supabase
+          .from("user_follows")
+          .select("id")
+          .eq("follower_id", user.id)
+          .eq("following_id", userId)
+          .single();
+
+        isFollowingUser = !!followData;
+      }
+
+      const profileWithStats = {
+        ...(base as ProfileDTO),
+        followers_count: details?.followers_count ?? 0,
+        following_count: details?.following_count ?? 0,
+        created_at: details?.created_at ?? null,
+        // Optional details for richer UI rendering
+        avatar_url: details?.avatar_url ?? null,
+        email: details?.email ?? null,
+        bio: details?.bio ?? null,
+        location: details?.location ?? null,
+        experience_level: details?.experience_level ?? null,
+        instagram: details?.instagram ?? null,
+        home_beach: details?.home_beach ?? null,
+        // Surf preferences
+        surf_styles: details?.surf_styles ?? null,
+        // Notification preferences
+        notif_push_enabled: details?.notif_push_enabled ?? true,
+        notif_forecast_alerts: details?.notif_forecast_alerts ?? true,
+        notif_email_enabled: details?.notif_email_enabled ?? true,
+        notif_inapp_enabled: details?.notif_inapp_enabled ?? true,
+        notif_session_invites: details?.notif_session_invites ?? true,
+        notif_likes: details?.notif_likes ?? true,
+        notif_follows: details?.notif_follows ?? true,
+        notif_reminders: details?.notif_reminders ?? true,
+        notif_xp_updates: details?.notif_xp_updates ?? true,
+        // Onboarding tracking
+        onboarding_completed_at: details?.onboarding_completed_at ?? null,
+        ...sessionStats,
+        isFollowing: isFollowingUser,
+        isOwnProfile: user?.id === userId,
+      };
+
+      return createSuccessResponse(profileWithStats);
+    } catch (error) {
+      console.error("Error fetching user profile:", error);
+      return handleApiError(error);
+    }
+  },
+  { optional: true, errorMessage: "Failed to load profile" }
+);
+
+// Compose: bot blocking + rate limit → optional-auth handler.
+export const GET = withBotBlockingAndRateLimit(profileHandler, "public-default");

--- a/app/api/profile/[id]/route.ts
+++ b/app/api/profile/[id]/route.ts
@@ -4,8 +4,8 @@ import { getProfileDTOById, getProfileWithHomeBeachById } from "@/lib/profile/fe
 import {
   withAuth,
   withBotBlockingAndRateLimit,
-  type OptionalAuthContext,
 } from "@/lib/middleware/api-wrappers";
+import type { OptionalAuthContext } from "@/lib/middleware/api-wrappers/types";
 import { PROFILE_FULL_SELECT } from "@/lib/profile/constants";
 import type { ProfileDTO } from "@/types/profile";
 
@@ -94,12 +94,18 @@ const profileHandler = withAuth(
       };
 
       if (!sessionsError && sessions) {
-        const completedSessions = sessions.filter(s => s.status === "completed");
+        const completedSessions = sessions.filter(
+          (s: { status: string | null }) => s.status === "completed"
+        );
         sessionStats.session_count = completedSessions.length;
 
         if (completedSessions.length > 0) {
-          const totalRating = completedSessions.reduce((sum, s) => sum + (s.rating || 0), 0);
-          sessionStats.average_rating = Math.round((totalRating / completedSessions.length) * 10) / 10;
+          const totalRating = completedSessions.reduce(
+            (sum: number, s: { rating: number | null }) => sum + (s.rating || 0),
+            0,
+          );
+          sessionStats.average_rating =
+            Math.round((totalRating / completedSessions.length) * 10) / 10;
         }
       }
 

--- a/app/api/session-planner/invitations/route.ts
+++ b/app/api/session-planner/invitations/route.ts
@@ -1,13 +1,12 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
 import {
-  createSupabaseServerClient,
-  createSupabaseServiceRoleClient,
-} from "@/lib/supabase/server";
-import {
+  withAuth,
   createSuccessResponse,
   createErrorResponse,
-} from "@/lib/api-utils";
+  type AuthenticatedContext,
+} from "@/lib/middleware/api-wrappers";
 import { notifySessionInvite } from "@/lib/notifications";
 import { sendSessionInviteEmail } from "@/lib/mailer/sessionInviteEmail";
 
@@ -22,7 +21,7 @@ const DEBUG_INVITES =
     process.env.DEBUG_INVITES === undefined);
 const debug = (...args: any[]) => {
   if (DEBUG_INVITES) {
-     
+
     console.log("[INVITES]", ...args);
   }
 };
@@ -154,831 +153,810 @@ const dedupeInvitationsById = (rows: RawInvitationRow[]) =>
   }, []);
 
 /**
+ * Resolve a service-role client for privileged reads/writes. Falls back to
+ * the request-scoped (Bearer-aware) client if the service role factory is
+ * unavailable — e.g. in tests that mock the service role out.
+ */
+async function getServiceClient(fallback: SupabaseClient): Promise<SupabaseClient> {
+  try {
+    if (typeof createSupabaseServiceRoleClient === "function") {
+      const serviceSupabase = await createSupabaseServiceRoleClient();
+      if (serviceSupabase) return serviceSupabase as unknown as SupabaseClient;
+    }
+  } catch {}
+  return fallback;
+}
+
+/**
  * Send session invitations to friends
  * POST /api/session-planner/invitations
  */
-export async function POST(request: NextRequest) {
-  try {
-    const body: InvitationRequest = await request.json();
-    const { sessionId, invitees, message } = body;
-    const idempotencyKey = request.headers.get("Idempotency-Key");
-    let emailAttempted = false;
-
-    debug("POST /invitations body", {
-      sessionId,
-      inviteesCount: Array.isArray(invitees) ? invitees.length : 0,
-      messagePresent: Boolean(message && message.length > 0),
-      idempotencyKey: Boolean(idempotencyKey),
-    });
-
-    if (!sessionId || !invitees || invitees.length === 0) {
-      return createErrorResponse(
-        "Session ID and invitees are required",
-        null,
-        400
-      );
-    }
-
-    const supabase = await createSupabaseServerClient();
-    let serviceSupabase: any = null;
+export const POST = withAuth(
+  async (request: NextRequest, { user, supabase }: AuthenticatedContext) => {
     try {
-      if (typeof createSupabaseServiceRoleClient === "function") {
-        serviceSupabase = await createSupabaseServiceRoleClient();
-      }
-    } catch {}
-    // In test environments, the service client may be undefined due to mocks; fall back to anon client
-    if (!serviceSupabase) serviceSupabase = supabase as any;
+      const body: InvitationRequest = await request.json();
+      const { sessionId, invitees, message } = body;
+      const idempotencyKey = request.headers.get("Idempotency-Key");
+      let emailAttempted = false;
 
-    // Get the current user
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-    if (userError || !user) {
-      return createErrorResponse("Authentication required", null, 401);
-    }
+      debug("POST /invitations body", {
+        sessionId,
+        inviteesCount: Array.isArray(invitees) ? invitees.length : 0,
+        messagePresent: Boolean(message && message.length > 0),
+        idempotencyKey: Boolean(idempotencyKey),
+      });
 
-    debug("Authenticated user", { userId: user.id });
-
-    // Verify the user owns the session
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .select("*")
-      .eq("id", sessionId)
-      .eq("user_id", user.id)
-      .single();
-
-    if (sessionError || !session) {
-      return createErrorResponse(
-        "Session not found or access denied",
-        null,
-        404
-      );
-    }
-
-    // Ensure session is planned (not completed)
-    if (session.status !== "planned") {
-      return createErrorResponse(
-        "Can only invite friends to planned sessions",
-        null,
-        400
-      );
-    }
-
-    debug("Session verified", {
-      sessionId: session.id,
-      beach: session.beach_name,
-      status: session.status,
-    });
-
-    const invitations: SessionInvitation[] = [];
-    const errors: string[] = [];
-    let invitationsSent = 0;
-    // Lazy import XP tracker to avoid module cost when not needed
-    const trackInviteXP = async (inviteId: string) => {
-      try {
-        const { trackXP } = await import("@/lib/gamification");
-        await trackXP("invite_friend", inviteId, "invite");
-      } catch (err) {
-        console.warn("XP tracking failed for invite:", err);
-      }
-    };
-
-    // Process each invitee
-    debug("Processing invitees", Array.isArray(invitees) ? invitees.length : 0);
-    for (const invitee of invitees) {
-      try {
-        let inviteeUserId: string | null = null;
-
-        if (invitee.userId) {
-          // Direct user ID invitation
-          inviteeUserId = invitee.userId;
-        } else if (invitee.email) {
-          // Email invitation - check if user exists
-          const { data: existingUser } = await supabase
-            .from("profiles")
-            .select("id")
-            .ilike("email", invitee.email)
-            .single();
-
-          if (existingUser) {
-            inviteeUserId = existingUser.id;
-          }
-        }
-
-        debug("Resolved invitee", {
-          providedUserId: Boolean(invitee.userId),
-          providedEmail: Boolean(invitee.email),
-          resolvedUserId: inviteeUserId || null,
-        });
-
-        const normalizedEmail = invitee.email ? invitee.email.toLowerCase() : undefined;
-
-        // Check for existing invitation (per-invitee uniqueness)
-        const { data: existingInvitation } = await serviceSupabase
-          .from("session_invitations")
-          .select("id")
-          .eq("session_id", sessionId)
-          .eq(
-            inviteeUserId ? "invitee_id" : "invitee_email",
-            inviteeUserId || normalizedEmail
-          )
-          .single();
-
-        if (existingInvitation) {
-          errors.push(
-            `Invitation already sent to ${
-              invitee.email || invitee.name || "user"
-            }`
-          );
-          debug("Duplicate invitation detected, skipping", {
-            sessionId,
-            inviteeUserId: inviteeUserId || null,
-            inviteeEmail: invitee.email || null,
-          });
-          continue;
-        }
-
-        const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-        const { data: recentInvitation } = await serviceSupabase
-          .from("session_invitations")
-          .select("id, created_at")
-          .eq(
-            inviteeUserId ? "invitee_id" : "invitee_email",
-            inviteeUserId || normalizedEmail
-          )
-          .gt("created_at", sevenDaysAgo)
-          .order("created_at", { ascending: false })
-          .maybeSingle();
-
-        if (recentInvitation) {
-          errors.push(
-            `Invitation already sent recently to ${
-              invitee.email || invitee.name || "user"
-            }`
-          );
-          debug("Recent invitation detected within 7 days, skipping", {
-            inviteeUserId: inviteeUserId || null,
-            inviteeEmail: invitee.email || null,
-          });
-          continue;
-        }
-
-        // Create invitation record
-        const perInviteeIdempKey = idempotencyKey
-          ? `${idempotencyKey}:${inviteeUserId || invitee.email || "unknown"}`
-          : null;
-
-        const invitationData = {
-          session_id: sessionId,
-          inviter_id: user.id,
-          invitee_id: inviteeUserId,
-          invitee_email: normalizedEmail,
-          status: "pending" as const,
-          message: message || null,
-          created_at: new Date().toISOString(),
-          idempotency_key: perInviteeIdempKey,
-        };
-
-        const { data: newInvitation, error: invitationError} = await serviceSupabase
-          .from("session_invitations")
-          .insert(invitationData)
-          .select()
-          .single();
-
-        if (invitationError) {
-          // Unique violation: treat as already had
-          if ((invitationError as any).code === "23505") {
-            errors.push(
-              `Invitation already exists for ${
-                invitee.email || invitee.name || "user"
-              }`
-            );
-            debug("Unique violation on insert - treated as duplicate", {
-              sessionId,
-              inviteeUserId: inviteeUserId || null,
-              inviteeEmail: invitee.email || null,
-            });
-            continue;
-          } else {
-            errors.push(
-              `Failed to invite ${invitee.email || invitee.name || "user"}: ${
-                invitationError.message
-              }`
-            );
-            debug("Insert error", invitationError);
-            continue;
-          }
-        }
-
-        const created = Array.isArray(newInvitation)
-          ? (newInvitation[0] as any)
-          : (newInvitation as any);
-
-        debug("Invitation inserted", {
-          id: created?.id,
-          inviteeId: created?.invitee_id,
-          inviteeEmail: created?.invitee_email ? "<redacted>" : null,
-        });
-
-        const invitationNotificationErrors: string[] = [];
-
-        invitations.push({
-          id: created?.id ?? "unknown",
-          sessionId: created?.session_id ?? sessionId,
-          inviterId: created?.inviter_id ?? user.id,
-          inviteeId: created?.invitee_id ?? inviteeUserId ?? null,
-          inviteeEmail: created?.invitee_email ?? normalizedEmail ?? null,
-          status: created?.status ?? ("pending" as const),
-          message: created?.message ?? (message || null),
-          createdAt: created?.created_at ?? new Date().toISOString(),
-          seenAt: created?.seen_at ?? null,
-          notificationErrors: invitationNotificationErrors,
-        });
-
-        invitationsSent++;
-
-        // Track invite send in user_events for growth metrics
-        void supabase.from("user_events").insert({
-          user_id: user.id,
-          event_type: "social_invite_send",
-          metadata: {
-            session_id: sessionId,
-            invitee_count: 1,
-          },
-        }).then(() => {}, () => {});
-
-        // Track XP for each friend invited
-        trackInviteXP(newInvitation.id);
-
-        const displayName = invitee.email || invitee.name || "user";
-
-        let activityId: string | undefined;
-
-        if (inviteeUserId) {
-          const { data: prefs, error: prefsError } = await supabase
-            .from("profiles")
-            .select("email, email_session_invites, inapp_session_invites")
-            .eq("id", inviteeUserId)
-            .single();
-
-          if (prefsError) {
-            const messageText = `Failed to load notification preferences for ${displayName}: ${prefsError.message}`;
-            errors.push(messageText);
-            invitationNotificationErrors.push(messageText);
-          } else {
-            if (prefs?.inapp_session_invites !== false) {
-              try {
-                activityId = await notifySessionInvite({
-                  actorId: user.id,
-                  recipientId: inviteeUserId,
-                  sessionId: sessionId,
-                  metadata: {
-                    beachName: session.beach_name,
-                    when: session.arrival_time,
-                    message: message || null,
-                  },
-                });
-                debug("Created in-app invite activity", { activityId });
-              } catch (activityErr) {
-                const msg = `Failed to create in-app notification for ${displayName}: ${activityErr instanceof Error ? activityErr.message : "Unknown error"}`;
-                console.error(msg, activityErr);
-                errors.push(msg);
-                invitationNotificationErrors.push(msg);
-              }
-            }
-
-            if (prefs?.email && prefs.email_session_invites !== false) {
-              const appUrl =
-                process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-              try {
-                debug("Sending invite email to user", {
-                  to: "<redacted>",
-                  appUrl,
-                });
-                emailAttempted = true;
-                await sendSessionInviteEmail({
-                  toEmail: prefs.email,
-                  inviter: {
-                    id: user.id,
-                    name: user.user_metadata?.full_name,
-                    username: user.user_metadata?.user_name,
-                  },
-                  session: {
-                    id: session.id,
-                    arrival_time: session.arrival_time,
-                    beach_name: session.beach_name,
-                  },
-                  message: message || undefined,
-                  activityId,
-                  appUrl,
-                });
-              } catch (mailErr) {
-                const msg = `Failed to send invite email to ${displayName}: ${mailErr instanceof Error ? mailErr.message : "Unknown error"}`;
-                console.error(msg, mailErr);
-                errors.push(msg);
-                invitationNotificationErrors.push(msg);
-              }
-            }
-          }
-        } else if (invitee.email) {
-          // Email-only invite (no in-app activity)
-          const appUrl =
-            process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
-          try {
-            debug("Sending invite email to address", {
-              to: "<redacted>",
-              appUrl,
-            });
-            emailAttempted = true;
-            await sendSessionInviteEmail({
-              toEmail: invitee.email,
-              inviter: {
-                id: user.id,
-                name: user.user_metadata?.full_name,
-                username: user.user_metadata?.user_name,
-              },
-              session: {
-                id: session.id,
-                arrival_time: session.arrival_time,
-                beach_name: session.beach_name,
-              },
-              message: message || undefined,
-              activityId,
-              appUrl,
-            });
-          } catch (mailErr) {
-            const msg = `Failed to send invite email to ${displayName}: ${mailErr instanceof Error ? mailErr.message : "Unknown error"}`;
-            console.error(msg, mailErr);
-            errors.push(msg);
-            invitationNotificationErrors.push(msg);
-          }
-        }
-      } catch (error) {
-        console.error("Error processing invitee:", error);
-        errors.push(
-          `Failed to process invitation for ${
-            invitee.email || invitee.name || "user"
-          }`
-        );
-      }
-    }
-
-    // Fire-and-forget: Send push notifications to all successfully invited users
-    const inviteeUserIds = invitations
-      .map((inv) => inv.inviteeId)
-      .filter(Boolean) as string[];
-
-    if (inviteeUserIds.length > 0) {
-      void Promise.allSettled([
-        // Push notifications
-        (async () => {
-          try {
-            const { sendSessionInvitePush } = await import(
-              "@/lib/services/push-notifications"
-            );
-            const inviterName =
-              user.user_metadata?.full_name ||
-              user.user_metadata?.user_name ||
-              "A surfer on Quiver";
-
-            await sendSessionInvitePush({
-              inviteeIds: inviteeUserIds,
-              inviterName,
-              beachName: session.beach_name || undefined,
-              arrivalTime: session.arrival_time,
-              sessionId: session.id,
-              message: message || undefined,
-            });
-            debug("Push notifications sent to invitees", {
-              count: inviteeUserIds.length,
-            });
-          } catch (err) {
-            console.error("Push notification failed:", err);
-            // Non-blocking error - don't fail the invitation
-          }
-        })(),
-
-        // In-app notification records
-        (async () => {
-          try {
-            const { data: profiles } = await serviceSupabase
-              .from("profiles")
-              .select("id, inapp_session_invites")
-              .in("id", inviteeUserIds);
-
-            const notificationRecords =
-              profiles
-                ?.filter((p: any) => p.inapp_session_invites !== false)
-                .map((p: any) => ({
-                  user_id: p.id,
-                  type: "session_invite" as const,
-                  data: {
-                    session_id: sessionId,
-                    inviter_id: user.id,
-                    beach_name: session.beach_name,
-                    arrival_time: session.arrival_time,
-                    message: message || null,
-                  },
-                })) || [];
-
-            if (notificationRecords.length > 0) {
-              await serviceSupabase
-                .from("notifications")
-                .insert(notificationRecords);
-              debug("In-app notification records created", {
-                count: notificationRecords.length,
-              });
-            }
-          } catch (err) {
-            console.error("In-app notification records failed:", err);
-            // Non-blocking error - don't fail the invitation
-          }
-        })(),
-      ]);
-    }
-
-    const response: InvitationResponse = {
-      sessionId,
-      invitationsSent,
-      invitations,
-      errors,
-    };
-
-    debug("POST response summary", {
-      invitationsSent,
-      invitationsCount: invitations.length,
-      errorsCount: errors.length,
-    });
-
-    // Consider operation successful if we created at least one invitation, even if some notifications/emails failed
-    const res = invitationsSent > 0
-      ? createSuccessResponse(response)
-      : createErrorResponse("No invitations could be created", errors.join("; ") || undefined, 400);
-    if (DEBUG_INVITES) {
-      try {
-        res.headers.set("x-invite-email-attempted", String(emailAttempted));
-      } catch {}
-    }
-    return res;
-  } catch (error) {
-    console.error("Error sending invitations:", error);
-    return createErrorResponse(
-      "Failed to send invitations",
-      error instanceof Error ? error.message : "Unknown error"
-    );
-  }
-}
-
-/**
- * Get session invitations for the current user
- * GET /api/session-planner/invitations?type=sent|received&sessionId=xxx
- */
-export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const type = searchParams.get("type") || "received";
-    const sessionId = searchParams.get("sessionId");
-
-    debug("GET /invitations", { type, sessionIdPresent: Boolean(sessionId) });
-
-    const supabase = await createSupabaseServerClient();
-
-    // Get the current user
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-    if (userError || !user) {
-      return createErrorResponse("Authentication required", null, 401);
-    }
-
-    // Handle friends type - return user's following list
-    if (type === "friends") {
-      const { data: following, error: followingError } = await supabase
-        .from("user_follows")
-        .select(
-          `
-          following:profiles!user_follows_following_id_fkey(
-            id,
-            full_name
-          )
-        `
-        )
-        .eq("follower_id", user.id)
-        .limit(50);
-
-      if (followingError) {
-        console.error("Error getting user following:", followingError);
+      if (!sessionId || !invitees || invitees.length === 0) {
         return createErrorResponse(
-          "Failed to fetch friends",
-          followingError.message
-        );
-      }
-
-      const friends = (following || [])
-        .map((f: any) => f.following)
-        .filter(Boolean);
-
-      return createSuccessResponse(friends);
-    }
-
-    let serviceSupabase: any = null;
-    try {
-      if (typeof createSupabaseServiceRoleClient === "function") {
-        serviceSupabase = await createSupabaseServiceRoleClient();
-      }
-    } catch {}
-    if (!serviceSupabase) serviceSupabase = supabase as any;
-
-    let invitations: any[] = [];
-    if (type === "sent") {
-      const { data, error } = await serviceSupabase
-        .from("session_invitations")
-        .select(BASE_INVITATION_FIELDS)
-        .eq("inviter_id", user.id)
-        .order("created_at", { ascending: false });
-
-      if (error) {
-        console.error("Error fetching sent invitations:", error);
-        return createErrorResponse(
-          "Failed to fetch invitations",
-          error.message
-        );
-      }
-
-      let rows: RawInvitationRow[] = Array.isArray(data) ? (data as RawInvitationRow[]) : [];
-      if (sessionId) {
-        rows = rows.filter((row) => row.session_id === sessionId);
-      }
-      rows = rows.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-      invitations = await buildEnrichedInvitations(serviceSupabase, rows);
-    } else {
-      const { data: dataById, error: errId } = await serviceSupabase
-        .from("session_invitations")
-        .select(BASE_INVITATION_FIELDS)
-        .eq("invitee_id", user.id)
-        .order("created_at", { ascending: false });
-      if (errId) {
-        console.error("Error fetching invitations by id:", errId);
-      }
-      const listById = Array.isArray(dataById)
-        ? (dataById as RawInvitationRow[])
-        : [];
-
-      let listByEmail: RawInvitationRow[] = [];
-      const emailVal = user.email;
-      if (emailVal && typeof emailVal === "string" && emailVal.length > 0) {
-        const { data: dataByEmail, error: errEmail } = await serviceSupabase
-          .from("session_invitations")
-          .select(BASE_INVITATION_FIELDS)
-          .ilike("invitee_email", emailVal)
-          .order("created_at", { ascending: false });
-        if (errEmail) {
-          console.error("Error fetching invitations by email:", errEmail);
-        }
-        listByEmail = Array.isArray(dataByEmail)
-          ? (dataByEmail as RawInvitationRow[])
-          : [];
-      }
-
-      let combined = dedupeInvitationsById([...listById, ...listByEmail]);
-
-      if (sessionId) {
-        combined = combined.filter((row) => row.session_id === sessionId);
-      }
-
-      combined = combined.sort((a, b) =>
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-
-      invitations = await buildEnrichedInvitations(serviceSupabase, combined);
-    }
-
-    debug("GET response summary", {
-      type,
-      count: Array.isArray(invitations) ? invitations.length : 0,
-    });
-
-    return createSuccessResponse(
-      {
-        type,
-        invitations: Array.isArray(invitations) ? invitations : [],
-      },
-      200
-    );
-  } catch (error) {
-    console.error("Error in GET /api/session-planner/invitations:", error);
-    return createErrorResponse(
-      "Internal server error",
-      error instanceof Error ? error.message : "Unknown error"
-    );
-  }
-}
-
-/**
- * Respond to a session invitation
- * PATCH /api/session-planner/invitations
- */
-export async function PATCH(request: NextRequest) {
-  try {
-    const body = await request.json();
-    const {
-      invitationId,
-      response: invitationResponse,
-      markSeen,
-      invitationIds,
-    } = body;
-
-    debug("PATCH /invitations", {
-      invitationIdPresent: Boolean(invitationId),
-      response: invitationResponse,
-      markSeen: Boolean(markSeen),
-      invitationIdsCount: Array.isArray(invitationIds) ? invitationIds.length : 0,
-    });
-
-    const supabase = await createSupabaseServerClient();
-
-    // Get the current user
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
-    if (userError || !user) {
-      return createErrorResponse("Authentication required", null, 401);
-    }
-
-    if (markSeen) {
-      if (!Array.isArray(invitationIds) || invitationIds.length === 0) {
-        return createErrorResponse(
-          "Invitation IDs are required to mark notifications as seen",
+          "Session ID and invitees are required",
           null,
           400
         );
       }
 
-      const { data: updatedRows, error: seenError } = await supabase
-        .from("session_invitations")
-        .update({ seen_at: new Date().toISOString() })
-        .in("id", invitationIds)
-        .select("id, seen_at");
+      const serviceSupabase: any = await getServiceClient(supabase);
 
-      if (seenError) {
-        console.error("Error marking invitations as seen:", seenError);
+      debug("Authenticated user", { userId: user.id });
+
+      // Verify the user owns the session
+      const { data: session, error: sessionError } = await supabase
+        .from("sessions")
+        .select("*")
+        .eq("id", sessionId)
+        .eq("user_id", user.id)
+        .single();
+
+      if (sessionError || !session) {
         return createErrorResponse(
-          "Failed to mark invitations as seen",
-          seenError.message
+          "Session not found or access denied",
+          null,
+          404
         );
       }
 
+      // Ensure session is planned (not completed)
+      if (session.status !== "planned") {
+        return createErrorResponse(
+          "Can only invite friends to planned sessions",
+          null,
+          400
+        );
+      }
+
+      debug("Session verified", {
+        sessionId: session.id,
+        beach: session.beach_name,
+        status: session.status,
+      });
+
+      const invitations: SessionInvitation[] = [];
+      const errors: string[] = [];
+      let invitationsSent = 0;
+      // Lazy import XP tracker to avoid module cost when not needed
+      const trackInviteXP = async (inviteId: string) => {
+        try {
+          const { trackXP } = await import("@/lib/gamification");
+          await trackXP("invite_friend", inviteId, "invite");
+        } catch (err) {
+          console.warn("XP tracking failed for invite:", err);
+        }
+      };
+
+      // Process each invitee
+      debug("Processing invitees", Array.isArray(invitees) ? invitees.length : 0);
+      for (const invitee of invitees) {
+        try {
+          let inviteeUserId: string | null = null;
+
+          if (invitee.userId) {
+            // Direct user ID invitation
+            inviteeUserId = invitee.userId;
+          } else if (invitee.email) {
+            // Email invitation - check if user exists
+            const { data: existingUser } = await supabase
+              .from("profiles")
+              .select("id")
+              .ilike("email", invitee.email)
+              .single();
+
+            if (existingUser) {
+              inviteeUserId = existingUser.id;
+            }
+          }
+
+          debug("Resolved invitee", {
+            providedUserId: Boolean(invitee.userId),
+            providedEmail: Boolean(invitee.email),
+            resolvedUserId: inviteeUserId || null,
+          });
+
+          const normalizedEmail = invitee.email ? invitee.email.toLowerCase() : undefined;
+
+          // Check for existing invitation (per-invitee uniqueness)
+          const { data: existingInvitation } = await serviceSupabase
+            .from("session_invitations")
+            .select("id")
+            .eq("session_id", sessionId)
+            .eq(
+              inviteeUserId ? "invitee_id" : "invitee_email",
+              inviteeUserId || normalizedEmail
+            )
+            .single();
+
+          if (existingInvitation) {
+            errors.push(
+              `Invitation already sent to ${
+                invitee.email || invitee.name || "user"
+              }`
+            );
+            debug("Duplicate invitation detected, skipping", {
+              sessionId,
+              inviteeUserId: inviteeUserId || null,
+              inviteeEmail: invitee.email || null,
+            });
+            continue;
+          }
+
+          const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+          const { data: recentInvitation } = await serviceSupabase
+            .from("session_invitations")
+            .select("id, created_at")
+            .eq(
+              inviteeUserId ? "invitee_id" : "invitee_email",
+              inviteeUserId || normalizedEmail
+            )
+            .gt("created_at", sevenDaysAgo)
+            .order("created_at", { ascending: false })
+            .maybeSingle();
+
+          if (recentInvitation) {
+            errors.push(
+              `Invitation already sent recently to ${
+                invitee.email || invitee.name || "user"
+              }`
+            );
+            debug("Recent invitation detected within 7 days, skipping", {
+              inviteeUserId: inviteeUserId || null,
+              inviteeEmail: invitee.email || null,
+            });
+            continue;
+          }
+
+          // Create invitation record
+          const perInviteeIdempKey = idempotencyKey
+            ? `${idempotencyKey}:${inviteeUserId || invitee.email || "unknown"}`
+            : null;
+
+          const invitationData = {
+            session_id: sessionId,
+            inviter_id: user.id,
+            invitee_id: inviteeUserId,
+            invitee_email: normalizedEmail,
+            status: "pending" as const,
+            message: message || null,
+            created_at: new Date().toISOString(),
+            idempotency_key: perInviteeIdempKey,
+          };
+
+          const { data: newInvitation, error: invitationError} = await serviceSupabase
+            .from("session_invitations")
+            .insert(invitationData)
+            .select()
+            .single();
+
+          if (invitationError) {
+            // Unique violation: treat as already had
+            if ((invitationError as any).code === "23505") {
+              errors.push(
+                `Invitation already exists for ${
+                  invitee.email || invitee.name || "user"
+                }`
+              );
+              debug("Unique violation on insert - treated as duplicate", {
+                sessionId,
+                inviteeUserId: inviteeUserId || null,
+                inviteeEmail: invitee.email || null,
+              });
+              continue;
+            } else {
+              errors.push(
+                `Failed to invite ${invitee.email || invitee.name || "user"}: ${
+                  invitationError.message
+                }`
+              );
+              debug("Insert error", invitationError);
+              continue;
+            }
+          }
+
+          const created = Array.isArray(newInvitation)
+            ? (newInvitation[0] as any)
+            : (newInvitation as any);
+
+          debug("Invitation inserted", {
+            id: created?.id,
+            inviteeId: created?.invitee_id,
+            inviteeEmail: created?.invitee_email ? "<redacted>" : null,
+          });
+
+          const invitationNotificationErrors: string[] = [];
+
+          invitations.push({
+            id: created?.id ?? "unknown",
+            sessionId: created?.session_id ?? sessionId,
+            inviterId: created?.inviter_id ?? user.id,
+            inviteeId: created?.invitee_id ?? inviteeUserId ?? null,
+            inviteeEmail: created?.invitee_email ?? normalizedEmail ?? null,
+            status: created?.status ?? ("pending" as const),
+            message: created?.message ?? (message || null),
+            createdAt: created?.created_at ?? new Date().toISOString(),
+            seenAt: created?.seen_at ?? null,
+            notificationErrors: invitationNotificationErrors,
+          });
+
+          invitationsSent++;
+
+          // Track invite send in user_events for growth metrics
+          void supabase.from("user_events").insert({
+            user_id: user.id,
+            event_type: "social_invite_send",
+            metadata: {
+              session_id: sessionId,
+              invitee_count: 1,
+            },
+          }).then(() => {}, () => {});
+
+          // Track XP for each friend invited
+          trackInviteXP(newInvitation.id);
+
+          const displayName = invitee.email || invitee.name || "user";
+
+          let activityId: string | undefined;
+
+          if (inviteeUserId) {
+            const { data: prefs, error: prefsError } = await supabase
+              .from("profiles")
+              .select("email, email_session_invites, inapp_session_invites")
+              .eq("id", inviteeUserId)
+              .single();
+
+            if (prefsError) {
+              const messageText = `Failed to load notification preferences for ${displayName}: ${prefsError.message}`;
+              errors.push(messageText);
+              invitationNotificationErrors.push(messageText);
+            } else {
+              if (prefs?.inapp_session_invites !== false) {
+                try {
+                  activityId = await notifySessionInvite({
+                    actorId: user.id,
+                    recipientId: inviteeUserId,
+                    sessionId: sessionId,
+                    metadata: {
+                      beachName: session.beach_name,
+                      when: session.arrival_time,
+                      message: message || null,
+                    },
+                  });
+                  debug("Created in-app invite activity", { activityId });
+                } catch (activityErr) {
+                  const msg = `Failed to create in-app notification for ${displayName}: ${activityErr instanceof Error ? activityErr.message : "Unknown error"}`;
+                  console.error(msg, activityErr);
+                  errors.push(msg);
+                  invitationNotificationErrors.push(msg);
+                }
+              }
+
+              if (prefs?.email && prefs.email_session_invites !== false) {
+                const appUrl =
+                  process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+                try {
+                  debug("Sending invite email to user", {
+                    to: "<redacted>",
+                    appUrl,
+                  });
+                  emailAttempted = true;
+                  await sendSessionInviteEmail({
+                    toEmail: prefs.email,
+                    inviter: {
+                      id: user.id,
+                      name: user.user_metadata?.full_name,
+                      username: user.user_metadata?.user_name,
+                    },
+                    session: {
+                      id: session.id,
+                      arrival_time: session.arrival_time,
+                      beach_name: session.beach_name,
+                    },
+                    message: message || undefined,
+                    activityId,
+                    appUrl,
+                  });
+                } catch (mailErr) {
+                  const msg = `Failed to send invite email to ${displayName}: ${mailErr instanceof Error ? mailErr.message : "Unknown error"}`;
+                  console.error(msg, mailErr);
+                  errors.push(msg);
+                  invitationNotificationErrors.push(msg);
+                }
+              }
+            }
+          } else if (invitee.email) {
+            // Email-only invite (no in-app activity)
+            const appUrl =
+              process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+            try {
+              debug("Sending invite email to address", {
+                to: "<redacted>",
+                appUrl,
+              });
+              emailAttempted = true;
+              await sendSessionInviteEmail({
+                toEmail: invitee.email,
+                inviter: {
+                  id: user.id,
+                  name: user.user_metadata?.full_name,
+                  username: user.user_metadata?.user_name,
+                },
+                session: {
+                  id: session.id,
+                  arrival_time: session.arrival_time,
+                  beach_name: session.beach_name,
+                },
+                message: message || undefined,
+                activityId,
+                appUrl,
+              });
+            } catch (mailErr) {
+              const msg = `Failed to send invite email to ${displayName}: ${mailErr instanceof Error ? mailErr.message : "Unknown error"}`;
+              console.error(msg, mailErr);
+              errors.push(msg);
+              invitationNotificationErrors.push(msg);
+            }
+          }
+        } catch (error) {
+          console.error("Error processing invitee:", error);
+          errors.push(
+            `Failed to process invitation for ${
+              invitee.email || invitee.name || "user"
+            }`
+          );
+        }
+      }
+
+      // Fire-and-forget: Send push notifications to all successfully invited users
+      const inviteeUserIds = invitations
+        .map((inv) => inv.inviteeId)
+        .filter(Boolean) as string[];
+
+      if (inviteeUserIds.length > 0) {
+        void Promise.allSettled([
+          // Push notifications
+          (async () => {
+            try {
+              const { sendSessionInvitePush } = await import(
+                "@/lib/services/push-notifications"
+              );
+              const inviterName =
+                user.user_metadata?.full_name ||
+                user.user_metadata?.user_name ||
+                "A surfer on Quiver";
+
+              await sendSessionInvitePush({
+                inviteeIds: inviteeUserIds,
+                inviterName,
+                beachName: session.beach_name || undefined,
+                arrivalTime: session.arrival_time,
+                sessionId: session.id,
+                message: message || undefined,
+              });
+              debug("Push notifications sent to invitees", {
+                count: inviteeUserIds.length,
+              });
+            } catch (err) {
+              console.error("Push notification failed:", err);
+              // Non-blocking error - don't fail the invitation
+            }
+          })(),
+
+          // In-app notification records
+          (async () => {
+            try {
+              const { data: profiles } = await serviceSupabase
+                .from("profiles")
+                .select("id, inapp_session_invites")
+                .in("id", inviteeUserIds);
+
+              const notificationRecords =
+                profiles
+                  ?.filter((p: any) => p.inapp_session_invites !== false)
+                  .map((p: any) => ({
+                    user_id: p.id,
+                    type: "session_invite" as const,
+                    data: {
+                      session_id: sessionId,
+                      inviter_id: user.id,
+                      beach_name: session.beach_name,
+                      arrival_time: session.arrival_time,
+                      message: message || null,
+                    },
+                  })) || [];
+
+              if (notificationRecords.length > 0) {
+                await serviceSupabase
+                  .from("notifications")
+                  .insert(notificationRecords);
+                debug("In-app notification records created", {
+                  count: notificationRecords.length,
+                });
+              }
+            } catch (err) {
+              console.error("In-app notification records failed:", err);
+              // Non-blocking error - don't fail the invitation
+            }
+          })(),
+        ]);
+      }
+
+      const response: InvitationResponse = {
+        sessionId,
+        invitationsSent,
+        invitations,
+        errors,
+      };
+
+      debug("POST response summary", {
+        invitationsSent,
+        invitationsCount: invitations.length,
+        errorsCount: errors.length,
+      });
+
+      // Consider operation successful if we created at least one invitation, even if some notifications/emails failed
+      const res = invitationsSent > 0
+        ? createSuccessResponse(response)
+        : createErrorResponse("No invitations could be created", errors.join("; ") || undefined, 400);
+      if (DEBUG_INVITES) {
+        try {
+          res.headers.set("x-invite-email-attempted", String(emailAttempted));
+        } catch {}
+      }
+      return res;
+    } catch (error) {
+      console.error("Error sending invitations:", error);
+      return createErrorResponse(
+        "Failed to send invitations",
+        error instanceof Error ? error.message : "Unknown error"
+      );
+    }
+  },
+  { errorMessage: "Failed to send invitations" }
+);
+
+/**
+ * Get session invitations for the current user
+ * GET /api/session-planner/invitations?type=sent|received&sessionId=xxx
+ */
+export const GET = withAuth(
+  async (request: NextRequest, { user, supabase }: AuthenticatedContext) => {
+    try {
+      const { searchParams } = new URL(request.url);
+      const type = searchParams.get("type") || "received";
+      const sessionId = searchParams.get("sessionId");
+
+      debug("GET /invitations", { type, sessionIdPresent: Boolean(sessionId) });
+
+      // Handle friends type - return user's following list
+      if (type === "friends") {
+        const { data: following, error: followingError } = await supabase
+          .from("user_follows")
+          .select(
+            `
+            following:profiles!user_follows_following_id_fkey(
+              id,
+              full_name
+            )
+          `
+          )
+          .eq("follower_id", user.id)
+          .limit(50);
+
+        if (followingError) {
+          console.error("Error getting user following:", followingError);
+          return createErrorResponse(
+            "Failed to fetch friends",
+            followingError.message
+          );
+        }
+
+        const friends = (following || [])
+          .map((f: any) => f.following)
+          .filter(Boolean);
+
+        return createSuccessResponse(friends);
+      }
+
+      const serviceSupabase: any = await getServiceClient(supabase);
+
+      let invitations: any[] = [];
+      if (type === "sent") {
+        const { data, error } = await serviceSupabase
+          .from("session_invitations")
+          .select(BASE_INVITATION_FIELDS)
+          .eq("inviter_id", user.id)
+          .order("created_at", { ascending: false });
+
+        if (error) {
+          console.error("Error fetching sent invitations:", error);
+          return createErrorResponse(
+            "Failed to fetch invitations",
+            error.message
+          );
+        }
+
+        let rows: RawInvitationRow[] = Array.isArray(data) ? (data as RawInvitationRow[]) : [];
+        if (sessionId) {
+          rows = rows.filter((row) => row.session_id === sessionId);
+        }
+        rows = rows.sort((a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+        invitations = await buildEnrichedInvitations(serviceSupabase, rows);
+      } else {
+        const { data: dataById, error: errId } = await serviceSupabase
+          .from("session_invitations")
+          .select(BASE_INVITATION_FIELDS)
+          .eq("invitee_id", user.id)
+          .order("created_at", { ascending: false });
+        if (errId) {
+          console.error("Error fetching invitations by id:", errId);
+        }
+        const listById = Array.isArray(dataById)
+          ? (dataById as RawInvitationRow[])
+          : [];
+
+        let listByEmail: RawInvitationRow[] = [];
+        const emailVal = user.email;
+        if (emailVal && typeof emailVal === "string" && emailVal.length > 0) {
+          const { data: dataByEmail, error: errEmail } = await serviceSupabase
+            .from("session_invitations")
+            .select(BASE_INVITATION_FIELDS)
+            .ilike("invitee_email", emailVal)
+            .order("created_at", { ascending: false });
+          if (errEmail) {
+            console.error("Error fetching invitations by email:", errEmail);
+          }
+          listByEmail = Array.isArray(dataByEmail)
+            ? (dataByEmail as RawInvitationRow[])
+            : [];
+        }
+
+        let combined = dedupeInvitationsById([...listById, ...listByEmail]);
+
+        if (sessionId) {
+          combined = combined.filter((row) => row.session_id === sessionId);
+        }
+
+        combined = combined.sort((a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+
+        invitations = await buildEnrichedInvitations(serviceSupabase, combined);
+      }
+
+      debug("GET response summary", {
+        type,
+        count: Array.isArray(invitations) ? invitations.length : 0,
+      });
+
       return createSuccessResponse(
         {
-          updated: updatedRows ?? [],
+          type,
+          invitations: Array.isArray(invitations) ? invitations : [],
         },
         200
       );
-    }
-
-    if (!invitationId || !invitationResponse) {
+    } catch (error) {
+      console.error("Error in GET /api/session-planner/invitations:", error);
       return createErrorResponse(
-        "Invitation ID and response are required",
-        null,
-        400
+        "Internal server error",
+        error instanceof Error ? error.message : "Unknown error"
       );
     }
+  },
+  { errorMessage: "Internal server error" }
+);
 
-    if (!["accepted", "declined"].includes(invitationResponse)) {
-      return createErrorResponse(
-        "Response must be 'accepted' or 'declined'",
-        null,
-        400
-      );
-    }
-
-    // Get the invitation and verify user can respond to it
-    const { data: invitation, error: invitationError } = await supabase
-      .from("session_invitations")
-      .select("*")
-      .eq("id", invitationId)
-      .or(`invitee_id.eq.${user.id},invitee_email.ilike.${user.email}`)
-      .single();
-
-    if (invitationError || !invitation) {
-      return createErrorResponse(
-        "Invitation not found or access denied",
-        null,
-        404
-      );
-    }
-
-    if (invitation.status !== "pending") {
-      return createErrorResponse(
-        "Invitation has already been responded to",
-        null,
-        400
-      );
-    }
-
-    // Update invitation status
-    const { data: updatedInvitation, error: updateError } = await supabase
-      .from("session_invitations")
-      .update({
-        status: invitationResponse,
-        responded_at: new Date().toISOString(),
-      })
-      .eq("id", invitationId)
-      .select()
-      .single();
-
-    if (updateError) {
-      console.error("Error updating invitation:", updateError);
-      return createErrorResponse(
-        "Failed to update invitation",
-        updateError.message
-      );
-    }
-
-    debug("Invitation updated", {
-      id: updatedInvitation.id,
-      status: updatedInvitation.status,
-    });
-
-    // Track invite response in user_events for growth metrics
-    void supabase.from("user_events").insert({
-      user_id: user.id,
-      event_type: "social_invite_respond",
-      metadata: {
-        invitation_id: invitationId,
-        action: invitationResponse,
-      },
-    }).then(() => {}, () => {});
-
-    // Send notification to session creator about the response
+/**
+ * Respond to a session invitation
+ * PATCH /api/session-planner/invitations
+ */
+export const PATCH = withAuth(
+  async (request: NextRequest, { user, supabase }: AuthenticatedContext) => {
     try {
-      // Get session details to find the creator
-      const { data: session, error: sessionError } = await supabase
-        .from("sessions")
-        .select("user_id, beach_name, arrival_time")
-        .eq("id", invitation.session_id)
+      const body = await request.json();
+      const {
+        invitationId,
+        response: invitationResponse,
+        markSeen,
+        invitationIds,
+      } = body;
+
+      debug("PATCH /invitations", {
+        invitationIdPresent: Boolean(invitationId),
+        response: invitationResponse,
+        markSeen: Boolean(markSeen),
+        invitationIdsCount: Array.isArray(invitationIds) ? invitationIds.length : 0,
+      });
+
+      if (markSeen) {
+        if (!Array.isArray(invitationIds) || invitationIds.length === 0) {
+          return createErrorResponse(
+            "Invitation IDs are required to mark notifications as seen",
+            null,
+            400
+          );
+        }
+
+        const { data: updatedRows, error: seenError } = await supabase
+          .from("session_invitations")
+          .update({ seen_at: new Date().toISOString() })
+          .in("id", invitationIds)
+          .select("id, seen_at");
+
+        if (seenError) {
+          console.error("Error marking invitations as seen:", seenError);
+          return createErrorResponse(
+            "Failed to mark invitations as seen",
+            seenError.message
+          );
+        }
+
+        return createSuccessResponse(
+          {
+            updated: updatedRows ?? [],
+          },
+          200
+        );
+      }
+
+      if (!invitationId || !invitationResponse) {
+        return createErrorResponse(
+          "Invitation ID and response are required",
+          null,
+          400
+        );
+      }
+
+      if (!["accepted", "declined"].includes(invitationResponse)) {
+        return createErrorResponse(
+          "Response must be 'accepted' or 'declined'",
+          null,
+          400
+        );
+      }
+
+      // Get the invitation and verify user can respond to it
+      const { data: invitation, error: invitationError } = await supabase
+        .from("session_invitations")
+        .select("*")
+        .eq("id", invitationId)
+        .or(`invitee_id.eq.${user.id},invitee_email.ilike.${user.email}`)
         .single();
 
-      if (!sessionError && session && session.user_id !== user.id) {
-        // Get creator's notification preferences
-        const { data: creatorPrefs } = await supabase
-          .from("profiles")
-          .select("inapp_session_invites, email_session_invites, email")
-          .eq("id", session.user_id)
+      if (invitationError || !invitation) {
+        return createErrorResponse(
+          "Invitation not found or access denied",
+          null,
+          404
+        );
+      }
+
+      if (invitation.status !== "pending") {
+        return createErrorResponse(
+          "Invitation has already been responded to",
+          null,
+          400
+        );
+      }
+
+      // Update invitation status
+      const { data: updatedInvitation, error: updateError } = await supabase
+        .from("session_invitations")
+        .update({
+          status: invitationResponse,
+          responded_at: new Date().toISOString(),
+        })
+        .eq("id", invitationId)
+        .select()
+        .single();
+
+      if (updateError) {
+        console.error("Error updating invitation:", updateError);
+        return createErrorResponse(
+          "Failed to update invitation",
+          updateError.message
+        );
+      }
+
+      debug("Invitation updated", {
+        id: updatedInvitation.id,
+        status: updatedInvitation.status,
+      });
+
+      // Track invite response in user_events for growth metrics
+      void supabase.from("user_events").insert({
+        user_id: user.id,
+        event_type: "social_invite_respond",
+        metadata: {
+          invitation_id: invitationId,
+          action: invitationResponse,
+        },
+      }).then(() => {}, () => {});
+
+      // Send notification to session creator about the response
+      try {
+        // Get session details to find the creator
+        const { data: session, error: sessionError } = await supabase
+          .from("sessions")
+          .select("user_id, beach_name, arrival_time")
+          .eq("id", invitation.session_id)
           .single();
 
-        // Create in-app notification if user has not disabled them
-        if (creatorPrefs?.inapp_session_invites !== false) {
-          const notificationData = {
-            action: invitationResponse,
-            invitee_id: user.id,
-            invitee_email: user.email,
-            session_id: invitation.session_id,
-            beach_name: session.beach_name,
-            arrival_time: session.arrival_time,
-          };
+        if (!sessionError && session && session.user_id !== user.id) {
+          // Get creator's notification preferences
+          const { data: creatorPrefs } = await supabase
+            .from("profiles")
+            .select("inapp_session_invites, email_session_invites, email")
+            .eq("id", session.user_id)
+            .single();
 
-          await supabase.from("notifications").insert({
-            user_id: session.user_id,
-            type: "session_invite_response",
-            data: notificationData,
-            title:
-              invitationResponse === "accepted"
-                ? "Invitation Accepted"
-                : "Invitation Declined",
-            message:
-              invitationResponse === "accepted"
-                ? `${user.email} accepted your invitation to surf at ${session.beach_name}`
-                : `${user.email} declined your invitation to surf at ${session.beach_name}`,
-            read: false,
-          });
+          // Create in-app notification if user has not disabled them
+          if (creatorPrefs?.inapp_session_invites !== false) {
+            const notificationData = {
+              action: invitationResponse,
+              invitee_id: user.id,
+              invitee_email: user.email,
+              session_id: invitation.session_id,
+              beach_name: session.beach_name,
+              arrival_time: session.arrival_time,
+            };
 
-          debug("Notification sent to session creator", {
-            creator_id: session.user_id,
-            type: "session_invite_response",
-            action: invitationResponse,
-          });
+            await supabase.from("notifications").insert({
+              user_id: session.user_id,
+              type: "session_invite_response",
+              data: notificationData,
+              title:
+                invitationResponse === "accepted"
+                  ? "Invitation Accepted"
+                  : "Invitation Declined",
+              message:
+                invitationResponse === "accepted"
+                  ? `${user.email} accepted your invitation to surf at ${session.beach_name}`
+                  : `${user.email} declined your invitation to surf at ${session.beach_name}`,
+              read: false,
+            });
+
+            debug("Notification sent to session creator", {
+              creator_id: session.user_id,
+              type: "session_invite_response",
+              action: invitationResponse,
+            });
+          }
         }
+      } catch (notificationError) {
+        // Log error but don't fail the response - notification is non-critical
+        console.error("Failed to send notification to session creator:", notificationError);
       }
-    } catch (notificationError) {
-      // Log error but don't fail the response - notification is non-critical
-      console.error("Failed to send notification to session creator:", notificationError);
-    }
 
-    return createSuccessResponse({
-      invitation: updatedInvitation,
-      message: `Invitation ${invitationResponse}`,
-    });
-  } catch (error) {
-    console.error("Error responding to invitation:", error);
-    return createErrorResponse(
-      "Failed to respond to invitation",
-      error instanceof Error ? error.message : "Unknown error"
-    );
-  }
-}
+      return createSuccessResponse({
+        invitation: updatedInvitation,
+        message: `Invitation ${invitationResponse}`,
+      });
+    } catch (error) {
+      console.error("Error responding to invitation:", error);
+      return createErrorResponse(
+        "Failed to respond to invitation",
+        error instanceof Error ? error.message : "Unknown error"
+      );
+    }
+  },
+  { errorMessage: "Failed to respond to invitation" }
+);

--- a/app/api/sessions/[id]/photos/route.ts
+++ b/app/api/sessions/[id]/photos/route.ts
@@ -9,8 +9,8 @@ import {
   createSuccessResponse,
   createAuthError,
   methodNotAllowed,
-  type OptionalAuthContext,
 } from "@/lib/middleware/api-wrappers";
+import type { OptionalAuthContext } from "@/lib/middleware/api-wrappers/types";
 import { getSessionPhotos } from "@/lib/supabase/storage";
 
 /**

--- a/app/api/sessions/[id]/photos/route.ts
+++ b/app/api/sessions/[id]/photos/route.ts
@@ -1,33 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
-  createAuthError,
-  createSuccessResponse,
   createValidationError,
   DEFAULT_SECURITY_HEADERS,
-  handleApiError,
   isValidUuid,
-  methodNotAllowed,
 } from "@/lib/api-utils";
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  withAuth,
+  createSuccessResponse,
+  createAuthError,
+  methodNotAllowed,
+  type OptionalAuthContext,
+} from "@/lib/middleware/api-wrappers";
 import { getSessionPhotos } from "@/lib/supabase/storage";
 
-export async function GET(
-  _request: NextRequest,
-  context: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id: sessionId } = (await context.params);
+/**
+ * GET /api/sessions/[id]/photos
+ *
+ * Public sessions are viewable by anyone (for guest-mode beach page feeds).
+ * Private sessions require the viewer to be the owner.
+ *
+ * Authentication is OPTIONAL. Public sessions don't require a user; private
+ * sessions require the session owner (cookie-session or Bearer token).
+ */
+export const GET = withAuth(
+  async (
+    _request: NextRequest,
+    { user, supabase, params }: OptionalAuthContext
+  ): Promise<NextResponse> => {
+    const sessionId = params.id;
     if (!sessionId || !isValidUuid(sessionId)) {
       return createValidationError("Invalid session id format");
     }
 
-    const supabase = await createSupabaseServerClient();
-
     // Fetch the session first so we can decide whether auth is required.
-    // Public sessions are viewable by anyone (for guest-mode beach page feeds),
-    // private sessions require the viewer to be the owner. Previously this
-    // handler rejected all unauthenticated requests with 401 before checking
-    // `is_public`, which broke the anonymous session carousel on beach detail.
     const { data: existing, error: existingError } = await supabase
       .from("sessions")
       .select("id, user_id, is_public")
@@ -61,12 +66,7 @@ export async function GET(
 
     // Private session — require an authenticated viewer who owns it.
     if (!existing.is_public) {
-      const {
-        data: { user },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError || !user) {
+      if (!user) {
         return createAuthError();
       }
 
@@ -87,10 +87,9 @@ export async function GET(
     // gates the data access for anonymous callers.
     const photos = await getSessionPhotos(sessionId, supabase);
     return createSuccessResponse({ photos });
-  } catch (error) {
-    return handleApiError(error, "Failed to load session photos");
-  }
-}
+  },
+  { optional: true, errorMessage: "Failed to load session photos" }
+);
 
 export function POST() {
   return methodNotAllowed(["GET"]);
@@ -107,5 +106,3 @@ export function PATCH() {
 export function DELETE() {
   return methodNotAllowed(["GET"]);
 }
-
-

--- a/app/api/surf/insights/route.ts
+++ b/app/api/surf/insights/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
 import {
   createSuccessResponse,
-  createAuthError,
-  handleApiError,
   validateOrError,
 } from '@/lib/api-utils';
-import { withRateLimit } from '@/lib/middleware/api-wrappers';
+import {
+  withAuth,
+  withRateLimit,
+  type OptionalAuthContext,
+} from '@/lib/middleware/api-wrappers';
 import { computeSimilarityInsights } from '@/lib/services/similarity-insights-service';
 
 export const dynamic = 'force-dynamic';
@@ -47,49 +48,20 @@ const QuerySchema = z.object({
  * user's historical high-rated sessions. Powered by bucket-based similarity
  * scoring algorithm.
  *
- * @param request - Next.js request with query params
- * @returns PersonalizedInsights with match quality and recommendations
- *
- * Query Parameters (Required):
- * - beachId: Beach UUID
- * - beachName: Beach name
- * - waveHeight: Wave height in feet
- * - wavePeriod: Wave period in seconds
- * - windSpeed: Wind speed in mph
- *
- * Query Parameters (Optional):
- * - windDirection: Wind direction in degrees (0-360)
- * - tideHeight: Tide height in feet
- * - tideStatus: Tide status (e.g., "Rising", "High Slack")
- * - windowStart: ISO timestamp for forecast window
- *
- * Authentication: Required (user session)
+ * Authentication: Optional. Anonymous callers receive a degraded/onboarding
+ * response that signals the data is unavailable without their session
+ * history — this avoids 401-ing native Bearer callers before we know if we
+ * can compute, and lets the shared client reuse the "needs more sessions"
+ * UI for the no-auth case.
  * Rate Limit: 10 requests/minute
- * Cache: Private, 5 minutes
- *
- * Response States:
- * - ready: Insights computed successfully
- * - onboarding: <3 rated sessions, user needs to log more sessions
- * - degraded: No sessions with forecast snapshots, data unavailable
- *
- * @example
- * GET /api/surf/insights?beachId=123&beachName=Ocean%20Beach&waveHeight=4.5&wavePeriod=12&windSpeed=8
- * GET /api/surf/insights?beachId=123&beachName=Ocean%20Beach&waveHeight=4.5&wavePeriod=12&windSpeed=8&windDirection=270&tideHeight=4.2
+ * Cache: Private, 5 minutes (60s for the anon degraded response)
  */
-async function insightsHandler(request: NextRequest): Promise<NextResponse> {
-  try {
-    // 1. Authenticate user
-    const supabase = await createSupabaseServerClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError || !user) {
-      return createAuthError('Authentication required');
-    }
-
-    // 2. Parse and validate query parameters
+const insightsHandler = withAuth(
+  async (
+    request: NextRequest,
+    { user }: OptionalAuthContext
+  ): Promise<NextResponse> => {
+    // Parse and validate query parameters
     const { searchParams } = new URL(request.url);
     const queryData = {
       beachId: searchParams.get('beachId') || undefined,
@@ -120,10 +92,19 @@ async function insightsHandler(request: NextRequest): Promise<NextResponse> {
       windowStart,
     } = validationResult.data;
 
-    // Request received - process insights
-    // Note: Using console.warn for production logging (console.log blocked by ESLint)
+    // Anonymous callers can't have session history; return the onboarding-style
+    // degraded response the client already knows how to render.
+    if (!user) {
+      const response = createSuccessResponse({
+        status: 'onboarding',
+        message:
+          'Sign in to see personalized insights based on your sessions.',
+      });
+      response.headers.set('Cache-Control', 'private, max-age=60');
+      return response;
+    }
 
-    // 3. Call similarity insights service
+    // Call similarity insights service
     const insights = await computeSimilarityInsights(user.id, {
       beachId,
       beachName,
@@ -136,21 +117,16 @@ async function insightsHandler(request: NextRequest): Promise<NextResponse> {
       windowStart,
     });
 
-    // Insights computed successfully - return to client
-
-    // 4. Return success response with private caching
+    // Return success response with private caching (5 minutes)
     const response = createSuccessResponse(insights);
-
-    // Add private cache header (5 minutes)
-    // Private cache ensures insights are user-specific and not shared
     response.headers.set('Cache-Control', 'private, max-age=300');
-
     return response;
-  } catch (error) {
-    console.error('❌ [InsightsAPI] Error computing insights:', error);
-    return handleApiError(error, 'Error computing personalized insights');
+  },
+  {
+    optional: true,
+    errorMessage: 'Error computing personalized insights',
   }
-}
+);
 
 // Apply rate limiting (10 req/min, same as surf discovery)
 export const GET = withRateLimit(insightsHandler, 'surf-insights');

--- a/app/api/surf/insights/route.ts
+++ b/app/api/surf/insights/route.ts
@@ -7,8 +7,8 @@ import {
 import {
   withAuth,
   withRateLimit,
-  type OptionalAuthContext,
 } from '@/lib/middleware/api-wrappers';
+import type { OptionalAuthContext } from '@/lib/middleware/api-wrappers/types';
 import { computeSimilarityInsights } from '@/lib/services/similarity-insights-service';
 
 export const dynamic = 'force-dynamic';

--- a/app/api/users/[id]/profile/route.ts
+++ b/app/api/users/[id]/profile/route.ts
@@ -10,7 +10,6 @@ export async function GET(request: NextRequest, props: { params: Promise<{ id: s
     const userId = params?.id;
     if (!isValidUuid(userId)) return createValidationError("Invalid user ID");
     // Delegate to canonical route
-    // @ts-expect-error: forward to existing handler signature
     return canonicalGet(request, { params: { id: userId } });
   } catch (error) {
     return handleApiError(error);


### PR DESCRIPTION
## Summary
Proactive follow-up to Phase 4.5. Migrates 8 API routes from cookie-only auth to the `withAuth` wrapper so both cookie (web) and Bearer (native) callers resolve correctly. `internal/send-welcome-email` intentionally stays cookie-only.

## Routes
- `comments/[commentId]` DELETE
- `auth/email/update` POST (withRateLimit outer, withAuth inner)
- `session-planner/invitations` GET/POST/PATCH
- `surf/insights` GET (optional)
- `events` POST (optional, preserves anon sessionId path)
- `profile/[id]` GET (optional)
- `intel` GET (optional)
- `sessions/[id]/photos` GET (optional)

## Test plan
- [x] 216/216 tests across 11 affected suites pass
- [x] `yarn typecheck` clean
- [x] Code Reviewer LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)