### PR TITLE
hotfix(discovery): today→tomorrow fall-through in pre-sunset dead zone

### DIFF
--- a/__tests__/api/surf-discover-pre-sunset.integration.test.ts
+++ b/__tests__/api/surf-discover-pre-sunset.integration.test.ts
@@ -1,0 +1,287 @@
+/**
+ * @jest-environment node
+ *
+ * Pre-sunset dead-zone integration test (PR #218 / commit 7e0f436f)
+ *
+ * Validates the orchestrator fall-through gate fix at the integration layer:
+ * runs the REAL discoverSurfSpots() against REAL Supabase (live forecast cache)
+ * with fake clock injection. The unit test (`surf-discovery-orchestrator.test.ts`,
+ * "pre-sunset dead zone: falls through to tomorrow ...") mocks selectBestWindow
+ * entirely; this test exercises the actual selectBestWindow + sunTimesCache +
+ * getTimezoneFromCoords chain.
+ *
+ * Three scenarios on the SAME real day:
+ *   1. ~10 min before today's San Diego sunset (dead zone) → window MUST be on tomorrow
+ *   2. 06:23 PDT today (regression guard for the "Tomorrow's dawn patrol" bug)
+ *      → window MUST be on today
+ *   3. ~30 min after today's sunset (existing post-sunset path) → window MUST be on tomorrow
+ *
+ * Sunset is computed dynamically via SunCalc since it shifts a minute per day.
+ *
+ * Skipped automatically when RUN_INTEGRATION_TESTS=true is not set OR the
+ * Supabase service-role env vars are missing (next/jest auto-loads .env.local).
+ * Run with:
+ *   RUN_INTEGRATION_TESTS=true yarn test:unit __tests__/api/surf-discover-pre-sunset.integration.test.ts
+ *
+ * IMPORTANT: jest.config.js maps `@/lib/supabase/server` to a global mock
+ * (`__tests__/setup/mock-supabase.ts`). We override that mapping at the top of
+ * this file via jest.mock() so the orchestrator and all discovery sub-modules
+ * (candidate-pool-builder, forecast-batch-fetcher, personalization-layer,
+ * response-formatter, preference-learning-service, beach-query-service,
+ * forecast-service-utils) hit a REAL service-role client built directly here.
+ */
+
+import SunCalc from "suncalc";
+import path from "node:path";
+
+// next/jest skips .env.local when NODE_ENV=test (Next.js convention). Load it
+// explicitly so we hit the REAL prod Supabase, not the localhost stub in .env.
+require("dotenv").config({
+  path: path.join(process.cwd(), ".env.local"),
+  override: true,
+});
+
+// Restore real fetch BEFORE importing supabase-js (jest.setup.js installs a mock).
+const undici = require("undici");
+global.fetch = undici.fetch;
+global.Headers = undici.Headers;
+global.Request = undici.Request;
+global.Response = undici.Response;
+
+// Build a REAL service-role client and inject it for both server.ts and the
+// supabase root module. The factory must be inside the jest.mock() so jest can
+// hoist it; we lazy-construct the client on first call to ensure env vars are
+// present when invoked.
+jest.mock("@/lib/supabase/server", () => {
+  const { createClient } = jest.requireActual("@supabase/supabase-js");
+  let cached: any = null;
+  const make = () => {
+    if (cached) return cached;
+    const url = (process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
+    const key = (process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim();
+    if (!url || !key) {
+      throw new Error(
+        `[integration test] missing Supabase env: NEXT_PUBLIC_SUPABASE_URL=${!!url} SUPABASE_SERVICE_ROLE_KEY=${!!key}`
+      );
+    }
+    cached = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    });
+    return cached;
+  };
+  return {
+    createSupabaseServiceRoleClient: () => make(),
+    createSupabaseServerClient: async () => make(),
+    createPublicReadClient: () => make(),
+  };
+});
+
+// The root @/lib/supabase mapping points at mock-supabase.ts too — but the
+// orchestrator chain only imports from @/lib/supabase/server and
+// @/lib/supabase/query-builders. query-builders is a pure function module that
+// doesn't construct a client (it builds query chains from a passed-in client).
+// Realtime mock from jest.setup.js stays in place — discovery doesn't subscribe.
+
+const TEST_USER_ID = "610a5745-1e1c-4907-b5d4-f1d0d96cb4e4"; // stcha0004@gmail.com
+const LA_JOLLA = { lat: 32.7486, lon: -117.2543 };
+
+const shouldRunIntegration =
+  process.env.RUN_INTEGRATION_TESTS === "true" &&
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+jest.setTimeout(60000);
+
+// Compute today's San Diego sunset dynamically. SunCalc returns a UTC Date.
+function getTodaySunset(): Date {
+  const realNow = new Date();
+  const sunTimes = SunCalc.getTimes(realNow, LA_JOLLA.lat, LA_JOLLA.lon);
+  return sunTimes.sunset;
+}
+
+(shouldRunIntegration ? describe : describe.skip)(
+  "discoverSurfSpots — pre-sunset dead-zone fall-through (PR #218)",
+  () => {
+    let todaySunset: Date;
+    let preSunsetDeadZone: Date;
+    let widerDeadZone: Date;
+    let earlyMorning: Date;
+    let postSunset: Date;
+
+    beforeAll(() => {
+      todaySunset = getTodaySunset();
+
+      // 10 min before today's sunset — inside the MIN_SESSION_HOURS reject zone
+      preSunsetDeadZone = new Date(todaySunset.getTime() - 10 * 60 * 1000);
+
+      // 1h 38min before today's sunset — OUTSIDE the MIN_SESSION_HOURS gate
+      // (1.6h > 1.0h) but inside the 3hr-cadence dead zone: the next forecast
+      // slot lands at-or-after sunset. Reproduces the user-reported 17:52 PDT
+      // empty-home bug fixed in commit 421b3f80.
+      widerDeadZone = new Date(todaySunset.getTime() - 98 * 60 * 1000);
+
+      // 06:23 today in PDT (= 13:23 UTC during DST). Anchor to today's sunset's
+      // UTC date minus 1 day if sunset is past midnight UTC, so we land on the
+      // same local PDT day as `preSunsetDeadZone`.
+      const sunsetLocalDateUTC = new Date(todaySunset.getTime() - 7 * 60 * 60 * 1000);
+      earlyMorning = new Date(Date.UTC(
+        sunsetLocalDateUTC.getUTCFullYear(),
+        sunsetLocalDateUTC.getUTCMonth(),
+        sunsetLocalDateUTC.getUTCDate(),
+        13, 23, 0, 0
+      ));
+
+      // 30 min after today's sunset
+      postSunset = new Date(todaySunset.getTime() + 30 * 60 * 1000);
+
+      // eslint-disable-next-line no-console
+      console.log("[integration test anchors]", {
+        realNowUTC: new Date().toISOString(),
+        todaySunsetUTC: todaySunset.toISOString(),
+        preSunsetDeadZoneUTC: preSunsetDeadZone.toISOString(),
+        widerDeadZoneUTC: widerDeadZone.toISOString(),
+        earlyMorningUTC: earlyMorning.toISOString(),
+        postSunsetUTC: postSunset.toISOString(),
+      });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    async function runDiscoverAt(fakeNow: Date): Promise<any> {
+      jest.useFakeTimers({
+        now: fakeNow,
+        // Don't fake setImmediate / nextTick — Supabase / fetch use them.
+        doNotFake: ["nextTick", "setImmediate", "queueMicrotask", "performance", "setTimeout", "clearTimeout"],
+      });
+
+      // Require AFTER fake timers installed so any module-init-time clocks see
+      // the fake. The orchestrator reads new Date()/Date.now() at call time.
+      const { discoverSurfSpots } = require("@/lib/services/discovery/surf-discovery-orchestrator");
+
+      try {
+        const result = await discoverSurfSpots(TEST_USER_ID, {
+          userLocation: LA_JOLLA,
+          maxResults: 10,
+        });
+        return result;
+      } finally {
+        jest.useRealTimers();
+      }
+    }
+
+    function describeRec(rec: any): string {
+      if (!rec) return "<no rec>";
+      const ws = rec.window?.start;
+      const wsIso = ws instanceof Date ? ws.toISOString() : String(ws);
+      return `beach=${rec.beach?.name} window.start=${wsIso}`;
+    }
+
+    test("scenario 1: pre-sunset dead zone (10 min before sunset) falls through to TOMORROW", async () => {
+      const result = await runDiscoverAt(preSunsetDeadZone);
+      const top = result.recommendations[0];
+
+      // eslint-disable-next-line no-console
+      console.log("[scenario 1 result]", {
+        recs: result.recommendations.length,
+        top: describeRec(top),
+        metadata: result.metadata,
+      });
+
+      expect(result.recommendations.length).toBeGreaterThan(0);
+      expect(top).toBeDefined();
+      expect(top.window).toBeDefined();
+
+      const windowStart = top.window.start instanceof Date
+        ? top.window.start
+        : new Date(top.window.start);
+
+      // The fix: window MUST be after today's sunset (i.e., on tomorrow).
+      expect(windowStart.getTime()).toBeGreaterThan(todaySunset.getTime());
+    });
+
+    test("scenario 1b: wider dead zone (1h 38min before sunset, 3hr cadence gap) falls through to TOMORROW", async () => {
+      const result = await runDiscoverAt(widerDeadZone);
+      const top = result.recommendations[0];
+
+      // eslint-disable-next-line no-console
+      console.log("[scenario 1b result]", {
+        recs: result.recommendations.length,
+        top: describeRec(top),
+        metadata: result.metadata,
+      });
+
+      expect(result.recommendations.length).toBeGreaterThan(0);
+      expect(top).toBeDefined();
+      expect(top.window).toBeDefined();
+
+      const windowStart = top.window.start instanceof Date
+        ? top.window.start
+        : new Date(top.window.start);
+
+      // The wider-dead-zone fix: at 1h 38min before sunset, MIN_SESSION_HOURS
+      // gate is closed (1.6h > 1.0h) but no remaining today forecast lands
+      // before sunset (next 3hr slot is post-sunset). Window MUST be on
+      // tomorrow — proving `hasUsableTodayForecast=false` opened the gate.
+      expect(windowStart.getTime()).toBeGreaterThan(todaySunset.getTime());
+    });
+
+    test("scenario 2: 06:23 PDT regression guard returns TODAY's window", async () => {
+      const result = await runDiscoverAt(earlyMorning);
+      const top = result.recommendations[0];
+
+      // eslint-disable-next-line no-console
+      console.log("[scenario 2 result]", {
+        recs: result.recommendations.length,
+        top: describeRec(top),
+        metadata: result.metadata,
+      });
+
+      expect(result.recommendations.length).toBeGreaterThan(0);
+      expect(top).toBeDefined();
+      expect(top.window).toBeDefined();
+
+      const windowStart = top.window.start instanceof Date
+        ? top.window.start
+        : new Date(top.window.start);
+
+      // 6:23 AM regression guard: window MUST be before today's sunset (i.e., today),
+      // not flipped to tomorrow's dawn patrol.
+      expect(windowStart.getTime()).toBeLessThan(todaySunset.getTime());
+    });
+
+    test("scenario 3: post-sunset (30 min after sunset) returns TOMORROW's window", async () => {
+      const result = await runDiscoverAt(postSunset);
+      const top = result.recommendations[0];
+
+      // eslint-disable-next-line no-console
+      console.log("[scenario 3 result]", {
+        recs: result.recommendations.length,
+        top: describeRec(top),
+        metadata: result.metadata,
+      });
+
+      expect(result.recommendations.length).toBeGreaterThan(0);
+      expect(top).toBeDefined();
+      expect(top.window).toBeDefined();
+
+      const windowStart = top.window.start instanceof Date
+        ? top.window.start
+        : new Date(top.window.start);
+
+      // Post-sunset path (existing behavior): window MUST be on tomorrow.
+      expect(windowStart.getTime()).toBeGreaterThan(todaySunset.getTime());
+    });
+  }
+);
+
+// When skipped, give a single passing assertion so Jest doesn't complain about
+// an empty test file in CI runs that don't set RUN_INTEGRATION_TESTS=true.
+if (!shouldRunIntegration) {
+  describe("discoverSurfSpots integration (skipped)", () => {
+    it("requires RUN_INTEGRATION_TESTS=true and Supabase env vars", () => {
+      expect(true).toBe(true);
+    });
+  });
+}

--- a/__tests__/lib/services/discovery/surf-discovery-orchestrator.test.ts
+++ b/__tests__/lib/services/discovery/surf-discovery-orchestrator.test.ts
@@ -1464,4 +1464,461 @@ describe('discoverSurfSpots - Today-First No-Fallback Guard', () => {
     );
     expect(staleFallbackWarn).toBeUndefined();
   });
+
+  test('pre-sunset dead zone: falls through to tomorrow when today-only fails within MIN_SESSION_HOURS of sunset', async () => {
+    // Reproduces the 19:21 PDT / sunset 19:31 dead zone on 2026-04-23:
+    // today has forecasts (pre-sunset), but selectBestWindow rejects them all
+    // because hoursUntilSunset < MIN_SESSION_HOURS (1.0h). The strict
+    // `isPostSunsetForBeach` gate (now > sunset) didn't fire at 19:21, so
+    // the orchestrator never reached for tomorrow and returned 0 recs.
+    const { selectBestWindow: mockSelectBestWindow } = require('@/lib/services/discovery/window-selector');
+
+    // Fake "now" = 10 minutes before sunset. 19:21 PDT on 2026-04-23 == 02:21Z on 2026-04-24.
+    const now = new Date('2026-04-24T02:21:00Z');
+    const sunset = new Date('2026-04-24T02:31:00Z'); // 19:31 PDT, same local day
+    jest.useFakeTimers().setSystemTime(now);
+
+    const todayIso = now.toISOString();
+    const tomorrowDawnIso = '2026-04-24T14:00:00.000Z'; // ~07:00 PDT next morning
+
+    const todayForecast: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: todayIso,
+      forecast_date: todayIso.split('T')[0],
+      forecast_time: '19:21:00',
+      wave_height: '2.5',
+      wave_period: '12s',
+      wind_speed: '6',
+      wind_direction_deg: 270,
+      tide_status: 'Rising',
+      data_source: 'CDIP',
+    };
+    const tomorrowForecast: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: tomorrowDawnIso,
+      forecast_date: tomorrowDawnIso.split('T')[0],
+      forecast_time: '14:00:00',
+      wave_height: '3.5',
+      wave_period: '13s',
+      wind_speed: '4',
+      wind_direction_deg: 270,
+      tide_status: 'Rising',
+      data_source: 'CDIP',
+    };
+
+    mockState.forecastBatchResponse = {
+      successful: [{ beach: mockBeach1, forecasts: [todayForecast, tomorrowForecast] }],
+      failed: [],
+      staleCount: 0,
+    };
+
+    // First call (today-only) returns null — window selector rejects all remaining
+    // today forecasts for being too close to sunset.
+    // Second call (full set, post-fix) returns the tomorrow dawn-patrol window.
+    mockSelectBestWindow.mockReset();
+    const tomorrowWindow = {
+      start: new Date(tomorrowDawnIso),
+      end: new Date(new Date(tomorrowDawnIso).getTime() + 3 * 60 * 60 * 1000),
+      tide: 'Rising',
+      wind: '4 mph W',
+      waveHeight: '3-4 ft',
+      wavePeriod: '13s',
+      dataSource: 'CDIP',
+      confidence: 88,
+      timezone: 'America/Los_Angeles',
+      sourceForecast: tomorrowForecast,
+    };
+    mockSelectBestWindow
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(tomorrowWindow);
+
+    jest.resetModules();
+    jest.doMock('@/lib/logger', () => ({
+      createContextLogger: jest.fn(() => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      })),
+    }));
+    jest.doMock('@/lib/services/discovery/window-selector', () => ({
+      selectBestWindow: mockSelectBestWindow,
+      getLocalDateStr: jest.fn((date: Date, _tz: string) => date.toISOString().split('T')[0]),
+      getLocalHour: jest.fn((date: Date, _tz: string) => date.getUTCHours()),
+      MIN_SESSION_HOURS: 1.0,
+    }));
+    jest.doMock('@/lib/services/discovery/candidate-pool-builder', () => ({
+      buildCandidatePool: jest.fn(async () => mockState.candidatePoolResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/forecast-batch-fetcher', () => ({
+      batchFetchForecasts: jest.fn(async () => mockState.forecastBatchResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/response-formatter', () => ({
+      enrichWithPhotos: jest.fn(async (recs: any[]) => recs),
+      generateDiscoverySummary: jest.fn(() => 'Tomorrow looks better'),
+      getRecommendationLabel: jest.fn(() => 'Worth it tomorrow'),
+      buildDiscoveryMessage: jest.fn(() => 'Worth it tomorrow — Tomorrow looks better'),
+    }));
+    jest.doMock('@/lib/services/preference-learning-service', () => ({
+      getUserSurfPreferences: jest.fn(async () => null),
+    }));
+    jest.doMock('@/lib/services/beach-query-service', () => ({
+      getFavoriteBeachesFromDb: jest.fn(async () => ({ success: true, data: [] })),
+    }));
+    // Supabase mock: return a sun_times row for beach-1 so sunTimesCache.get(beach.id)
+    // resolves to a sunset that matches `todayStr`, which is what drives the
+    // "effectively over" gate.
+    jest.doMock('@/lib/supabase/server', () => ({
+      createSupabaseServiceRoleClient: jest.fn(() => ({
+        from: jest.fn((table: string) => ({
+          select: jest.fn(() => ({
+            in: jest.fn(() => ({
+              in: jest.fn(() => ({
+                order: jest.fn(() => Promise.resolve({
+                  data: table === 'sun_times'
+                    ? [{ beach_id: 'beach-1', sunrise_utc: '2026-04-23T13:07:00Z', sunset_utc: sunset.toISOString() }]
+                    : [],
+                  error: null,
+                })),
+              })),
+            })),
+            eq: jest.fn(() => ({
+              in: jest.fn(() => Promise.resolve({ data: [], error: null })),
+            })),
+          })),
+        })),
+      })),
+    }));
+    jest.doMock('@/lib/domains/scoring', () => ({
+      createDiscoveryScoringEngine: jest.fn(() => ({})),
+      scoreBeachWithEngine: jest.fn(() => ({
+        total: 80,
+        subscores: { waveHeightFit: 22, periodEnergyScore: 18, windAlignment: 16, tideFit: 12, affinityBonus: 0, personalizationBonus: 0, distancePenalty: 0 },
+        matchQuality: 'excellent',
+        reasons: ['Dawn patrol'],
+        warnings: [],
+        conditionBadges: [],
+      })),
+    }));
+    jest.doMock('@/lib/utils/timezone-utils.server', () => ({
+      getTimezoneFromCoords: jest.fn(() => 'America/Los_Angeles'),
+    }));
+    jest.doMock('@/lib/services/discovery/personalization-layer', () => ({
+      fetchPersonalizationContext: jest.fn(async () => ({
+        implicitPrefs: null, learnedPrefs: null, affinityMap: new Map(), preferredBreakType: null, implicitWeight: 0,
+      })),
+      calculatePersonalizationBonus: jest.fn(() => ({ total: 0, affinityBonus: 0, personalizationBonus: 0, reasons: [] })),
+    }));
+
+    try {
+      const { discoverSurfSpots: freshDiscover } = require('@/lib/services/discovery/surf-discovery-orchestrator');
+      const result = await freshDiscover(testUserId, { userLocation: defaultUserLocation });
+
+      // Post-fix: selectBestWindow must have been called TWICE — first today-only
+      // (null), then full set (tomorrow window) — because `todayIsEffectivelyOver`
+      // fires when hoursUntilSunset < MIN_SESSION_HOURS.
+      expect(mockSelectBestWindow).toHaveBeenCalledTimes(2);
+      expect(result.recommendations).toHaveLength(1);
+      expect(result.recommendations[0].window.start.toISOString()).toBe(tomorrowDawnIso);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('wider dead zone: falls through when remaining today forecasts are all post-sunset (3hr cadence gap)', async () => {
+    // The 17:52 PDT / sunset 19:30 case: hoursUntilSunset=1.6h (gate stays
+    // closed under MIN_SESSION_HOURS=1.0h), but the only cached today slots
+    // are 20:00 and 23:00 — both past sunset. Without the
+    // `hasUsableTodayForecast` check, today returns null and tomorrow
+    // fall-through never fires, leaving the home screen empty.
+    const { selectBestWindow: mockSelectBestWindow } = require('@/lib/services/discovery/window-selector');
+
+    // Fake "now" = 17:52 PDT (1.6h before sunset).
+    const now = new Date('2026-04-25T00:52:00Z'); // 17:52 PDT 2026-04-24
+    const sunset = new Date('2026-04-25T02:30:00Z'); // 19:30 PDT 2026-04-24
+    jest.useFakeTimers().setSystemTime(now);
+
+    const todayPostSunset1Iso = '2026-04-25T03:00:00.000Z'; // 20:00 PDT today
+    const todayPostSunset2Iso = '2026-04-25T06:00:00.000Z'; // 23:00 PDT today
+    const tomorrowDawnIso = '2026-04-25T14:00:00.000Z'; // ~07:00 PDT next morning
+
+    const todayPostSunset1: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: todayPostSunset1Iso,
+      forecast_date: todayPostSunset1Iso.split('T')[0],
+      forecast_time: '20:00:00',
+      wave_height: '2.0', wave_period: '12s', wind_speed: '6',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+    const todayPostSunset2: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: todayPostSunset2Iso,
+      forecast_date: todayPostSunset2Iso.split('T')[0],
+      forecast_time: '23:00:00',
+      wave_height: '2.0', wave_period: '12s', wind_speed: '6',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+    const tomorrowForecast: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: tomorrowDawnIso,
+      forecast_date: tomorrowDawnIso.split('T')[0],
+      forecast_time: '07:00:00',
+      wave_height: '3.5', wave_period: '13s', wind_speed: '4',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+
+    mockState.forecastBatchResponse = {
+      successful: [{ beach: mockBeach1, forecasts: [todayPostSunset1, todayPostSunset2, tomorrowForecast] }],
+      failed: [],
+      staleCount: 0,
+    };
+
+    mockSelectBestWindow.mockReset();
+    const tomorrowWindow = {
+      start: new Date(tomorrowDawnIso),
+      end: new Date(new Date(tomorrowDawnIso).getTime() + 3 * 60 * 60 * 1000),
+      tide: 'Rising',
+      wind: '4 mph W',
+      waveHeight: '3-4 ft',
+      wavePeriod: '13s',
+      dataSource: 'CDIP',
+      confidence: 88,
+      timezone: 'America/Los_Angeles',
+      sourceForecast: tomorrowForecast,
+    };
+    mockSelectBestWindow
+      .mockReturnValueOnce(null) // today-only call
+      .mockReturnValueOnce(tomorrowWindow); // full-set fall-through call
+
+    jest.resetModules();
+    jest.doMock('@/lib/logger', () => ({
+      createContextLogger: jest.fn(() => ({
+        debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(),
+      })),
+    }));
+    jest.doMock('@/lib/services/discovery/window-selector', () => ({
+      selectBestWindow: mockSelectBestWindow,
+      getLocalDateStr: jest.fn((date: Date, _tz: string) => date.toISOString().split('T')[0]),
+      getLocalHour: jest.fn((date: Date, _tz: string) => date.getUTCHours()),
+      MIN_SESSION_HOURS: 1.0,
+    }));
+    jest.doMock('@/lib/services/discovery/candidate-pool-builder', () => ({
+      buildCandidatePool: jest.fn(async () => mockState.candidatePoolResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/forecast-batch-fetcher', () => ({
+      batchFetchForecasts: jest.fn(async () => mockState.forecastBatchResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/response-formatter', () => ({
+      enrichWithPhotos: jest.fn(async (recs: any[]) => recs),
+      generateDiscoverySummary: jest.fn(() => 'Tomorrow looks better'),
+      getRecommendationLabel: jest.fn(() => 'Worth it tomorrow'),
+      buildDiscoveryMessage: jest.fn(() => 'Worth it tomorrow — Tomorrow looks better'),
+    }));
+    jest.doMock('@/lib/services/preference-learning-service', () => ({
+      getUserSurfPreferences: jest.fn(async () => null),
+    }));
+    jest.doMock('@/lib/services/beach-query-service', () => ({
+      getFavoriteBeachesFromDb: jest.fn(async () => ({ success: true, data: [] })),
+    }));
+    jest.doMock('@/lib/supabase/server', () => ({
+      createSupabaseServiceRoleClient: jest.fn(() => ({
+        from: jest.fn((table: string) => ({
+          select: jest.fn(() => ({
+            in: jest.fn(() => ({
+              in: jest.fn(() => ({
+                order: jest.fn(() => Promise.resolve({
+                  data: table === 'sun_times'
+                    ? [{ beach_id: 'beach-1', sunrise_utc: '2026-04-24T13:07:00Z', sunset_utc: sunset.toISOString() }]
+                    : [],
+                  error: null,
+                })),
+              })),
+            })),
+            eq: jest.fn(() => ({
+              in: jest.fn(() => Promise.resolve({ data: [], error: null })),
+            })),
+          })),
+        })),
+      })),
+    }));
+    jest.doMock('@/lib/domains/scoring', () => ({
+      createDiscoveryScoringEngine: jest.fn(() => ({})),
+      scoreBeachWithEngine: jest.fn(() => ({
+        total: 80,
+        subscores: { waveHeightFit: 22, periodEnergyScore: 18, windAlignment: 16, tideFit: 12, affinityBonus: 0, personalizationBonus: 0, distancePenalty: 0 },
+        matchQuality: 'excellent',
+        reasons: ['Dawn patrol'], warnings: [], conditionBadges: [],
+      })),
+    }));
+    jest.doMock('@/lib/utils/timezone-utils.server', () => ({
+      getTimezoneFromCoords: jest.fn(() => 'America/Los_Angeles'),
+    }));
+    jest.doMock('@/lib/services/discovery/personalization-layer', () => ({
+      fetchPersonalizationContext: jest.fn(async () => ({
+        implicitPrefs: null, learnedPrefs: null, affinityMap: new Map(), preferredBreakType: null, implicitWeight: 0,
+      })),
+      calculatePersonalizationBonus: jest.fn(() => ({ total: 0, affinityBonus: 0, personalizationBonus: 0, reasons: [] })),
+    }));
+
+    try {
+      const { discoverSurfSpots: freshDiscover } = require('@/lib/services/discovery/surf-discovery-orchestrator');
+      const result = await freshDiscover(testUserId, { userLocation: defaultUserLocation });
+
+      // Both calls must have happened: today-only (null), then full set
+      // (tomorrow window) — driven by `hasUsableTodayForecast=false`.
+      expect(mockSelectBestWindow).toHaveBeenCalledTimes(2);
+      expect(result.recommendations).toHaveLength(1);
+      expect(result.recommendations[0].window.start.toISOString()).toBe(tomorrowDawnIso);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('wider dead zone with stale-cache: pre-sunset slot is in the past, gate must still open', async () => {
+    // Defensive case: at 17:52 PDT today's cache contains an old 11:00 PDT
+    // slot (still pre-sunset, but stale per window-selector's past tolerance)
+    // plus the same post-sunset 20:00/23:00 slots. Without the past-tolerance
+    // mirror, `hasUsableTodayForecast` would count 11:00 as usable and leave
+    // the gate closed — yet `selectBestWindow` would reject 11:00 as stale,
+    // returning null and producing an empty home. The fix's cutoff
+    // (FORECAST_WINDOW_DURATION + PAST_WINDOW_TOLERANCE = 45min) excludes
+    // 11:00 (~7h old) so the gate opens and tomorrow fall-through fires.
+    const { selectBestWindow: mockSelectBestWindow } = require('@/lib/services/discovery/window-selector');
+
+    const now = new Date('2026-04-25T00:52:00Z'); // 17:52 PDT 2026-04-24
+    const sunset = new Date('2026-04-25T02:30:00Z'); // 19:30 PDT 2026-04-24
+    jest.useFakeTimers().setSystemTime(now);
+
+    const stalePreSunsetIso = '2026-04-24T18:00:00.000Z'; // 11:00 PDT today (stale)
+    const todayPostSunsetIso = '2026-04-25T03:00:00.000Z'; // 20:00 PDT today
+    const tomorrowDawnIso = '2026-04-25T14:00:00.000Z'; // ~07:00 PDT next morning
+
+    const stalePreSunset: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: stalePreSunsetIso,
+      forecast_date: stalePreSunsetIso.split('T')[0],
+      forecast_time: '11:00:00',
+      wave_height: '2.0', wave_period: '12s', wind_speed: '6',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+    const todayPostSunset: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: todayPostSunsetIso,
+      forecast_date: todayPostSunsetIso.split('T')[0],
+      forecast_time: '20:00:00',
+      wave_height: '2.0', wave_period: '12s', wind_speed: '6',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+    const tomorrowForecast: Partial<EnhancedForecastEntity> = {
+      beach_id: 'beach-1',
+      forecast_at: tomorrowDawnIso,
+      forecast_date: tomorrowDawnIso.split('T')[0],
+      forecast_time: '07:00:00',
+      wave_height: '3.5', wave_period: '13s', wind_speed: '4',
+      wind_direction_deg: 270, tide_status: 'Rising', data_source: 'CDIP',
+    };
+
+    mockState.forecastBatchResponse = {
+      successful: [{ beach: mockBeach1, forecasts: [stalePreSunset, todayPostSunset, tomorrowForecast] }],
+      failed: [],
+      staleCount: 0,
+    };
+
+    mockSelectBestWindow.mockReset();
+    const tomorrowWindow = {
+      start: new Date(tomorrowDawnIso),
+      end: new Date(new Date(tomorrowDawnIso).getTime() + 3 * 60 * 60 * 1000),
+      tide: 'Rising', wind: '4 mph W', waveHeight: '3-4 ft', wavePeriod: '13s',
+      dataSource: 'CDIP', confidence: 88, timezone: 'America/Los_Angeles',
+      sourceForecast: tomorrowForecast,
+    };
+    mockSelectBestWindow
+      .mockReturnValueOnce(null) // today-only call (stale + post-sunset all rejected)
+      .mockReturnValueOnce(tomorrowWindow); // full-set fall-through call
+
+    jest.resetModules();
+    jest.doMock('@/lib/logger', () => ({
+      createContextLogger: jest.fn(() => ({
+        debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn(),
+      })),
+    }));
+    jest.doMock('@/lib/services/discovery/window-selector', () => ({
+      selectBestWindow: mockSelectBestWindow,
+      getLocalDateStr: jest.fn((date: Date, _tz: string) => date.toISOString().split('T')[0]),
+      getLocalHour: jest.fn((date: Date, _tz: string) => date.getUTCHours()),
+      MIN_SESSION_HOURS: 1.0,
+      FORECAST_WINDOW_DURATION_MINUTES: 30,
+      PAST_WINDOW_TOLERANCE_MINUTES: 15,
+    }));
+    jest.doMock('@/lib/services/discovery/candidate-pool-builder', () => ({
+      buildCandidatePool: jest.fn(async () => mockState.candidatePoolResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/forecast-batch-fetcher', () => ({
+      batchFetchForecasts: jest.fn(async () => mockState.forecastBatchResponse),
+    }));
+    jest.doMock('@/lib/services/discovery/response-formatter', () => ({
+      enrichWithPhotos: jest.fn(async (recs: any[]) => recs),
+      generateDiscoverySummary: jest.fn(() => 'Tomorrow looks better'),
+      getRecommendationLabel: jest.fn(() => 'Worth it tomorrow'),
+      buildDiscoveryMessage: jest.fn(() => 'Worth it tomorrow — Tomorrow looks better'),
+    }));
+    jest.doMock('@/lib/services/preference-learning-service', () => ({
+      getUserSurfPreferences: jest.fn(async () => null),
+    }));
+    jest.doMock('@/lib/services/beach-query-service', () => ({
+      getFavoriteBeachesFromDb: jest.fn(async () => ({ success: true, data: [] })),
+    }));
+    jest.doMock('@/lib/supabase/server', () => ({
+      createSupabaseServiceRoleClient: jest.fn(() => ({
+        from: jest.fn((table: string) => ({
+          select: jest.fn(() => ({
+            in: jest.fn(() => ({
+              in: jest.fn(() => ({
+                order: jest.fn(() => Promise.resolve({
+                  data: table === 'sun_times'
+                    ? [{ beach_id: 'beach-1', sunrise_utc: '2026-04-24T13:07:00Z', sunset_utc: sunset.toISOString() }]
+                    : [],
+                  error: null,
+                })),
+              })),
+            })),
+            eq: jest.fn(() => ({
+              in: jest.fn(() => Promise.resolve({ data: [], error: null })),
+            })),
+          })),
+        })),
+      })),
+    }));
+    jest.doMock('@/lib/domains/scoring', () => ({
+      createDiscoveryScoringEngine: jest.fn(() => ({})),
+      scoreBeachWithEngine: jest.fn(() => ({
+        total: 80,
+        subscores: { waveHeightFit: 22, periodEnergyScore: 18, windAlignment: 16, tideFit: 12, affinityBonus: 0, personalizationBonus: 0, distancePenalty: 0 },
+        matchQuality: 'excellent',
+        reasons: ['Dawn patrol'], warnings: [], conditionBadges: [],
+      })),
+    }));
+    jest.doMock('@/lib/utils/timezone-utils.server', () => ({
+      getTimezoneFromCoords: jest.fn(() => 'America/Los_Angeles'),
+    }));
+    jest.doMock('@/lib/services/discovery/personalization-layer', () => ({
+      fetchPersonalizationContext: jest.fn(async () => ({
+        implicitPrefs: null, learnedPrefs: null, affinityMap: new Map(), preferredBreakType: null, implicitWeight: 0,
+      })),
+      calculatePersonalizationBonus: jest.fn(() => ({ total: 0, affinityBonus: 0, personalizationBonus: 0, reasons: [] })),
+    }));
+
+    try {
+      const { discoverSurfSpots: freshDiscover } = require('@/lib/services/discovery/surf-discovery-orchestrator');
+      const result = await freshDiscover(testUserId, { userLocation: defaultUserLocation });
+
+      // Past-tolerance mirror should have excluded the 11:00 PDT slot, so
+      // hasUsableTodayForecast=false → gate opens → fall-through fires.
+      expect(mockSelectBestWindow).toHaveBeenCalledTimes(2);
+      expect(result.recommendations).toHaveLength(1);
+      expect(result.recommendations[0].window.start.toISOString()).toBe(tomorrowDawnIso);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/lib/services/discovery/surf-discovery-orchestrator.ts
+++ b/lib/services/discovery/surf-discovery-orchestrator.ts
@@ -42,7 +42,14 @@ import { isFutureDayInTimezone } from '@/lib/utils/condition-tier-utils';
 // Import from other discovery modules
 import { buildCandidatePool } from './candidate-pool-builder';
 import { batchFetchForecasts } from './forecast-batch-fetcher';
-import { selectBestWindow, getLocalDateStr, getLocalHour } from './window-selector';
+import {
+  selectBestWindow,
+  getLocalDateStr,
+  getLocalHour,
+  MIN_SESSION_HOURS,
+  FORECAST_WINDOW_DURATION_MINUTES,
+  PAST_WINDOW_TOLERANCE_MINUTES,
+} from './window-selector';
 import {
   enrichWithPhotos,
   generateDiscoverySummary,
@@ -571,27 +578,52 @@ async function discoverSurfSpotsInner(
     // regression guarded by the no-fall-through test in this suite). Fall
     // through to the full forecast set in two cases:
     //   1. todayForecasts was empty (data only starts tomorrow)
-    //   2. today-only returned null AND we're already post-sunset for this
-    //      beach, so "today" is genuinely over and holding the line would
-    //      return zero recommendations for the whole evening.
+    //   2. today-only returned null AND today is physically over for surf —
+    //      either past sunset, OR within MIN_SESSION_HOURS of it so no
+    //      remaining forecast can form a viable window. Mirrors the
+    //      window-selector's own pre-sunset reject at
+    //      window-selector-core.ts:565, closing the dead-zone where
+    //      today-only returns null but we aren't technically past sunset
+    //      yet (e.g. 19:21 PDT with sunset 19:31).
     const nowForFallback = new Date();
     const beachSunTimes = sunTimesCache.get(beach.id);
     const beachSameDaySunset = beachSunTimes?.sunsets.find(
       (s: Date) => getLocalDateStr(s, beachTz) === todayStr
     );
-    const isPostSunsetForBeach =
-      !!beachSameDaySunset && nowForFallback.getTime() > beachSameDaySunset.getTime();
+    const hoursUntilSunset = beachSameDaySunset
+      ? (beachSameDaySunset.getTime() - nowForFallback.getTime()) / (60 * 60 * 1000)
+      : null;
+    // Forecasts arrive at 3-hour cadence, so the dead zone is wider than the
+    // sunset proximity check alone catches: at 17:52 PDT with sunset 19:30,
+    // hoursUntilSunset=1.6 (gate stays closed) but the only remaining today
+    // slots are 20:00/23:00 (both post-sunset). Detect that case explicitly
+    // by checking whether any cached today forecast is still pre-sunset AND
+    // not yet stale per the window selector's own past-tolerance filter
+    // (window-selector-core.ts:103-110). Mirroring that filter keeps this
+    // gate aligned with what selectBestWindow actually accepts.
+    const pastToleranceMs =
+      (FORECAST_WINDOW_DURATION_MINUTES + PAST_WINDOW_TOLERANCE_MINUTES) * 60 * 1000;
+    const usableCutoffMs = nowForFallback.getTime() - pastToleranceMs;
+    const hasUsableTodayForecast = beachSameDaySunset
+      ? todayForecasts.some(f => {
+          const t = new Date(f.forecast_at).getTime();
+          return t <= beachSameDaySunset.getTime() && t >= usableCutoffMs;
+        })
+      : todayForecasts.length > 0;
+    const todayIsEffectivelyOver =
+      (hoursUntilSunset !== null && hoursUntilSunset < MIN_SESSION_HOURS) ||
+      (todayForecasts.length > 0 && !hasUsableTodayForecast);
 
     let bestWindow = todayForecasts.length > 0
       ? selectBestWindow(todayForecasts, beach, userPrefs, horizonHours, sunTimesCache, timeSlot)
       : null;
 
-    if (!bestWindow && (todayForecasts.length === 0 || isPostSunsetForBeach)) {
+    if (!bestWindow && (todayForecasts.length === 0 || todayIsEffectivelyOver)) {
       bestWindow = selectBestWindow(forecasts, beach, userPrefs, horizonHours, sunTimesCache, timeSlot);
       if (!bestWindow && todayForecasts.length === 0) {
         log.warn(`[discoverSurfSpots] ${beach.name}: no today forecasts (total=${forecasts.length}), tomorrow fallback returned null`);
       } else if (!bestWindow) {
-        log.warn(`[discoverSurfSpots] ${beach.name}: post-sunset fall-through failed (today=${todayForecasts.length}, total=${forecasts.length})`);
+        log.warn(`[discoverSurfSpots] ${beach.name}: pre/post-sunset fall-through failed (today=${todayForecasts.length}, total=${forecasts.length}, hoursUntilSunset=${hoursUntilSunset?.toFixed(2)})`);
       }
     }
 


### PR DESCRIPTION
## Summary

Hotfix for the user-reported empty-home-screen bug: at 17:52 PDT with SD sunset 19:30, the home screen rendered "We couldn't find any surf spots near you right now" even though every San Diego beach scored 72-100 on tomorrow's forecasts.

Squashes 5 sequential discovery commits already on \`main\` (\`6f89c294\`, \`50df5912\`, \`7e0f436f\`, \`421b3f80\`, \`2a8fb659\`) into a single focused commit on top of \`prod\`. Identical net behavior — the squash collapses the historical iteration so the prod merge surface is minimal.

## Root cause

Forecasts arrive at 3-hour cadence, so the today-first / tomorrow-fallback gate has a **wider dead zone** than any single proximity check catches:

- \`selectBestWindow(todayForecasts)\` correctly rejects post-sunset slots
- Orchestrator's fall-through to tomorrow was originally gated on strict \`now > sunset\`, then \`hoursUntilSunset < MIN_SESSION_HOURS\` (1.0h)
- At 17:52 PDT with sunset 19:30: \`hoursUntilSunset=1.6h\` (gate stays closed under threshold), but next today slot is 20:00 (post-sunset). All filters reject; tomorrow never tried; **0 recs returned**.

## Fix

Extend \`todayIsEffectivelyOver\` to also fire when no cached today forecast is both:
1. Pre-sunset (\`forecast_at <= sunset\`), AND
2. Within the window selector's past tolerance (\`FORECAST_WINDOW_DURATION + PAST_WINDOW_TOLERANCE = 45min\`)

Mirrors \`window-selector-core.ts:103-110\` so the gate's notion of "usable" matches what \`selectBestWindow\` actually accepts.

**6:23 AM regression guard preserved**: at pre-dawn, today's slots at 06:00–18:00 are abundant and pre-sunset, so \`hasUsableTodayForecast\` stays true and the new branch doesn't fire.

## Test plan

- [x] 29 unit tests pass — \`__tests__/lib/services/discovery/surf-discovery-orchestrator.test.ts\` including:
  - Original 6:23 AM "Tomorrow's dawn patrol" regression guard
  - Narrow dead zone (10min before sunset, \`MIN_SESSION_HOURS\` branch)
  - **Wider dead zone (3hr cadence gap, new \`hasUsableTodayForecast\` branch)**
  - **Wider dead zone with stale-cache (past-tolerance mirror)**
- [x] 4 integration scenarios pass against **real prod Supabase forecasts** with fake clock injection — \`__tests__/api/surf-discover-pre-sunset.integration.test.ts\`:
  - Scenario 1: narrow dead zone → tomorrow window ✓
  - **Scenario 1b: wider dead zone (1h 38min before sunset) → tomorrow window ✓**
  - Scenario 2: 06:23 PDT regression guard → today window ✓
  - Scenario 3: post-sunset → tomorrow window ✓
- [x] TypeScript clean
- [x] E2E specs (\`discover\`, \`home\`, \`onboarding-entry-points\`) all green against dev preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)