### PR TITLE
fix(alerts): replace fragile two-hop join + unit-aware parsers (A4.2-A4.4)

### DIFF
--- a/__tests__/api/cron/condition-alert-evaluate.test.ts
+++ b/__tests__/api/cron/condition-alert-evaluate.test.ts
@@ -1,0 +1,390 @@
+/** @jest-environment node */
+
+/**
+ * Unit tests for condition-alert-evaluate — A4.2 flat-query rewrite.
+ *
+ * Covers:
+ * 1. Happy path: 1 rule + matching forecast => 1 alert_queue upsert, queued >= 1.
+ * 2. Empty rules: 0 rules => message "No rules to evaluate", no DB writes after rules query.
+ * 3. Missing profile: rule exists but profile lookup returns empty => rule skipped,
+ *    summary.errors incremented, route does not crash.
+ * 4. Existing delivery for today: alert_deliveries row present => all rules for user skipped.
+ *
+ * Mocking strategy: per-table chain factory matching the established pattern in
+ * condition-alert-deliver.test.ts. Each Supabase table gets its own chain that
+ * simulates the fluent filter API and resolves from a seeded store.
+ */
+
+// Polyfill Response.json for Jest node env
+if (typeof (globalThis as any).Response?.json !== "function") {
+  (globalThis as any).Response.json = (data: any, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    });
+}
+
+import { GET } from "@/app/api/cron/condition-alert-evaluate/route";
+import { expectConsoleErrors } from "@/__tests__/setup/test-utils";
+
+// ---- Mocks ----
+
+jest.mock("@/lib/api-utils", () => ({
+  validateCronRequest: jest.fn(() => true),
+}));
+
+// withCronObservability: pass through to the handler without touching cron_runs table.
+jest.mock("@/lib/cron/observability", () => ({
+  withCronObservability: jest.fn(async (_route: string, handler: () => Promise<unknown>) =>
+    handler()
+  ),
+}));
+
+// Mock window-finder + sunrise + timezone-utils so we control matching behaviour.
+const mockFindMatchingWindows = jest.fn();
+const mockFilterToDaylight = jest.fn((hours: any[]) => hours); // pass-through by default
+const mockGetDaylightWindow = jest.fn(() => ({
+  sunrise: new Date("2026-04-26T13:00:00Z"),
+  sunset: new Date("2026-04-27T02:00:00Z"),
+}));
+const mockGetUtcDayBounds = jest.fn(() => ({
+  start: "2026-04-26T00:00:00.000Z",
+  end: "2026-04-27T00:00:00.000Z",
+}));
+const mockResolveEntitlement = jest.fn(() => "free" as const);
+
+jest.mock("@/lib/alerts/window-finder", () => ({
+  findMatchingWindows: (...args: any[]) => mockFindMatchingWindows(...args),
+}));
+jest.mock("@/lib/alerts/sunrise", () => ({
+  filterToDaylight: (...args: any[]) => mockFilterToDaylight(...args),
+  getDaylightWindow: (...args: any[]) => mockGetDaylightWindow(...args),
+}));
+jest.mock("@/lib/alerts/timezone-utils", () => ({
+  getUtcDayBounds: (...args: any[]) => mockGetUtcDayBounds(...args),
+}));
+jest.mock("@/lib/alerts/entitlements", () => ({
+  resolveEntitlement: (...args: any[]) => mockResolveEntitlement(...args),
+  CAPS: {
+    free: { beaches: 1, rulesPerBeach: 3, totalRules: 3 },
+    premium: { beaches: 10, rulesPerBeach: 5, totalRules: 50 },
+  },
+}));
+
+// ---- Store + mock Supabase ----
+
+const USER_A = "00000000-0000-0000-0000-000000000001";
+const RULE_1 = "00000000-0000-0000-0000-0000000000a1";
+const BEACH_1 = "00000000-0000-0000-0000-0000000000b1";
+
+interface Store {
+  rules: any[];
+  profiles: any[];
+  beaches: any[];
+  entitlements: any[];
+  deliveries: any[]; // alert_deliveries
+  forecasts: any[]; // enhanced_forecasts
+  queueUpserts: any[];
+  ruleUpdates: { id: string; last_matched_at: string }[];
+}
+
+const store: Store = {
+  rules: [],
+  profiles: [],
+  beaches: [],
+  entitlements: [],
+  deliveries: [],
+  forecasts: [],
+  queueUpserts: [],
+  ruleUpdates: [],
+};
+
+/**
+ * Builds a minimal Supabase query chain. Supports the fluent methods used by
+ * condition-alert-evaluate: select, eq, in, gte, lt, order, limit, upsert, update.
+ * Resolves via `rowsResolver()` so seeding after chain creation is fine.
+ */
+function makeChain(rowsResolver: () => any[], onUpsert?: (row: any) => void) {
+  const chain: any = {
+    _filters: {} as Record<string, any>,
+    select: jest.fn(() => chain),
+    eq: jest.fn((_col: string, val: any) => { chain._filters[_col] = val; return chain; }),
+    in: jest.fn((_col: string, vals: any[]) => { chain._filters[`${_col}__in`] = vals; return chain; }),
+    gte: jest.fn(() => chain),
+    lt: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    upsert: jest.fn((row: any, _opts?: any) => {
+      onUpsert?.(row);
+      return Promise.resolve({ error: null });
+    }),
+    update: jest.fn((vals: any) => {
+      const updateChain: any = {
+        eq: jest.fn((_col: string, val: any) => {
+          store.ruleUpdates.push({ id: val, ...vals });
+          return Promise.resolve({ error: null });
+        }),
+      };
+      return updateChain;
+    }),
+    // Promise resolution (then is the terminal for most selects)
+    then: jest.fn((resolve: any) =>
+      resolve({ data: rowsResolver(), error: null })
+    ),
+    single: jest.fn(() => Promise.resolve({ data: rowsResolver()[0] ?? null, error: null })),
+    maybeSingle: jest.fn(() => Promise.resolve({ data: rowsResolver()[0] ?? null, error: null })),
+  };
+  return chain;
+}
+
+function mockFrom(table: string) {
+  switch (table) {
+    case "alert_rules": {
+      const chain = makeChain(() => store.rules);
+      // Also handle update (for last_matched_at)
+      chain.update = jest.fn((vals: any) => ({
+        eq: jest.fn((_col: string, val: any) => {
+          store.ruleUpdates.push({ id: val, ...vals });
+          return Promise.resolve({ error: null });
+        }),
+      }));
+      return chain;
+    }
+    case "profiles":
+      return makeChain(() => store.profiles);
+    case "beaches":
+      return makeChain(() => store.beaches);
+    case "user_entitlements":
+      return makeChain(() => store.entitlements);
+    case "alert_deliveries":
+      return makeChain(() => store.deliveries);
+    case "enhanced_forecasts":
+      return makeChain(() => store.forecasts);
+    case "alert_queue":
+      return makeChain(() => [], (row) => store.queueUpserts.push(row));
+    default:
+      return makeChain(() => []);
+  }
+}
+
+const mockSupabase = { from: jest.fn(mockFrom) };
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient: jest.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+// ---- Seed helpers ----
+
+function seedRule(overrides: Partial<any> = {}) {
+  store.rules.push({
+    id: RULE_1,
+    user_id: USER_A,
+    beach_id: BEACH_1,
+    name: "Test Rule",
+    conditions: { swell_height_min: 2 },
+    notify_email: true,
+    notify_push: false,
+    preset_type: "glass_off",
+    created_at: "2026-04-01T00:00:00Z",
+    ...overrides,
+  });
+}
+
+function seedProfile(overrides: Partial<any> = {}) {
+  store.profiles.push({
+    id: USER_A,
+    home_beach_id: BEACH_1,
+    notif_forecast_alerts: true,
+    notif_email_enabled: true,
+    notif_push_enabled: false,
+    ...overrides,
+  });
+}
+
+function seedBeach(overrides: Partial<any> = {}) {
+  store.beaches.push({
+    id: BEACH_1,
+    name: "Test Beach",
+    slug: "test-beach",
+    lat: 34.0,
+    lon: -118.5,
+    timezone: "America/Los_Angeles",
+    wind_offshore_deg: 270,
+    wind_offshore_tol_deg: 45,
+    aspect_deg: 270,
+    preferred_tide_ft_min: null,
+    preferred_tide_ft_max: null,
+    preferred_tide_direction: null,
+    swell_window_center_deg: null,
+    swell_window_halfwidth_deg: null,
+    ...overrides,
+  });
+}
+
+function seedForecast() {
+  store.forecasts.push({
+    forecast_at: "2026-04-26T14:00:00Z",
+    wave_height: "3.5",
+    wave_period: "12s",
+    swell_1_height: "3",
+    swell_1_period: "12s",
+    swell_1_direction: "270",
+    wind_speed: "5 mph",
+    wind_direction_deg: 270,
+    tide_height: "2.1",
+    tide_status: "rising",
+  });
+}
+
+function seedMatchingWindow() {
+  mockFindMatchingWindows.mockReturnValueOnce([
+    {
+      rule_id: RULE_1,
+      rule_name: "Test Rule",
+      beach_id: BEACH_1,
+      beach_name: "Test Beach",
+      beach_timezone: "America/Los_Angeles",
+      window_start: "2026-04-26T14:00:00Z",
+      window_end: "2026-04-26T16:00:00Z",
+      best_hour: "2026-04-26T15:00:00Z",
+      best_score: 0.9,
+      conditions_snapshot: { wave_height: 3.5 },
+      notify_email: true,
+      notify_push: false,
+    },
+  ]);
+}
+
+function makeRequest(): Request {
+  return new Request("https://quiversurf.app/api/cron/condition-alert-evaluate", {
+    method: "GET",
+    headers: { authorization: "Bearer dummy" },
+  });
+}
+
+// ---- Reset ----
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  store.rules = [];
+  store.profiles = [];
+  store.beaches = [];
+  store.entitlements = [];
+  store.deliveries = [];
+  store.forecasts = [];
+  store.queueUpserts = [];
+  store.ruleUpdates = [];
+
+  // Stable defaults — tests that need different behaviour override these.
+  mockFindMatchingWindows.mockReturnValue([]);
+  mockFilterToDaylight.mockImplementation((hours: any[]) => hours);
+  mockGetDaylightWindow.mockReturnValue({
+    sunrise: new Date("2026-04-26T13:00:00Z"),
+    sunset: new Date("2026-04-27T02:00:00Z"),
+  });
+  mockGetUtcDayBounds.mockReturnValue({
+    start: "2026-04-26T00:00:00.000Z",
+    end: "2026-04-27T00:00:00.000Z",
+  });
+  mockResolveEntitlement.mockReturnValue("free");
+
+  // Reset the mockSupabase.from implementation so per-test seeds are isolated.
+  mockSupabase.from.mockImplementation(mockFrom);
+});
+
+// ---- Tests ----
+
+describe("condition-alert-evaluate — A4.2 flat queries", () => {
+  it("1. happy path: 1 rule + matching forecast window => upserts 1 alert_queue row", async () => {
+    seedRule();
+    seedProfile();
+    seedBeach();
+    seedForecast();
+    seedMatchingWindow();
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.evaluated).toBe(1);
+    expect(body.matched).toBe(1);
+    expect(body.queued).toBeGreaterThanOrEqual(1);
+    expect(body.errors).toBe(0);
+
+    expect(store.queueUpserts).toHaveLength(1);
+    expect(store.queueUpserts[0]).toMatchObject({
+      user_id: USER_A,
+      rule_id: RULE_1,
+      beach_id: BEACH_1,
+      alert_date: expect.any(String),
+    });
+
+    // last_matched_at must be stamped
+    expect(store.ruleUpdates).toHaveLength(1);
+    expect(store.ruleUpdates[0].id).toBe(RULE_1);
+    expect(store.ruleUpdates[0].last_matched_at).toBeDefined();
+  });
+
+  it("2. empty rules: 0 enabled rules => no DB writes after rules query, message returned", async () => {
+    // No rules seeded — rules store stays empty.
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.message).toBe("No rules to evaluate");
+    // The early-return spreads `result` which includes queued:0 — confirm it's 0.
+    expect(body.queued).toBe(0);
+
+    // No queue upserts, no rule updates
+    expect(store.queueUpserts).toHaveLength(0);
+    expect(store.ruleUpdates).toHaveLength(0);
+  });
+
+  it("3. missing profile: rule exists but profile lookup returns empty => errors++ and route does not crash", async () => {
+    seedRule();
+    // No profile seeded — profilesById.get(USER_A) will be undefined.
+    seedBeach();
+
+    const res = await GET(makeRequest());
+
+    // The route logs console.error for the missing-profile case — declare that
+    // intentional so the afterEach guard doesn't fail the test.
+    expectConsoleErrors([/No profile found for user/]);
+
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // Route should complete without crashing and increment errors for the rule
+    // where no profile was found.
+    expect(body.errors).toBeGreaterThanOrEqual(1);
+    // No queue writes since the rule was skipped.
+    expect(store.queueUpserts).toHaveLength(0);
+  });
+
+  it("4. existing delivery for today: all rules for that user are skipped", async () => {
+    seedRule();
+    seedProfile();
+    seedBeach();
+    seedForecast();
+    seedMatchingWindow();
+
+    // Pre-seed a delivery for today so the dedupe check fires.
+    store.deliveries.push({
+      id: "00000000-0000-0000-0000-000000000099",
+      user_id: USER_A,
+      alert_date: "2026-04-26",
+      channel: "email",
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // evaluated stays 0 because we never enter the inner rule loop
+    expect(body.queued).toBe(0);
+    // No queue upserts, no rule updates
+    expect(store.queueUpserts).toHaveLength(0);
+    expect(store.ruleUpdates).toHaveLength(0);
+  });
+});

--- a/__tests__/lib/alerts/forecast-parsers.test.ts
+++ b/__tests__/lib/alerts/forecast-parsers.test.ts
@@ -1,4 +1,4 @@
-import { parseWindSpeedToKt } from "@/lib/alerts/forecast-parsers";
+import { parseWindSpeedToKt, parseSwellDirectionToDegrees } from "@/lib/alerts/forecast-parsers";
 
 describe("parseWindSpeedToKt", () => {
   it("parses kt explicit", () => {
@@ -21,5 +21,34 @@ describe("parseWindSpeedToKt", () => {
   it("returns null for unparseable", () => {
     expect(parseWindSpeedToKt(null)).toBeNull();
     expect(parseWindSpeedToKt("calm")).toBeNull();
+  });
+});
+
+describe("parseSwellDirectionToDegrees", () => {
+  it("converts cardinal", () => {
+    expect(parseSwellDirectionToDegrees("N")).toBe(0);
+    expect(parseSwellDirectionToDegrees("E")).toBe(90);
+    expect(parseSwellDirectionToDegrees("S")).toBe(180);
+    expect(parseSwellDirectionToDegrees("W")).toBe(270);
+  });
+
+  it("converts intercardinal", () => {
+    expect(parseSwellDirectionToDegrees("NE")).toBe(45);
+    expect(parseSwellDirectionToDegrees("SW")).toBe(225);
+  });
+
+  it("converts secondary intercardinal", () => {
+    expect(parseSwellDirectionToDegrees("WNW")).toBe(292.5);
+    expect(parseSwellDirectionToDegrees("ESE")).toBe(112.5);
+  });
+
+  it("passes through numeric strings", () => {
+    expect(parseSwellDirectionToDegrees("180")).toBe(180);
+    expect(parseSwellDirectionToDegrees("180.5")).toBe(180.5);
+  });
+
+  it("returns null for invalid", () => {
+    expect(parseSwellDirectionToDegrees(null)).toBeNull();
+    expect(parseSwellDirectionToDegrees("XYZ")).toBeNull();
   });
 });

--- a/__tests__/lib/alerts/forecast-parsers.test.ts
+++ b/__tests__/lib/alerts/forecast-parsers.test.ts
@@ -1,0 +1,25 @@
+import { parseWindSpeedToKt } from "@/lib/alerts/forecast-parsers";
+
+describe("parseWindSpeedToKt", () => {
+  it("parses kt explicit", () => {
+    expect(parseWindSpeedToKt("8 kt")).toBeCloseTo(8);
+    expect(parseWindSpeedToKt("8 knots")).toBeCloseTo(8);
+  });
+
+  it("converts mph to kt", () => {
+    expect(parseWindSpeedToKt("10 mph")).toBeCloseTo(8.69, 2);
+  });
+
+  it("converts m/s to kt", () => {
+    expect(parseWindSpeedToKt("5 m/s")).toBeCloseTo(9.72, 2);
+  });
+
+  it("treats bare number as mph (current ingest convention)", () => {
+    expect(parseWindSpeedToKt("10")).toBeCloseTo(8.69, 2);
+  });
+
+  it("returns null for unparseable", () => {
+    expect(parseWindSpeedToKt(null)).toBeNull();
+    expect(parseWindSpeedToKt("calm")).toBeNull();
+  });
+});

--- a/app/api/cron/condition-alert-evaluate/route.ts
+++ b/app/api/cron/condition-alert-evaluate/route.ts
@@ -7,6 +7,7 @@ import { findMatchingWindows } from "@/lib/alerts/window-finder";
 import { filterToDaylight, getDaylightWindow } from "@/lib/alerts/sunrise";
 import { CAPS, resolveEntitlement } from "@/lib/alerts/entitlements";
 import { getUtcDayBounds } from "@/lib/alerts/timezone-utils";
+import { parseWindSpeedToKt } from "@/lib/alerts/forecast-parsers";
 import type { AlertConditions, BeachAlertMeta, ForecastHour } from "@/lib/alerts/types";
 import type { Database } from "@/types/database.generated";
 
@@ -189,7 +190,7 @@ export async function GET(request: Request) {
                 swell_1_height: f.swell_1_height ? parseFloat(f.swell_1_height) : null,
                 swell_1_period: f.swell_1_period ? parseFloat(f.swell_1_period.replace("s", "")) : null,
                 swell_1_direction: f.swell_1_direction ? parseFloat(String(f.swell_1_direction)) : null,
-                wind_speed: f.wind_speed ? parseFloat(f.wind_speed) : null,
+                wind_speed: parseWindSpeedToKt(f.wind_speed),
                 wind_direction_deg: f.wind_direction_deg,
                 tide_height: f.tide_height ? parseFloat(f.tide_height) : null,
                 tide_status: f.tide_status,

--- a/app/api/cron/condition-alert-evaluate/route.ts
+++ b/app/api/cron/condition-alert-evaluate/route.ts
@@ -7,7 +7,7 @@ import { findMatchingWindows } from "@/lib/alerts/window-finder";
 import { filterToDaylight, getDaylightWindow } from "@/lib/alerts/sunrise";
 import { CAPS, resolveEntitlement } from "@/lib/alerts/entitlements";
 import { getUtcDayBounds } from "@/lib/alerts/timezone-utils";
-import { parseWindSpeedToKt } from "@/lib/alerts/forecast-parsers";
+import { parseWindSpeedToKt, parseSwellDirectionToDegrees } from "@/lib/alerts/forecast-parsers";
 import type { AlertConditions, BeachAlertMeta, ForecastHour } from "@/lib/alerts/types";
 import type { Database } from "@/types/database.generated";
 
@@ -189,7 +189,7 @@ export async function GET(request: Request) {
                 wave_period: f.wave_period ? parseFloat(f.wave_period.replace("s", "")) : null,
                 swell_1_height: f.swell_1_height ? parseFloat(f.swell_1_height) : null,
                 swell_1_period: f.swell_1_period ? parseFloat(f.swell_1_period.replace("s", "")) : null,
-                swell_1_direction: f.swell_1_direction ? parseFloat(String(f.swell_1_direction)) : null,
+                swell_1_direction: parseSwellDirectionToDegrees(f.swell_1_direction),
                 wind_speed: parseWindSpeedToKt(f.wind_speed),
                 wind_direction_deg: f.wind_direction_deg,
                 tide_height: f.tide_height ? parseFloat(f.tide_height) : null,

--- a/app/api/cron/condition-alert-evaluate/route.ts
+++ b/app/api/cron/condition-alert-evaluate/route.ts
@@ -1,8 +1,3 @@
-// @ts-nocheck — PostgREST resolves alert_rules→auth.users→profiles at runtime
-// via an explicit `profiles!inner(...)` hint, but TypeScript can't follow the
-// two-hop FK chain, so the generated types report
-// `could not find the relation between alert_rules and profiles` even though
-// the query works at runtime. See 20260408163000_add_condition_alerts.sql.
 // app/api/cron/condition-alert-evaluate/route.ts
 import { NextResponse } from "next/server";
 import { validateCronRequest } from "@/lib/api-utils";
@@ -13,6 +8,7 @@ import { filterToDaylight, getDaylightWindow } from "@/lib/alerts/sunrise";
 import { CAPS, resolveEntitlement } from "@/lib/alerts/entitlements";
 import { getUtcDayBounds } from "@/lib/alerts/timezone-utils";
 import type { AlertConditions, BeachAlertMeta, ForecastHour } from "@/lib/alerts/types";
+import type { Database } from "@/types/database.generated";
 
 export const revalidate = 0;
 export const runtime = "nodejs";
@@ -20,6 +16,32 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
 const CONTEXT_TAG = "[condition-alert-evaluate]";
+
+type ProfileRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "home_beach_id" | "notif_forecast_alerts" | "notif_email_enabled" | "notif_push_enabled"
+>;
+type BeachRow = Pick<
+  Database["public"]["Tables"]["beaches"]["Row"],
+  | "id"
+  | "name"
+  | "slug"
+  | "lat"
+  | "lon"
+  | "timezone"
+  | "wind_offshore_deg"
+  | "wind_offshore_tol_deg"
+  | "aspect_deg"
+  | "preferred_tide_ft_min"
+  | "preferred_tide_ft_max"
+  | "preferred_tide_direction"
+  | "swell_window_center_deg"
+  | "swell_window_halfwidth_deg"
+>;
+type EntitlementRow = Pick<
+  Database["public"]["Tables"]["user_entitlements"]["Row"],
+  "user_id" | "is_pro" | "is_trialing" | "billing_issue" | "expires_at"
+>;
 
 export async function GET(request: Request) {
   if (!validateCronRequest(request)) {
@@ -34,19 +56,13 @@ export async function GET(request: Request) {
       async () => {
         const result = { evaluated: 0, matched: 0, queued: 0, skipped: 0, errors: 0 };
 
-        // 1. Fetch all enabled rules with user + beach data. user_entitlements
-        //    is joined so resolveEntitlement can read entitlement without an
-        //    N+1 query per user (previously 1 DB round-trip per user per tick).
+        // 1. Fetch all enabled rules — flat select, no embeds.
+        //    Previously this used profiles!inner(...) which requires PostgREST to
+        //    resolve the two-hop FK alert_rules.user_id → auth.users.id ← profiles.id.
+        //    That embed was throwing silently in prod (A2 diagnosis H1, ~60% confidence).
         const { data: rules, error: rulesError } = await supabase
           .from("alert_rules")
-          .select(`
-            id, user_id, beach_id, name, conditions, notify_email, notify_push, preset_type, created_at,
-            beaches!inner(id, name, slug, lat, lon, timezone, wind_offshore_deg, wind_offshore_tol_deg, aspect_deg,
-              preferred_tide_ft_min, preferred_tide_ft_max, preferred_tide_direction,
-              swell_window_center_deg, swell_window_halfwidth_deg),
-            profiles!inner(id, home_beach_id, notif_forecast_alerts, notif_email_enabled, notif_push_enabled),
-            user_entitlements(is_pro, is_trialing, billing_issue, expires_at)
-          `)
+          .select("id, user_id, beach_id, name, conditions, notify_email, notify_push, preset_type, created_at")
           .eq("enabled", true);
 
         if (rulesError) throw rulesError;
@@ -55,11 +71,60 @@ export async function GET(request: Request) {
           return { ...result, message: "No rules to evaluate" };
         }
 
-        // 2. Group rules by user
+        // 2. Collect distinct user + beach IDs for batch lookups.
+        const userIds = [...new Set(rules.map((r) => r.user_id))];
+        const beachIds = [...new Set(rules.map((r) => r.beach_id))];
+
+        // 3. Three flat selects in parallel — no join resolution, no relationship hop.
+        const [profilesRes, beachesRes, entitlementsRes] = await Promise.all([
+          supabase
+            .from("profiles")
+            .select("id, home_beach_id, notif_forecast_alerts, notif_email_enabled, notif_push_enabled")
+            .in("id", userIds),
+          supabase
+            .from("beaches")
+            .select(
+              "id, name, slug, lat, lon, timezone, wind_offshore_deg, wind_offshore_tol_deg, aspect_deg, preferred_tide_ft_min, preferred_tide_ft_max, preferred_tide_direction, swell_window_center_deg, swell_window_halfwidth_deg"
+            )
+            .in("id", beachIds),
+          supabase
+            .from("user_entitlements")
+            .select("user_id, is_pro, is_trialing, billing_issue, expires_at")
+            .in("user_id", userIds),
+        ]);
+
+        if (profilesRes.error) throw profilesRes.error;
+        if (beachesRes.error) throw beachesRes.error;
+        // user_entitlements legitimately has no rows for free users — only throw on hard errors.
+        if (entitlementsRes.error) throw entitlementsRes.error;
+
+        // 4. Build O(1) lookup maps.
+        const profilesById = new Map<string, ProfileRow>();
+        for (const p of profilesRes.data ?? []) profilesById.set(p.id, p);
+
+        const beachesById = new Map<string, BeachRow>();
+        for (const b of beachesRes.data ?? []) beachesById.set(b.id, b);
+
+        const entitlementByUserId = new Map<string, EntitlementRow>();
+        for (const e of entitlementsRes.data ?? []) entitlementByUserId.set(e.user_id, e);
+
+        // 5. Group rules by user, skipping users with no profile or alerts disabled.
         const byUser = new Map<string, typeof rules>();
         for (const rule of rules) {
-          if (!rule.profiles?.notif_forecast_alerts) {
+          const profile = profilesById.get(rule.user_id);
+          if (!profile) {
+            console.error(`${CONTEXT_TAG} No profile found for user ${rule.user_id}, skipping rule ${rule.id}`);
+            result.errors++;
+            continue;
+          }
+          if (!profile.notif_forecast_alerts) {
             result.skipped++;
+            continue;
+          }
+          const beach = beachesById.get(rule.beach_id);
+          if (!beach) {
+            console.error(`${CONTEXT_TAG} No beach found for beach_id ${rule.beach_id}, skipping rule ${rule.id}`);
+            result.errors++;
             continue;
           }
           const existing = byUser.get(rule.user_id) ?? [];
@@ -67,14 +132,16 @@ export async function GET(request: Request) {
           byUser.set(rule.user_id, existing);
         }
 
-        // 3. Evaluate each user's rules
+        // 6. Evaluate each user's rules.
         for (const [userId, userRules] of byUser) {
           try {
-            const homeBeachId = userRules[0].profiles?.home_beach_id;
-            const homeBeachTz = userRules.find((r) => r.beach_id === homeBeachId)?.beaches?.timezone ?? "America/New_York";
+            const profile = profilesById.get(userId)!;
+            const homeBeachId = profile.home_beach_id;
+            const homeBeach = homeBeachId ? beachesById.get(homeBeachId) : undefined;
+            const homeBeachTz = homeBeach?.timezone ?? "America/New_York";
             const userLocalDate = new Date().toLocaleDateString("en-CA", { timeZone: homeBeachTz });
 
-            // Check if already delivered today
+            // Check if already delivered today.
             const { data: existing } = await supabase
               .from("alert_deliveries")
               .select("id")
@@ -87,10 +154,8 @@ export async function GET(request: Request) {
               continue;
             }
 
-            // Apply entitlement caps — skip newest rules first. resolveEntitlement
-            // reads from the user_entitlements row joined above (no N+1) and
-            // honors ALERT_PREVIEW_MODE + ALERT_BETA_USER_IDS bypasses.
-            const entitlementRow = userRules[0].user_entitlements ?? null;
+            // Apply entitlement caps — skip newest rules first.
+            const entitlementRow = entitlementByUserId.get(userId) ?? null;
             const tier = resolveEntitlement(userId, entitlementRow);
             const caps = CAPS[tier];
             const sortedRules = [...userRules].sort(
@@ -100,14 +165,16 @@ export async function GET(request: Request) {
 
             for (const rule of activeRules) {
               result.evaluated++;
-              const beach = rule.beaches as unknown as BeachAlertMeta;
+              const beach = beachesById.get(rule.beach_id) as BeachAlertMeta;
               const conditions = rule.conditions as AlertConditions;
 
               const { start: todayStart, end: todayEnd } = getUtcDayBounds(userLocalDate, beach.timezone);
 
               const { data: forecasts } = await supabase
                 .from("enhanced_forecasts")
-                .select("forecast_at, wave_height, wave_period, swell_1_height, swell_1_period, swell_1_direction, wind_speed, wind_direction_deg, tide_height, tide_status")
+                .select(
+                  "forecast_at, wave_height, wave_period, swell_1_height, swell_1_period, swell_1_direction, wind_speed, wind_direction_deg, tide_height, tide_status"
+                )
                 .eq("beach_id", rule.beach_id)
                 .gte("forecast_at", todayStart)
                 .lt("forecast_at", todayEnd)
@@ -143,7 +210,7 @@ export async function GET(request: Request) {
                 const clampedSendAt = sendAtDate < sunrise ? sunrise : sendAtDate;
                 const sendAt = clampedSendAt < new Date() ? new Date() : clampedSendAt;
 
-                const { error: insertError } = await (supabase as any)
+                const { error: insertError } = await supabase
                   .from("alert_queue")
                   .upsert(
                     {
@@ -155,7 +222,9 @@ export async function GET(request: Request) {
                       window_start: window.window_start,
                       window_end: window.window_end,
                       best_hour: window.best_hour,
-                      conditions_snapshot: window.conditions_snapshot,
+                      // conditions_snapshot is Record<string,unknown> from MatchingWindow
+                      // but the DB column is typed as Json — structurally compatible.
+                      conditions_snapshot: window.conditions_snapshot as import("@/types/database.generated").Json,
                     },
                     { onConflict: "rule_id,alert_date,window_start", ignoreDuplicates: true }
                   );

--- a/lib/alerts/forecast-parsers.ts
+++ b/lib/alerts/forecast-parsers.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse a wind_speed text value (e.g. "10 mph", "8 kt", "5 m/s") to knots.
+ *
+ * Returns null for null input or unparseable strings.
+ *
+ * Bare numbers are treated as mph — that's the current ingest convention
+ * for enhanced_forecasts.wind_speed. If we ever migrate that column to a
+ * numeric kt field, callers should switch to reading the new column directly.
+ */
+export function parseWindSpeedToKt(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const num = parseFloat(raw);
+  if (Number.isNaN(num)) return null;
+  if (raw.includes("kt") || raw.includes("knot")) return num;
+  if (raw.includes("m/s")) return num * 1.9438;     // m/s → kt
+  if (raw.includes("mph")) return num * 0.868976;   // mph → kt
+  // Bare number = treat as mph (current ingest convention)
+  return num * 0.868976;
+}

--- a/lib/alerts/forecast-parsers.ts
+++ b/lib/alerts/forecast-parsers.ts
@@ -17,3 +17,38 @@ export function parseWindSpeedToKt(raw: string | null | undefined): number | nul
   // Bare number = treat as mph (current ingest convention)
   return num * 0.868976;
 }
+
+/**
+ * Parse a swell direction value to degrees. Accepts:
+ * - 16-point cardinal text: "N", "NNE", "NE", "ENE", "E", … "NNW"
+ * - Numeric strings: "180", "180.5"
+ *
+ * Returns null for null input or unparseable strings.
+ */
+const CARDINAL_TO_DEGREES: Record<string, number> = {
+  N:    0,
+  NNE:  22.5,
+  NE:   45,
+  ENE:  67.5,
+  E:    90,
+  ESE:  112.5,
+  SE:   135,
+  SSE:  157.5,
+  S:    180,
+  SSW:  202.5,
+  SW:   225,
+  WSW:  247.5,
+  W:    270,
+  WNW:  292.5,
+  NW:   315,
+  NNW:  337.5,
+};
+
+export function parseSwellDirectionToDegrees(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const upper = raw.trim().toUpperCase();
+  if (upper in CARDINAL_TO_DEGREES) return CARDINAL_TO_DEGREES[upper];
+  const num = parseFloat(raw);
+  if (Number.isNaN(num)) return null;
+  return num;
+}


### PR DESCRIPTION
## Summary

Phase A4.2-A4.4 of the alerts engine fix. Stacked on top of #236 (A4.1 observability). After #236 merges to main, this PR retargets to main.

- **A4.2** — Replace PostgREST two-hop embed in matcher with 4 flat queries + in-memory Maps. Removes \`@ts-nocheck\`. The most-likely root cause of zero matcher firings per the A2 forensic diagnosis.
- **A4.3** — \`parseWindSpeedToKt\` handles \"mph\", \"kt\", \"knots\", \"m/s\", and bare numbers. Old code silently treated mph as kt (~15% over-permissive).
- **A4.4** — \`parseSwellDirectionToDegrees\` handles 16-point cardinal text (\"W\", \"WNW\", \"S\") + numeric strings. Latent landmine (parseFloat(\"W\")=NaN); no current rule uses direction bounds but future presets would have hit it.

## Why two PRs

\`docs/superpowers/specs/2026-04-27-alerts-matcher-fix-a4-design.md\` calls this sequencing non-negotiable: A4.1 (cron_runs observability) **must** ship and prove itself in prod before A4.2-A4.4 — otherwise we have no measurement signal to confirm the rewrite worked. After A4.1 deploys, one query tells us whether the matcher fired. With both PRs merged + deployed, the founder's \`daily_check_in\` rule should produce a queue row at the next 09:00 UTC tick.

## Validation in prod (post-merge + release)

Manual via SQL on prod:

\`\`\`sql
SELECT
  (SELECT status FROM cron_runs
   WHERE route = '/api/cron/condition-alert-evaluate'
   ORDER BY started_at DESC LIMIT 1) AS last_run_status,
  (SELECT summary FROM cron_runs
   WHERE route = '/api/cron/condition-alert-evaluate'
   ORDER BY started_at DESC LIMIT 1) AS last_run_summary,
  (SELECT COUNT(*) FROM alert_queue) AS queue_total,
  (SELECT COUNT(*) FROM alert_rules WHERE last_matched_at IS NOT NULL) AS rules_ever_matched;
\`\`\`

Success: \`last_run_status='ok'\`, \`summary.queued ≥ 1\`, \`queue_total ≥ 1\`. Failure modes covered:
- \`last_run_status='error'\`: read \`error_message\`, fix, redeploy
- \`last_run_status='ok'\` and \`summary.evaluated=0\`: H2 from diagnosis (rules-fetch returns empty)
- \`last_run_status='ok'\` and \`summary.evaluated > 0\` but \`summary.queued=0\`: \`findMatchingWindows\` is rejecting all rules — debug from there

## Test plan

- [x] \`yarn test:unit __tests__/lib/alerts/forecast-parsers.test.ts\` — 10/10 (5 wind + 5 direction)
- [x] \`yarn test:unit __tests__/api/cron/condition-alert-evaluate.test.ts\` — 4/4 (happy path, empty rules, missing profile, existing delivery)
- [x] \`yarn test:unit __tests__/lib/cron/observability.test.ts\` — 3/3 (still passing)
- [x] All existing alerts tests passing (14 suites, 117 tests)
- [x] \`yarn typecheck\` clean
- [ ] After merge + release: validation SQL above
- [ ] Confirm founder \`daily_check_in\` rule produces an \`alert_queue\` row

## Spec / plan

- Spec: \`docs/superpowers/specs/2026-04-27-alerts-matcher-fix-a4-design.md\` sections A4.2-A4.4
- Plan: \`docs/superpowers/plans/2026-04-27-alerts-matcher-fix-a4.md\` Tasks 5-7

## Out of scope

- Migrating \`enhanced_forecasts.wind_speed\` to a numeric kt column (separate ticket — affects multiple consumers beyond the matcher)
- Adding \`withCronObservability\` to other crons (start with alerts engine, expand later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)