### PR TITLE
fix(alerts): TS spread errors + lint warnings on A4 work

### DIFF
--- a/__tests__/api/cron/condition-alert-evaluate.test.ts
+++ b/__tests__/api/cron/condition-alert-evaluate.test.ts
@@ -41,17 +41,19 @@ jest.mock("@/lib/cron/observability", () => ({
 }));
 
 // Mock window-finder + sunrise + timezone-utils so we control matching behaviour.
-const mockFindMatchingWindows = jest.fn();
-const mockFilterToDaylight = jest.fn((hours: any[]) => hours); // pass-through by default
-const mockGetDaylightWindow = jest.fn(() => ({
+// jest.fn<TReturn, TArgs extends any[]> accepts variadic args so the (...args)
+// spread in the jest.mock factory below typechecks cleanly.
+const mockFindMatchingWindows = jest.fn<any, any[]>();
+const mockFilterToDaylight = jest.fn<any, any[]>((...args: any[]) => args[0]);
+const mockGetDaylightWindow = jest.fn<any, any[]>(() => ({
   sunrise: new Date("2026-04-26T13:00:00Z"),
   sunset: new Date("2026-04-27T02:00:00Z"),
 }));
-const mockGetUtcDayBounds = jest.fn(() => ({
+const mockGetUtcDayBounds = jest.fn<any, any[]>(() => ({
   start: "2026-04-26T00:00:00.000Z",
   end: "2026-04-27T00:00:00.000Z",
 }));
-const mockResolveEntitlement = jest.fn(() => "free" as const);
+const mockResolveEntitlement = jest.fn<any, any[]>(() => "free" as const);
 
 jest.mock("@/lib/alerts/window-finder", () => ({
   findMatchingWindows: (...args: any[]) => mockFindMatchingWindows(...args),
@@ -322,7 +324,7 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
     // last_matched_at must be stamped
     expect(store.ruleUpdates).toHaveLength(1);
     expect(store.ruleUpdates[0].id).toBe(RULE_1);
-    expect(store.ruleUpdates[0].last_matched_at).toBeDefined();
+    expect(typeof store.ruleUpdates[0].last_matched_at).toBe("string");
   });
 
   it("2. empty rules: 0 enabled rules => no DB writes after rules query, message returned", async () => {

--- a/lib/cron/observability.ts
+++ b/lib/cron/observability.ts
@@ -8,7 +8,14 @@ export async function withCronObservability<T>(
   const start = Date.now();
 
   // cron_runs is not yet in the generated types — cast to any until db:types is regenerated.
-  const db = supabase as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  const db = supabase as unknown as {
+    from: (table: "cron_runs") => {
+      insert: (row: Record<string, unknown>) => {
+        select: (cols: string) => { single: () => Promise<{ data: { id: string } | null }> };
+      };
+      update: (row: Record<string, unknown>) => { eq: (col: string, val: string) => Promise<unknown> };
+    };
+  };
 
   let runId: string | null = null;
   try {


### PR DESCRIPTION
## Summary

Prod-gate workflow on #239 (release of A4 to prod) caught 4 TS2556 errors and 2 lint warnings that local \`yarn typecheck\` masked. Fixes the gate failures so #239 can land.

- **TS2556 (test file):** \`jest.fn(() => …)\` typed as 0-arg, but the \`jest.mock\` factories spread variadic args into it. Changed to \`jest.fn<any, any[]>()\` which accepts variadic args.
- **\`jest/no-restricted-matchers\`:** replaced \`expect(x).toBeDefined()\` with a typeof check (more specific).
- **Unused \`eslint-disable\` (\`lib/cron/observability.ts\`):** replaced the \`as any\` cast with a focused inline interface so the disable comment isn't needed.

## Test plan

- [x] \`yarn typecheck\` clean
- [x] \`npx eslint --max-warnings=0\` clean on all modified files
- [x] \`yarn test:unit\` 17/17 across all 3 alerts test suites
- [ ] Prod-gate workflow passes once this is included in a release PR (will be picked up by the next release-prod-from-main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)