### PR TITLE
fix(alerts): raise mellow_session + clean_groundswell swell floors

### DIFF
--- a/__tests__/lib/alerts/presets.test.ts
+++ b/__tests__/lib/alerts/presets.test.ts
@@ -56,8 +56,16 @@ describe("presets", () => {
     const conditions = preset.buildConditions(mockBeach);
     expect(conditions.tide_height_min_ft).toBe(2);
     expect(conditions.tide_height_max_ft).toBe(5);
-    expect(conditions.swell_height_min).toBe(1);
+    expect(conditions.swell_height_min).toBe(1.5);
     expect(conditions.swell_height_max).toBe(4);
+  });
+
+  it("clean_groundswell has 2ft floor + 12s period", () => {
+    const preset = getPreset("clean_groundswell")!;
+    const conditions = preset.buildConditions(mockBeach);
+    expect(conditions.swell_height_min).toBe(2);
+    expect(conditions.swell_period_min).toBe(12);
+    expect(conditions.wind_speed_max_kt).toBe(10);
   });
 
   it("tide_window uses beach preferred tide range and direction", () => {

--- a/__tests__/lib/alerts/rpc-preset-parity.test.ts
+++ b/__tests__/lib/alerts/rpc-preset-parity.test.ts
@@ -62,7 +62,7 @@ const EXPECTED_TS_CONDITIONS: Record<(typeof ALLOWED_PRESETS)[number], unknown> 
       swell_period_min: 10,
     },
     mellow_session: {
-      swell_height_min: 1,
+      swell_height_min: 1.5,
       swell_height_max: 4,
       wind_speed_max_kt: 8,
       // tide_height_min_ft / max omitted because TEST_BEACH has null preferences

--- a/lib/alerts/presets.ts
+++ b/lib/alerts/presets.ts
@@ -22,10 +22,10 @@ export const PRESETS: PresetDefinition[] = [
     type: "mellow_session",
     name: "Mellow Session",
     description: "Small, clean, and fun — great for longboarding or learning",
-    conditionsSummary: "1-4ft swell, <8kt wind, favorable tide",
+    conditionsSummary: "1.5-4ft swell, <8kt wind, favorable tide",
     group: "popular",
     buildConditions: (beach: BeachAlertMeta): AlertConditions => ({
-      swell_height_min: 1,
+      swell_height_min: 1.5,
       swell_height_max: 4,
       wind_speed_max_kt: 8,
       tide_height_min_ft: beach.preferred_tide_ft_min ?? undefined,
@@ -59,9 +59,10 @@ export const PRESETS: PresetDefinition[] = [
     name: "Clean Groundswell",
     description:
       "Long-period swell with clean conditions — quality over quantity",
-    conditionsSummary: "12s+ period, <10kt wind, favorable direction",
+    conditionsSummary: "2ft+ swell, 12s+ period, <10kt wind, favorable direction",
     group: "specific",
     buildConditions: (beach: BeachAlertMeta): AlertConditions => ({
+      swell_height_min: 2,
       swell_period_min: 12,
       wind_speed_max_kt: 10,
       swell_direction_min_deg:

--- a/supabase/migrations/20260427180000_tune_mellow_session_swell_floor.sql
+++ b/supabase/migrations/20260427180000_tune_mellow_session_swell_floor.sql
@@ -1,0 +1,56 @@
+-- Tune mellow_session preset: swell_height_min 1 -> 1.5
+--
+-- Keeps SQL preset_default_conditions() in lockstep with TS PRESETS.mellow_session
+-- (lib/alerts/presets.ts). Parity is enforced by __tests__/lib/alerts/rpc-preset-parity.test.ts.
+--
+-- Rationale: 1ft floor was matching tiny-but-clean conditions and would have
+-- produced low-value alerts. 1.5ft is the minimum height a beginner session
+-- is actually rideable.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION preset_default_conditions(p_preset text, p_beach_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_tide_min numeric;
+  v_tide_max numeric;
+  v_result jsonb;
+BEGIN
+  CASE p_preset
+    WHEN 'glass_off' THEN
+      RETURN jsonb_build_object(
+        'wind_direction', 'offshore',
+        'wind_speed_max_kt', 5,
+        'swell_height_min', 2
+      );
+    WHEN 'big_day' THEN
+      RETURN jsonb_build_object(
+        'swell_height_min', 6,
+        'swell_period_min', 10
+      );
+    WHEN 'mellow_session' THEN
+      SELECT b.preferred_tide_ft_min, b.preferred_tide_ft_max
+        INTO v_tide_min, v_tide_max
+      FROM beaches b WHERE b.id = p_beach_id;
+      v_result := jsonb_build_object(
+        'swell_height_min', 1.5,
+        'swell_height_max', 4,
+        'wind_speed_max_kt', 8
+      );
+      IF v_tide_min IS NOT NULL THEN
+        v_result := v_result || jsonb_build_object('tide_height_min_ft', v_tide_min);
+      END IF;
+      IF v_tide_max IS NOT NULL THEN
+        v_result := v_result || jsonb_build_object('tide_height_max_ft', v_tide_max);
+      END IF;
+      RETURN v_result;
+    ELSE
+      RAISE EXCEPTION 'Unknown preset_type: %', p_preset;
+  END CASE;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- `mellow_session.swell_height_min`: **1ft → 1.5ft**
- `clean_groundswell`: add **`swell_height_min: 2`** (was unbounded)
- Mirror the SQL helper `preset_default_conditions()` so the anon-capture RPC produces the same JSONB as `getPreset(...).buildConditions()` (parity is enforced by `__tests__/lib/alerts/rpc-preset-parity.test.ts`)

## Why
Yesterday's manual matcher run produced 8 queued alerts off rules that matched tiny-but-clean conditions (e.g. 0.7–1.2ft @ 15s for `clean_groundswell`). Period and wind looked great in isolation, but a 1ft wave isn't an alert-worthy session for any user. Raising the height floors prevents the matcher from sending low-value notifications without filtering out legitimate small-but-fun mellow days.

`ALERTS_DELIVERY_ENABLED` is currently `false` in prod — this PR is a prerequisite for flipping it back on.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn test:unit __tests__/lib/alerts/presets.test.ts __tests__/lib/alerts/rpc-preset-parity.test.ts` (12 passed, 1 skip — the live-RPC parity is intentionally skipped pending migration-replay repair)
- [ ] Apply migration `20260427180000_tune_mellow_session_swell_floor.sql` to prod via Supabase MCP after merge
- [ ] Re-trigger matcher manually and confirm previously-queued tiny conditions no longer match

🤖 Generated with [Claude Code](https://claude.com/claude-code)