### PR TITLE
test(admin): update test-push route test for Phase 5i pipeline

### DIFF
--- a/__tests__/app/api/admin/test-push/route.test.ts
+++ b/__tests__/app/api/admin/test-push/route.test.ts
@@ -1,5 +1,8 @@
 /**
- * Tests for admin test push endpoint
+ * Tests for admin test push endpoint.
+ *
+ * Phase 5i migrated this route from `sendPushNotification` (direct FCM) to
+ * `enqueueNotification` (centralized pipeline). The mock surface tracks that.
  */
 
 // Use lightweight NextResponse mock (NextResponse.json)
@@ -17,8 +20,8 @@ jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServiceRoleClient: jest.fn(() => ({})),
 }));
 
-jest.mock("@/lib/services/push-notifications", () => ({
-  sendPushNotification: jest.fn(),
+jest.mock("@/lib/notifications/enqueue", () => ({
+  enqueueNotification: jest.fn(),
 }));
 
 describe("POST /api/admin/test-push", () => {
@@ -41,7 +44,7 @@ describe("POST /api/admin/test-push", () => {
     expect((res as any).status).toBe(403);
   });
 
-  it("sends push to the current admin user", async () => {
+  it("enqueues an admin_test notification for the current admin user", async () => {
     const { authenticateAdmin } = await import("@/lib/auth/admin");
     const authenticateAdminMock =
       authenticateAdmin as unknown as jest.MockedFunction<typeof authenticateAdmin>;
@@ -50,13 +53,14 @@ describe("POST /api/admin/test-push", () => {
       user: { id: "admin-123", email: "admin@example.com" } as any,
     });
 
-    const { sendPushNotification } = await import("@/lib/services/push-notifications");
-    const sendPushNotificationMock =
-      sendPushNotification as unknown as jest.MockedFunction<typeof sendPushNotification>;
-    sendPushNotificationMock.mockResolvedValue({
-      success: 1,
-      failed: 0,
-    });
+    const { enqueueNotification } = await import("@/lib/notifications/enqueue");
+    const enqueueMock = enqueueNotification as unknown as jest.MockedFunction<
+      typeof enqueueNotification
+    >;
+    enqueueMock.mockResolvedValue({
+      enqueued: true,
+      eventId: "evt-1",
+    } as any);
 
     const { POST } = await import("@/app/api/admin/test-push/route");
     const res = await POST({
@@ -65,18 +69,47 @@ describe("POST /api/admin/test-push", () => {
     const json = await (res as Response).json();
 
     expect(json.success).toBe(true);
-    expect(sendPushNotification).toHaveBeenCalledWith(
+    expect(json.data).toEqual(
       expect.objectContaining({
-        userIds: ["admin-123"],
-        title: "Hello",
-        body: "Test",
-        data: expect.objectContaining({
-          type: "test_push",
-          url: "/profile",
-        }),
+        toUserId: "admin-123",
+        eventId: "evt-1",
+      })
+    );
+    expect(enqueueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "admin_test",
+        recipientUserId: "admin-123",
+        payload: { title: "Hello", body: "Test" },
+        dedupeKey: expect.stringMatching(/^admin_test:admin-123:/),
       })
     );
   });
+
+  it("returns 500 when enqueue fails", async () => {
+    const { authenticateAdmin } = await import("@/lib/auth/admin");
+    const authenticateAdminMock =
+      authenticateAdmin as unknown as jest.MockedFunction<typeof authenticateAdmin>;
+    authenticateAdminMock.mockResolvedValue({
+      success: true,
+      user: { id: "admin-123", email: "admin@example.com" } as any,
+    });
+
+    const { enqueueNotification } = await import("@/lib/notifications/enqueue");
+    const enqueueMock = enqueueNotification as unknown as jest.MockedFunction<
+      typeof enqueueNotification
+    >;
+    enqueueMock.mockResolvedValue({
+      enqueued: false,
+      reason: "validation_failed",
+      message: "bad payload",
+    } as any);
+
+    const { POST } = await import("@/app/api/admin/test-push/route");
+    const res = await POST({
+      json: async () => ({ title: "Hello", body: "Test" }),
+    } as any);
+    expect((res as any).status).toBe(500);
+    const json = await (res as Response).json();
+    expect(json.success).toBe(false);
+  });
 });
-
-


### PR DESCRIPTION
Cherry-picks the test fix that landed via release PR #245 onto main.

The route at \`app/api/admin/test-push/route.ts\` was migrated in commit \`ed3f6b06\` (Phase 5i) from \`sendPushNotification\` to \`enqueueNotification\`, but its unit test was never updated. The test was failing on main but went undetected because Prod Gate only runs on PRs to \`prod\`. PR #245 surfaced and fixed it; this PR brings the fix back to main so future release PRs don't trip on the same regression.

Verified locally: \`npx jest __tests__/app/api/admin/test-push/route.test.ts\` → 3/3 passing.

## Test plan

- [ ] Prod Gate-equivalent CI passes (lint/typecheck/build/jest)
- [ ] No follow-up PR needed — purely test-side change