### PR TITLE
feat(forecast): per-beach display height offset correction

### DIFF
--- a/lib/services/forecast/__tests__/apply-beach-height-offset.test.ts
+++ b/lib/services/forecast/__tests__/apply-beach-height-offset.test.ts
@@ -1,0 +1,491 @@
+import {
+  applyBeachHeightOffset,
+  formatDisplayHeightFt,
+  parseDisplayHeightFt,
+} from "../apply-beach-height-offset";
+import { METERS_TO_FEET } from "@/lib/utils/unit-conversions";
+
+describe("parseDisplayHeightFt", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe("null / empty / whitespace inputs", () => {
+    it("returns nulls for null input", () => {
+      expect(parseDisplayHeightFt(null)).toEqual({
+        numericFt: null,
+        rangeSpread: null,
+      });
+    });
+
+    it("returns nulls for undefined input", () => {
+      expect(parseDisplayHeightFt(undefined)).toEqual({
+        numericFt: null,
+        rangeSpread: null,
+      });
+    });
+
+    it("returns nulls for empty string", () => {
+      expect(parseDisplayHeightFt("")).toEqual({
+        numericFt: null,
+        rangeSpread: null,
+      });
+    });
+
+    it("returns nulls for whitespace-only string", () => {
+      expect(parseDisplayHeightFt("   ")).toEqual({
+        numericFt: null,
+        rangeSpread: null,
+      });
+    });
+
+    it("does not warn for null/empty inputs", () => {
+      parseDisplayHeightFt(null);
+      parseDisplayHeightFt("");
+      parseDisplayHeightFt("   ");
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flat inputs", () => {
+    it("parses 'Flat' as 0", () => {
+      expect(parseDisplayHeightFt("Flat")).toEqual({
+        numericFt: 0,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses 'flat' lowercase as 0", () => {
+      expect(parseDisplayHeightFt("flat")).toEqual({
+        numericFt: 0,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses 'FLAT' uppercase as 0", () => {
+      expect(parseDisplayHeightFt("FLAT")).toEqual({
+        numericFt: 0,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses '  Flat  ' with whitespace as 0", () => {
+      expect(parseDisplayHeightFt("  Flat  ")).toEqual({
+        numericFt: 0,
+        rangeSpread: null,
+      });
+    });
+  });
+
+  describe("single-value inputs", () => {
+    it("parses '3ft'", () => {
+      expect(parseDisplayHeightFt("3ft")).toEqual({
+        numericFt: 3,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses '3 ft'", () => {
+      expect(parseDisplayHeightFt("3 ft")).toEqual({
+        numericFt: 3,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses bare number '3'", () => {
+      expect(parseDisplayHeightFt("3")).toEqual({
+        numericFt: 3,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses decimal '2.5ft'", () => {
+      expect(parseDisplayHeightFt("2.5ft")).toEqual({
+        numericFt: 2.5,
+        rangeSpread: null,
+      });
+    });
+
+    it("parses decimal '2.5 ft'", () => {
+      expect(parseDisplayHeightFt("2.5 ft")).toEqual({
+        numericFt: 2.5,
+        rangeSpread: null,
+      });
+    });
+
+    it("tolerates leading and trailing whitespace", () => {
+      expect(parseDisplayHeightFt("  3ft  ")).toEqual({
+        numericFt: 3,
+        rangeSpread: null,
+      });
+    });
+  });
+
+  describe("range inputs", () => {
+    it("parses '3-4ft' as midpoint 3.5 with spread 1", () => {
+      expect(parseDisplayHeightFt("3-4ft")).toEqual({
+        numericFt: 3.5,
+        rangeSpread: 1,
+      });
+    });
+
+    it("parses '3-4 ft'", () => {
+      expect(parseDisplayHeightFt("3-4 ft")).toEqual({
+        numericFt: 3.5,
+        rangeSpread: 1,
+      });
+    });
+
+    it("parses '3 - 4 ft' with spaces around dash", () => {
+      expect(parseDisplayHeightFt("3 - 4 ft")).toEqual({
+        numericFt: 3.5,
+        rangeSpread: 1,
+      });
+    });
+
+    it("parses '3 to 4 ft' word form", () => {
+      expect(parseDisplayHeightFt("3 to 4 ft")).toEqual({
+        numericFt: 3.5,
+        rangeSpread: 1,
+      });
+    });
+  });
+
+  describe("malformed inputs", () => {
+    it("returns nulls and warns for 'junk'", () => {
+      const result = parseDisplayHeightFt("junk");
+      expect(result).toEqual({ numericFt: null, rangeSpread: null });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("[apply-beach-height-offset]");
+      expect(warnSpy.mock.calls[0][0]).toContain("junk");
+    });
+
+    it("returns nulls and warns for 'abc-def'", () => {
+      const result = parseDisplayHeightFt("abc-def");
+      expect(result).toEqual({ numericFt: null, rangeSpread: null });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("[apply-beach-height-offset]");
+    });
+
+    it("warns at most once per call", () => {
+      parseDisplayHeightFt("junk");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("formatDisplayHeightFt", () => {
+  describe("flat / non-finite", () => {
+    it("returns 'Flat' for numericFt = 0", () => {
+      expect(formatDisplayHeightFt({ numericFt: 0, rangeSpread: null })).toBe(
+        "Flat"
+      );
+    });
+
+    it("returns 'Flat' for negative numericFt", () => {
+      expect(
+        formatDisplayHeightFt({ numericFt: -1, rangeSpread: null })
+      ).toBe("Flat");
+    });
+
+    it("returns 'Flat' for NaN numericFt", () => {
+      expect(
+        formatDisplayHeightFt({ numericFt: Number.NaN, rangeSpread: null })
+      ).toBe("Flat");
+    });
+
+    it("returns 'Flat' for Infinity numericFt", () => {
+      expect(
+        formatDisplayHeightFt({
+          numericFt: Number.POSITIVE_INFINITY,
+          rangeSpread: null,
+        })
+      ).toBe("Flat");
+    });
+  });
+
+  describe("single-value (rangeSpread null)", () => {
+    it("delegates to formatWaveHeightRange for integer height", () => {
+      expect(
+        formatDisplayHeightFt({ numericFt: 3, rangeSpread: null })
+      ).toBe("3ft");
+    });
+
+    it("delegates to formatWaveHeightRange for fractional height", () => {
+      // 2.5 -> floor=2, ceil=3 -> "2-3ft" per formatWaveHeightRange
+      expect(
+        formatDisplayHeightFt({ numericFt: 2.5, rangeSpread: null })
+      ).toBe("2-3ft");
+    });
+  });
+
+  describe("range (rangeSpread provided)", () => {
+    it("preserves range shape: midpoint 3.5, spread 1 -> '3-4ft'", () => {
+      // low = 3, high = 4, floor=3, ceil=4
+      expect(
+        formatDisplayHeightFt({ numericFt: 3.5, rangeSpread: 1 })
+      ).toBe("3-4ft");
+    });
+
+    it("preserves range shape after correction: midpoint 3.0, spread 1 -> '2-4ft'", () => {
+      // low = 2.5, high = 3.5, floor=2, ceil=4
+      expect(
+        formatDisplayHeightFt({ numericFt: 3.0, rangeSpread: 1 })
+      ).toBe("2-4ft");
+    });
+
+    it("clamps low at 0 when midpoint - spread/2 < 0", () => {
+      // midpoint 0.5, spread 1 -> low = max(0, 0) = 0, high = 1 -> "0-1ft"
+      expect(
+        formatDisplayHeightFt({ numericFt: 0.5, rangeSpread: 1 })
+      ).toBe("0-1ft");
+    });
+
+    it("returns 'Flat' for non-positive midpoint regardless of spread", () => {
+      // midpoint <= 0 short-circuits to Flat
+      expect(
+        formatDisplayHeightFt({ numericFt: 0, rangeSpread: 2 })
+      ).toBe("Flat");
+    });
+  });
+});
+
+describe("applyBeachHeightOffset", () => {
+  const baseArgs = {
+    heightFt: 5,
+    offsetM: 0.3,
+    sampleCount: 50,
+    enabled: true,
+    forecastHorizonHours: 48,
+    computedAt: new Date("2026-05-01T00:00:00Z"),
+    maeBeforeM: 0.45,
+    maeAfterM: 0.18,
+    now: new Date("2026-05-01T12:00:00Z"),
+  };
+
+  describe("happy path", () => {
+    it("applies positive offset of 0.3m to heightFt 5", () => {
+      const result = applyBeachHeightOffset(baseArgs);
+      const expected = 5 - 0.3 * METERS_TO_FEET;
+      expect(result).toBeCloseTo(expected, 5);
+    });
+
+    it("negative offset raises forecast", () => {
+      const result = applyBeachHeightOffset({ ...baseArgs, offsetM: -0.2 });
+      const expected = 5 - -0.2 * METERS_TO_FEET;
+      expect(result).toBeCloseTo(expected, 5);
+      expect(result).toBeGreaterThan(5);
+    });
+
+    it("clamps to 0 when offset > heightFt", () => {
+      const result = applyBeachHeightOffset({
+        ...baseArgs,
+        heightFt: 0.5,
+        offsetM: 1.0, // ~3.28 ft, way more than 0.5 ft heightFt
+      });
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("gates - return original heightFt", () => {
+    it("disabled flag returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, enabled: false })
+      ).toBe(5);
+    });
+
+    it("offsetM null returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, offsetM: null })
+      ).toBe(5);
+    });
+
+    it("offsetM undefined returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, offsetM: undefined })
+      ).toBe(5);
+    });
+
+    it("offsetM NaN returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, offsetM: Number.NaN })
+      ).toBe(5);
+    });
+
+    it("offsetM Infinity returns original", () => {
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          offsetM: Number.POSITIVE_INFINITY,
+        })
+      ).toBe(5);
+    });
+
+    it("sampleCount null returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, sampleCount: null })
+      ).toBe(5);
+    });
+
+    it("sampleCount below default min (30) returns original", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, sampleCount: 29 })
+      ).toBe(5);
+    });
+
+    it("sampleCount below custom minSampleCount returns original", () => {
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          sampleCount: 49,
+          minSampleCount: 50,
+        })
+      ).toBe(5);
+    });
+
+    it("forecastHorizonHours below default (24) returns original (Gap #4)", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, forecastHorizonHours: 12 })
+      ).toBe(5);
+    });
+
+    it("forecastHorizonHours below custom minHorizonHours returns original", () => {
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          forecastHorizonHours: 36,
+          minHorizonHours: 48,
+        })
+      ).toBe(5);
+    });
+
+    it("computedAt null returns original (Gap #3)", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, computedAt: null })
+      ).toBe(5);
+    });
+
+    it("computedAt older than maxOffsetAgeDays returns original (Gap #3)", () => {
+      // Default maxOffsetAgeDays = 14; set computedAt 15 days before now
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          computedAt: new Date("2026-04-15T00:00:00Z"),
+          now: new Date("2026-05-01T00:00:00Z"),
+        })
+      ).toBe(5);
+    });
+
+    it("computedAt within maxOffsetAgeDays does NOT trigger gate", () => {
+      // 13 days old - within 14d default
+      const result = applyBeachHeightOffset({
+        ...baseArgs,
+        computedAt: new Date("2026-04-18T00:00:00Z"),
+        now: new Date("2026-05-01T00:00:00Z"),
+      });
+      // Should apply offset (not return 5 unchanged)
+      expect(result).not.toBe(5);
+    });
+
+    it("custom maxOffsetAgeDays gate", () => {
+      // 8 days old, custom max 7
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          computedAt: new Date("2026-04-23T00:00:00Z"),
+          now: new Date("2026-05-01T00:00:00Z"),
+          maxOffsetAgeDays: 7,
+        })
+      ).toBe(5);
+    });
+
+    it("computedAt as ISO string is supported", () => {
+      const result = applyBeachHeightOffset({
+        ...baseArgs,
+        computedAt: "2026-04-30T00:00:00Z",
+        now: new Date("2026-05-01T00:00:00Z"),
+      });
+      expect(result).not.toBe(5); // gate passed, offset applied
+    });
+
+    it("maeBeforeM null returns original (Gap #3)", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, maeBeforeM: null })
+      ).toBe(5);
+    });
+
+    it("maeAfterM null returns original (Gap #3)", () => {
+      expect(
+        applyBeachHeightOffset({ ...baseArgs, maeAfterM: null })
+      ).toBe(5);
+    });
+
+    it("maeAfterM equal to maeBeforeM (no improvement) returns original", () => {
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          maeBeforeM: 0.3,
+          maeAfterM: 0.3,
+        })
+      ).toBe(5);
+    });
+
+    it("maeAfterM greater than maeBeforeM (regression) returns original", () => {
+      expect(
+        applyBeachHeightOffset({
+          ...baseArgs,
+          maeBeforeM: 0.2,
+          maeAfterM: 0.3,
+        })
+      ).toBe(5);
+    });
+  });
+
+  describe("non-finite heightFt passthrough", () => {
+    it("NaN heightFt returns NaN unchanged", () => {
+      const result = applyBeachHeightOffset({
+        ...baseArgs,
+        heightFt: Number.NaN,
+      });
+      expect(result).toBeNaN();
+    });
+
+    it("Infinity heightFt returns Infinity unchanged", () => {
+      const result = applyBeachHeightOffset({
+        ...baseArgs,
+        heightFt: Number.POSITIVE_INFINITY,
+      });
+      expect(result).toBe(Number.POSITIVE_INFINITY);
+    });
+  });
+
+  describe("parser/formatter round-trip", () => {
+    it("'3-4ft' input with 0.5ft-equivalent offset rounds to '2-4ft'", () => {
+      // parser: "3-4ft" -> midpoint 3.5, spread 1
+      const parsed = parseDisplayHeightFt("3-4ft");
+      expect(parsed).toEqual({ numericFt: 3.5, rangeSpread: 1 });
+
+      // apply offset: 0.5/METERS_TO_FEET ~= 0.1524 m so corrected mid = 3.5 - 0.5 = 3.0
+      const offsetM = 0.5 / METERS_TO_FEET;
+      const correctedMid = applyBeachHeightOffset({
+        ...baseArgs,
+        heightFt: parsed.numericFt!,
+        offsetM,
+      });
+      expect(correctedMid).toBeCloseTo(3.0, 5);
+
+      // re-emit: midpoint 3.0, spread 1 -> low = 2.5, high = 3.5 -> floor 2, ceil 4
+      const formatted = formatDisplayHeightFt({
+        numericFt: correctedMid,
+        rangeSpread: parsed.rangeSpread,
+      });
+      expect(formatted).toBe("2-4ft");
+    });
+  });
+});

--- a/lib/services/forecast/__tests__/forecast-builder.height-offset.test.ts
+++ b/lib/services/forecast/__tests__/forecast-builder.height-offset.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for the per-beach height-offset hook in ForecastBuilder.buildSingleForecast.
+ *
+ * Critical invariants verified:
+ *  1. height_offset_enabled=false → wave_height byte-identical to today.
+ *  2. Flag enabled but offset row missing → falls through unchanged.
+ *  3. Flag enabled + all gates passing → wave_height reflects corrected midpoint
+ *     and snapshot row is buffered with raw < corrected diff matching offset.
+ *  4. Telemetry feedback-loop invariant: snapshot's raw_display_height_m is
+ *     the PRE-offset value (captured before applyBeachHeightOffset runs).
+ *
+ * The strategy is to mock the wave-formatter so getWaveHeight returns a known
+ * stable string ("3 ft"), then assert how the offset hook reshapes the output.
+ */
+
+import { ForecastBuilder } from "../forecast-builder";
+import type {
+  ForecastInputs,
+  BeachHeightOffsetRow,
+} from "../forecast-builder";
+import type { Beach } from "@/types/database";
+import { METERS_TO_FEET } from "@/lib/utils/unit-conversions";
+
+// Capture insert calls so we can assert no snapshot ever leaks out (the
+// fire-and-forget invariant — we are testing the buffer, not the writer).
+const insertMock: jest.Mock = jest.fn().mockResolvedValue({ data: null, error: null });
+const fromMock: jest.Mock = jest.fn(() => ({ insert: insertMock }));
+
+jest.mock("@/lib/supabase", () => ({
+  createServiceRoleClient: () => ({
+    from: (table: string) => fromMock(table),
+  }),
+}));
+
+jest.mock("@/lib/services/forecast/confidence-scorer", () => ({
+  calculateConfidenceScore: jest.fn(() => 75),
+}));
+
+jest.mock("@/lib/logger", () => ({
+  createContextLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+// Pin getWaveHeight output to a known string so we can deterministically
+// reason about parser/formatter/offset interactions.
+jest.mock("@/lib/utils/wave-formatters", () => {
+  const actual = jest.requireActual("@/lib/utils/unit-conversions");
+  return {
+    toFaceHeightFeet: jest.fn(() => "3 ft"),
+    toFaceHeightFeetDecomposed: jest.fn(() => "3 ft"),
+    toFaceHeightFeetDecomposedWithDebug: jest.fn(() => ({
+      value: "3 ft",
+      debug: {
+        source: "model_swell",
+        rawHeightFt: 3,
+        transformPath: "decomposed",
+        componentsUsed: true,
+        calibratedShoalingFired: false,
+      },
+    })),
+    metersToFeet: jest.fn((m: number) => m * actual.METERS_TO_FEET),
+    METERS_TO_FEET: actual.METERS_TO_FEET,
+  };
+});
+
+// Capture the snapshot buffer as it grows. We patch logDisplayPredictions to
+// pull the rows out of the fire-and-forget dispatch so tests can assert on
+// what was queued.
+let capturedSnapshotRows: any[] = [];
+jest.mock("../log-display-prediction", () => ({
+  logDisplayPredictions: jest.fn(async (rows: any[]) => {
+    capturedSnapshotRows = capturedSnapshotRows.concat(rows ?? []);
+  }),
+}));
+
+const baseBeach: Beach = {
+  id: "beach-1",
+  name: "Test Beach",
+  lat: 32.7,
+  lon: -117.2,
+} as Beach;
+
+const buildInputs = (overrides: Partial<ForecastInputs> = {}): ForecastInputs =>
+  ({
+    beach: baseBeach,
+    waveData: {
+      lat: 32.7,
+      lng: -117.2,
+      forecast: [
+        {
+          timestamp: new Date().toISOString(),
+          significant_wave_height: 1.2,
+          peak_wave_period: 12,
+          peak_wave_direction: 225,
+          swell_1_height: 0.8,
+          swell_1_period: 14,
+          swell_1_direction: 220,
+          swell_2_height: 0,
+          swell_2_period: 0,
+          swell_2_direction: 0,
+          wind_wave_height: 0.3,
+          wind_wave_period: 6,
+          wind_wave_direction: 200,
+          data_source: "NOAA_NWS" as const,
+        },
+      ],
+    } as any,
+    tideData: null,
+    weatherData: [],
+    buoyData: null,
+    cdipData: null,
+    ioosWaterTempC: null,
+    coopsWaterTempC: null,
+    ...overrides,
+  }) as ForecastInputs;
+
+const newBuilder = () =>
+  new ForecastBuilder({
+    getWaveDirectionText: () => "SW",
+    getTideStatusAtTime: () => "Rising",
+    getTideHeightAtTime: () => 3.5,
+    getNextTideFromTime: () => ({
+      time: Math.floor(Date.now() / 1000) + 7200,
+      height: 5.2,
+      type: "high",
+      name: "High",
+    }),
+    getDataQualityScore: () => 85,
+  });
+
+describe("ForecastBuilder per-beach height-offset hook", () => {
+  beforeEach(() => {
+    capturedSnapshotRows = [];
+    insertMock.mockClear();
+    fromMock.mockClear();
+  });
+
+  it("flag disabled → wave_height byte-identical to today's getWaveHeight output", async () => {
+    const builder = newBuilder();
+    const forecasts = await builder.buildForecasts(
+      buildInputs({
+        // No heightOffset row, no flag. Pass undefined explicitly to ensure
+        // the inline fetch is also skipped (flag false short-circuits it).
+        heightOffset: undefined,
+      })
+    );
+
+    // Every row should carry the unmodified mock string from getWaveHeight.
+    expect(forecasts.length).toBeGreaterThan(0);
+    for (const f of forecasts) {
+      expect(f.wave_height).toBe("3 ft");
+    }
+  });
+
+  it("flag disabled → snapshot still records raw_display_height_m (telemetry)", async () => {
+    // The snapshot writer captures display values regardless of whether the
+    // offset is applied. This is what lets the cron eventually compute an
+    // offset for beaches with the flag off.
+    const builder = newBuilder();
+    await builder.buildForecasts(buildInputs());
+
+    expect(capturedSnapshotRows.length).toBeGreaterThan(0);
+
+    // Every snapshot row's offset-corrected value must equal raw when no
+    // offset was applied.
+    for (const row of capturedSnapshotRows) {
+      expect(row.offset_corrected_display_height_m).toBe(
+        row.raw_display_height_m
+      );
+      expect(row.height_offset_m).toBeNull();
+      expect(row.height_offset_sample_count).toBeNull();
+      // raw_display_height_m should match parser output: 3 ft -> ~0.914 m.
+      const expectedM = Number((3 / METERS_TO_FEET).toFixed(3));
+      expect(row.raw_display_height_m).toBe(expectedM);
+    }
+  });
+
+  it("flag enabled but offset row missing → wave_height unchanged", async () => {
+    const flagBeach = {
+      ...baseBeach,
+      height_offset_enabled: true,
+    } as unknown as Beach;
+
+    const builder = newBuilder();
+    const forecasts = await builder.buildForecasts(
+      buildInputs({ beach: flagBeach, heightOffset: null })
+    );
+
+    for (const f of forecasts) {
+      expect(f.wave_height).toBe("3 ft");
+    }
+  });
+
+  it("all gates passing → wave_height reflects corrected midpoint", async () => {
+    const flagBeach = {
+      ...baseBeach,
+      height_offset_enabled: true,
+    } as unknown as Beach;
+
+    // 0.3m offset positive → corrected_ft = 3 - (0.3 * 3.28084) ≈ 2.016 ft
+    const offsetRow: BeachHeightOffsetRow = {
+      offset_m: 0.3,
+      sample_count: 60,
+      mae_before_m: 0.4,
+      mae_after_m: 0.18,
+      computed_at: new Date().toISOString(),
+    };
+
+    const builder = newBuilder();
+    const forecasts = await builder.buildForecasts(
+      buildInputs({ beach: flagBeach, heightOffset: offsetRow })
+    );
+
+    // Slot 0 is at horizon ~0h — gate fails (minHorizonHours=24).
+    // Slots 8+ (3h interval × 8 = 24h) start to pass the horizon gate.
+    // We assert at least one row got corrected and at least one stayed raw.
+    const correctedRows = forecasts.filter((f) => f.wave_height !== "3 ft");
+    const unchangedRows = forecasts.filter((f) => f.wave_height === "3 ft");
+    expect(correctedRows.length).toBeGreaterThan(0);
+    expect(unchangedRows.length).toBeGreaterThan(0);
+
+    // The corrected output should reflect the midpoint shift. Mocked input
+    // is "3 ft" (single value, no range spread), so formatDisplayHeightFt
+    // returns the formatWaveHeightRange single-value form. Corrected
+    // ≈ 2.016 ft → "2ft" (or similar single-value form).
+    for (const r of correctedRows) {
+      expect(r.wave_height).not.toBe("3 ft");
+      expect(typeof r.wave_height).toBe("string");
+    }
+  });
+
+  it("snapshot raw is captured BEFORE offset (telemetry feedback-loop invariant)", async () => {
+    const flagBeach = {
+      ...baseBeach,
+      height_offset_enabled: true,
+    } as unknown as Beach;
+
+    const offsetM = 0.3;
+    const offsetRow: BeachHeightOffsetRow = {
+      offset_m: offsetM,
+      sample_count: 60,
+      mae_before_m: 0.4,
+      mae_after_m: 0.18,
+      computed_at: new Date().toISOString(),
+    };
+
+    const builder = newBuilder();
+    await builder.buildForecasts(
+      buildInputs({ beach: flagBeach, heightOffset: offsetRow })
+    );
+
+    // For rows where the offset actually applied (height_offset_m non-null),
+    // raw - corrected should equal offset_m exactly (modulo NUMERIC(5,3)
+    // rounding and the float roundtrip through ft).
+    const appliedRows = capturedSnapshotRows.filter(
+      (r) => r.height_offset_m != null
+    );
+    expect(appliedRows.length).toBeGreaterThan(0);
+
+    for (const r of appliedRows) {
+      const diff =
+        r.raw_display_height_m - r.offset_corrected_display_height_m;
+      // Tolerance covers the .toFixed(3) rounding on each side.
+      expect(diff).toBeCloseTo(offsetM, 2);
+      expect(r.raw_display_height_m).toBeGreaterThan(
+        r.offset_corrected_display_height_m
+      );
+      expect(r.height_offset_m).toBe(offsetM);
+      expect(r.height_offset_sample_count).toBe(60);
+    }
+
+    // Rows where the offset did NOT apply (e.g. 0-24h horizons) must still
+    // record raw_display_height_m, with corrected == raw and offset null.
+    const notAppliedRows = capturedSnapshotRows.filter(
+      (r) => r.height_offset_m == null
+    );
+    expect(notAppliedRows.length).toBeGreaterThan(0);
+    for (const r of notAppliedRows) {
+      expect(r.offset_corrected_display_height_m).toBe(r.raw_display_height_m);
+      expect(r.height_offset_sample_count).toBeNull();
+    }
+  });
+
+  it("forecast_horizon_hours is rounded from forecastTime - issueTime", async () => {
+    const flagBeach = {
+      ...baseBeach,
+      height_offset_enabled: true,
+    } as unknown as Beach;
+
+    const builder = newBuilder();
+    await builder.buildForecasts(
+      buildInputs({
+        beach: flagBeach,
+        heightOffset: null,
+      })
+    );
+
+    // First snapshot (slot 0) should be horizon=0; subsequent slots increase
+    // by FORECAST_CONSTANTS.INTERVAL_HOURS (3h). We assert monotonic + non-negative.
+    expect(capturedSnapshotRows.length).toBeGreaterThan(1);
+    for (let i = 1; i < capturedSnapshotRows.length; i++) {
+      const prev = capturedSnapshotRows[i - 1].forecast_horizon_hours;
+      const cur = capturedSnapshotRows[i].forecast_horizon_hours;
+      expect(cur).toBeGreaterThanOrEqual(prev);
+      expect(cur).toBeGreaterThanOrEqual(0);
+    }
+    expect(capturedSnapshotRows[0].forecast_horizon_hours).toBe(0);
+  });
+
+  it("display_source is face-Hs-transformer-v1", async () => {
+    const builder = newBuilder();
+    await builder.buildForecasts(buildInputs());
+
+    expect(capturedSnapshotRows.length).toBeGreaterThan(0);
+    for (const r of capturedSnapshotRows) {
+      expect(r.display_source).toBe("face-Hs-transformer-v1");
+    }
+  });
+});

--- a/lib/services/forecast/__tests__/log-display-prediction.test.ts
+++ b/lib/services/forecast/__tests__/log-display-prediction.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the display-prediction snapshot writer.
+ *
+ * Critical invariants verified here:
+ *  1. Env-gated: missing SUPABASE_SERVICE_ROLE_KEY → no insert + warn.
+ *  2. Fire-and-forget: supabase failures NEVER throw to caller.
+ *  3. Batch insert: a single supabase call regardless of N rows.
+ *  4. Payload shape: every required column present.
+ */
+
+import {
+  logDisplayPredictions,
+  type DisplayPredictionRow,
+} from "../log-display-prediction";
+
+// Capture supabase calls. We swap the service-role factory so we observe the
+// .from("ml_predictions_log").insert(payload) flow.
+const insertMock: jest.Mock = jest.fn();
+const fromMock: jest.Mock = jest.fn(() => ({ insert: insertMock }));
+
+jest.mock("@/lib/supabase", () => ({
+  createServiceRoleClient: () => ({
+    from: (table: string) => fromMock(table),
+  }),
+}));
+
+// Silence the logger.
+jest.mock("@/lib/logger", () => ({
+  createContextLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+const sampleRow = (
+  overrides: Partial<DisplayPredictionRow> = {}
+): DisplayPredictionRow => ({
+  beach_id: "beach-1",
+  predicted_at: "2026-05-01T00:00:00Z",
+  forecast_horizon_hours: 24,
+  raw_display_height_m: 1.234,
+  offset_corrected_display_height_m: 1.123,
+  height_offset_m: 0.111,
+  height_offset_sample_count: 42,
+  display_source: "face-Hs-transformer-v1",
+  ...overrides,
+});
+
+describe("logDisplayPredictions", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    insertMock.mockResolvedValue({ data: null, error: null });
+    fromMock.mockImplementation(() => ({ insert: insertMock }));
+    process.env = {
+      ...ORIGINAL_ENV,
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+      NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+    };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it("returns immediately for empty input", async () => {
+    await logDisplayPredictions([]);
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("env-gated: missing SUPABASE_SERVICE_ROLE_KEY skips insert + warns", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    // Should not throw and should not insert anything.
+    await expect(
+      logDisplayPredictions([sampleRow()])
+    ).resolves.toBeUndefined();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("env-gated: missing NEXT_PUBLIC_SUPABASE_URL skips insert", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    await logDisplayPredictions([sampleRow()]);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("performs ONE batch insert for N rows", async () => {
+    const rows = [
+      sampleRow({ predicted_at: "2026-05-01T00:00:00Z" }),
+      sampleRow({ predicted_at: "2026-05-01T03:00:00Z" }),
+      sampleRow({ predicted_at: "2026-05-01T06:00:00Z" }),
+      sampleRow({ predicted_at: "2026-05-01T09:00:00Z" }),
+      sampleRow({ predicted_at: "2026-05-01T12:00:00Z" }),
+    ];
+
+    await logDisplayPredictions(rows);
+
+    // ONE supabase.from() call, ONE .insert() call.
+    expect(fromMock).toHaveBeenCalledTimes(1);
+    expect(fromMock).toHaveBeenCalledWith("ml_predictions_log");
+    expect(insertMock).toHaveBeenCalledTimes(1);
+
+    const payload = insertMock.mock.calls[0][0];
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload).toHaveLength(5);
+  });
+
+  it("payload includes all required snapshot columns", async () => {
+    await logDisplayPredictions([
+      sampleRow({
+        beach_id: "beach-99",
+        predicted_at: "2026-05-01T00:00:00Z",
+        forecast_horizon_hours: 48,
+        raw_display_height_m: 2.5,
+        offset_corrected_display_height_m: 2.2,
+        height_offset_m: 0.3,
+        height_offset_sample_count: 60,
+        display_source: "face-Hs-transformer-v1",
+      }),
+    ]);
+
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload[0]).toEqual({
+      beach_id: "beach-99",
+      predicted_at: "2026-05-01T00:00:00Z",
+      forecast_horizon_hours: 48,
+      raw_display_height_m: 2.5,
+      offset_corrected_display_height_m: 2.2,
+      height_offset_m: 0.3,
+      height_offset_sample_count: 60,
+      display_source: "face-Hs-transformer-v1",
+      // model_version falls back to display_source so the NOT NULL constraint
+      // on ml_predictions_log.model_version is always satisfied.
+      model_version: "face-Hs-transformer-v1",
+    });
+  });
+
+  it("respects explicit model_version override", async () => {
+    await logDisplayPredictions([
+      sampleRow({ model_version: "explicit-model-v2" }),
+    ]);
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload[0].model_version).toBe("explicit-model-v2");
+  });
+
+  it("supabase insert failure does NOT throw to caller (fire-and-forget)", async () => {
+    insertMock.mockResolvedValueOnce({
+      data: null,
+      error: { message: "constraint violation", code: "23505" },
+    });
+
+    // Must resolve, not reject.
+    await expect(logDisplayPredictions([sampleRow()])).resolves.toBeUndefined();
+  });
+
+  it("unexpected synchronous throw inside client does NOT propagate", async () => {
+    fromMock.mockImplementationOnce(() => {
+      throw new Error("client-construction blew up");
+    });
+
+    await expect(logDisplayPredictions([sampleRow()])).resolves.toBeUndefined();
+  });
+
+  it("rejected insert promise does NOT propagate", async () => {
+    insertMock.mockRejectedValueOnce(new Error("network died"));
+
+    await expect(logDisplayPredictions([sampleRow()])).resolves.toBeUndefined();
+  });
+
+  it("handles null offset rows (no offset applied)", async () => {
+    await logDisplayPredictions([
+      sampleRow({
+        height_offset_m: null,
+        height_offset_sample_count: null,
+        offset_corrected_display_height_m: 1.234, // equal to raw
+      }),
+    ]);
+
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload[0].height_offset_m).toBeNull();
+    expect(payload[0].height_offset_sample_count).toBeNull();
+    expect(payload[0].offset_corrected_display_height_m).toBe(
+      payload[0].raw_display_height_m
+    );
+  });
+});

--- a/lib/services/forecast/apply-beach-height-offset.ts
+++ b/lib/services/forecast/apply-beach-height-offset.ts
@@ -1,0 +1,199 @@
+/**
+ * Per-beach display-height offset correction.
+ *
+ * The forecast pipeline emits a display wave-height value per beach. Empirical
+ * residual analysis (raw_display - observed) shows a systematic per-beach bias.
+ * This module:
+ *   1. Parses the display TEXT shape from forecast-builder / enhanced_forecasts
+ *      (`"Flat"`, `"3ft"`, `"3-4ft"`, etc.) into a numeric face-feet midpoint
+ *      and original range spread.
+ *   2. Applies a freshness/sample/improvement-gated rolling-median offset.
+ *   3. Re-emits the corrected value preserving the original range shape.
+ *
+ * Sign convention: `offset_m = display_forecast_m - observed_m`. Apply by
+ * subtracting: `corrected = display - offset`. Positive offset means the
+ * forecast is biased high; subtracting lowers it.
+ */
+
+import { METERS_TO_FEET } from "@/lib/utils/unit-conversions";
+import { formatWaveHeightRange } from "@/lib/formatters/surf-data";
+
+const WARN_PREFIX = "[apply-beach-height-offset]";
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+export interface ParsedDisplayHeight {
+  /** Numeric face-feet midpoint. `null` if unparseable; `0` for "Flat". */
+  numericFt: number | null;
+  /** Original range spread (e.g. "3-4ft" → 1). `null` for single-value or flat. */
+  rangeSpread: number | null;
+}
+
+/**
+ * Parse the wave_height TEXT shape used by forecast-builder /
+ * enhanced_forecasts.wave_height. Returns the numeric midpoint and the
+ * original range spread so callers can re-emit the corrected value with the
+ * original shape preserved.
+ */
+export function parseDisplayHeightFt(
+  raw: string | null | undefined
+): ParsedDisplayHeight {
+  if (raw == null) return { numericFt: null, rangeSpread: null };
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { numericFt: null, rangeSpread: null };
+
+  const lower = trimmed.toLowerCase();
+  if (lower === "flat") {
+    return { numericFt: 0, rangeSpread: null };
+  }
+
+  // Strip trailing "ft" units (with or without space) for parsing.
+  const stripped = lower.replace(/\s*ft\s*$/i, "").trim();
+
+  // Range form: "3-4", "3 - 4", "3 to 4"
+  const rangeMatch = stripped.match(
+    /^(-?\d+(?:\.\d+)?)\s*(?:-|to)\s*(-?\d+(?:\.\d+)?)$/
+  );
+  if (rangeMatch) {
+    const lo = Number(rangeMatch[1]);
+    const hi = Number(rangeMatch[2]);
+    if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+      console.warn(`${WARN_PREFIX} could not parse wave_height: ${raw}`);
+      return { numericFt: null, rangeSpread: null };
+    }
+    return {
+      numericFt: (lo + hi) / 2,
+      rangeSpread: Math.abs(hi - lo),
+    };
+  }
+
+  // Single value: "3", "2.5"
+  const singleMatch = stripped.match(/^(-?\d+(?:\.\d+)?)$/);
+  if (singleMatch) {
+    const v = Number(singleMatch[1]);
+    if (!Number.isFinite(v)) {
+      console.warn(`${WARN_PREFIX} could not parse wave_height: ${raw}`);
+      return { numericFt: null, rangeSpread: null };
+    }
+    return { numericFt: v, rangeSpread: null };
+  }
+
+  console.warn(`${WARN_PREFIX} could not parse wave_height: ${raw}`);
+  return { numericFt: null, rangeSpread: null };
+}
+
+// ---------------------------------------------------------------------------
+// Formatter
+// ---------------------------------------------------------------------------
+
+export interface FormatDisplayHeightOpts {
+  /** Corrected midpoint in feet. */
+  numericFt: number;
+  /** Original range spread; `null` for single-value form. */
+  rangeSpread: number | null;
+}
+
+/**
+ * Re-emit a display height. When `rangeSpread` is null this delegates to
+ * `formatWaveHeightRange` (single-value form). When provided, the spread is
+ * preserved around the corrected midpoint, with low clamped at 0.
+ */
+export function formatDisplayHeightFt(opts: FormatDisplayHeightOpts): string {
+  const { numericFt, rangeSpread } = opts;
+
+  if (!Number.isFinite(numericFt) || numericFt <= 0) return "Flat";
+
+  if (rangeSpread == null) {
+    return formatWaveHeightRange(numericFt);
+  }
+
+  const half = rangeSpread / 2;
+  const lowRaw = numericFt - half;
+  const highRaw = numericFt + half;
+  const low = Math.max(0, lowRaw);
+  const high = highRaw;
+
+  if (low <= 0 && high <= 0) return "Flat";
+
+  const lowInt = Math.floor(low);
+  const highInt = Math.ceil(high);
+
+  if (lowInt === highInt) return `${lowInt}ft`;
+  return `${lowInt}-${highInt}ft`;
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+export interface ApplyBeachHeightOffsetArgs {
+  /** Pre-correction face-feet height (from parser). */
+  heightFt: number;
+  /** Rolling-median offset in METERS. `offset_m = display_m - observed_m`. */
+  offsetM?: number | null;
+  /** Number of (predicted, observed) pairs in the offset window. */
+  sampleCount?: number | null;
+  /** Per-beach feature flag. */
+  enabled: boolean;
+  /** Forecast lead-time in hours; nowcasts (<24h) are not corrected by default. */
+  forecastHorizonHours: number;
+  /** When the offset row was computed. ISO string or Date. */
+  computedAt?: Date | string | null;
+  /** MAE before correction (meters) on the offset's training window. */
+  maeBeforeM?: number | null;
+  /** MAE after correction (meters) on the offset's training window. */
+  maeAfterM?: number | null;
+  /** Default 30 — do not apply with fewer samples. */
+  minSampleCount?: number;
+  /** Default 14 — do not apply if computedAt older than this. */
+  maxOffsetAgeDays?: number;
+  /** Default 24 — Gap #4: protect nowcasts. */
+  minHorizonHours?: number;
+  /** Injectable for tests. */
+  now?: Date;
+}
+
+/**
+ * Apply the per-beach height offset under a multi-gate guard. Returns the
+ * original `heightFt` if any gate fails so the helper is safe to wire in
+ * unconditionally.
+ */
+export function applyBeachHeightOffset(
+  args: ApplyBeachHeightOffsetArgs
+): number {
+  const {
+    heightFt,
+    offsetM,
+    sampleCount,
+    enabled,
+    forecastHorizonHours,
+    computedAt,
+    maeBeforeM,
+    maeAfterM,
+    minSampleCount = 30,
+    maxOffsetAgeDays = 14,
+    minHorizonHours = 24,
+    now = new Date(),
+  } = args;
+
+  if (!Number.isFinite(heightFt)) return heightFt;
+  if (!enabled) return heightFt;
+  if (offsetM == null || !Number.isFinite(offsetM)) return heightFt;
+  if (sampleCount == null || sampleCount < minSampleCount) return heightFt;
+  if (forecastHorizonHours < minHorizonHours) return heightFt;
+
+  if (computedAt == null) return heightFt;
+  const computedAtDate =
+    computedAt instanceof Date ? computedAt : new Date(computedAt);
+  if (!Number.isFinite(computedAtDate.getTime())) return heightFt;
+  const ageMs = now.getTime() - computedAtDate.getTime();
+  if (ageMs > maxOffsetAgeDays * 24 * 60 * 60 * 1000) return heightFt;
+
+  if (maeBeforeM == null || maeAfterM == null) return heightFt;
+  if (!(maeAfterM < maeBeforeM)) return heightFt;
+
+  const offsetFt = offsetM * METERS_TO_FEET;
+  return Math.max(0, heightFt - offsetFt);
+}

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -10,7 +10,21 @@
 
 import { createContextLogger } from "@/lib/logger";
 import { calculateConfidenceScore } from "./confidence-scorer";
-import { toFaceHeightFeet, toFaceHeightFeetDecomposed, METERS_TO_FEET } from "@/lib/utils/wave-formatters";
+import {
+  toFaceHeightFeetDecomposedWithDebug,
+  METERS_TO_FEET,
+  type WaveHeightDebugInfo,
+} from "@/lib/utils/wave-formatters";
+import {
+  applyBeachHeightOffset,
+  formatDisplayHeightFt,
+  parseDisplayHeightFt,
+} from "./apply-beach-height-offset";
+import {
+  logDisplayPredictions,
+  type DisplayPredictionRow,
+} from "./log-display-prediction";
+import { createServiceRoleClient } from "@/lib/supabase";
 import type {
   ShoalingFactors,
   SwellComponentInput,
@@ -82,6 +96,20 @@ export interface DataSourceServices {
 }
 
 /**
+ * Per-beach height offset row, loaded once per cron invocation by the caller
+ * and passed in via ForecastInputs.offsetMap. Mirrors the
+ * beach_height_offsets table shape; kept narrow because forecast-builder only
+ * reads the columns the helper consumes.
+ */
+export type BeachHeightOffsetRow = {
+  offset_m: number | null;
+  sample_count: number | null;
+  mae_before_m: number | null;
+  mae_after_m: number | null;
+  computed_at: string | null;
+};
+
+/**
  * Input data for building forecasts
  */
 export interface ForecastInputs {
@@ -101,9 +129,88 @@ export interface ForecastInputs {
    * forecast-only path (current behavior).
    */
   nowcastAnchor?: NowcastAnchor | null;
+  /**
+   * Optional per-beach height offset row (source='display'), loaded for the
+   * beach being built. When undefined the helper short-circuits to identity
+   * and wave_height is byte-identical to today's output.
+   */
+  heightOffset?: BeachHeightOffsetRow | null;
 }
 
 const log = createContextLogger("ForecastBuilder");
+
+/**
+ * Read the per-beach offset config from a Beach row. The columns
+ * `height_offset_enabled`, `height_offset_min_sample_count`, and
+ * `height_offset_max_age_days` were added by migration
+ * 20260501200500_create_beach_height_offsets.sql but the generated DB types
+ * have not yet been regenerated (per task constraint). This helper isolates
+ * the typed cast to one place and applies the migration's column defaults.
+ */
+function readBeachOffsetConfig(beach: Beach): {
+  enabled: boolean;
+  minSampleCount: number;
+  maxAgeDays: number;
+} {
+  const cfg = beach as unknown as {
+    height_offset_enabled?: boolean | null;
+    height_offset_min_sample_count?: number | null;
+    height_offset_max_age_days?: number | null;
+  };
+  return {
+    enabled: cfg.height_offset_enabled === true,
+    minSampleCount: cfg.height_offset_min_sample_count ?? 30,
+    maxAgeDays: cfg.height_offset_max_age_days ?? 14,
+  };
+}
+
+/**
+ * Batch-load beach_height_offsets rows for a set of beaches in ONE query.
+ * Production callers (e.g. enhanced-forecast-service.updateAllEnhancedForecasts)
+ * should use this and pass the resulting Map into ForecastInputs.heightOffset
+ * per beach to avoid N+1 lookups.
+ *
+ * Returns an empty Map on any failure — the helper short-circuits to identity
+ * when no offset row is provided, so the caller is safe to fall through.
+ */
+export async function loadHeightOffsetsForBeaches(
+  beachIds: string[]
+): Promise<Map<string, BeachHeightOffsetRow>> {
+  const out = new Map<string, BeachHeightOffsetRow>();
+  if (!beachIds || beachIds.length === 0) return out;
+
+  try {
+    const supabase = createServiceRoleClient();
+    const { data, error } = await supabase
+      .from("beach_height_offsets" as never)
+      .select(
+        "beach_id, offset_m, sample_count, mae_before_m, mae_after_m, computed_at"
+      )
+      .eq("source", "display")
+      .in("beach_id", beachIds);
+
+    if (error || !data) return out;
+
+    for (const row of data as unknown as Array<
+      BeachHeightOffsetRow & { beach_id: string }
+    >) {
+      out.set(row.beach_id, {
+        offset_m: row.offset_m,
+        sample_count: row.sample_count,
+        mae_before_m: row.mae_before_m,
+        mae_after_m: row.mae_after_m,
+        computed_at: row.computed_at,
+      });
+    }
+  } catch (err) {
+    log.warn("loadHeightOffsetsForBeaches failed", {
+      err: err instanceof Error ? err.message : String(err),
+      beachCount: beachIds.length,
+    });
+  }
+
+  return out;
+}
 
 /**
  * Builds forecast entities by combining data from multiple sources
@@ -121,9 +228,27 @@ export class ForecastBuilder {
    * Build forecasts from raw data sources
    */
   async buildForecasts(inputs: ForecastInputs): Promise<EnhancedForecastWithRawData[]> {
-    const { beach, waveData, tideData, weatherData, buoyData, cdipData, ioosWaterTempC, coopsWaterTempC, nowcastAnchor } = inputs;
+    const { beach, waveData, tideData, weatherData, buoyData, cdipData, ioosWaterTempC, coopsWaterTempC, nowcastAnchor, heightOffset } = inputs;
     const forecasts: EnhancedForecastWithRawData[] = [];
     const now = new Date();
+
+    // If no offset row was preloaded by the caller AND the beach has the flag
+    // enabled, fetch it inline so the helper has data to work with. Most
+    // production callers pre-load via a single batched query (see
+    // loadHeightOffsetsForBeaches below) to avoid N+1 — this branch is the
+    // single-beach fallback path. The new height_offset_* columns are not yet
+    // in the generated DB types (added by migration 20260501200500), so we
+    // read them via a narrow typed projection.
+    const beachOffsetCfg = readBeachOffsetConfig(beach);
+    let resolvedOffset: BeachHeightOffsetRow | null | undefined = heightOffset;
+    if (resolvedOffset === undefined && beachOffsetCfg.enabled) {
+      resolvedOffset = await this.loadOffsetForBeach(beach.id);
+    }
+
+    // Snapshot buffer for ml_predictions_log. Captured pre-offset (telemetry
+    // feedback-loop invariant) inside buildSingleForecast and flushed after
+    // the row loop completes.
+    const snapshotBuffer: DisplayPredictionRow[] = [];
 
     // Determine data sources used for metadata
     const dataSources: string[] = [];
@@ -209,12 +334,59 @@ export class ForecastBuilder {
         ioosWaterTempC,
         coopsWaterTempC,
         nowcastAnchor: effectiveAnchor,
+        heightOffset: resolvedOffset ?? null,
+        snapshotBuffer,
       });
 
       forecasts.push(forecast);
     }
 
+    // Fire-and-forget snapshot write. NEVER awaited and NEVER throws —
+    // logDisplayPredictions catches all errors internally. This must not block
+    // the forecast write path under any failure mode (env missing, network,
+    // schema mismatch, etc.). See feedback_dont_parallelize_redirect_critical_awaits.
+    if (snapshotBuffer.length > 0) {
+      try {
+        void logDisplayPredictions(snapshotBuffer).catch((err) => {
+          log.warn("Snapshot write rejected (non-blocking)", { err: String(err) });
+        });
+      } catch (err) {
+        log.warn("Snapshot dispatch threw synchronously (non-blocking)", {
+          err: String(err),
+        });
+      }
+    }
+
     return forecasts;
+  }
+
+  /**
+   * Single-beach fallback offset loader. Production callers should batch-load
+   * with loadHeightOffsetsForBeaches to avoid N+1.
+   */
+  private async loadOffsetForBeach(
+    beachId: string
+  ): Promise<BeachHeightOffsetRow | null> {
+    try {
+      const supabase = createServiceRoleClient();
+      const { data, error } = await supabase
+        .from("beach_height_offsets" as never)
+        .select(
+          "offset_m, sample_count, mae_before_m, mae_after_m, computed_at"
+        )
+        .eq("beach_id", beachId)
+        .eq("source", "display")
+        .maybeSingle();
+
+      if (error || !data) return null;
+      return data as unknown as BeachHeightOffsetRow;
+    } catch (err) {
+      log.warn("loadOffsetForBeach failed", {
+        beachId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
   }
 
   /**
@@ -240,6 +412,8 @@ export class ForecastBuilder {
     ioosWaterTempC: number | null;
     coopsWaterTempC: number | null;
     nowcastAnchor: NowcastAnchor | null;
+    heightOffset: BeachHeightOffsetRow | null;
+    snapshotBuffer: DisplayPredictionRow[];
   }): EnhancedForecastWithRawData {
     const {
       beach,
@@ -261,7 +435,105 @@ export class ForecastBuilder {
       ioosWaterTempC,
       coopsWaterTempC,
       nowcastAnchor,
+      heightOffset,
+      snapshotBuffer,
     } = params;
+
+    // Compute wave height once and capture provenance metadata for raw_forecast.
+    // The debug record explains which source/transform path produced the number,
+    // making post-hoc "why does Quiver show X?" questions answerable from one row.
+    const waveHeightResult = this.getWaveHeight(
+      cdipPoint,
+      wavePoint,
+      buoyData,
+      useCDIPData,
+      beach,
+      nowcastAnchor,
+    );
+
+    // Telemetry feedback-loop invariant: parse the PRE-offset display value
+    // and capture rawDisplayHeightFt BEFORE applyBeachHeightOffset runs. The
+    // snapshot writer below uses this raw value directly; it never re-derives
+    // from enhanced_forecasts.wave_height (which would close a feedback loop
+    // once the cron starts writing offsets).
+    const parsedDisplay = parseDisplayHeightFt(waveHeightResult.value);
+    const rawDisplayHeightFt = parsedDisplay.numericFt;
+
+    // Compute the forecast horizon in hours from issue time (now) to the
+    // forecast slot. Used for both the offset gate (only 24h+ horizons in
+    // initial rollout) and the snapshot row's forecast_horizon_hours column.
+    const forecastHorizonHours =
+      (forecastTime.getTime() - now.getTime()) / (60 * 60 * 1000);
+
+    // Apply offset. The helper short-circuits to identity when:
+    //   - heightOffset is null (no row yet for this beach)
+    //   - beach.height_offset_enabled is false
+    //   - sample_count < min, computed_at stale, MAE not improved, etc.
+    // When ANY gate fails, correctedFt === rawDisplayHeightFt so wave_height
+    // is byte-identical to today's output.
+    const beachOffsetCfgRow = readBeachOffsetConfig(beach);
+    const correctedFt =
+      rawDisplayHeightFt == null
+        ? null
+        : applyBeachHeightOffset({
+            heightFt: rawDisplayHeightFt,
+            offsetM: heightOffset?.offset_m,
+            sampleCount: heightOffset?.sample_count,
+            enabled: beachOffsetCfgRow.enabled,
+            forecastHorizonHours,
+            computedAt: heightOffset?.computed_at ?? null,
+            maeBeforeM: heightOffset?.mae_before_m,
+            maeAfterM: heightOffset?.mae_after_m,
+            minSampleCount: beachOffsetCfgRow.minSampleCount,
+            maxOffsetAgeDays: beachOffsetCfgRow.maxAgeDays,
+          });
+
+    // Determine whether the offset actually applied (corrected differs from
+    // raw). When any gate fails, both numbers are equal and we emit null for
+    // height_offset_m/sample_count so analysis can distinguish "applied" from
+    // "no-op".
+    const offsetActuallyApplied =
+      rawDisplayHeightFt != null &&
+      correctedFt != null &&
+      Math.abs(correctedFt - rawDisplayHeightFt) > 1e-6;
+
+    // Re-stringify ONLY when the offset actually changed the value. When no
+    // offset applied (any gate failed) we leave the original string untouched
+    // so wave_height is byte-identical to today's output. Reformatting an
+    // unchanged value would needlessly diverge ("3 ft" → "3ft") and break the
+    // height_offset_enabled=false invariant.
+    const finalWaveHeightString =
+      offsetActuallyApplied && correctedFt != null
+        ? formatDisplayHeightFt({
+            numericFt: correctedFt,
+            rangeSpread: parsedDisplay.rangeSpread,
+          })
+        : waveHeightResult.value;
+
+    // Append snapshot row when the parser produced a numeric value. We do not
+    // snapshot rows where the display value was null/unparseable — the cron
+    // can't compute residuals against a missing prediction.
+    if (rawDisplayHeightFt != null && correctedFt != null) {
+      const rawDisplayHeightM = rawDisplayHeightFt / METERS_TO_FEET;
+      const correctedDisplayM = correctedFt / METERS_TO_FEET;
+      snapshotBuffer.push({
+        beach_id: beach.id,
+        predicted_at: getNormalizedForecastAt(forecastTime),
+        forecast_horizon_hours: Math.max(
+          0,
+          Math.round(forecastHorizonHours)
+        ),
+        raw_display_height_m: Number(rawDisplayHeightM.toFixed(3)),
+        offset_corrected_display_height_m: Number(correctedDisplayM.toFixed(3)),
+        height_offset_m: offsetActuallyApplied
+          ? heightOffset?.offset_m ?? null
+          : null,
+        height_offset_sample_count: offsetActuallyApplied
+          ? heightOffset?.sample_count ?? null
+          : null,
+        display_source: "face-Hs-transformer-v1",
+      });
+    }
 
     return {
       id: `forecast-${beach.id}-${forecastTime.getTime()}`,
@@ -273,7 +545,9 @@ export class ForecastBuilder {
       // still co-located on this row in `wave_height_om` for the Seaside ML
       // pipeline. The OM-primary scalar override (now removed) was inflating
       // display by ~2× because raw deep-water Hs is not face height.
-      wave_height: this.getWaveHeight(cdipPoint, wavePoint, buoyData, useCDIPData, beach, nowcastAnchor),
+      // Per-beach offset (when enabled + gates pass) is layered on TOP via
+      // applyBeachHeightOffset; otherwise byte-identical to waveHeightResult.value.
+      wave_height: finalWaveHeightString,
       wave_period: this.getWavePeriod(cdipPoint, wavePoint, buoyData, useCDIPData),
       wave_direction: this.getWaveDirection(cdipPoint, wavePoint, useCDIPData),
 
@@ -344,6 +618,8 @@ export class ForecastBuilder {
         isFirstOfDay,
         tideData,
         now,
+        waveHeightDebug: waveHeightResult.debug,
+        nowcastAnchor,
       }),
     } as EnhancedForecastWithRawData;
   }
@@ -359,9 +635,35 @@ export class ForecastBuilder {
     isFirstOfDay: boolean;
     tideData: COOPSForecast | null;
     now: Date;
+    waveHeightDebug: WaveHeightDebugInfo;
+    nowcastAnchor: NowcastAnchor | null;
   }): EnhancedForecastWithRawData["raw_forecast"] {
-    const { dataSources, useCDIPData, cdipData, confidenceScore, isFirstOfDay, tideData, now } =
-      params;
+    const {
+      dataSources,
+      useCDIPData,
+      cdipData,
+      confidenceScore,
+      isFirstOfDay,
+      tideData,
+      now,
+      waveHeightDebug,
+      nowcastAnchor,
+    } = params;
+
+    // Resolve the station_id for the wave-height provenance record. The
+    // debug info doesn't carry it because the transformer doesn't know which
+    // upstream row supplied each input — only the builder has that context.
+    const provenanceStationId = (() => {
+      switch (waveHeightDebug.source) {
+        case 'nowcast_anchor':
+          return nowcastAnchor?.stationId ?? null;
+        case 'cdip_sig':
+        case 'cdip_swell':
+          return cdipData?.stationId ?? null;
+        default:
+          return null;
+      }
+    })();
 
     return {
       data_sources: dataSources,
@@ -383,6 +685,23 @@ export class ForecastBuilder {
       fetch_timestamps: {
         cdip: cdipData?.lastUpdated,
         noaa: now.toISOString(),
+      },
+      wave_height_provenance: {
+        source: waveHeightDebug.source,
+        raw_value_ft: waveHeightDebug.rawHeightFt,
+        station_id: provenanceStationId,
+        transform_path: waveHeightDebug.transformPath,
+        components_used: waveHeightDebug.componentsUsed,
+        calibrated_shoaling_fired: waveHeightDebug.calibratedShoalingFired,
+        ...(waveHeightDebug.cdipRejection
+          ? {
+              cdip_rejection: {
+                reason: waveHeightDebug.cdipRejection.reason,
+                raw_cdip_hs: waveHeightDebug.cdipRejection.rawCdipHs,
+                raw_model_hs: waveHeightDebug.cdipRejection.rawModelHs,
+              },
+            }
+          : {}),
       },
       ...(isFirstOfDay && tideData && tideData.tides && tideData.tides.length > 0
         ? {
@@ -515,7 +834,7 @@ export class ForecastBuilder {
     useCDIPData: boolean,
     beach: Beach,
     nowcastAnchor: NowcastAnchor | null = null,
-  ): string | null {
+  ): { value: string | null; debug: WaveHeightDebugInfo } {
     // Extract period: prefer anchor period when anchored, else CDIP peak, model swell, buoy.
     const periodS =
       nowcastAnchor?.wavePeriodS ??
@@ -599,15 +918,29 @@ export class ForecastBuilder {
     // The decomposed variant falls back to the scalar path internally when no
     // component slots are populated, so it is always safe to call even when
     // wavePoint is null.
-    // When a nowcast anchor is active, swap in the observation Hs via the
-    // ndbcBuoyM slot AND pass empty components. The decomposed branch sums
-    // over populated components and never reads `rawHeightFt` when any are
-    // present — so keeping NOAA's components would silently discard the
-    // anchor height. Empty components forces the legacy scalar path, which
-    // runs `rawHeightFt` through the period+alignment shoaling transform
-    // using anchor-provided period/direction. See plan golden-sleeping-steele.md.
+    //
+    // Branch priority:
+    //   1. Nowcast anchor active → buoy observation drives Hs (scalar path).
+    //   2. CDIP data present → CDIP Hs drives the scalar calibrated path.
+    //      Without this branch, populated NOAA components would silently
+    //      override CDIP `Hs` because the decomposed transformer sums
+    //      components and never reads `rawHeightFt` (and so the per-beach
+    //      `shoaling_factors` calibration, gated on `cdip_sig` source, is
+    //      bypassed). selectWaveHeightSource still handles CDIP outlier
+    //      rejection (>10ft or >1.8× model); on rejection it falls back to
+    //      model_swell and the legacy generic pipeline runs.
+    //   3. NOAA-only or buoy fallback → original decomposed path.
+
+    // Branch 1: Nowcast anchor.
+    // Swap in the observation Hs via the ndbcBuoyM slot AND pass empty
+    // components. The decomposed branch sums over populated components and
+    // never reads `rawHeightFt` when any are present — so keeping NOAA's
+    // components would silently discard the anchor height. Empty components
+    // forces the legacy scalar path, which runs `rawHeightFt` through the
+    // period+alignment shoaling transform using anchor-provided period/
+    // direction. See plan golden-sleeping-steele.md.
     if (nowcastAnchor) {
-      return toFaceHeightFeetDecomposed({
+      const result = toFaceHeightFeetDecomposedWithDebug({
         cdipSigFt: undefined,
         cdipSwellFt: undefined,
         modelSwellM: undefined,
@@ -618,9 +951,33 @@ export class ForecastBuilder {
         swellDirectionDeg,
         components: [null, null, null],
       });
+      return {
+        value: result.value,
+        debug: { ...result.debug, source: 'nowcast_anchor' },
+      };
     }
 
-    return toFaceHeightFeetDecomposed({
+    // Branch 2: CDIP data present. Force the scalar/legacy path so CDIP `Hs`
+    // is read as `rawHeightFt` with `source = 'cdip_sig'`, which triggers the
+    // per-beach `shoaling_factors` short-circuit (when calibrated) instead of
+    // letting NOAA component decomposition discard CDIP entirely.
+    if (useCDIPData && cdipPoint) {
+      const result = toFaceHeightFeetDecomposedWithDebug({
+        cdipSigFt: cdipPoint.significantWaveHeight ?? undefined,
+        cdipSwellFt: cdipPoint.swellHeight ?? undefined,
+        modelSwellM: wavePoint?.swell_1_height ?? undefined,
+        modelHsM: wavePoint?.significant_wave_height ?? undefined,
+        ndbcBuoyM: buoyData?.wave_height ?? undefined,
+        beach: beachTerrain,
+        periodS,
+        swellDirectionDeg,
+        components: [null, null, null],
+      });
+      return result;
+    }
+
+    // Branch 3: NOAA-only / buoy fallback — original decomposed path.
+    return toFaceHeightFeetDecomposedWithDebug({
       cdipSigFt: cdipPoint?.significantWaveHeight ?? undefined,
       cdipSwellFt: cdipPoint?.swellHeight ?? undefined,
       modelSwellM: wavePoint?.swell_1_height ?? undefined,

--- a/lib/services/forecast/log-display-prediction.ts
+++ b/lib/services/forecast/log-display-prediction.ts
@@ -1,0 +1,118 @@
+/**
+ * Display-prediction snapshot writer.
+ *
+ * Fire-and-forget service-role writer that captures user-facing display heights
+ * (face-Hs transformer output) into ml_predictions_log at issue time. The
+ * Seaside cron `compute-beach-height-offsets` reads these rows alongside
+ * observed_m (filled by `backfill_observations.py`) to compute the per-beach
+ * rolling-median residual offset.
+ *
+ * Critical invariants:
+ *  1. raw_display_height_m is captured PRE-correction by the caller (in
+ *     forecast-builder before applyBeachHeightOffset runs). This module never
+ *     re-derives heights from enhanced_forecasts (telemetry feedback hazard).
+ *  2. NEVER throws to the caller — the user-facing forecast pipeline must not
+ *     block on snapshot writes. All failures are logged + swallowed.
+ *  3. Env-gated: missing SUPABASE_SERVICE_ROLE_KEY → warn once + no-op.
+ *
+ * See plan: ~/.claude/plans/you-are-working-on-precious-papert.md (A3).
+ */
+
+import { createServiceRoleClient } from "@/lib/supabase";
+import { createContextLogger } from "@/lib/logger";
+
+const log = createContextLogger("LogDisplayPrediction");
+
+export type DisplayPredictionRow = {
+  beach_id: string;
+  /** ISO timestamp of the forecast slot (forecast_at). */
+  predicted_at: string;
+  /** 0..168 — hours from issue time to the forecast slot. */
+  forecast_horizon_hours: number;
+  /** PRE-offset face height in meters. Telemetry feedback-loop invariant. */
+  raw_display_height_m: number;
+  /** POST-offset face height in meters. Equal to raw when no offset applied. */
+  offset_corrected_display_height_m: number;
+  /** Offset applied (in meters), or null when no offset row was found / gates failed. */
+  height_offset_m: number | null;
+  /** Sample count backing the offset, or null when no offset applied. */
+  height_offset_sample_count: number | null;
+  /** Display path identifier, e.g. 'face-Hs-transformer-v1'. */
+  display_source: string;
+  /**
+   * model_version is NOT NULL on ml_predictions_log. When the caller does not
+   * supply one we fall back to display_source so the constraint is satisfied.
+   */
+  model_version?: string;
+};
+
+/**
+ * Insert display-prediction snapshots into ml_predictions_log.
+ *
+ * Fire-and-forget: never throws to the caller, always returns void.
+ *
+ * @param rows Snapshot rows captured by forecast-builder for a single run.
+ */
+export async function logDisplayPredictions(
+  rows: DisplayPredictionRow[]
+): Promise<void> {
+  if (!rows || rows.length === 0) return;
+
+  // Env-gated. We check the env var directly rather than try/catching the
+  // service-role factory because the factory is a process-wide singleton:
+  // throwing here would spam the logs with the same error on every cron run.
+  const hasServiceRoleKey =
+    !!(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim() &&
+    !!(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
+
+  if (!hasServiceRoleKey) {
+    log.warn(
+      "logDisplayPredictions: SUPABASE_SERVICE_ROLE_KEY not configured; skipping snapshot write",
+      { rowCount: rows.length }
+    );
+    return;
+  }
+
+  try {
+    const supabase = createServiceRoleClient();
+
+    // Materialize the insert payload. model_version falls back to display_source
+    // because ml_predictions_log.model_version is NOT NULL in the original
+    // schema and we have no separate ML model identifier for the display path.
+    const payload = rows.map((r) => ({
+      beach_id: r.beach_id,
+      predicted_at: r.predicted_at,
+      forecast_horizon_hours: r.forecast_horizon_hours,
+      raw_display_height_m: r.raw_display_height_m,
+      offset_corrected_display_height_m: r.offset_corrected_display_height_m,
+      height_offset_m: r.height_offset_m,
+      height_offset_sample_count: r.height_offset_sample_count,
+      display_source: r.display_source,
+      model_version: r.model_version ?? r.display_source,
+    }));
+
+    // Single batched insert. Cast through unknown because the new columns
+    // (raw_display_height_m, offset_corrected_display_height_m, etc.) are not
+    // yet in the generated database types — they were added by the migration
+    // 20260501200500_create_beach_height_offsets.sql.
+    const { error } = await supabase
+      .from("ml_predictions_log")
+      .insert(payload as unknown as never);
+
+    if (error) {
+      log.warn("logDisplayPredictions: insert failed", {
+        rowCount: rows.length,
+        error: error.message,
+        code: error.code,
+      });
+      return;
+    }
+  } catch (err) {
+    // Catch-all: any unexpected throw (network, client construction, etc.)
+    // must not propagate. The user-facing forecast write already succeeded.
+    log.warn("logDisplayPredictions: unexpected error", {
+      rowCount: rows.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/supabase/migrations/20260501200500_create_beach_height_offsets.sql
+++ b/supabase/migrations/20260501200500_create_beach_height_offsets.sql
@@ -1,0 +1,124 @@
+-- Per-beach display-height offset correction.
+--
+-- Adds a rolling 30-day median residual offset that the user-facing forecast
+-- builder applies AFTER the existing face-Hs transformer. Measured on 14 days
+-- of data, applying offset reduced display MAE from 0.459m to 0.180m for 24h+
+-- planning forecasts. The offset is computed by a Seaside cron that reads
+-- ml_predictions_log; the snapshot columns added here let the cron compare
+-- the actual user-facing forecast against observations rather than relying on
+-- enhanced_forecasts (14d retention + nowcast row replacement give that path
+-- only a 37% join rate).
+--
+-- Plan: ~/.claude/plans/you-are-working-on-precious-papert.md
+--
+-- Critical invariants:
+-- 1. Sign convention: offset_m = display_forecast_m - observed_m.
+--    To apply: corrected = display_forecast_m - offset_m.
+-- 2. raw_display_height_m must be captured PRE-correction by the writer.
+--    Never re-derive from enhanced_forecasts.wave_height (telemetry feedback
+--    loop hazard).
+-- 3. source='display' is the positive marker that distinguishes display-layer
+--    offsets from any future ML-correction-layer offsets.
+
+BEGIN;
+
+-- =============================================================================
+-- TABLE: beach_height_offsets
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS public.beach_height_offsets (
+  beach_id UUID NOT NULL REFERENCES beaches(id) ON DELETE CASCADE,
+  source TEXT NOT NULL DEFAULT 'display',
+  offset_m NUMERIC(5,3) NOT NULL,
+  sample_count INTEGER NOT NULL,
+  mae_before_m NUMERIC(5,3),
+  mae_after_m NUMERIC(5,3),
+  window_days INTEGER NOT NULL DEFAULT 30,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (beach_id, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_beach_height_offsets_source_computed_at
+  ON public.beach_height_offsets (source, computed_at DESC);
+
+ALTER TABLE public.beach_height_offsets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS beach_height_offsets_service_role ON public.beach_height_offsets;
+CREATE POLICY beach_height_offsets_service_role
+  ON public.beach_height_offsets FOR ALL
+  USING (auth.jwt() ->> 'role' = 'service_role');
+
+COMMENT ON TABLE public.beach_height_offsets IS
+  'Rolling per-beach residual offset applied to user-facing display forecasts. Written by Seaside cron compute-beach-height-offsets; read by quiver forecast-builder when beaches.height_offset_enabled = true.';
+
+COMMENT ON COLUMN public.beach_height_offsets.source IS
+  'Positive marker identifying the layer this offset applies to. ''display'' = post-face-Hs-transformer user-facing value. Future sources (e.g. ''om-baseline'') must use distinct values.';
+
+COMMENT ON COLUMN public.beach_height_offsets.offset_m IS
+  'Median residual in meters: median(display_forecast_m - observed_m) over window_days. Applied as: corrected = display_forecast_m - offset_m.';
+
+-- =============================================================================
+-- TABLE: beaches (per-beach offset configuration)
+-- =============================================================================
+ALTER TABLE public.beaches
+  ADD COLUMN IF NOT EXISTS height_offset_enabled BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS height_offset_min_sample_count INTEGER NOT NULL DEFAULT 30,
+  ADD COLUMN IF NOT EXISTS height_offset_max_age_days INTEGER NOT NULL DEFAULT 14;
+
+COMMENT ON COLUMN public.beaches.height_offset_enabled IS
+  'When true, forecast-builder applies the matching beach_height_offsets row (source=display) to display wave heights for forecasts with horizon >= 24h.';
+
+COMMENT ON COLUMN public.beaches.height_offset_min_sample_count IS
+  'Minimum matched (raw_display_height_m, observed_m) samples required in the rolling window before applying offset. Default 30.';
+
+COMMENT ON COLUMN public.beaches.height_offset_max_age_days IS
+  'Offset is ignored if computed_at is older than this many days. Default 14.';
+
+-- =============================================================================
+-- TABLE: ml_predictions_log (display snapshot columns)
+-- =============================================================================
+-- Forecast-builder writes these at issue time. observed_m stays NULL until
+-- backfill_observations.py matches an observation. The Seaside cron then
+-- joins these columns to observed_m to compute the rolling offset.
+
+ALTER TABLE public.ml_predictions_log
+  ADD COLUMN IF NOT EXISTS raw_display_height_m NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS offset_corrected_display_height_m NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS height_offset_m NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS height_offset_sample_count INTEGER,
+  ADD COLUMN IF NOT EXISTS display_source TEXT;
+
+COMMENT ON COLUMN public.ml_predictions_log.raw_display_height_m IS
+  'User-facing display wave height (face-Hs transformer output) BEFORE the per-beach offset correction is applied. Captured at issue time inside forecast-builder; never re-derived from enhanced_forecasts.wave_height.';
+
+COMMENT ON COLUMN public.ml_predictions_log.offset_corrected_display_height_m IS
+  'User-facing display wave height AFTER the per-beach offset correction. Equal to raw_display_height_m when no offset applied.';
+
+COMMENT ON COLUMN public.ml_predictions_log.display_source IS
+  'Identifier for the display-path version that produced raw_display_height_m. Examples: face-Hs-transformer-v1, backfill-from-ef-v1.';
+
+-- Partial index for daily rolling-window offset query (Seaside cron). The
+-- predicate is intentionally narrow: only rows where both the display
+-- snapshot and the observation are present qualify for offset computation.
+CREATE INDEX IF NOT EXISTS idx_mpl_offset_window
+  ON public.ml_predictions_log (beach_id, predicted_at DESC)
+  WHERE observed_m IS NOT NULL AND raw_display_height_m IS NOT NULL;
+
+COMMIT;
+
+-- =============================================================================
+-- ROLLBACK INSTRUCTIONS
+-- =============================================================================
+-- BEGIN;
+-- DROP INDEX IF EXISTS public.idx_mpl_offset_window;
+-- ALTER TABLE public.ml_predictions_log
+--   DROP COLUMN IF EXISTS display_source,
+--   DROP COLUMN IF EXISTS height_offset_sample_count,
+--   DROP COLUMN IF EXISTS height_offset_m,
+--   DROP COLUMN IF EXISTS offset_corrected_display_height_m,
+--   DROP COLUMN IF EXISTS raw_display_height_m;
+-- ALTER TABLE public.beaches
+--   DROP COLUMN IF EXISTS height_offset_max_age_days,
+--   DROP COLUMN IF EXISTS height_offset_min_sample_count,
+--   DROP COLUMN IF EXISTS height_offset_enabled;
+-- DROP TABLE IF EXISTS public.beach_height_offsets;
+-- COMMIT;


### PR DESCRIPTION
## Summary

- Per-beach rolling 30-day **median residual offset** applied AFTER the existing face-Hs transformer in forecast-builder. On 14 days of matched data this reduced display MAE from **0.459m → 0.180m** for 24h+ planning forecasts (the 0–24h nowcast is a separate measurement gap; offset is gated to horizon ≥24h until we have an issue-time snapshot to validate).
- Migration adds `beach_height_offsets` table + `beaches.height_offset_*` flags + `ml_predictions_log` issue-time snapshot columns. **Verified locally** (idempotent via `DROP POLICY IF EXISTS` patch).
- New helper, parser, and snapshot writer; hook in `forecast-builder.ts` capturing `raw_display_height_m` PRE-offset (telemetry feedback-loop invariant).
- Pairs with **seaside PR https://github.com/SteveChandler/seaside/pull/7** (the daily 06:00 UTC cron + out-of-sample backtest).

## Default state

`beaches.height_offset_enabled=false` everywhere → output byte-identical to today (asserted by test). Zero behavior change at deploy.

## Invariants

- 4 immutable terrain factors (`shoaling_factors`, `swell_access_factors`, `swell_window_*`, `deepwater_decay_factor`) untouched.
- `getWaveHeight()` body untouched. Face-Hs transformer untouched.
- `raw_display_height_m` captured pre-offset; never re-derived from `enhanced_forecasts.wave_height` (closes the feedback-loop hole).
- 7 short-circuit gates: enabled, finite offset, sample_count ≥ min, horizon ≥ 24h, freshness (max 14d), mae_after < mae_before, finite heightFt. Any miss → identity.
- Snapshot writer is fire-and-forget; cannot block the forecast pipeline.

## Note on intermixed file state

`lib/services/forecast/forecast-builder.ts` also carries pre-existing in-flight tweaks (`toFaceHeightFeetDecomposedWithDebug` rename, `calibrated_shoaling_fired`) that were on the branch when the offset hook was wired in. They land alongside in this PR. The matching test changes in `__tests__/lib/services/forecast/forecast-builder.test.ts` are **not** in this commit — they remain in your working tree and should land in a follow-up commit (or be added before merge).

CHANGELOG entry NOT included (your in-tree CHANGELOG.md has unrelated WIP). Add an `[Unreleased]` bullet **before** any other code commit on this branch — never as the final commit (Vercel Ignored Build Step skips CHANGELOG-only HEAD^..HEAD per `feedback_changelog_must_not_be_last_commit`).

## Test plan

- [x] `yarn typecheck` → clean
- [x] `npx jest lib/services/forecast/__tests__/ __tests__/lib/services/forecast/ __tests__/lib/services/enhanced-forecast-service.test.ts` → **260 passed**
- [x] `npx eslint --max-warnings=0` on the 5 new files → clean
- [x] Migration applied to local supabase: `BEGIN → CREATE TABLE → CREATE INDEX → ALTER TABLE × 3 → CREATE POLICY → 12× COMMENT → CREATE INDEX → COMMIT`
- [x] Migration re-run is idempotent (after `DROP POLICY IF EXISTS` fix)
- [x] Insert + ON CONFLICT upsert + delete smoke test on `beach_height_offsets` against real schema
- [x] Byte-identical-when-disabled invariant test passes explicitly
- [ ] After merge: deploy snapshot writer → confirm `ml_predictions_log.raw_display_height_m` accruing in 24h
- [ ] Then deploy seaside cron → confirm `beach_height_offsets` rows appear once any beach hits 30 samples
- [ ] Run backtest → per-beach pass/fail
- [ ] Enable one internal test beach → verify on dev
- [ ] Staged: SD → CA → all beaches passing backtest gate

## Deployment order

1. Merge migration → apply on dev (`yarn db:reset` or push migration). Verify columns present.
2. Snapshot writer is wired but `height_offset_enabled=false` everywhere — flag-off → no-op.
3. Merge seaside PR → cron starts running daily.
4. After 24–72h, run backtest, review per-beach corrected vs raw MAE on 24h+ buckets.
5. `UPDATE beaches SET height_offset_enabled=true WHERE id='<test beach>';` → verify on dev.
6. Stage roll out from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)