### PR TITLE
feat(forecast): expose latestObservation on beach reads (two-channel PR2)

### DIFF
--- a/__tests__/actions/forecast-actions.test.ts
+++ b/__tests__/actions/forecast-actions.test.ts
@@ -84,6 +84,10 @@ beforeEach(() => {
       if (table === "ten_day_enhanced_forecasts") return tenDayViewChain;
       return makeChain();
     }),
+    // getBeachForecastPreview now also fetches a live observation via the
+    // get_nowcast_anchors RPC. Default to "no observation" so existing tests
+    // remain focused on forecast-side behavior.
+    rpc: jest.fn().mockResolvedValue({ data: [], error: null }),
   };
 
   (createSupabaseServiceRoleClient as unknown as jest.Mock).mockResolvedValue(

--- a/__tests__/lib/services/observations/nowcast-anchor.test.ts
+++ b/__tests__/lib/services/observations/nowcast-anchor.test.ts
@@ -5,7 +5,7 @@
  * used by ForecastBuilder to anchor nowcast displays on real buoy data.
  */
 
-import { fetchNowcastAnchors } from "@/lib/services/observations/nowcast-anchor";
+import { fetchLatestObservation, fetchNowcastAnchors } from "@/lib/services/observations/nowcast-anchor";
 
 const mockRpcRows = [
   {
@@ -129,5 +129,48 @@ describe("fetchNowcastAnchors", () => {
     const anchor = result.get("beach-d")!;
     expect(anchor.wavePeriodS).toBeNull();
     expect(anchor.waveDirectionDeg).toBeNull();
+  });
+});
+
+describe("fetchLatestObservation", () => {
+  test("returns shape (without beachId) when fresh observation exists", async () => {
+    const supabase = makeSupabaseMock(mockRpcRows);
+    const result = await fetchLatestObservation(supabase, "beach-a");
+
+    expect(result).toEqual({
+      stationId: "edu_ucsd_cdip_073",
+      observedAt: "2026-04-19T14:56:00Z",
+      waveHeightM: 0.8,
+      wavePeriodS: 14,
+      waveDirectionDeg: 197,
+    });
+  });
+
+  test("returns null when beach has no fresh observation", async () => {
+    const supabase = makeSupabaseMock(mockRpcRows);
+    const result = await fetchLatestObservation(supabase, "beach-with-no-station");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when RPC errors out — never throws on the request path", async () => {
+    const supabase = makeSupabaseMock(null, new Error("connection refused"));
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await fetchLatestObservation(supabase, "beach-a");
+    expect(result).toBeNull();
+    warnSpy.mockRestore();
+  });
+
+  test("returns null when RPC returns empty array", async () => {
+    const supabase = makeSupabaseMock([]);
+    const result = await fetchLatestObservation(supabase, "beach-a");
+    expect(result).toBeNull();
+  });
+
+  test("forwards maxAgeHours through to underlying RPC", async () => {
+    const supabase = makeSupabaseMock([]);
+    await fetchLatestObservation(supabase, "beach-a", { maxAgeHours: 1.5 });
+    expect(supabase.rpc).toHaveBeenCalledWith("get_nowcast_anchors", {
+      max_age_hours: 1.5,
+    });
   });
 });

--- a/actions/forecast-actions.ts
+++ b/actions/forecast-actions.ts
@@ -7,9 +7,11 @@ import { isDataStale } from "@/lib/utils/forecast-client-utils";
 import { trackFallback } from "@/lib/monitoring/fallback-tracker";
 import { resolveConfidence } from "@/lib/monitoring/fallback-helpers";
 import { extractForecastDate as extractForecastDateFromAt } from "@/lib/utils/forecast-at-adapter";
+import { fetchLatestObservation } from "@/lib/services/observations/nowcast-anchor";
 import type { Beach, Forecast } from "@/types/database";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { ForecastTimeInfo } from "@/lib/utils/current-forecast-utils";
+import type { LatestObservation } from "@/lib/services/observations/nowcast-anchor.types";
 
 // Metadata interface for forecast transparency
 export interface ForecastMetadata {
@@ -224,16 +226,22 @@ export async function getBeachForecastPreview(beachId: string) {
 
     const dayAfterTomorrow = new Date(new Date(tomorrow + 'T00:00:00Z').getTime() + 86400000).toISOString().split('T')[0];
 
-    // Get today's and tomorrow's forecasts from enhanced_forecasts table (to handle forward-looking logic)
-    const { data: enhancedForecasts, error: enhancedError } = await (supabase as any)
-      .from("enhanced_forecasts")
-      .select(
-        "forecast_at, forecast_date, forecast_time, wave_height, wind_speed, wind_direction, weather_condition, confidence_score, data_source"
-      )
-      .eq("beach_id", beachId)
-      .gte("forecast_at", `${today}T00:00:00Z`)
-      .lt("forecast_at", `${dayAfterTomorrow}T00:00:00Z`)
-      .order("forecast_at", { ascending: true });
+    // Forecast row + latest live-buoy observation fetched in parallel — both
+    // feed the beach detail hero (forecast number + LiveBuoyChip).
+    const [enhancedResult, latestObservation] = await Promise.all([
+      (supabase as any)
+        .from("enhanced_forecasts")
+        .select(
+          "forecast_at, forecast_date, forecast_time, wave_height, wind_speed, wind_direction, weather_condition, confidence_score, data_source"
+        )
+        .eq("beach_id", beachId)
+        .gte("forecast_at", `${today}T00:00:00Z`)
+        .lt("forecast_at", `${dayAfterTomorrow}T00:00:00Z`)
+        .order("forecast_at", { ascending: true }),
+      fetchLatestObservation(supabase, beachId),
+    ]);
+
+    const { data: enhancedForecasts, error: enhancedError } = enhancedResult;
 
     if (enhancedError) {
       console.error("Error fetching enhanced forecast preview:", enhancedError);
@@ -253,6 +261,9 @@ export async function getBeachForecastPreview(beachId: string) {
             wind_direction: currentForecast.wind_direction,
             weather_condition: currentForecast.weather_condition,
             confidence_score: currentForecast.confidence_score,
+            // Live-buoy channel — peer to the forecast number, displayed in
+            // the LiveBuoyChip. Null when no station resolves or no fresh obs.
+            latestObservation,
             // Include metadata for transparency
             metadata: {
               primarySource: currentForecast.data_source || "FALLBACK",

--- a/app/api/forecasts/scored/[beachId]/route.ts
+++ b/app/api/forecasts/scored/[beachId]/route.ts
@@ -18,6 +18,7 @@ import {
   parseWavePeriod,
   getDirectionDegrees,
 } from "@/lib/utils/number-parsing";
+import { fetchLatestObservation } from "@/lib/services/observations/nowcast-anchor";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { Beach } from "@/types/database";
 
@@ -305,20 +306,27 @@ export const GET = withErrorHandler(
       return createNotFoundError("Beach");
     }
 
-    // Fetch next 24 hours of enhanced forecasts (8 slots × 3h = 24h)
+    // Fetch next 24 hours of enhanced forecasts (8 slots × 3h = 24h) and
+    // the latest live-buoy observation in parallel — both feed the beach
+    // detail UI (forecast slots + LiveBuoyChip).
     const now = new Date().toISOString();
     const twentyFourHoursLater = new Date(
       Date.now() + 24 * 60 * 60 * 1000
     ).toISOString();
 
-    const { data: forecasts, error: forecastError } = await supabase
-      .from("enhanced_forecasts")
-      .select("*")
-      .eq("beach_id", validBeachId)
-      .gte("forecast_at", now)
-      .lt("forecast_at", twentyFourHoursLater)
-      .order("forecast_at")
-      .limit(8);
+    const [forecastsResult, latestObservation] = await Promise.all([
+      supabase
+        .from("enhanced_forecasts")
+        .select("*")
+        .eq("beach_id", validBeachId)
+        .gte("forecast_at", now)
+        .lt("forecast_at", twentyFourHoursLater)
+        .order("forecast_at")
+        .limit(8),
+      fetchLatestObservation(supabase, validBeachId),
+    ]);
+
+    const { data: forecasts, error: forecastError } = forecastsResult;
 
     if (forecastError) {
       throw new Error(forecastError.message);
@@ -346,6 +354,9 @@ export const GET = withErrorHandler(
         breakType: beach.break_type ?? null,
         isCalibrated,
       },
+      // Top-level (not per-slot) — the live observation is a single "now"
+      // reading that doesn't vary across the 8 forecast slots.
+      latestObservation,
     });
   },
   { errorMessage: "Failed to fetch scored forecast" }

--- a/lib/config/forecast-staleness.ts
+++ b/lib/config/forecast-staleness.ts
@@ -14,12 +14,17 @@
  * - NOAA_NWS: Enhanced forecasts regenerate daily (6 AM), so 12-hour threshold prevents
  *   unnecessary regeneration attempts while providing buffer until next update
  * - FALLBACK: Fallback data is less critical and can tolerate longer staleness
+ * - NOWCAST_ANCHOR: Single-row buoy observation accepted as ground truth in the
+ *   nowcast window. 6h matches CDIP-via-IOOS ingestion lag (2h sync cron +
+ *   up-to-3h source staleness) — a stale anchor still beats a hallucinated
+ *   forecast since swells don't swing 100% in 6h.
  * - DEFAULT: Default threshold for unknown or unspecified sources
  */
 export const STALENESS_THRESHOLDS = {
   CDIP: 4,          // 4 hours (CDIP buoy cron doesn't reliably update every beach every hour)
   NOAA_NWS: 12,     // 12 hours (Enhanced forecasts regenerate daily, matches actual update cadence)
   FALLBACK: 12,     // 12 hours (fallback data less critical)
+  NOWCAST_ANCHOR: 6, // 6 hours (matches CDIP-via-IOOS ingestion lag; see forecast-builder shouldApplyNowcastAnchor)
   DEFAULT: 6        // Default for unknown sources
 } as const;
 

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -44,18 +44,18 @@ import {
 } from "@/types/forecast";
 import type { NowcastAnchor } from "@/lib/services/observations/nowcast-anchor.types";
 import { isNowcastAnchorEnabled } from "@/lib/services/observations/nowcast-anchor.types";
+import { STALENESS_THRESHOLDS } from "@/lib/config/forecast-staleness";
 import { pickDominantSwell } from "@/lib/domains/conditions";
 
 /**
  * Nowcast-anchor design (see plan golden-sleeping-steele.md):
  *  - NOWCAST_WINDOW_MS: forecast rows within ±1.5h of now may be anchored.
- *  - ANCHOR_FRESHNESS_MS: observations up to 6h old count as valid anchors.
- * The freshness cap is wider than the forecast window to accommodate CDIP-via-IOOS
- * ingestion lag (2h sync cron + up-to-3h source staleness). A 4h-old buoy reading
- * still beats a hallucinated NOAA forecast — swells don't swing 100% in 6h.
+ *  - ANCHOR_FRESHNESS_MS: observations up to NOWCAST_ANCHOR hours old count as valid.
+ * Sourced from STALENESS_THRESHOLDS.NOWCAST_ANCHOR for one source of truth across
+ * forecast-builder + the display-side `fetchLatestObservation` helper.
  */
 const NOWCAST_WINDOW_MS = 1.5 * 60 * 60 * 1000;
-const ANCHOR_FRESHNESS_MS = 6 * 60 * 60 * 1000;
+const ANCHOR_FRESHNESS_MS = STALENESS_THRESHOLDS.NOWCAST_ANCHOR * 60 * 60 * 1000;
 
 export function shouldApplyNowcastAnchor(args: {
   beachFeatures: string[] | null | undefined;

--- a/lib/services/observations/nowcast-anchor.ts
+++ b/lib/services/observations/nowcast-anchor.ts
@@ -1,7 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { NowcastAnchor } from "./nowcast-anchor.types";
+import type { LatestObservation, NowcastAnchor } from "./nowcast-anchor.types";
+import { STALENESS_THRESHOLDS } from "@/lib/config/forecast-staleness";
 
-const DEFAULT_MAX_AGE_HOURS = 6;
+const DEFAULT_MAX_AGE_HOURS = STALENESS_THRESHOLDS.NOWCAST_ANCHOR;
 const LOG_PREFIX = "[nowcast-anchor]";
 
 type FetchOptions = {
@@ -71,4 +72,30 @@ export async function fetchNowcastAnchors(
     console.warn(`${LOG_PREFIX} unexpected failure, falling through to forecast-only`, err);
     return new Map();
   }
+}
+
+/**
+ * Fetch the latest buoy observation for a single beach, for the display-side
+ * "live channel" UI on the beach detail page. Returns null when no station
+ * resolves, no fresh observation exists, or the RPC fails.
+ *
+ * Reuses `get_nowcast_anchors` to keep one source of truth for what counts
+ * as a fresh observation. The map-style fetcher is overkill for single-beach
+ * reads on the request path, hence this thin wrapper.
+ */
+export async function fetchLatestObservation(
+  supabase: SupabaseClient,
+  beachId: string,
+  options: FetchOptions = {},
+): Promise<LatestObservation | null> {
+  const map = await fetchNowcastAnchors(supabase, options);
+  const anchor = map.get(beachId);
+  if (!anchor) return null;
+  return {
+    stationId: anchor.stationId,
+    observedAt: anchor.observedAt,
+    waveHeightM: anchor.waveHeightM,
+    wavePeriodS: anchor.wavePeriodS,
+    waveDirectionDeg: anchor.waveDirectionDeg,
+  };
 }

--- a/lib/services/observations/nowcast-anchor.types.ts
+++ b/lib/services/observations/nowcast-anchor.types.ts
@@ -12,6 +12,21 @@ export interface NowcastAnchor {
   waveDirectionDeg: number | null;
 }
 
+/**
+ * Display-side shape for the live-buoy channel — what the UI shows next to
+ * the forecast number on the beach detail page. Sourced from the same
+ * `get_nowcast_anchors` RPC as NowcastAnchor but without the `beachId`
+ * (caller already knows it) and semantically scoped to "show this to the
+ * user," not "merge into a forecast value."
+ */
+export interface LatestObservation {
+  stationId: string;
+  observedAt: string;
+  waveHeightM: number;
+  wavePeriodS: number | null;
+  waveDirectionDeg: number | null;
+}
+
 /** Feature flag value carried in `beaches.features` text[] column. */
 export const NOWCAST_ANCHOR_FEATURE_FLAG = "observation_anchor" as const;
 


### PR DESCRIPTION
## Summary

- Adds `latestObservation` to two beach read paths: `getBeachForecastPreview()` (beach detail) and `/api/forecasts/scored/[beachId]` (scored API).
- Powered by new `fetchLatestObservation()` helper — reuses the existing `get_nowcast_anchors` RPC. No migration.
- Cleanup: `ANCHOR_FRESHNESS_MS` moved into `STALENESS_THRESHOLDS.NOWCAST_ANCHOR` for one source of truth.

PR2 of the **two-channel wave height** plan (`~/.claude/plans/research-plan-1-freeze-moonlit-panda.md`). Purely additive backend — no UI, no `forecast-builder.ts` logic changes. Safe to land in parallel with #249. PR3 (LiveBuoyChip) waits until #249 has soaked ~1 week.

## Why

Quiver currently merges NOAA forecast + CDIP observation + nowcast anchor into one `wave_height` field. Surfline-style two-channel UI exposes the live observation as a peer to the forecast, removing the merge as a structural failure mode (OB Pier 1.4 ft, station selection, calibration drift). PR2 wires the data; PR3 builds the chip; PR4 (deferred) rips the merge.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `yarn test:unit __tests__/lib/services/observations/nowcast-anchor.test.ts` — 13/13 pass (5 new for `fetchLatestObservation`)
- [x] Blast-radius: forecast-actions, use-forecast-preview, forecast-staleness, forecast-builder-nowcast-anchor, wave-height-consistency — 88/88 pass
- [ ] Manual: `curl /api/forecasts/scored/<OB-Pier-ID>` against dev — confirm `latestObservation.stationId` matches `get_beach_observation_station(beach_id)` resolver pick

## Notes

- CHANGELOG entry intentionally not included — repo CHANGELOG has unrelated WIP. Add `[Unreleased]` bullet manually as a non-final commit per `feedback_changelog_must_not_be_last_commit`.
- `LatestObservation.source` field deferred — `get_nowcast_anchors` RPC doesn't expose it. Add later if UI needs to label IOOS vs NDBC distinctly; `stationId` carries the info implicitly today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)