### PR TITLE
Promote main → prod (May 1 #2): snapshot writer fire-and-forget fix

### DIFF
--- a/__tests__/lib/services/discovery/hero-ranking/scenario-matrix.test.ts
+++ b/__tests__/lib/services/discovery/hero-ranking/scenario-matrix.test.ts
@@ -17,7 +17,25 @@ import { scenarioMatrix } from "./__fixtures__/scenario-matrix";
 // pacific-beach. Hero-ranking area owners to investigate and remove the skip.
 const KNOWN_FAILING_SCENARIOS = new Set(["S swell 195 @ 15s 3.5ft, glassy AM"]);
 
+// Freeze "now" at the fixture date so the windowSelector doesn't filter all
+// forecasts as past times after UTC rolls over. Fixtures are scoped to
+// 2026-05-01 (see scenario-matrix.ts dateBase). Without this, the suite
+// silently flips red the moment the day rolls.
+const FIXTURE_NOW = new Date("2026-05-01T08:00:00Z");
+
 describe("hero-ranking scenario matrix", () => {
+  beforeAll(() => {
+    jest.useFakeTimers({
+      doNotFake: ["nextTick", "setImmediate", "queueMicrotask"],
+    });
+    jest.setSystemTime(FIXTURE_NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+
   describe.each(scenarioMatrix.map((fx) => [fx.name, fx] as const))(
     "%s",
     (_name, fx) => {

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -341,17 +341,18 @@ export class ForecastBuilder {
       forecasts.push(forecast);
     }
 
-    // Fire-and-forget snapshot write. NEVER awaited and NEVER throws —
-    // logDisplayPredictions catches all errors internally. This must not block
-    // the forecast write path under any failure mode (env missing, network,
-    // schema mismatch, etc.). See feedback_dont_parallelize_redirect_critical_awaits.
+    // Snapshot write — awaited so the Vercel runtime keeps the function alive
+    // until the round-trip to Supabase finishes. Fire-and-forget got killed by
+    // the response-tear-down in serverless (saw 1824 enhanced_forecasts writes
+    // but 0 ml_predictions_log inserts on the first prod cron tick).
+    // logDisplayPredictions catches all errors internally so this can never
+    // throw past us; cost is one ~50-200ms round-trip at the end of
+    // buildForecasts, amortized over the per-beach forecast build time.
     if (snapshotBuffer.length > 0) {
       try {
-        void logDisplayPredictions(snapshotBuffer).catch((err) => {
-          log.warn("Snapshot write rejected (non-blocking)", { err: String(err) });
-        });
+        await logDisplayPredictions(snapshotBuffer);
       } catch (err) {
-        log.warn("Snapshot dispatch threw synchronously (non-blocking)", {
+        log.warn("Snapshot dispatch threw (caught, non-blocking)", {
           err: String(err),
         });
       }

--- a/lib/services/forecast/log-display-prediction.ts
+++ b/lib/services/forecast/log-display-prediction.ts
@@ -60,6 +60,8 @@ export async function logDisplayPredictions(
 ): Promise<void> {
   if (!rows || rows.length === 0) return;
 
+  log.info("logDisplayPredictions: entry", { rowCount: rows.length });
+
   const hasServiceRoleKey =
     !!(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim() &&
     !!(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
@@ -78,9 +80,6 @@ export async function logDisplayPredictions(
   try {
     const supabase = createServiceRoleClient();
 
-    // Materialize the insert payload. model_version falls back to display_source
-    // because ml_predictions_log.model_version is NOT NULL in the original
-    // schema and we have no separate ML model identifier for the display path.
     const payload = rows.map((r) => ({
       beach_id: r.beach_id,
       predicted_at: r.predicted_at,
@@ -93,10 +92,6 @@ export async function logDisplayPredictions(
       model_version: r.model_version ?? r.display_source,
     }));
 
-    // Single batched insert. Cast through unknown because the new columns
-    // (raw_display_height_m, offset_corrected_display_height_m, etc.) are not
-    // yet in the generated database types — they were added by the migration
-    // 20260501200500_create_beach_height_offsets.sql.
     const { error } = await supabase
       .from("ml_predictions_log")
       .insert(payload as unknown as never);
@@ -109,9 +104,9 @@ export async function logDisplayPredictions(
       });
       return;
     }
+
+    log.info("logDisplayPredictions: insert ok", { rowCount: rows.length });
   } catch (err) {
-    // Catch-all: any unexpected throw (network, client construction, etc.)
-    // must not propagate. The user-facing forecast write already succeeded.
     log.warn("logDisplayPredictions: unexpected error", {
       rowCount: rows.length,
       error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary
Follow-up to PR #251 (display-height offset). First prod cron tick wrote 1,824 enhanced_forecasts rows but 0 ml_predictions_log inserts. Vercel serverless was killing the fire-and-forget snapshot write before the round-trip to Supabase completed.

## Changes
- \`forecast-builder.ts:344\` — \`await logDisplayPredictions(...)\` instead of \`void\`. The function still catches all errors internally; cost is one ~50–200ms round-trip per beach, amortized over build time.
- \`log-display-prediction.ts\` — added \`log.info\` on entry and after successful insert so the next cron tick produces ground truth in Vercel logs.

## Test plan
- [x] Local Jest: 6 affected suites green (70/70)
- [ ] Prod CI gate
- [ ] Next cron tick at :30 or :00 — verify rows accruing in \`ml_predictions_log WHERE raw_display_height_m IS NOT NULL\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)