### PR TITLE
Promote main → prod (May 1 #3): surgical snapshot diagnostics

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -320,6 +320,8 @@ const ALLOWED_CONSOLE_PATTERNS = [
   /\[hls-proxy\]/,
   /\[LogDisplayPrediction\]/,
   /\[ForecastBuilder\]/,
+  /\[LDP-DIAG\]/,
+  /\[FB-DIAG\]/,
   /GoTrueClient.*Multiple GoTrueClient instances/,
   /limit exceeded/,
   /must be authenticated/,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -319,6 +319,7 @@ const ALLOWED_CONSOLE_PATTERNS = [
   /\[cam-resolve\]/,
   /\[hls-proxy\]/,
   /\[LogDisplayPrediction\]/,
+  /\[ForecastBuilder\]/,
   /GoTrueClient.*Multiple GoTrueClient instances/,
   /limit exceeded/,
   /must be authenticated/,

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -341,13 +341,17 @@ export class ForecastBuilder {
       forecasts.push(forecast);
     }
 
+    // DIAGNOSTIC: warn-level so it shows in prod logs while we're confirming
+    // the snapshot writer landed. Tells us per-beach whether the buffer was
+    // empty (parser/correctedFt issue) or had rows (insert path issue).
+    log.warn("buildForecasts: snapshot buffer", {
+      beach: inputs.beach.slug,
+      snapshotCount: snapshotBuffer.length,
+      forecastCount: forecasts.length,
+    });
+
     // Snapshot write — awaited so the Vercel runtime keeps the function alive
-    // until the round-trip to Supabase finishes. Fire-and-forget got killed by
-    // the response-tear-down in serverless (saw 1824 enhanced_forecasts writes
-    // but 0 ml_predictions_log inserts on the first prod cron tick).
-    // logDisplayPredictions catches all errors internally so this can never
-    // throw past us; cost is one ~50-200ms round-trip at the end of
-    // buildForecasts, amortized over the per-beach forecast build time.
+    // until the round-trip to Supabase finishes.
     if (snapshotBuffer.length > 0) {
       try {
         await logDisplayPredictions(snapshotBuffer);

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -341,25 +341,36 @@ export class ForecastBuilder {
       forecasts.push(forecast);
     }
 
-    // DIAGNOSTIC: warn-level so it shows in prod logs while we're confirming
-    // the snapshot writer landed. Tells us per-beach whether the buffer was
-    // empty (parser/correctedFt issue) or had rows (insert path issue).
-    log.warn("buildForecasts: snapshot buffer", {
+    // SURGICAL DIAGNOSTIC (revert once landing): console.error bypasses the
+    // logger's prod min-level filter so we can see exactly what each beach
+    // produces and whether logDisplayPredictions is actually invoked.
+    console.error("[FB-DIAG] snapshot buffer ready", {
       beach: inputs.beach.slug,
+      beachId: inputs.beach.id,
       snapshotCount: snapshotBuffer.length,
       forecastCount: forecasts.length,
     });
 
-    // Snapshot write — awaited so the Vercel runtime keeps the function alive
-    // until the round-trip to Supabase finishes.
     if (snapshotBuffer.length > 0) {
+      console.error("[FB-DIAG] calling logDisplayPredictions", {
+        beach: inputs.beach.slug,
+        rowCount: snapshotBuffer.length,
+      });
       try {
         await logDisplayPredictions(snapshotBuffer);
+        console.error("[FB-DIAG] logDisplayPredictions returned", {
+          beach: inputs.beach.slug,
+        });
       } catch (err) {
-        log.warn("Snapshot dispatch threw (caught, non-blocking)", {
-          err: String(err),
+        console.error("[FB-DIAG] logDisplayPredictions threw", {
+          beach: inputs.beach.slug,
+          err: err instanceof Error ? err.message : String(err),
         });
       }
+    } else {
+      console.error("[FB-DIAG] skipped: empty buffer", {
+        beach: inputs.beach.slug,
+      });
     }
 
     return forecasts;

--- a/lib/services/forecast/log-display-prediction.ts
+++ b/lib/services/forecast/log-display-prediction.ts
@@ -60,7 +60,10 @@ export async function logDisplayPredictions(
 ): Promise<void> {
   if (!rows || rows.length === 0) return;
 
-  log.info("logDisplayPredictions: entry", { rowCount: rows.length });
+  // DIAGNOSTIC: temporarily warn-level until snapshot-writer rollout confirmed
+  // landing rows in prod. Prod logger drops info-level. Revert to log.info once
+  // ml_predictions_log shows accruing rows.
+  log.warn("logDisplayPredictions: entry", { rowCount: rows.length });
 
   const hasServiceRoleKey =
     !!(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim() &&
@@ -105,7 +108,8 @@ export async function logDisplayPredictions(
       return;
     }
 
-    log.info("logDisplayPredictions: insert ok", { rowCount: rows.length });
+    // DIAGNOSTIC: temporarily warn-level (see entry-log comment above).
+    log.warn("logDisplayPredictions: insert ok", { rowCount: rows.length });
   } catch (err) {
     log.warn("logDisplayPredictions: unexpected error", {
       rowCount: rows.length,

--- a/lib/services/forecast/log-display-prediction.ts
+++ b/lib/services/forecast/log-display-prediction.ts
@@ -58,18 +58,27 @@ let warnedMissingServiceRoleKey = false;
 export async function logDisplayPredictions(
   rows: DisplayPredictionRow[]
 ): Promise<void> {
-  if (!rows || rows.length === 0) return;
+  // SURGICAL DIAGNOSTIC (revert once landing): console.error bypasses the
+  // logger's prod min-level filter and always reaches Vercel runtime logs.
+  console.error("[LDP-DIAG] entry", {
+    rowCount: rows?.length ?? 0,
+    firstBeachId: rows?.[0]?.beach_id ?? null,
+  });
 
-  // DIAGNOSTIC: temporarily warn-level until snapshot-writer rollout confirmed
-  // landing rows in prod. Prod logger drops info-level. Revert to log.info once
-  // ml_predictions_log shows accruing rows.
-  log.warn("logDisplayPredictions: entry", { rowCount: rows.length });
+  if (!rows || rows.length === 0) {
+    console.error("[LDP-DIAG] early-return: empty rows");
+    return;
+  }
 
   const hasServiceRoleKey =
     !!(process.env.SUPABASE_SERVICE_ROLE_KEY || "").trim() &&
     !!(process.env.NEXT_PUBLIC_SUPABASE_URL || "").trim();
 
   if (!hasServiceRoleKey) {
+    console.error("[LDP-DIAG] early-return: env-gate", {
+      hasServiceKey: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
+      hasUrl: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
+    });
     if (!warnedMissingServiceRoleKey) {
       warnedMissingServiceRoleKey = true;
       log.warn(
@@ -82,6 +91,7 @@ export async function logDisplayPredictions(
 
   try {
     const supabase = createServiceRoleClient();
+    console.error("[LDP-DIAG] client constructed");
 
     const payload = rows.map((r) => ({
       beach_id: r.beach_id,
@@ -95,9 +105,21 @@ export async function logDisplayPredictions(
       model_version: r.model_version ?? r.display_source,
     }));
 
-    const { error } = await supabase
+    console.error("[LDP-DIAG] inserting", { payloadCount: payload.length });
+
+    const { data, error, status, statusText } = await supabase
       .from("ml_predictions_log")
-      .insert(payload as unknown as never);
+      .insert(payload as unknown as never)
+      .select("id");
+
+    console.error("[LDP-DIAG] insert returned", {
+      hasError: !!error,
+      errorMessage: error?.message ?? null,
+      errorCode: error?.code ?? null,
+      status,
+      statusText,
+      returnedRowCount: Array.isArray(data) ? data.length : 0,
+    });
 
     if (error) {
       log.warn("logDisplayPredictions: insert failed", {
@@ -108,9 +130,12 @@ export async function logDisplayPredictions(
       return;
     }
 
-    // DIAGNOSTIC: temporarily warn-level (see entry-log comment above).
     log.warn("logDisplayPredictions: insert ok", { rowCount: rows.length });
   } catch (err) {
+    console.error("[LDP-DIAG] catch", {
+      err: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     log.warn("logDisplayPredictions: unexpected error", {
       rowCount: rows.length,
       error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary
Surgical \`console.error\` tracing in \`buildForecasts\` and \`logDisplayPredictions\` to bypass the prod logger's min-level filter. Tags every checkpoint with \`[FB-DIAG]\` / \`[LDP-DIAG]\`.

After one cron tick we'll have a complete trace and can revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)