### PR TITLE
fix(alerts): close notification cliff for native users (Half 1)

### DIFF
--- a/__tests__/api/alerts/seed-default.test.ts
+++ b/__tests__/api/alerts/seed-default.test.ts
@@ -1,0 +1,226 @@
+/** @jest-environment node */
+
+// NextResponse.json relies on Response.json() which jsdom doesn't ship.
+if (typeof (globalThis as any).Response?.json !== "function") {
+  (globalThis as any).Response.json = (data: any, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        ...(init?.headers || {}),
+      },
+    });
+}
+
+/**
+ * Unit tests for POST /api/alerts/seed-default.
+ *
+ * The route is thin: profile lookup → optional 400 → delegate to
+ * seedDefaultRuleForUser. We mock `withAuth` to inject a fake user/supabase
+ * and mock `seedDefaultRuleForUser` to verify the route forwards the right
+ * args and surfaces the right responses.
+ */
+
+const mockUser = { id: "user-1" };
+
+type ProfileRow = {
+  home_beach_id: string | null;
+  experience_level: string | null;
+  notif_email_enabled: boolean | null;
+  notif_push_enabled: boolean | null;
+};
+
+let mockProfileResult: {
+  data: ProfileRow | null;
+  error: { message: string } | null;
+} = {
+  data: {
+    home_beach_id: "beach-123",
+    experience_level: "beginner",
+    notif_email_enabled: true,
+    notif_push_enabled: false,
+  },
+  error: null,
+};
+
+const seedSpy = jest.fn();
+
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  return {
+    ...actual,
+    withAuth: (handler: any) => (request: any) => {
+      const supabase = {
+        from: (_table: string) => ({
+          select: (_cols: string) => ({
+            eq: (_col: string, _val: string) => ({
+              single: () => Promise.resolve(mockProfileResult),
+            }),
+          }),
+        }),
+      };
+      return handler(request, { user: mockUser, supabase, params: {} });
+    },
+  };
+});
+
+jest.mock("@/lib/alerts/seed-default-rule", () => ({
+  seedDefaultRuleForUser: (...args: unknown[]) => seedSpy(...args),
+}));
+
+import { POST } from "@/app/api/alerts/seed-default/route";
+
+function makeReq(): any {
+  return { headers: { get: () => null } };
+}
+
+beforeEach(() => {
+  seedSpy.mockReset();
+  mockProfileResult = {
+    data: {
+      home_beach_id: "beach-123",
+      experience_level: "beginner",
+      notif_email_enabled: true,
+      notif_push_enabled: false,
+    },
+    error: null,
+  };
+});
+
+describe("POST /api/alerts/seed-default", () => {
+  it("returns 400 when home_beach_id is missing", async () => {
+    mockProfileResult = {
+      data: {
+        home_beach_id: null,
+        experience_level: null,
+        notif_email_enabled: true,
+        notif_push_enabled: false,
+      },
+      error: null,
+    };
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: false,
+      error: "home_beach_id_required",
+    });
+    expect(seedSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards beach + experience to seedDefaultRuleForUser and returns 200 on success", async () => {
+    seedSpy.mockResolvedValueOnce({
+      seeded: true,
+      ruleId: "rule-abc",
+      presetType: "mellow_session",
+    });
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      data: {
+        seeded: true,
+        ruleId: "rule-abc",
+        presetType: "mellow_session",
+      },
+    });
+
+    expect(seedSpy).toHaveBeenCalledTimes(1);
+    expect(seedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        beachId: "beach-123",
+        experienceLevel: "beginner",
+        notifyEmail: true,
+        notifyPush: false,
+      })
+    );
+  });
+
+  it("forwards profile notif flags to seedDefaultRuleForUser (push opted in)", async () => {
+    mockProfileResult = {
+      data: {
+        home_beach_id: "beach-123",
+        experience_level: "beginner",
+        notif_email_enabled: false,
+        notif_push_enabled: true,
+      },
+      error: null,
+    };
+    seedSpy.mockResolvedValueOnce({
+      seeded: true,
+      ruleId: "rule-abc",
+      presetType: "mellow_session",
+    });
+
+    await POST(makeReq());
+
+    expect(seedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ notifyEmail: false, notifyPush: true })
+    );
+  });
+
+  it("falls back to email=true / push=false when profile flags are null", async () => {
+    mockProfileResult = {
+      data: {
+        home_beach_id: "beach-123",
+        experience_level: "beginner",
+        notif_email_enabled: null,
+        notif_push_enabled: null,
+      },
+      error: null,
+    };
+    seedSpy.mockResolvedValueOnce({
+      seeded: true,
+      ruleId: "rule-abc",
+      presetType: "mellow_session",
+    });
+
+    await POST(makeReq());
+
+    expect(seedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ notifyEmail: true, notifyPush: false })
+    );
+  });
+
+  it("passes null experience_level through (mellow_session fallback lives in seedDefaultRuleForUser)", async () => {
+    mockProfileResult = {
+      data: {
+        home_beach_id: "beach-123",
+        experience_level: null,
+        notif_email_enabled: true,
+        notif_push_enabled: false,
+      },
+      error: null,
+    };
+    seedSpy.mockResolvedValueOnce({
+      seeded: true,
+      ruleId: "rule-xyz",
+      presetType: "mellow_session",
+    });
+
+    await POST(makeReq());
+
+    expect(seedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ experienceLevel: null })
+    );
+  });
+
+  it("returns 200 with already_has_rules on a re-seed", async () => {
+    seedSpy.mockResolvedValueOnce({
+      seeded: false,
+      reason: "already_has_rules",
+    });
+
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      success: true,
+      data: { seeded: false, reason: "already_has_rules" },
+    });
+  });
+});

--- a/__tests__/lib/alerts/seed-default-rule.test.ts
+++ b/__tests__/lib/alerts/seed-default-rule.test.ts
@@ -123,7 +123,7 @@ function baseState(overrides: Partial<MockState> = {}): MockState {
 }
 
 describe("seedDefaultRuleForUser", () => {
-  it("returns no_experience_level when level is null", async () => {
+  it("seeds mellow_session when level is null", async () => {
     const state = baseState();
     const supabase = makeMockSupabase(state);
 
@@ -136,11 +136,18 @@ describe("seedDefaultRuleForUser", () => {
       notifyPush: false,
     });
 
-    expect(result).toEqual({ seeded: false, reason: "no_experience_level" });
-    expect(state.insertPayload).toBeNull();
+    expect(result).toEqual({
+      seeded: true,
+      ruleId: "rule-abc",
+      presetType: "mellow_session",
+    });
+    expect(state.insertPayload).toMatchObject({
+      preset_type: "mellow_session",
+      name: "Mellow session at your home break",
+    });
   });
 
-  it("returns no_experience_level when level is undefined", async () => {
+  it("seeds mellow_session when level is undefined", async () => {
     const state = baseState();
     const supabase = makeMockSupabase(state);
 
@@ -153,7 +160,11 @@ describe("seedDefaultRuleForUser", () => {
       notifyPush: false,
     });
 
-    expect(result).toEqual({ seeded: false, reason: "no_experience_level" });
+    expect(result).toMatchObject({
+      seeded: true,
+      presetType: "mellow_session",
+    });
+    expect(state.insertPayload?.preset_type).toBe("mellow_session");
   });
 
   it("inserts mellow_session for beginner", async () => {

--- a/actions/onboarding-actions.ts
+++ b/actions/onboarding-actions.ts
@@ -237,8 +237,8 @@ export async function saveOnboardingData(data: OnboardingData) {
 
       // Seed a default alert rule on the user's home beach so they get a
       // retention hook ("you were right, I would've surfed") within their
-      // first days. Skipped when experience_level is null — we don't guess.
-      // Non-blocking: failures here must never fail onboarding.
+      // first days. Falls back to mellow_session when experience_level is
+      // null so every new user is reachable. Non-blocking.
       try {
         const { seedDefaultRuleForUser } = await import('@/lib/alerts/seed-default-rule');
         const seedResult = await seedDefaultRuleForUser({

--- a/app/api/alerts/seed-default/route.ts
+++ b/app/api/alerts/seed-default/route.ts
@@ -1,0 +1,53 @@
+import type { NextRequest } from "next/server";
+import {
+  withAuth,
+  createSuccessResponse,
+  createValidationError,
+  type AuthenticatedContext,
+} from "@/lib/middleware/api-wrappers";
+import {
+  seedDefaultRuleForUser,
+  type ExperienceLevel,
+} from "@/lib/alerts/seed-default-rule";
+
+/**
+ * POST /api/alerts/seed-default — Seed the authenticated user's default alert
+ * rule on their home beach. Idempotent: if any rule already exists, returns
+ * `{ seeded: false, reason: "already_has_rules" }`.
+ *
+ * Native callers hit this from `finalizeOnboarding` because server actions
+ * (the web's seed path) don't carry Bearer auth — see
+ * `reference_native_cannot_use_server_actions.md`.
+ */
+export const POST = withAuth(
+  async (_request: NextRequest, { user, supabase }: AuthenticatedContext) => {
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select(
+        "home_beach_id, experience_level, notif_email_enabled, notif_push_enabled"
+      )
+      .eq("id", user.id)
+      .single();
+
+    if (profileError) throw profileError;
+
+    if (!profile?.home_beach_id) {
+      return createValidationError("home_beach_id_required");
+    }
+
+    // Mirror the web seed path defaults at actions/onboarding-actions.ts:249
+    // — email opt-in is the higher-signal channel, push defaults off until the
+    // user enables it.
+    const result = await seedDefaultRuleForUser({
+      supabase,
+      userId: user.id,
+      beachId: profile.home_beach_id,
+      experienceLevel: (profile.experience_level ?? null) as ExperienceLevel,
+      notifyEmail: profile.notif_email_enabled ?? true,
+      notifyPush: profile.notif_push_enabled ?? false,
+    });
+
+    return createSuccessResponse(result);
+  },
+  { errorMessage: "Failed to seed default alert rule" }
+);

--- a/lib/alerts/seed-default-rule.ts
+++ b/lib/alerts/seed-default-rule.ts
@@ -17,7 +17,6 @@ export type SeedResult =
   | {
       seeded: false;
       reason:
-        | "no_experience_level"
         | "already_has_rules"
         | "beach_not_found"
         | "beach_missing_coordinates"
@@ -39,11 +38,12 @@ export interface SeedDefaultRuleParams {
 const BEACH_META_COLUMNS =
   "id, name, slug, lat, lon, timezone, wind_offshore_deg, wind_offshore_tol_deg, aspect_deg, preferred_tide_ft_min, preferred_tide_ft_max, preferred_tide_direction, swell_window_center_deg, swell_window_halfwidth_deg";
 
-function pickPreset(level: ExperienceLevel): SeedPresetType | null {
-  if (!level) return null;
+function pickPreset(level: ExperienceLevel): SeedPresetType {
   if (level === "advanced" || level === "expert") return "clean_groundswell";
-  if (level === "beginner" || level === "intermediate") return "mellow_session";
-  return null;
+  // beginner, intermediate, null, undefined → safe default. We'd rather
+  // over-notify a stronger surfer with mellow conditions than leave any
+  // new user unreachable because experience_level wasn't captured.
+  return "mellow_session";
 }
 
 function nameForPreset(preset: SeedPresetType): string {
@@ -56,9 +56,10 @@ function nameForPreset(preset: SeedPresetType): string {
  * Seeds a single default alert rule on a user's home beach, tuned to their
  * experience level. Non-throwing: returns a structured result the caller logs.
  *
- * Idempotent — bails if the user already has any rule. Skips when
- * experience_level is null (we don't guess). Called from saveOnboardingData
- * after the profile update commits.
+ * Idempotent — bails if the user already has any rule. Falls back to
+ * mellow_session when experience_level is null/undefined so every new user
+ * is reachable. Called from saveOnboardingData (web) and
+ * /api/alerts/seed-default (native) after the profile update commits.
  */
 export async function seedDefaultRuleForUser(
   params: SeedDefaultRuleParams
@@ -67,9 +68,6 @@ export async function seedDefaultRuleForUser(
     params;
 
   const presetType = pickPreset(experienceLevel);
-  if (!presetType) {
-    return { seeded: false, reason: "no_experience_level" };
-  }
 
   const { count, error: countError } = await supabase
     .from("alert_rules")
@@ -118,8 +116,6 @@ export async function seedDefaultRuleForUser(
   };
 
   const preset = getPreset(presetType);
-  // AlertConditions is a structural shape; the DB column is Json. Cast once
-  // here so the insert payload typechecks cleanly.
   const conditions = (preset ? preset.buildConditions(beachMeta) : {}) as Json;
 
   const { data: inserted, error: insertError } = await supabase


### PR DESCRIPTION
## Summary
- `pickPreset(null)` falls back to `mellow_session` instead of bailing with `no_experience_level`; dead branch + reason removed from `SeedResult` union
- New `POST /api/alerts/seed-default` route handler (`withAuth`) reads home_beach_id + experience_level + notif flags from the profile, returns 400 `home_beach_id_required` if missing, otherwise delegates to the existing idempotent `seedDefaultRuleForUser`
- Mirrors web seed defaults (`notif_email_enabled ?? true` / `notif_push_enabled ?? false`) so rule-level channel flags reflect user prefs
- Stale onboarding-actions comment updated; CHANGELOG already on `main` from `6c4909d9`

Pairs with native commit `052344a` on quiver-native (skip removed + finalizeOnboarding posts to `/api/alerts/seed-default`).

Plan: `~/.claude/plans/half-1-notification-cliff-squishy-rainbow.md`

## Test plan
- [x] `yarn test:unit __tests__/api/alerts/seed-default.test.ts __tests__/lib/alerts/seed-default-rule.test.ts` — 17/17 pass
- [x] `yarn typecheck` — clean
- [ ] After deploy to dev: fresh native signup → verify exactly one `alert_rules` row seeded with `preset_type = mellow_session`
- [ ] Re-POST `/api/alerts/seed-default` with same Bearer → confirm `{ seeded: false, reason: "already_has_rules" }`
- [ ] Operational follow-up: backfill in-flight users via `SELECT p.id FROM profiles p LEFT JOIN alert_rules ar ON ar.user_id = p.id WHERE p.onboarding_completed_at IS NOT NULL AND ar.id IS NULL;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)