### PR TITLE
fix(types): add 3 missing Beach fields to mocks (unblocks PR #265)

### DIFF
--- a/__tests__/lib/utils/viewport-filter.test.ts
+++ b/__tests__/lib/utils/viewport-filter.test.ts
@@ -36,6 +36,8 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     geog: null,
     hazards: null,
     local_etiquette: null,
+    max_wind_any_mph: null,
+    max_wind_onshore_mph: null,
     owner_id: null,
     parking_tips: null,
     preference_model: null,
@@ -44,6 +46,7 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     preferred_tide_ft_min: null,
     real_takeaways: null,
     region: null,
+    region_id: null,
     review_count: null,
     shoaling_factors: null,
     skill_level: "intermediate", // NOT NULL DEFAULT 'intermediate' since 20260312
@@ -73,9 +76,6 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     wind_onshore_bad_kt: null,
     deepwater_decay_factor: null,
     persona: null,
-    max_wind_any_mph: null,
-    max_wind_onshore_mph: null,
-    region_id: null,
 
     // Apply overrides
     ...overrides,

--- a/__tests__/lib/utils/viewport-filter.test.ts
+++ b/__tests__/lib/utils/viewport-filter.test.ts
@@ -73,6 +73,9 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     wind_onshore_bad_kt: null,
     deepwater_decay_factor: null,
     persona: null,
+    max_wind_any_mph: null,
+    max_wind_onshore_mph: null,
+    region_id: null,
 
     // Apply overrides
     ...overrides,

--- a/lib/utils/beach-defaults.ts
+++ b/lib/utils/beach-defaults.ts
@@ -100,6 +100,11 @@ function getBeachDefaults(): Omit<
     wind_onshore_bad_kt: null,
     wind_exposure_factors: null,
     wind_analyzed_at: null,
+    max_wind_any_mph: null,
+    max_wind_onshore_mph: null,
+
+    // Region linkage
+    region_id: null,
 
     // Height offset (per-beach calibration; non-nullable in schema)
     height_offset_enabled: false,

--- a/lib/utils/beach-defaults.ts
+++ b/lib/utils/beach-defaults.ts
@@ -42,6 +42,7 @@ function getBeachDefaults(): Omit<
     state: null,
     country: null,
     region: null,
+    region_id: null,
     slug: null,
     geog: null,
     timezone: null,
@@ -102,9 +103,6 @@ function getBeachDefaults(): Omit<
     wind_analyzed_at: null,
     max_wind_any_mph: null,
     max_wind_onshore_mph: null,
-
-    // Region linkage
-    region_id: null,
 
     // Height offset (per-beach calibration; non-nullable in schema)
     height_offset_enabled: false,


### PR DESCRIPTION
## Summary

Pre-existing typecheck failure that surfaced when the prod release gate ran on #265. Main pushes don't run typecheck, so this regression slipped in via #262 (types regen) and accumulated until the next release PR.

- \`lib/utils/beach-defaults.ts\` — \`getBeachDefaults()\` missing \`max_wind_any_mph\`, \`max_wind_onshore_mph\`, \`region_id\`
- \`__tests__/lib/utils/viewport-filter.test.ts\` — local \`makeBeach\` helper has the same gap (predates the \`beach-defaults.ts\` consolidation)

Both errors set to \`null\` (matches every other nullable column default).

## Test plan
- [x] \`yarn typecheck\` clean locally
- [ ] CI: TypeScript Check passes
- [ ] Merge → re-run #265 release gate

## Why this is needed now

PR #265 (\`prod ← main\`) is blocked on this typecheck. Merging this fix → re-run #265 → migration \`20260503234500_add_home_hero_forecast_viewed_event.sql\` reaches prod → unblocks native home.tsx event rename push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)