### PR TITLE
fix(types): backfill 3 Beach columns missed in #262 type regen

### DIFF
--- a/__tests__/lib/utils/viewport-filter.test.ts
+++ b/__tests__/lib/utils/viewport-filter.test.ts
@@ -36,6 +36,8 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     geog: null,
     hazards: null,
     local_etiquette: null,
+    max_wind_any_mph: null,
+    max_wind_onshore_mph: null,
     owner_id: null,
     parking_tips: null,
     preference_model: null,
@@ -44,6 +46,7 @@ function makeBeach(overrides: Partial<Beach> & { id: string; name: string }): Be
     preferred_tide_ft_min: null,
     real_takeaways: null,
     region: null,
+    region_id: null,
     review_count: null,
     shoaling_factors: null,
     skill_level: "intermediate", // NOT NULL DEFAULT 'intermediate' since 20260312

--- a/lib/utils/beach-defaults.ts
+++ b/lib/utils/beach-defaults.ts
@@ -42,6 +42,7 @@ function getBeachDefaults(): Omit<
     state: null,
     country: null,
     region: null,
+    region_id: null,
     slug: null,
     geog: null,
     timezone: null,
@@ -100,6 +101,8 @@ function getBeachDefaults(): Omit<
     wind_onshore_bad_kt: null,
     wind_exposure_factors: null,
     wind_analyzed_at: null,
+    max_wind_any_mph: null,
+    max_wind_onshore_mph: null,
 
     // Height offset (per-beach calibration; non-nullable in schema)
     height_offset_enabled: false,


### PR DESCRIPTION
## Summary
- `database.generated.ts` regen in PR #262 (commit 5cbbc045) added 3 new Beach columns (`max_wind_any_mph`, `max_wind_onshore_mph`, `region_id`) but didn't update the downstream consumers
- Surfaces as TypeScript errors that **only fire on the prod CI gate** (full typecheck + build); main's CI is lighthouse + Vercel preview only, so the drift slipped through
- Adds the 3 fields to the canonical default mock and the one outlier inline mock

## Files changed
- `lib/utils/beach-defaults.ts` — `getBeachDefaults()` returns now matches the regenerated `Beach` type
- `__tests__/lib/utils/viewport-filter.test.ts` — inline `makeBeach()` mock matches too

## Verification
- `yarn typecheck` passes locally
- 6 lines added, 0 changed

## Why this matters now
This is blocking PR #265 (Promote main → prod), which is needed to land the
`home_hero_forecast_viewed` CHECK migration before quiver-native can push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)