### PR TITLE
fix(cron): resolve active prod cron failures

### DIFF
--- a/__tests__/api/cron/forecast-digest-email.test.ts
+++ b/__tests__/api/cron/forecast-digest-email.test.ts
@@ -18,4 +18,16 @@ describe("Cron: forecast-digest-email", () => {
     expect(source).not.toContain("enqueueNotification(");
     expect(source).not.toContain("dedupeKey: `daily_digest:");
   });
+
+  it("uses canonical beach tide preference columns", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/api/cron/forecast-digest-email/route.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("preferred_tide_ft_min");
+    expect(source).toContain("preferred_tide_ft_max");
+    expect(source).not.toContain("tide_min_ft");
+    expect(source).not.toContain("tide_max_ft");
+  });
 });

--- a/__tests__/migrations/drop-stale-email-candidate-rpc-overloads.test.ts
+++ b/__tests__/migrations/drop-stale-email-candidate-rpc-overloads.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("stale email candidate RPC overload cleanup migration", () => {
+  const migrationSQL = readFileSync(
+    join(
+      __dirname,
+      "../../supabase/migrations/20260506130915_drop_stale_email_candidate_rpc_overloads.sql"
+    ),
+    "utf-8"
+  );
+
+  const normalizedSQL = migrationSQL.replace(/\s+/g, " ").toLowerCase();
+
+  it("wraps the overload cleanup in a transaction", () => {
+    expect(migrationSQL).toMatch(/^\s*BEGIN;\s*$/m);
+    expect(migrationSQL).toMatch(/^\s*COMMIT;\s*$/m);
+  });
+
+  it("drops only the stale two-argument candidate overloads", () => {
+    expect(normalizedSQL).toContain(
+      "drop function if exists public.get_conditions_alert_candidates(integer, integer);"
+    );
+    expect(normalizedSQL).toContain(
+      "drop function if exists public.get_session_prompt_candidates(integer, integer);"
+    );
+    expect(normalizedSQL).not.toContain(
+      "drop function if exists public.get_conditions_alert_candidates(integer);"
+    );
+    expect(normalizedSQL).not.toContain(
+      "drop function if exists public.get_session_prompt_candidates(integer);"
+    );
+  });
+
+  it("reloads the PostgREST schema cache", () => {
+    expect(normalizedSQL).toContain("notify pgrst, 'reload schema';");
+  });
+});

--- a/app/api/cron/forecast-digest-email/route.ts
+++ b/app/api/cron/forecast-digest-email/route.ts
@@ -82,8 +82,8 @@ interface EligibleUser {
   beach_swell_window_halfwidth_deg: number | null;
   beach_wind_offshore_deg: number | null;
   beach_wind_offshore_tol_deg: number | null;
-  beach_tide_min_ft: number | null;
-  beach_tide_max_ft: number | null;
+  beach_preferred_tide_ft_min: number | null;
+  beach_preferred_tide_ft_max: number | null;
 }
 
 interface DigestRunSummary {
@@ -355,8 +355,8 @@ async function _GET(request: Request): Promise<Response> {
           swell_window_halfwidth_deg,
           wind_offshore_deg,
           wind_offshore_tol_deg,
-          tide_min_ft,
-          tide_max_ft
+          preferred_tide_ft_min,
+          preferred_tide_ft_max
         )
       `
       )
@@ -434,8 +434,8 @@ async function _GET(request: Request): Promise<Response> {
           swell_window_halfwidth_deg: beach.swell_window_halfwidth_deg,
           wind_offshore_deg: beach.wind_offshore_deg,
           wind_offshore_tol_deg: beach.wind_offshore_tol_deg,
-          preferred_tide_ft_min: beach.tide_min_ft,
-          preferred_tide_ft_max: beach.tide_max_ft,
+          preferred_tide_ft_min: beach.preferred_tide_ft_min,
+          preferred_tide_ft_max: beach.preferred_tide_ft_max,
         };
 
         const matchResult = evaluateDigestMatch(

--- a/supabase/migrations/20260506130915_drop_stale_email_candidate_rpc_overloads.sql
+++ b/supabase/migrations/20260506130915_drop_stale_email_candidate_rpc_overloads.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.get_conditions_alert_candidates(integer, integer);
+DROP FUNCTION IF EXISTS public.get_session_prompt_candidates(integer, integer);
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/vercel.json
+++ b/vercel.json
@@ -130,10 +130,6 @@
       "schedule": "45 * * * *"
     },
     {
-      "path": "/api/cron/resolve-youtube-cams",
-      "schedule": "0 */6 * * *"
-    },
-    {
       "path": "/api/cron/resolve-cam-thumbnails",
       "schedule": "0 4 * * 1-6"
     },


### PR DESCRIPTION
## Summary
- drop stale two-argument email candidate RPC overloads from prod schema via checked-in migration
- update forecast digest cron to use preferred tide columns that exist on public.beaches
- remove resolve-youtube-cams from scheduled Vercel crons so missing YOUTUBE_API_KEY no longer creates scheduled prod failures

## Verification
- Supabase prod preflight showed stale overloads present and cleanup migration missing
- Supabase prod DDL applied via MCP apply_migration as drop_stale_email_candidate_rpc_overloads
- Supabase prod verification: only one-arg candidate RPCs remain; high-threshold RPC calls return cleanly
- source ~/.nvm/nvm.sh && nvm use 22 && yarn typecheck
- source ~/.nvm/nvm.sh && nvm use 22 && yarn test:unit --runTestsByPath __tests__/migrations/drop-stale-email-candidate-rpc-overloads.test.ts __tests__/api/cron/forecast-digest-email.test.ts
- source ~/.nvm/nvm.sh && nvm use 22 && yarn test:unit --bail=0
- source ~/.nvm/nvm.sh && nvm use 22 && NODE_OPTIONS="--max-old-space-size=8192" npx eslint --max-warnings=0 app/api/cron/forecast-digest-email/route.ts __tests__/api/cron/forecast-digest-email.test.ts __tests__/migrations/drop-stale-email-candidate-rpc-overloads.test.ts

## Notes
- This is a focused prod hotfix from origin/prod, not a full main promotion.
- Do not manually trigger email crons for verification unless explicitly approved; successful runs can send emails.
