### PR TITLE
Promote v5.1 tester forecast gate

### DIFF
--- a/__tests__/actions/forecast-actions.test.ts
+++ b/__tests__/actions/forecast-actions.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "../setup/vitest-shim";
 import * as ForecastActionsModule from "@/actions/forecast-actions";
-import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+import {
+  createSupabaseServerClient,
+  createSupabaseServiceRoleClient,
+} from "@/lib/supabase/server";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 
 // Unwrap server action wrappers to direct functions
@@ -16,6 +19,7 @@ const updateAllBeachForecasts = ForecastActionsModule.updateAllBeachForecasts;
 jest.mock("@/lib/supabase/server", () => ({
   __esModule: true,
   createSupabaseServiceRoleClient: jest.fn(),
+  createSupabaseServerClient: jest.fn(),
 }));
 
 // Mock the forecast utility modules
@@ -93,6 +97,14 @@ beforeEach(() => {
   (createSupabaseServiceRoleClient as unknown as jest.Mock).mockResolvedValue(
     mockSupabaseClient
   );
+  (createSupabaseServerClient as unknown as jest.Mock).mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: { user: null },
+        error: null,
+      }),
+    },
+  });
 });
 
 describe("Forecast Actions", () => {

--- a/__tests__/api/forecasts/forecasts-bulk.test.ts
+++ b/__tests__/api/forecasts/forecasts-bulk.test.ts
@@ -19,6 +19,12 @@ const mockSupabaseClient = createMockSupabaseClient();
 
 jest.mock("@/lib/middleware/api-wrappers", () => ({
   withRateLimit: (handler: any) => handler,
+  withAuth: (handler: any) => (request: any, context: any) =>
+    handler(request, {
+      params: context?.params ?? {},
+      user: null,
+      supabase: mockSupabaseClient,
+    }),
   createSuccessResponse: jest.fn((data: any) => {
     return new Response(JSON.stringify({ success: true, data }), {
       status: 200,

--- a/__tests__/app/api/cron/ccc-sync.test.ts
+++ b/__tests__/app/api/cron/ccc-sync.test.ts
@@ -1,0 +1,225 @@
+import { GET } from "@/app/api/cron/ccc-sync/route";
+import { validateCronRequest } from "@/lib/api-utils";
+import {
+  fetchCCCLocations,
+  matchCCCToBeaches,
+  upsertCCCLocations,
+} from "@/lib/services/ccc";
+
+jest.mock("@/lib/cron/observability", () => ({
+  withObservedCron:
+    <H extends (request: Request) => Promise<Response>>(
+      _route: string,
+      handler: H
+    ): H =>
+      handler,
+}));
+
+jest.mock("@/lib/api-utils", () => {
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }
+
+  return {
+    createSuccessResponse: jest.fn((data: unknown, status = 200) =>
+      jsonResponse(
+        {
+          success: true,
+          data,
+          timestamp: new Date().toISOString(),
+        },
+        status
+      )
+    ),
+    createErrorResponse: jest.fn(
+      (error: string, details: unknown, status = 500) =>
+        jsonResponse(
+          {
+            success: false,
+            error,
+            details,
+            timestamp: new Date().toISOString(),
+          },
+          status
+        )
+    ),
+    handleApiError: jest.fn((error: unknown) =>
+      jsonResponse(
+        {
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+          timestamp: new Date().toISOString(),
+        },
+        500
+      )
+    ),
+    validateCronRequest: jest.fn(() => true),
+  };
+});
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServiceRoleClient: jest.fn(() => ({ from: jest.fn() })),
+}));
+
+jest.mock("@/lib/services/ccc", () => ({
+  fetchCCCLocations: jest.fn(),
+  upsertCCCLocations: jest.fn(),
+  matchCCCToBeaches: jest.fn(),
+}));
+
+const mockValidateCronRequest = validateCronRequest as jest.MockedFunction<
+  typeof validateCronRequest
+>;
+const mockFetchCCCLocations = fetchCCCLocations as jest.MockedFunction<
+  typeof fetchCCCLocations
+>;
+const mockUpsertCCCLocations = upsertCCCLocations as jest.MockedFunction<
+  typeof upsertCCCLocations
+>;
+const mockMatchCCCToBeaches = matchCCCToBeaches as jest.MockedFunction<
+  typeof matchCCCToBeaches
+>;
+
+function createCronRequest(url = "http://localhost/api/cron/ccc-sync"): Request {
+  return new Request(url, {
+    headers: {
+      "x-vercel-cron": "1",
+    },
+  });
+}
+
+describe("GET /api/cron/ccc-sync", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-07T16:23:57Z"));
+    jest.clearAllMocks();
+
+    mockValidateCronRequest.mockReturnValue(true);
+    mockFetchCCCLocations.mockResolvedValue({
+      locations: [
+        {
+          ccc_id: 1,
+          name: "Test Access",
+          lat: 33.1,
+          lon: -117.3,
+          county: "San Diego",
+          has_parking: true,
+          has_fee: false,
+          has_restrooms: true,
+          has_ada_access: false,
+          has_dog_friendly: false,
+          has_stroller_friendly: false,
+          has_campground: false,
+          has_boating: false,
+          has_fishing: false,
+          has_picnic_area: false,
+          has_volleyball: false,
+          has_bike_path: false,
+          has_tidepools: false,
+          has_sandy_beach: true,
+          has_rocky_shore: false,
+          has_bluff_trail: false,
+          has_wildlife_viewing: false,
+          has_visitor_center: false,
+          raw_data: {},
+          synced_at: "2026-05-07T16:23:57.000Z",
+        },
+      ],
+      totalRaw: 1,
+      skipped: 0,
+      notModified: false,
+      errors: [],
+    });
+    mockUpsertCCCLocations.mockResolvedValue({
+      upserted: 1,
+      batches: 1,
+      errors: [],
+    });
+    mockMatchCCCToBeaches.mockResolvedValue({
+      beachesEvaluated: 2,
+      matchesFound: 3,
+      matchesUpserted: 3,
+      viewRefreshed: true,
+      errors: [],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("rejects an explicit invalid phase without running sync work", async () => {
+    const response = await GET(
+      createCronRequest("http://localhost/api/cron/ccc-sync?phase=bogus")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid phase");
+    expect(mockFetchCCCLocations).not.toHaveBeenCalled();
+    expect(mockUpsertCCCLocations).not.toHaveBeenCalled();
+    expect(mockMatchCCCToBeaches).not.toHaveBeenCalled();
+  });
+
+  it("returns an ok skipped result for missing phase outside scheduled windows", async () => {
+    const response = await GET(createCronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      phase: "skipped",
+      accepted_phases: ["import", "match"],
+    });
+    expect(body.data.reason).toContain('Missing query param "phase"');
+    expect(mockFetchCCCLocations).not.toHaveBeenCalled();
+    expect(mockUpsertCCCLocations).not.toHaveBeenCalled();
+    expect(mockMatchCCCToBeaches).not.toHaveBeenCalled();
+  });
+
+  it("infers import for a missing phase during the monthly import window", async () => {
+    jest.setSystemTime(new Date("2026-06-01T06:12:00Z"));
+
+    const response = await GET(createCronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      phase: "import",
+      inferred_phase: true,
+      fetch: {
+        totalRaw: 1,
+      },
+      upsert: {
+        upserted: 1,
+      },
+    });
+    expect(mockFetchCCCLocations).toHaveBeenCalledTimes(1);
+    expect(mockUpsertCCCLocations).toHaveBeenCalledTimes(1);
+    expect(mockMatchCCCToBeaches).not.toHaveBeenCalled();
+  });
+
+  it("infers match for a missing phase during the monthly match window", async () => {
+    jest.setSystemTime(new Date("2026-06-01T07:12:00Z"));
+
+    const response = await GET(createCronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      phase: "match",
+      inferred_phase: true,
+      match: {
+        beachesEvaluated: 2,
+        matchesFound: 3,
+      },
+    });
+    expect(mockFetchCCCLocations).not.toHaveBeenCalled();
+    expect(mockUpsertCCCLocations).not.toHaveBeenCalled();
+    expect(mockMatchCCCToBeaches).toHaveBeenCalledWith(expect.anything(), 1500);
+  });
+});

--- a/__tests__/app/api/forecasts/bulk/route.test.ts
+++ b/__tests__/app/api/forecasts/bulk/route.test.ts
@@ -24,6 +24,10 @@ jest.mock("@/lib/supabase/api-server-client", () => ({
   createAPIServerClient: jest.fn(() => mockSupabaseClient),
 }));
 
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: jest.fn(() => mockSupabaseClient),
+}));
+
 // Mock API utils
 jest.mock("@/lib/api-utils", () => {
   const actual = jest.requireActual("@/lib/api-utils");

--- a/actions/forecast-actions.ts
+++ b/actions/forecast-actions.ts
@@ -8,6 +8,10 @@ import { trackFallback } from "@/lib/monitoring/fallback-tracker";
 import { resolveConfidence } from "@/lib/monitoring/fallback-helpers";
 import { extractForecastDate as extractForecastDateFromAt } from "@/lib/utils/forecast-at-adapter";
 import { fetchLatestObservation } from "@/lib/services/observations/nowcast-anchor";
+import {
+  applyV51DisplayOverrideToForecasts,
+  isV51DisplayAllowlistedCurrentUser,
+} from "@/lib/services/forecast/v5-display-gate";
 import type { Beach, Forecast } from "@/types/database";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { ForecastTimeInfo } from "@/lib/utils/current-forecast-utils";
@@ -122,6 +126,7 @@ export async function getEnhancedBeachForecasts(
 ) {
   try {
     const supabase = await createSupabaseServiceRoleClient();
+    const useV51Display = await isV51DisplayAllowlistedCurrentUser();
 
     // Prefer the legacy compatibility view if present (tests assert against it), fallback to table
     const today = new Date().toISOString().split("T")[0];
@@ -194,9 +199,12 @@ export async function getEnhancedBeachForecasts(
     });
 
     // Enrich forecasts with metadata for transparency
-    const forecastsWithMetadata: EnhancedForecastWithMetadata[] = (
-      data || []
-    ).map((forecast: EnhancedForecastEntity) => ({
+    const displayForecasts = await applyV51DisplayOverrideToForecasts(
+      (data || []) as EnhancedForecastEntity[],
+      { enabled: useV51Display }
+    );
+
+    const forecastsWithMetadata: EnhancedForecastWithMetadata[] = displayForecasts.map((forecast) => ({
       ...forecast,
       metadata: extractForecastMetadata(forecast),
     }));
@@ -215,6 +223,7 @@ export async function getEnhancedBeachForecasts(
 export async function getBeachForecastPreview(beachId: string) {
   try {
     const supabase = await createSupabaseServiceRoleClient();
+    const useV51Display = await isV51DisplayAllowlistedCurrentUser();
     const { getCurrentForecast } = await import(
       "@/lib/utils/current-forecast-utils"
     );
@@ -232,7 +241,7 @@ export async function getBeachForecastPreview(beachId: string) {
       (supabase as any)
         .from("enhanced_forecasts")
         .select(
-          "forecast_at, forecast_date, forecast_time, wave_height, wind_speed, wind_direction, weather_condition, confidence_score, data_source"
+          "forecast_at, forecast_date, forecast_time, wave_height, wave_height_om, wave_direction_om, swell_direction_om, swell_1_direction, wind_speed, wind_direction, weather_condition, confidence_score, data_source"
         )
         .eq("beach_id", beachId)
         .gte("forecast_at", `${today}T00:00:00Z`)
@@ -248,8 +257,12 @@ export async function getBeachForecastPreview(beachId: string) {
     }
 
     if (enhancedForecasts && enhancedForecasts.length > 0) {
+      const displayForecasts = await applyV51DisplayOverrideToForecasts(
+        enhancedForecasts as EnhancedForecastEntity[],
+        { enabled: useV51Display }
+      );
       // Use time-aware selection to get the most appropriate forecast
-      const currentForecast = getCurrentForecast(enhancedForecasts as any[]);
+      const currentForecast = getCurrentForecast(displayForecasts as any[]);
 
       if (currentForecast) {
         return {

--- a/app/api/cron/ccc-sync/route.ts
+++ b/app/api/cron/ccc-sync/route.ts
@@ -19,17 +19,32 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 300; // Vercel hard limit (5min)
 
 type SyncPhase = "import" | "match";
+type PhaseResolution =
+  | { kind: "run"; phase: SyncPhase; inferred: boolean }
+  | { kind: "skip"; reason: string }
+  | { kind: "invalid"; details: string };
+
+const SYNC_PHASES: readonly SyncPhase[] = ["import", "match"];
 
 interface ImportSyncResult {
   phase: "import";
   fetch: FetchResult;
   upsert: UpsertResult;
   duration_ms: number;
+  inferred_phase?: boolean;
 }
 
 interface MatchSyncResult {
   phase: "match";
   match: MatchResult;
+  duration_ms: number;
+  inferred_phase?: boolean;
+}
+
+interface SkippedSyncResult {
+  phase: "skipped";
+  reason: string;
+  accepted_phases: readonly SyncPhase[];
   duration_ms: number;
 }
 
@@ -72,25 +87,43 @@ async function _GET(request: Request): Promise<Response> {
     }
 
     const url = new URL(request.url);
-    const phase = url.searchParams.get("phase") as SyncPhase | null;
+    const phaseResolution = resolvePhase(url.searchParams, new Date());
 
-    if (!phase || !["import", "match"].includes(phase)) {
+    if (phaseResolution.kind === "invalid") {
       return createErrorResponse(
         "Invalid phase",
-        'Query param "phase" must be "import" or "match"',
+        phaseResolution.details,
         400
       );
     }
 
+    if (phaseResolution.kind === "skip") {
+      const result: SkippedSyncResult = {
+        phase: "skipped",
+        reason: phaseResolution.reason,
+        accepted_phases: SYNC_PHASES,
+        duration_ms: Date.now() - startTime,
+      };
+      console.log("[CCC] Skipping CCC sync:", result.reason);
+      return createSuccessResponse(result);
+    }
+
+    const { phase, inferred } = phaseResolution;
     console.log(`[CCC] Starting CCC sync (phase=${phase})...`);
 
     if (phase === "import") {
-      const result = await runImportPhase(startTime);
+      const result = {
+        ...(await runImportPhase(startTime)),
+        inferred_phase: inferred,
+      };
       console.log("[CCC] Import phase complete:", JSON.stringify(result, null, 2));
       return createSuccessResponse(result);
     } else {
       const radiusM = parseInt(url.searchParams.get("radiusM") || "1500", 10);
-      const result = await runMatchPhase(startTime, radiusM);
+      const result = {
+        ...(await runMatchPhase(startTime, radiusM)),
+        inferred_phase: inferred,
+      };
       console.log("[CCC] Match phase complete:", JSON.stringify(result, null, 2));
       return createSuccessResponse(result);
     }
@@ -101,6 +134,47 @@ async function _GET(request: Request): Promise<Response> {
 }
 
 export const GET = withObservedCron("/api/cron/ccc-sync", _GET);
+
+function isSyncPhase(value: string): value is SyncPhase {
+  return (SYNC_PHASES as readonly string[]).includes(value);
+}
+
+function resolvePhase(
+  searchParams: URLSearchParams,
+  now: Date
+): PhaseResolution {
+  const rawPhase = searchParams.get("phase");
+
+  if (rawPhase !== null) {
+    const normalizedPhase = rawPhase.trim().toLowerCase();
+
+    if (isSyncPhase(normalizedPhase)) {
+      return { kind: "run", phase: normalizedPhase, inferred: false };
+    }
+
+    return {
+      kind: "invalid",
+      details: 'Query param "phase" must be "import" or "match"',
+    };
+  }
+
+  const utcDay = now.getUTCDate();
+  const utcHour = now.getUTCHours();
+
+  if (utcDay === 1 && utcHour === 6) {
+    return { kind: "run", phase: "import", inferred: true };
+  }
+
+  if (utcDay === 1 && utcHour === 7) {
+    return { kind: "run", phase: "match", inferred: true };
+  }
+
+  return {
+    kind: "skip",
+    reason:
+      'Missing query param "phase"; only the scheduled 06:00/07:00 UTC monthly windows are inferred automatically',
+  };
+}
 
 /**
  * Import Phase

--- a/app/api/forecasts/bulk/route.ts
+++ b/app/api/forecasts/bulk/route.ts
@@ -3,8 +3,18 @@ import {
   createSuccessResponse,
   handleApiError,
 } from "@/lib/api-utils";
-import { createAPIServerClient } from "@/lib/supabase/api-server-client";
-import { withRateLimit } from "@/lib/middleware/api-wrappers";
+import {
+  withAuth,
+  withRateLimit,
+} from "@/lib/middleware/api-wrappers";
+import type { OptionalAuthContext } from "@/lib/middleware/api-wrappers/types";
+import {
+  applyV51DisplayOverrideToForecasts,
+  isV51DisplayAllowlistedUser,
+} from "@/lib/services/forecast/v5-display-gate";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+import type { Database } from "@/types/database.generated";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 export const dynamic = 'force-dynamic';
 
@@ -35,7 +45,90 @@ export const dynamic = 'force-dynamic';
  *   }
  * }
  */
-async function bulkForecastHandler(request: NextRequest) {
+function nextUtcDateString(date: Date): string {
+  return new Date(date.getTime() + 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split("T")[0];
+}
+
+function currentForecastRank(
+  row: Pick<EnhancedForecastEntity, "forecast_date" | "forecast_time">,
+  targetDate: string,
+  currentTime: string
+): [number, number] {
+  if (row.forecast_date === targetDate && row.forecast_time >= currentTime) {
+    return [1, secondsFromTime(row.forecast_time)];
+  }
+
+  if (row.forecast_date === nextUtcDateString(new Date(`${targetDate}T00:00:00Z`))) {
+    return [2, secondsFromTime(row.forecast_time)];
+  }
+
+  return [3, -secondsFromTime(row.forecast_time)];
+}
+
+function secondsFromTime(time: string): number {
+  const [hours = "0", minutes = "0", seconds = "0"] = time.split(":");
+  return Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+}
+
+async function fetchBulkCurrentForecastsWithV51Display(
+  supabase: SupabaseClient<Database>,
+  beachIds: string[]
+): Promise<{ data: Array<{ beach_id: string; wave_height: string | null }> | null; error: { message: string } | null }> {
+  const now = new Date();
+  const targetDate = now.toISOString().split("T")[0];
+  const tomorrow = nextUtcDateString(now);
+  const currentTime = now.toISOString().slice(11, 19);
+
+  const { data, error } = await supabase
+    .from("enhanced_forecasts")
+    .select(
+      "beach_id, forecast_date, forecast_time, forecast_at, wave_height, wave_height_om, wave_direction_om, swell_direction_om, swell_1_direction"
+    )
+    .in("beach_id", beachIds)
+    .in("forecast_date", [targetDate, tomorrow]);
+
+  if (error || !data) {
+    return { data: null, error: error ? { message: error.message } : null };
+  }
+
+  const rankedByBeach = new Map<string, EnhancedForecastEntity>();
+  for (const row of data as unknown as EnhancedForecastEntity[]) {
+    const current = rankedByBeach.get(row.beach_id);
+    if (!current) {
+      rankedByBeach.set(row.beach_id, row);
+      continue;
+    }
+
+    const nextRank = currentForecastRank(row, targetDate, currentTime);
+    const currentRank = currentForecastRank(current, targetDate, currentTime);
+    if (
+      nextRank[0] < currentRank[0] ||
+      (nextRank[0] === currentRank[0] && nextRank[1] < currentRank[1])
+    ) {
+      rankedByBeach.set(row.beach_id, row);
+    }
+  }
+
+  const displayRows = await applyV51DisplayOverrideToForecasts(
+    Array.from(rankedByBeach.values()),
+    { enabled: true }
+  );
+
+  return {
+    data: displayRows.map((row) => ({
+      beach_id: row.beach_id,
+      wave_height: row.wave_height,
+    })),
+    error: null,
+  };
+}
+
+async function bulkForecastHandler(
+  request: NextRequest,
+  context: OptionalAuthContext
+) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const beachIdsParam = searchParams.get("beachIds");
@@ -58,16 +151,14 @@ async function bulkForecastHandler(request: NextRequest) {
     // Limit to prevent abuse
     const maxBeaches = 50;
     const limitedBeachIds = beachIds.slice(0, maxBeaches);
+    const { supabase } = context;
 
-    const supabase = await createAPIServerClient();
-
-    // Use RPC to get exactly 1 row per beach (database-side aggregation).
-    // This eliminates the risk of PostgREST's 1,000-row default limit silently
-    // truncating results — the old .gte("forecast_date", today) query fetched
-    // ~4,700 rows for 50 beaches, cutting off later-sorting UUIDs.
-    const { data, error } = await supabase.rpc("get_bulk_current_forecasts", {
-      p_beach_ids: limitedBeachIds,
-    });
+    const useV51Display = isV51DisplayAllowlistedUser(context?.user ?? null);
+    const { data, error } = useV51Display
+      ? await fetchBulkCurrentForecastsWithV51Display(supabase, limitedBeachIds)
+      : await supabase.rpc("get_bulk_current_forecasts", {
+          p_beach_ids: limitedBeachIds,
+        });
 
     if (error) {
       console.error("Error fetching bulk forecasts:", error);
@@ -134,4 +225,10 @@ async function bulkForecastHandler(request: NextRequest) {
 }
 
 // Apply rate limiting to prevent abuse of bulk operations
-export const GET = withRateLimit(bulkForecastHandler, "forecast-bulk");
+export const GET = withRateLimit(
+  withAuth(bulkForecastHandler, {
+    optional: true,
+    errorMessage: "Unexpected error fetching forecasts",
+  }),
+  "forecast-bulk"
+);

--- a/app/api/forecasts/scored/[beachId]/route.ts
+++ b/app/api/forecasts/scored/[beachId]/route.ts
@@ -1,12 +1,10 @@
 import type { NextRequest } from "next/server";
 import {
-  withErrorHandler,
+  withAuth,
   validateUuidParam,
   createSuccessResponse,
   createNotFoundError,
 } from "@/lib/middleware/api-wrappers";
-import type { RouteContext } from "@/lib/middleware/api-wrappers";
-import { createAPIServerClient } from "@/lib/supabase/api-server-client";
 import {
   createDiscoveryScoringEngine,
   scoreBeachWithEngine,
@@ -19,6 +17,10 @@ import {
   getDirectionDegrees,
 } from "@/lib/utils/number-parsing";
 import { fetchLatestObservation } from "@/lib/services/observations/nowcast-anchor";
+import {
+  applyV51DisplayOverrideToForecasts,
+  isV51DisplayAllowlistedUser,
+} from "@/lib/services/forecast/v5-display-gate";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 import type { Beach } from "@/types/database";
 
@@ -281,19 +283,16 @@ export function identifyGoldenWindows(slots: TimeSlot[]): GoldenWindow[] {
 // Route handler
 // ---------------------------------------------------------------------------
 
-export const GET = withErrorHandler(
-  async (request: NextRequest, context?: RouteContext) => {
-    const params = context?.params
-      ? await Promise.resolve(context.params)
-      : {};
+export const GET = withAuth(
+  async (request: NextRequest, context) => {
+    const params = context.params ?? {};
     const beachId = (params as Record<string, string>).beachId;
 
     // Validate beachId
     const uuidResult = validateUuidParam(beachId, "beachId");
     if ("error" in uuidResult) return uuidResult.error;
     const validBeachId = uuidResult.value;
-
-    const supabase = await createAPIServerClient();
+    const { supabase, user } = context;
 
     // Fetch beach
     const { data: beach, error: beachError } = await supabase
@@ -332,7 +331,10 @@ export const GET = withErrorHandler(
       throw new Error(forecastError.message);
     }
 
-    const forecastList = (forecasts ?? []) as EnhancedForecastEntity[];
+    const forecastList = await applyV51DisplayOverrideToForecasts(
+      (forecasts ?? []) as EnhancedForecastEntity[],
+      { enabled: isV51DisplayAllowlistedUser(user) }
+    );
 
     // Score all slots
     const timeSlots = scoreForecastSlots(forecastList, beach as Beach);
@@ -359,5 +361,5 @@ export const GET = withErrorHandler(
       latestObservation,
     });
   },
-  { errorMessage: "Failed to fetch scored forecast" }
+  { optional: true, errorMessage: "Failed to fetch scored forecast" }
 );

--- a/e2e/ccc-sync-api.spec.ts
+++ b/e2e/ccc-sync-api.spec.ts
@@ -64,23 +64,20 @@ test.describe('CCC Sync API - authentication', () => {
 
 test.describe('CCC Sync API - parameter validation', () => {
   /**
-   * Phase validation tests send the x-vercel-cron header which the route
-   * accepts unconditionally when VERCEL_ENV is set. In CI / local environments
-   * this header may or may not be accepted depending on the VERCEL_ENV env var.
-   *
-   * We therefore test both outcomes:
-   *   - If x-vercel-cron is accepted: we expect 400 for invalid phase
-   *   - If it is rejected: we expect 401 (auth fails before param validation)
-   *
-   * This avoids brittle env-specific failures.
+   * Phase validation tests send the x-vercel-cron header so they exercise
+   * parameter handling after cron auth passes.
+   * Missing phase should skip safely while explicit invalid phase values still
+   * fail validation.
    */
 
-  test('returns 400 or 401 for missing phase param when cron header is present', async ({ request }) => {
+  test('returns safe skip for missing phase param when cron header is present', async ({ request }) => {
     const response = await request.get('/api/cron/ccc-sync', {
       headers: { 'x-vercel-cron': '1' },
     });
-    // 400 = auth passed, phase missing; 401 = cron header not trusted in this env
-    expect([400, 401]).toContain(response.status());
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body?.data?.phase).toBe('skipped');
   });
 
   test('returns 400 or 401 for invalid phase value', async ({ request }) => {

--- a/lib/services/forecast/__tests__/v5-display-gate.test.ts
+++ b/lib/services/forecast/__tests__/v5-display-gate.test.ts
@@ -1,0 +1,128 @@
+import {
+  applyV51DisplayOverrideToForecasts,
+  isV51DisplayAllowlistedUser,
+} from "../v5-display-gate";
+import type { CalibrationVersion } from "../calibration-v5";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+
+jest.mock("@/lib/logger", () => ({
+  createContextLogger: () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: jest.fn(),
+}));
+
+const CALIBRATION: CalibrationVersion = {
+  version: "v5_c.20260511_0630",
+  knots: {
+    "<0.5m": { om_anchor: 0.4, obs: 0.787, n: 1155 },
+    "0.5-1.0m": { om_anchor: 0.803, obs: 0.803, n: 17999 },
+    "1.0-1.5m": { om_anchor: 1.097, obs: 1.097, n: 8134 },
+    "1.5m+": { om_anchor: 1.628, obs: 1.628, n: 2840 },
+  },
+  g_dir: {
+    "S/SW": { g: -0.093, n: 6296 },
+    W: { g: -0.097, n: 9475 },
+    NW: { g: 0.231, n: 3670 },
+    OTHER: { g: -0.01, n: 10687 },
+  },
+  guardrails: {
+    passthrough_cells: [{ direction_bucket: "W", om_bucket: "0.5-1.0m" }],
+  },
+};
+
+function forecast(
+  overrides: Partial<EnhancedForecastEntity> = {}
+): EnhancedForecastEntity {
+  return {
+    id: "forecast-1",
+    beach_id: "beach-1",
+    forecast_at: "2026-05-12T15:00:00Z",
+    forecast_date: "2026-05-12",
+    forecast_time: "15:00:00",
+    wave_height: "3-4ft",
+    wave_height_om: 1,
+    wave_direction_om: null,
+    swell_direction_om: null,
+    swell_1_direction: "SSW",
+    water_temp: null,
+    confidence_score: 80,
+    data_source: "OPEN_METEO",
+    created_at: "2026-05-12T12:00:00Z",
+    updated_at: "2026-05-12T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("isV51DisplayAllowlistedUser", () => {
+  it("allows the Steve and Jake production identities", () => {
+    expect(
+      isV51DisplayAllowlistedUser({
+        id: "73040cff-afe9-4fa0-a874-2016203fc015",
+        email: "other@example.com",
+      })
+    ).toBe(true);
+    expect(
+      isV51DisplayAllowlistedUser({
+        id: "not-listed",
+        email: "JAKEHUMPHREY18@gmail.com",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects unrelated and plus-test identities", () => {
+    expect(
+      isV51DisplayAllowlistedUser({
+        id: "not-listed",
+        email: "omg.its.thefuture+test@gmail.com",
+      })
+    ).toBe(false);
+    expect(isV51DisplayAllowlistedUser(null)).toBe(false);
+  });
+});
+
+describe("applyV51DisplayOverrideToForecasts", () => {
+  it("leaves forecasts untouched when disabled", async () => {
+    const rows = [forecast()];
+    await expect(
+      applyV51DisplayOverrideToForecasts(rows, {
+        enabled: false,
+        calibration: CALIBRATION,
+      })
+    ).resolves.toBe(rows);
+  });
+
+  it("replaces wave_height with v5.1 display when enabled", async () => {
+    const [row] = await applyV51DisplayOverrideToForecasts([forecast()], {
+      enabled: true,
+      calibration: CALIBRATION,
+    });
+
+    expect(row.wave_height).toBe("2-4ft");
+  });
+
+  it("uses the W x 0.5-1.0m raw-OM passthrough guardrail", async () => {
+    const [row] = await applyV51DisplayOverrideToForecasts(
+      [forecast({ wave_height: "1ft", wave_height_om: 0.8, swell_1_direction: "W" })],
+      { enabled: true, calibration: CALIBRATION }
+    );
+
+    expect(row.wave_height).toBe("2-3ft");
+  });
+
+  it("falls back to OM direction when swell_1_direction is missing", async () => {
+    const [row] = await applyV51DisplayOverrideToForecasts(
+      [forecast({ wave_height_om: 0.8, swell_1_direction: null, wave_direction_om: 270 })],
+      { enabled: true, calibration: CALIBRATION }
+    );
+
+    expect(row.wave_height).toBe("2-4ft");
+  });
+});
+

--- a/lib/services/forecast/calibration-v5.ts
+++ b/lib/services/forecast/calibration-v5.ts
@@ -44,7 +44,7 @@ type Guardrails = {
   }>;
 };
 
-type CalibrationVersion = {
+export type CalibrationVersion = {
   version: string;
   knots: Knots;
   g_dir: GDir;

--- a/lib/services/forecast/v5-display-gate.ts
+++ b/lib/services/forecast/v5-display-gate.ts
@@ -1,0 +1,112 @@
+import type { User } from "@supabase/supabase-js";
+import {
+  computeV5Shadow,
+  getActiveCalibration,
+  type CalibrationVersion,
+} from "./calibration-v5";
+import {
+  formatDisplayHeightFt,
+  parseDisplayHeightFt,
+} from "./apply-beach-height-offset";
+import { cardinalToDegrees } from "./forecast-transformer";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { METERS_TO_FEET } from "@/lib/utils/unit-conversions";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+
+type ForecastDisplayUser = Pick<User, "id" | "email">;
+
+const V51_DISPLAY_USER_IDS = new Set([
+  "73040cff-afe9-4fa0-a874-2016203fc015",
+  "f0f4ffaa-5f9b-4fad-93a6-2d624d4cdabe",
+  "58272d19-78c1-4197-9880-9b4053fe094f",
+]);
+
+const V51_DISPLAY_EMAILS = new Set([
+  "omg.its.thefuture@gmail.com",
+  "jakehumphrey18@gmail.com",
+  "jakehumphrey@hey.com",
+]);
+
+export function isV51DisplayAllowlistedUser(
+  user: ForecastDisplayUser | null | undefined
+): boolean {
+  if (!user) return false;
+  if (user.id && V51_DISPLAY_USER_IDS.has(user.id)) return true;
+  const email = user.email?.trim().toLowerCase();
+  return !!email && V51_DISPLAY_EMAILS.has(email);
+}
+
+export async function isV51DisplayAllowlistedCurrentUser(): Promise<boolean> {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+      error,
+    } = await supabase.auth.getUser();
+
+    if (error) return false;
+    return isV51DisplayAllowlistedUser(user);
+  } catch {
+    return false;
+  }
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+function primaryDirectionDeg(forecast: EnhancedForecastEntity): number | null {
+  return (
+    cardinalToDegrees(forecast.swell_1_direction) ??
+    toFiniteNumber(forecast.wave_direction_om) ??
+    toFiniteNumber(forecast.swell_direction_om) ??
+    null
+  );
+}
+
+function applyV51DisplayOverrideToForecast<T extends EnhancedForecastEntity>(
+  forecast: T,
+  calibration: CalibrationVersion
+): T {
+  const v5 = computeV5Shadow({
+    wave_height_om_m: forecast.wave_height_om,
+    primary_swell_direction_deg: primaryDirectionDeg(forecast),
+    calibration,
+  });
+
+  if (!v5) return forecast;
+
+  const parsedDisplay = parseDisplayHeightFt(forecast.wave_height);
+  const waveHeight = formatDisplayHeightFt({
+    numericFt: v5.v5_shadow_height_m * METERS_TO_FEET,
+    rangeSpread: parsedDisplay.rangeSpread,
+  });
+
+  if (waveHeight === forecast.wave_height) return forecast;
+  return { ...forecast, wave_height: waveHeight };
+}
+
+export async function applyV51DisplayOverrideToForecasts<
+  T extends EnhancedForecastEntity,
+>(
+  forecasts: T[],
+  options: {
+    enabled: boolean;
+    calibration?: CalibrationVersion | null;
+  }
+): Promise<T[]> {
+  if (!options.enabled || forecasts.length === 0) return forecasts;
+
+  const calibration =
+    options.calibration === undefined
+      ? await getActiveCalibration()
+      : options.calibration;
+
+  if (!calibration) return forecasts;
+
+  return forecasts.map((forecast) =>
+    applyV51DisplayOverrideToForecast(forecast, calibration)
+  );
+}
+


### PR DESCRIPTION
## Summary
- promote v5.1 forecast display gate for Steve and Jake allowlisted users
- include current main ccc-sync cron fix already deployed to dev

## Verification
- yarn typecheck
- yarn test:unit --runTestsByPath lib/services/forecast/__tests__/v5-display-gate.test.ts __tests__/actions/forecast-actions.test.ts __tests__/app/api/forecasts/bulk/route.test.ts __tests__/api/forecasts/forecasts-bulk.test.ts app/api/forecasts/scored/[beachId]/__tests__/route.test.ts
- npx eslint --max-warnings=0 lib/services/forecast/v5-display-gate.ts lib/services/forecast/__tests__/v5-display-gate.test.ts actions/forecast-actions.ts app/api/forecasts/bulk/route.ts app/api/forecasts/scored/[beachId]/route.ts __tests__/actions/forecast-actions.test.ts __tests__/app/api/forecasts/bulk/route.test.ts __tests__/api/forecasts/forecasts-bulk.test.ts
- yarn test:unit --bail=0

## Notes
- no DB migrations or prod DB mutations