### PR TITLE
fix(cams): hide stale OB camera thumbnail

### DIFF
--- a/__tests__/lib/media/cam-thumbnail.test.ts
+++ b/__tests__/lib/media/cam-thumbnail.test.ts
@@ -1,4 +1,7 @@
-import { getCamThumbnailUrl } from "@/lib/media/cam-thumbnail";
+import {
+  getCamThumbnailUrl,
+  getDisplayCamThumbnailUrl,
+} from "@/lib/media/cam-thumbnail";
 
 describe("getCamThumbnailUrl", () => {
   // --- Null / undefined / empty ---
@@ -90,5 +93,41 @@ describe("getCamThumbnailUrl", () => {
   // --- Invalid URLs ---
   it("returns null for invalid URL strings", () => {
     expect(getCamThumbnailUrl("not-a-valid-url")).toBeNull();
+  });
+});
+
+describe("getDisplayCamThumbnailUrl", () => {
+  it("ignores stored OB Hotel page captures", () => {
+    expect(
+      getDisplayCamThumbnailUrl({
+        cameraUrl: "https://www.obhotel.com/Webcam-Oceanbeach.php",
+        thumbnailUrl:
+          "https://vawdnbbgawichorsjiwe.supabase.co/storage/v1/object/public/cam-thumbnails/65d177de-e75a-4ad8-aa0d-48a67c0851b0.jpg",
+      })
+    ).toBeNull();
+  });
+
+  it("keeps real provider thumbnails for OB Hotel if one is supplied", () => {
+    expect(
+      getDisplayCamThumbnailUrl({
+        cameraUrl: "https://www.obhotel.com/Webcam-Oceanbeach.php",
+        thumbnailUrl:
+          "https://storage.hdontap.com/wowza_stream_thumbnails/snapshot_obhotel.stream.jpg",
+      })
+    ).toBe(
+      "https://storage.hdontap.com/wowza_stream_thumbnails/snapshot_obhotel.stream.jpg"
+    );
+  });
+
+  it("keeps stored thumbnails for other camera hosts", () => {
+    expect(
+      getDisplayCamThumbnailUrl({
+        cameraUrl: "https://streams.surfchex.com:8443/live/wb3.stream/playlist.m3u8",
+        thumbnailUrl:
+          "https://vawdnbbgawichorsjiwe.supabase.co/storage/v1/object/public/cam-thumbnails/4b88f10a-c794-4144-b17a-133af9fee9f9.jpg",
+      })
+    ).toBe(
+      "https://vawdnbbgawichorsjiwe.supabase.co/storage/v1/object/public/cam-thumbnails/4b88f10a-c794-4144-b17a-133af9fee9f9.jpg"
+    );
   });
 });

--- a/components/cams/cam-card.tsx
+++ b/components/cams/cam-card.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { MapPin } from "lucide-react";
 import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
-import { getCamThumbnailUrl } from "@/lib/media/cam-thumbnail";
+import { getDisplayCamThumbnailUrl } from "@/lib/media/cam-thumbnail";
 import type { CamBeachWithRegion } from "@/actions/beach/cam-actions";
 
 interface CamCardProps {
@@ -13,7 +13,10 @@ interface CamCardProps {
 }
 
 export function CamCard({ beach }: CamCardProps) {
-  const thumbnailUrl = beach.thumbnail_url || getCamThumbnailUrl(beach.camera_url);
+  const thumbnailUrl = getDisplayCamThumbnailUrl({
+    cameraUrl: beach.camera_url,
+    thumbnailUrl: beach.thumbnail_url,
+  });
   const [imgError, setImgError] = useState(false);
   const showThumbnail = thumbnailUrl && !imgError;
 

--- a/lib/media/cam-thumbnail.ts
+++ b/lib/media/cam-thumbnail.ts
@@ -35,3 +35,42 @@ export function getCamThumbnailUrl(
     return null;
   }
 }
+
+const QUIVER_CAM_THUMBNAIL_BUCKET_PATH = "/storage/v1/object/public/cam-thumbnails/";
+const STORED_PAGE_CAPTURE_HOSTS = new Set(["obhotel.com", "www.obhotel.com"]);
+
+function isQuiverStoredCamThumbnail(thumbnailUrl: string): boolean {
+  try {
+    return new URL(thumbnailUrl).pathname.includes(QUIVER_CAM_THUMBNAIL_BUCKET_PATH);
+  } catch {
+    return false;
+  }
+}
+
+function isKnownPageCaptureCamera(cameraUrl: string | null | undefined): boolean {
+  if (!cameraUrl) return false;
+
+  try {
+    return STORED_PAGE_CAPTURE_HOSTS.has(new URL(cameraUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function getDisplayCamThumbnailUrl({
+  cameraUrl,
+  thumbnailUrl,
+}: {
+  cameraUrl: string | null | undefined;
+  thumbnailUrl: string | null | undefined;
+}): string | null {
+  if (
+    thumbnailUrl &&
+    isKnownPageCaptureCamera(cameraUrl) &&
+    isQuiverStoredCamThumbnail(thumbnailUrl)
+  ) {
+    return getCamThumbnailUrl(cameraUrl);
+  }
+
+  return thumbnailUrl || getCamThumbnailUrl(cameraUrl);
+}


### PR DESCRIPTION
## Summary
- ignore the stale stored OB Hotel page-capture thumbnail on cam cards
- keep real provider thumbnails and other stored cam thumbnails
- add regression coverage for display thumbnail selection

## Verification
- yarn typecheck
- npx eslint --max-warnings=0 components/cams/cam-card.tsx lib/media/cam-thumbnail.ts __tests__/lib/media/cam-thumbnail.test.ts
- yarn test:unit __tests__/lib/media/cam-thumbnail.test.ts --runInBand
- yarn test:unit --bail=0