### PR TITLE
fix: apply v5 surf heights to surf call

### DIFF
--- a/__tests__/actions/spot/spot-surf-report-actions.test.ts
+++ b/__tests__/actions/spot/spot-surf-report-actions.test.ts
@@ -4,6 +4,7 @@
 
 import type { Beach } from "@/types/database";
 import type { EnhancedForecastEntity } from "@/types/forecast";
+import type { CalibrationVersion } from "@/lib/services/forecast/calibration-v5";
 
 // Mock server modules
 jest.mock("@/lib/supabase/server", () => ({
@@ -31,6 +32,14 @@ jest.mock("@/lib/domains/user-preferences", () => ({
 jest.mock("@/lib/utils/timezone-utils.server", () => ({
   getTimezoneFromCoords: jest.fn(() => "America/Los_Angeles"),
 }));
+
+jest.mock("@/lib/services/forecast/calibration-v5", () => {
+  const actual = jest.requireActual("@/lib/services/forecast/calibration-v5");
+  return {
+    ...actual,
+    getActiveCalibration: jest.fn(),
+  };
+});
 
 // Track call count for formatDateInTimezone to return different values
 let formatDateCallCount = 0;
@@ -79,6 +88,25 @@ describe("spot-surf-report-actions", () => {
       confidence_score: 80,
     },
   ];
+
+  const calibration: CalibrationVersion = {
+    version: "v5_c.20260511_0630",
+    knots: {
+      "<0.5m": { om_anchor: 0.4, obs: 0.787, n: 1155 },
+      "0.5-1.0m": { om_anchor: 0.803, obs: 0.803, n: 17999 },
+      "1.0-1.5m": { om_anchor: 1.097, obs: 1.097, n: 8134 },
+      "1.5m+": { om_anchor: 1.628, obs: 1.628, n: 2840 },
+    },
+    g_dir: {
+      "S/SW": { g: -0.093, n: 6296 },
+      W: { g: -0.097, n: 9475 },
+      NW: { g: 0.231, n: 3670 },
+      OTHER: { g: -0.01, n: 10687 },
+    },
+    guardrails: {
+      passthrough_cells: [{ direction_bucket: "W", om_bucket: "0.5-1.0m" }],
+    },
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -422,6 +450,92 @@ describe("spot-surf-report-actions", () => {
       expect(mockSelectBestWindow).toHaveBeenCalled();
       const callArgs = mockSelectBestWindow.mock.calls[0][0];
       expect(callArgs.userPrefs).toBeNull();
+    });
+
+    it("builds forecastContext from v5.1 display heights for PB Point-like rows", async () => {
+      const { createSupabaseServerClient, createSupabaseServiceRoleClient } = await import(
+        "@/lib/supabase/server"
+      );
+      const { getBatchSunTimes } = await import("@/lib/services/discovery");
+      const { getActiveCalibration } = await import("@/lib/services/forecast/calibration-v5");
+
+      (getActiveCalibration as jest.Mock).mockResolvedValue(calibration);
+      (createSupabaseServerClient as jest.Mock).mockReturnValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({ data: { user: null } }),
+        },
+        from: jest.fn(() => ({
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              single: jest.fn().mockResolvedValue({ data: null, error: null }),
+            })),
+          })),
+        })),
+      });
+
+      const mockSunTimesCache = new Map([
+        [
+          "beach-123",
+          {
+            sunrises: [new Date("2024-01-15T14:47:00Z")],
+            sunsets: [new Date("2024-01-16T01:00:00Z")],
+          },
+        ],
+      ]);
+      (getBatchSunTimes as jest.Mock).mockResolvedValue(mockSunTimesCache);
+
+      const pbPointForecasts: Partial<EnhancedForecastEntity>[] = [
+        {
+          ...mockForecasts[0],
+          wave_height: "0.5 ft",
+          wave_height_om: 1.22,
+          swell_1_direction: "WNW",
+          swell_1_period: "12",
+          wind_speed: "4 mph",
+          wind_direction: "S",
+        },
+      ];
+      (createSupabaseServiceRoleClient as jest.Mock).mockReturnValue({
+        from: jest.fn(() => ({
+          select: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              gte: jest.fn(() => ({
+                lt: jest.fn(() => ({
+                  order: jest.fn(() => ({
+                    limit: jest.fn(async () => ({
+                      data: pbPointForecasts,
+                      error: null,
+                    })),
+                  })),
+                })),
+              })),
+            })),
+          })),
+        })),
+      });
+
+      mockSelectBestWindow.mockImplementation(({ forecasts }) => {
+        const sourceForecast = forecasts[0];
+        return {
+          start: new Date("2024-01-15T16:00:00Z"),
+          end: new Date("2024-01-15T20:00:00Z"),
+          score: 82,
+          waveHeight: sourceForecast.wave_height,
+          wavePeriod: sourceForecast.swell_1_period,
+          peakTime: new Date(sourceForecast.forecast_at),
+          sourceForecast,
+        };
+      });
+
+      const { getSpotSurfReport } = await import(
+        "@/actions/spot/spot-surf-report-actions"
+      );
+      const result = await getSpotSurfReport(mockBeach);
+
+      expect(mockSelectBestWindow).toHaveBeenCalled();
+      expect(mockSelectBestWindow.mock.calls[0][0].forecasts[0].wave_height).toBe("4-5ft");
+      expect(result?.forecastContext?.waveHeight).toBe("4-5ft");
+      expect(result?.forecastContext?.waveHeightRangeLabel).toBe("4-5 ft");
     });
 
     // ------------------------------------------------------------------------

--- a/__tests__/services/forecast-recommendation-context.test.ts
+++ b/__tests__/services/forecast-recommendation-context.test.ts
@@ -106,6 +106,42 @@ describe("buildForecastRecommendationContext", () => {
     expect(context?.source).toBe("looking_ahead");
   });
 
+  it("parses display ranges as positive wave heights", () => {
+    const sourceForecast = row({
+      forecast_at: "2026-05-08T23:00:00.000Z",
+      wave_height: "4-5ft",
+      wave_period: "12s",
+      wave_direction: "WNW",
+      swell_1_period: "12s",
+      swell_1_direction: "WNW",
+    });
+    const window: PersonalizedForecastWindow = {
+      start: new Date("2026-05-08T22:30:00.000Z"),
+      end: new Date("2026-05-09T01:30:00.000Z"),
+      tide: "Rising",
+      wind: "5 mph W",
+      waveHeight: "4-5ft",
+      wavePeriod: "12s",
+      dataSource: "OPEN_METEO",
+      confidence: 80,
+      timezone: "America/Los_Angeles",
+      score: 82,
+      peakTime: new Date("2026-05-08T23:00:00.000Z"),
+      sourceForecast,
+    };
+
+    const context = buildForecastRecommendationContext({
+      beach: beach(),
+      forecasts: [sourceForecast],
+      window,
+      now: new Date("2026-05-08T13:00:00.000Z"),
+    });
+
+    expect(context?.waveHeight).toBe("4-5ft");
+    expect(context?.waveHeightFt).toBe(4.5);
+    expect(context?.waveHeightRangeLabel).toBe("4-5 ft");
+  });
+
   it("falls back to now when the current row is rideable and no best window exists", () => {
     const context = buildForecastRecommendationContext({
       beach: beach(),

--- a/actions/spot/spot-surf-report-actions.ts
+++ b/actions/spot/spot-surf-report-actions.ts
@@ -18,6 +18,7 @@ import {
   buildForecastRecommendationContext,
   type ForecastRecommendationContext,
 } from '@/lib/services/forecast-recommendation-context';
+import { applyV51DisplayOverrideToForecasts } from '@/lib/services/forecast/v5-display-gate';
 
 export interface SpotSurfReportResult {
   report: SurfCallResult;
@@ -298,7 +299,10 @@ const getCachedSurfReport = unstable_cache(
       };
     }
 
-    const forecasts = data as EnhancedForecastEntity[];
+    const forecasts = await applyV51DisplayOverrideToForecasts(
+      data as EnhancedForecastEntity[],
+      { enabled: true },
+    );
 
     // 4. Filter to today first; fall back to tomorrow if no viable window today
     const todayForecasts = forecasts.filter(f => extractForecastDate(f.forecast_at, beachTz) === todayStr);

--- a/lib/services/forecast-recommendation-context.ts
+++ b/lib/services/forecast-recommendation-context.ts
@@ -68,7 +68,8 @@ const DEFAULT_RIDEABLE = {
 function parseNumbers(value: unknown): number[] {
   if (typeof value === "number" && Number.isFinite(value)) return [value];
   if (typeof value !== "string") return [];
-  const match = value.match(/-?\d+(?:\.\d+)?/g);
+  const normalized = value.replace(/(\d)\s*-\s*(\d)/g, "$1 $2");
+  const match = normalized.match(/-?\d+(?:\.\d+)?/g);
   if (!match) return [];
   const values = match.map(Number).filter(Number.isFinite);
   return values;


### PR DESCRIPTION
## Summary
- apply v5.1 display-height overrides before surf-call window selection and forecastContext creation
- fix range parsing so 4-5ft is treated as 4.5ft, not a negative range
- add PB Point-like regression coverage for surf-call context

## Tests
- PATH="/opt/homebrew/opt/node@22/bin:/Library/Frameworks/Python.framework/Versions/3.9/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/stevenchandler/.codex/tmp/arg0/codex-arg0wm4ZzD:/Users/stevenchandler/.local/bin:/Users/stevenchandler/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/stevenchandler/.nvm/versions/node/v22.8.0/bin:/Library/Frameworks/Python.framework/Versions/3.9/bin:/User/stevenchandler/Dev/chromedriver:/Applications/Codex.app/Contents/Resources" yarn test:unit --runInBand __tests__/actions/spot/spot-surf-report-actions.test.ts lib/services/forecast/__tests__/v5-display-gate.test.ts __tests__/services/forecast-recommendation-context.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:/Library/Frameworks/Python.framework/Versions/3.9/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Users/stevenchandler/.codex/tmp/arg0/codex-arg0wm4ZzD:/Users/stevenchandler/.local/bin:/Users/stevenchandler/.antigravity/antigravity/bin:/opt/homebrew/opt/openjdk@17/bin:/Users/stevenchandler/.nvm/versions/node/v22.8.0/bin:/Library/Frameworks/Python.framework/Versions/3.9/bin:/User/stevenchandler/Dev/chromedriver:/Applications/Codex.app/Contents/Resources" yarn typecheck