### PR TITLE
fix(landing): restore header and safer spot picks

### DIFF
--- a/__tests__/components/landing/auth-aware-landing-wrapper.signup-confirm.test.tsx
+++ b/__tests__/components/landing/auth-aware-landing-wrapper.signup-confirm.test.tsx
@@ -32,6 +32,11 @@ jest.mock("@/components/oracle/oracle-home-screen", () => ({
 jest.mock("@/components/landing-page/hero-section", () => ({
   HeroSection: () => <div data-testid="hero-section" />,
 }));
+jest.mock("@/components/landing-page/navbar", () => ({
+  Navbar: ({ position }: { position?: string }) => (
+    <nav data-position={position} data-testid="landing-navbar" />
+  ),
+}));
 jest.mock("@/components/landing-page/surf-highlights-section", () => ({
   SurfHighlightsSection: () => <div data-testid="surf-highlights" />,
 }));
@@ -88,7 +93,10 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     ).not.toBeInTheDocument();
 
     // Should render unauth landing sections even while auth is initializing.
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("landing-navbar")).toHaveAttribute(
+      "data-position",
+      "static"
+    );
     expect(screen.getByTestId("hero-section")).toBeInTheDocument();
 
     // Should show the email confirmation modal
@@ -226,7 +234,7 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     render(<AuthAwareLandingWrapper />);
 
     // Should render landing page
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("landing-navbar")).toBeInTheDocument();
     expect(screen.getByTestId("hero-section")).toBeInTheDocument();
 
     // Should NOT show modal
@@ -249,7 +257,7 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     });
 
     // Should NOT show landing page elements
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("landing-navbar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("hero-section")).not.toBeInTheDocument();
 
     // Should NOT show modal
@@ -263,7 +271,7 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     render(<AuthAwareLandingWrapper />);
 
     // Should render landing page, not redirect to sign-in
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("landing-navbar")).toBeInTheDocument();
     expect(screen.getByTestId("hero-section")).toBeInTheDocument();
     expect(replace).not.toHaveBeenCalled();
 
@@ -282,7 +290,7 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     render(<AuthAwareLandingWrapper />);
 
     // Should render landing page
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("landing-navbar")).toBeInTheDocument();
 
     // Should NOT show modal
     expect(screen.queryByText("Check your email")).not.toBeInTheDocument();
@@ -310,4 +318,3 @@ describe("AuthAwareLandingWrapper post-signup confirm email", () => {
     expect(replace).toHaveBeenCalledWith("/");
   });
 });
-

--- a/__tests__/lib/data/server/featured-beaches.test.ts
+++ b/__tests__/lib/data/server/featured-beaches.test.ts
@@ -2,7 +2,11 @@
  * @jest-environment node
  */
 
-import { getFeaturedBeaches } from "@/lib/data/server/featured-beaches";
+import {
+  getFeaturedBeaches,
+  sortLandingFeaturedBeaches,
+} from "@/lib/data/server/featured-beaches";
+import type { EnrichedBeach } from "@/lib/data/server/featured-beaches";
 
 // Mock Supabase server client
 const mockFrom = jest.fn();
@@ -155,5 +159,59 @@ describe("getFeaturedBeaches", () => {
 
     expect(result.isNearby).toBe(false);
     expect(Array.isArray(result.beaches)).toBe(true);
+  });
+});
+
+describe("sortLandingFeaturedBeaches", () => {
+  function beach(
+    id: string,
+    name: string,
+    skill_level: string | null,
+    score: number,
+    average_rating = 4
+  ): EnrichedBeach {
+    return {
+      id,
+      name,
+      city: "San Diego",
+      state: "CA",
+      slug: name.toLowerCase().replace(/\s+/g, "-"),
+      average_rating,
+      review_count: 10,
+      skill_level,
+      photo_url: `https://example.com/${id}.jpg`,
+      has_real_photo: true,
+      score,
+    };
+  }
+
+  it("prioritizes beginner and intermediate beaches over advanced score-only winners", () => {
+    const result = sortLandingFeaturedBeaches([
+      beach("expert", "Expert Reef", "expert", 92),
+      beach("advanced", "Advanced Slab", "advanced", 88),
+      beach("intermediate", "Intermediate Beach", "intermediate", 55),
+      beach("beginner", "Beginner Cove", "beginner", 48),
+    ]);
+
+    expect(result.map((item) => item.name)).toEqual([
+      "Beginner Cove",
+      "Intermediate Beach",
+      "Advanced Slab",
+      "Expert Reef",
+    ]);
+  });
+
+  it("uses score and rating only within the same landing skill tier", () => {
+    const result = sortLandingFeaturedBeaches([
+      beach("lower", "Lower Score Beginner", "beginner", 48, 4.8),
+      beach("higher", "Higher Score Beginner", "beginner", 65, 3.8),
+      beach("intermediate", "Intermediate Beach", "intermediate", 80, 4.9),
+    ]);
+
+    expect(result.map((item) => item.name)).toEqual([
+      "Higher Score Beginner",
+      "Lower Score Beginner",
+      "Intermediate Beach",
+    ]);
   });
 });

--- a/app/api/beaches/featured/route.ts
+++ b/app/api/beaches/featured/route.ts
@@ -6,7 +6,10 @@ import {
   methodNotAllowed,
 } from "@/lib/api-utils";
 import { withRateLimit } from "@/lib/middleware/api-wrappers";
-import { getFeaturedBeaches } from "@/lib/data/server/featured-beaches";
+import {
+  getFeaturedBeaches,
+  sortLandingFeaturedBeaches,
+} from "@/lib/data/server/featured-beaches";
 import { isValidLatitude, isValidLongitude } from "@/lib/coordinate-validation";
 import { getBatchFreshForecastsFromCache } from "@/lib/utils/forecast-service-utils";
 import { calculateDayScore } from "@/lib/utils/regional-forecast-utils";
@@ -23,7 +26,7 @@ import type { EnrichedBeach } from "@/lib/data/server/featured-beaches";
  * - First, get beaches with actual photos (from beach_photos table)
  * - Then, fill remaining slots with beaches that have fallback images in FALLBACK_IMAGE_BY_NAME
  * - Enrich with forecast data from cache (current conditions)
- * - Sort by score descending (best conditions first)
+ * - Sort for landing-page fit: real photos, beginner/intermediate skill, then score
  * - This ensures visual variety and no duplicate photos on the landing page
  *
  * Security:
@@ -85,19 +88,13 @@ async function featuredBeachesHandler(request: NextRequest) {
       };
     });
 
-    // Sort by score descending (nulls last)
-    enrichedBeaches.sort((a, b) => {
-      if (a.score == null && b.score == null) return 0;
-      if (a.score == null) return 1;
-      if (b.score == null) return -1;
-      return b.score - a.score;
-    });
+    const sortedBeaches = sortLandingFeaturedBeaches(enrichedBeaches);
 
     // Short cache for forecast-enriched data (2 minutes for personalized, 5 minutes otherwise)
     if (coordinates) {
-      return createSuccessResponse({ beaches: enrichedBeaches, isNearby });
+      return createSuccessResponse({ beaches: sortedBeaches, isNearby });
     }
-    return await createCachedResponse({ beaches: enrichedBeaches, isNearby }, CacheDuration.SHORT);
+    return await createCachedResponse({ beaches: sortedBeaches, isNearby }, CacheDuration.SHORT);
   } catch (error) {
     console.error("Error fetching featured beaches:", error);
     // Return empty array rather than error for graceful degradation

--- a/components/landing-page/ARCHITECTURE.md
+++ b/components/landing-page/ARCHITECTURE.md
@@ -78,7 +78,7 @@ export function AuthAwareLandingWrapper() {
 
 ### Launch-Week Header Behavior
 
-The unauthenticated `/` route intentionally omits the landing navbar during the iPhone pre-order campaign so the first viewport opens directly on the App Store launch video. Returning-user auto-login still records the `quiver_returning_user` flag in auth, but the launch landing page no longer forwards an `autoOpenLogin` prop or auto-opens the navbar auth modal.
+The unauthenticated `/` route renders the landing navbar in normal document flow above the App Store launch video. Returning-user auto-login still records the `quiver_returning_user` flag in auth, but the launch landing page no longer forwards an `autoOpenLogin` prop or auto-opens the navbar auth modal.
 
 **Architecture Decisions:**
 

--- a/components/landing-page/auth-aware-landing-wrapper.tsx
+++ b/components/landing-page/auth-aware-landing-wrapper.tsx
@@ -7,6 +7,7 @@ import dynamic from "next/dynamic";
 import { PerformanceUtils } from "@/lib/utils/performance-utils";
 import { hasSupabaseAuthCookie } from "@/lib/utils/supabase-cookie-utils";
 import { BODY_CLASSES, PERFORMANCE_TIMING } from "@/lib/constants/css-classes";
+import { Navbar } from "@/components/landing-page/navbar";
 import { HeroSection } from "@/components/landing-page/hero-section";
 import { LandingInteractiveSections } from "@/components/landing-page/landing-interactive-sections";
 import { OracleHomeSkeleton } from "@/components/oracle/oracle-home-skeleton";
@@ -134,6 +135,8 @@ export function AuthAwareLandingWrapper() {
   // but hidden via CSS (body.js-loaded) when this client version is available.
   return (
     <>
+      <Navbar position="static" />
+
       <main role="main">
         <HeroSection />
 

--- a/components/landing-page/navbar.tsx
+++ b/components/landing-page/navbar.tsx
@@ -64,7 +64,15 @@ const GROUPED_STATIC_ITEMS = STATIC_MENU_ITEMS.reduce(
   {} as Record<string, typeof STATIC_MENU_ITEMS>
 );
 
-export function Navbar({ autoOpenLogin = false }: { autoOpenLogin?: boolean }) {
+type NavbarPosition = "overlay" | "static";
+
+export function Navbar({
+  autoOpenLogin = false,
+  position = "overlay",
+}: {
+  autoOpenLogin?: boolean;
+  position?: NavbarPosition;
+}) {
   const [mounted, setMounted] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [authModalOpen, setAuthModalOpen] = useState(false);
@@ -118,7 +126,13 @@ export function Navbar({ autoOpenLogin = false }: { autoOpenLogin?: boolean }) {
   }, [regionName]);
 
   return (
-    <nav className="absolute top-0 left-0 right-0 z-50 w-full">
+    <nav
+      className={
+        position === "static"
+          ? "relative z-50 w-full bg-[#252D6B]"
+          : "absolute top-0 left-0 right-0 z-50 w-full"
+      }
+    >
       <div className="max-w-7xl mx-auto px-6">
         <div className="flex justify-between items-center py-5">
           {/* Logo */}

--- a/components/landing-page/surf-highlights-section.tsx
+++ b/components/landing-page/surf-highlights-section.tsx
@@ -24,6 +24,8 @@ interface Beach {
   wave_height?: string | number | null;
 }
 
+const LANDING_SCORE_BADGE_MINIMUM = 60;
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -93,7 +95,11 @@ export function SurfHighlightsSection() {
             averageRating: beach.average_rating ?? null,
             reviewCount: beach.review_count ?? null,
             skillLevel: beach.skill_level ?? null,
-            score: beach.score ?? null,
+            score:
+              typeof beach.score === "number" &&
+              beach.score >= LANDING_SCORE_BADGE_MINIMUM
+                ? beach.score
+                : null,
             waveHeight: beach.wave_height ?? null,
             delay: index,
           };

--- a/lib/data/server/featured-beaches.ts
+++ b/lib/data/server/featured-beaches.ts
@@ -211,6 +211,69 @@ function sortFeaturedBeaches(beaches: EnrichedBeach[]): EnrichedBeach[] {
   });
 }
 
+function getLandingSkillPriority(skillLevel?: string | null): number {
+  const normalized = (skillLevel ?? "").trim().toLowerCase();
+
+  if (normalized.includes("expert")) return 5;
+  if (
+    normalized.includes("beginner") ||
+    normalized.includes("longboard") ||
+    normalized.includes("easy") ||
+    normalized.includes("mellow") ||
+    normalized.includes("lower-intermediate")
+  ) {
+    return 0;
+  }
+  if (normalized.includes("intermediate") && normalized.includes("advanced")) {
+    return 2;
+  }
+  if (normalized.includes("intermediate")) return 1;
+  if (normalized.includes("advanced")) return 4;
+  return 3;
+}
+
+function compareNullableNumberDesc(
+  a: number | null | undefined,
+  b: number | null | undefined
+): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return b - a;
+}
+
+export function sortLandingFeaturedBeaches(
+  beaches: EnrichedBeach[]
+): EnrichedBeach[] {
+  return [...beaches].sort((a, b) => {
+    if (a.has_real_photo !== b.has_real_photo) {
+      return a.has_real_photo ? -1 : 1;
+    }
+
+    const skillDelta =
+      getLandingSkillPriority(a.skill_level) -
+      getLandingSkillPriority(b.skill_level);
+    if (skillDelta !== 0) return skillDelta;
+
+    const scoreDelta = compareNullableNumberDesc(a.score, b.score);
+    if (scoreDelta !== 0) return scoreDelta;
+
+    const ratingDelta = compareNullableNumberDesc(
+      a.average_rating,
+      b.average_rating
+    );
+    if (ratingDelta !== 0) return ratingDelta;
+
+    const reviewDelta = compareNullableNumberDesc(
+      a.review_count,
+      b.review_count
+    );
+    if (reviewDelta !== 0) return reviewDelta;
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
 /**
  * Builds the global featured beaches list (no proximity filtering).
  * Photos-first beaches, then fallback-image beaches, deduped and sorted.


### PR DESCRIPTION
## Summary
- Restores the landing page header above the launch video for unauthenticated visitors.
- Changes featured beach ranking to prefer beginner/intermediate-friendly spots before advanced/expert score-only winners.
- Hides low condition score badges in the landing carousel so mediocre scores do not read as recommendations.

## Verification
- `npx eslint --max-warnings=0 app/api/beaches/featured/route.ts lib/data/server/featured-beaches.ts components/landing-page/surf-highlights-section.tsx __tests__/lib/data/server/featured-beaches.test.ts __tests__/components/landing/auth-aware-landing-wrapper.signup-confirm.test.tsx components/landing-page/navbar.tsx components/landing-page/auth-aware-landing-wrapper.tsx` - passed
- `yarn test:unit --runInBand __tests__/lib/data/server/featured-beaches.test.ts __tests__/components/landing-page/surf-highlights-location-prompt.test.tsx __tests__/components/landing/auth-aware-landing-wrapper.signup-confirm.test.tsx __tests__/components/landing-page/navbar.search-navigation.test.tsx` - passed
- `yarn typecheck` - passed
- `VERCEL_ENV=preview yarn build` - passed

## Release Notes
- No DB migrations.
- No env changes.
