### PR TITLE
feat(forecast): add feedback capture bridge to prod

### DIFF
--- a/__tests__/app/api/forecast-feedback-route.test.ts
+++ b/__tests__/app/api/forecast-feedback-route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/forecast-feedback/route";
+
+const mockUser = { id: "user-1" };
+
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/api-utils");
+  return {
+    withAuth:
+      (
+        handler: (
+          request: NextRequest,
+          context: { user: typeof mockUser; supabase: Record<string, never> },
+        ) => Promise<Response>,
+      ) =>
+      (request: NextRequest) =>
+        handler(request, { user: mockUser, supabase: {} }),
+    createErrorResponse: actual.createErrorResponse,
+    createSuccessResponse: actual.createSuccessResponse,
+    createValidationError: actual.createValidationError,
+  };
+});
+
+const originalEnv = process.env;
+
+function basePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    beachId: "11111111-1111-4111-8111-111111111111",
+    forecastAt: "2026-05-24T14:00:00.000Z",
+    windowStart: "2026-05-24T14:00:00.000Z",
+    windowEnd: null,
+    issuedAt: "2026-05-24T10:00:00.000Z",
+    predictedAt: "2026-05-24T10:15:00.000Z",
+    forecastHorizonHours: 4,
+    feedbackKind: "forecast_accuracy",
+    feedbackValue: "too_low",
+    feedbackNote: "Saw waist-high waves.",
+    displayedContext: { wave_height_ft: "2-3 ft" },
+    sourceModelContext: { data_source: "NOAA_NWS" },
+    calibrationContext: { beach_is_calibrated: true },
+    surfCallContext: { verdict: "YES", score: 82 },
+    missingFlags: {},
+    auditMetadata: { surface: "forecast_tab" },
+    clientSource: "quiver-web",
+    clientVersion: "test-client",
+    correlationId: "corr-client",
+    requestId: "req-client",
+    ...overrides,
+  };
+}
+
+function requestWithBody(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/forecast-feedback", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/forecast-feedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      ML_INTERNAL_SECRET: "test-secret",
+      ML_SERVICE_URL: "https://ml.example.test/",
+      VERCEL_GIT_COMMIT_SHA: "git-sha",
+    };
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          id: "feedback-row-1",
+          contract_version: "forecast-feedback-context.v1",
+          correlation_id: "corr-client",
+        }),
+        { status: 200 },
+      ),
+    );
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("forwards authenticated web/native feedback to Seaside with the internal secret", async () => {
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      id: "feedback-row-1",
+      contractVersion: "forecast-feedback-context.v1",
+      correlationId: "corr-client",
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe(
+      "https://ml.example.test/internal/forecast-feedback",
+    );
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "X-Internal-Secret": "test-secret",
+    });
+
+    const forwarded = JSON.parse(String(init.body));
+    expect(forwarded).toMatchObject({
+      user_id: "user-1",
+      beach_id: "11111111-1111-4111-8111-111111111111",
+      forecast_at: "2026-05-24T14:00:00.000Z",
+      feedback_kind: "forecast_accuracy",
+      feedback_value: "too_low",
+      ingest_path: "quiver-api/forecast-feedback",
+      request_id: "req-client",
+      correlation_id: "corr-client",
+      client_source: "quiver-web",
+      client_version: "test-client",
+      schema_version: 1,
+      contract_version: "forecast-feedback-context.v1",
+    });
+    expect(forwarded.displayed_context.wave_height_ft).toBe("2-3 ft");
+    expect(forwarded.source_model_context.data_source).toBe("NOAA_NWS");
+  });
+
+  it("adds explicit missing flags for empty context groups before calling Seaside", async () => {
+    await POST(
+      requestWithBody(
+        basePayload({
+          surfCallContext: {},
+          missingFlags: {},
+        }),
+      ),
+    );
+
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    const forwarded = JSON.parse(String(init.body));
+    expect(forwarded.surf_call_context).toEqual({});
+    expect(forwarded.missing_flags.surf_call_context).toBe(true);
+  });
+
+  it("returns a configuration error without calling Seaside when the secret is missing", async () => {
+    delete process.env.ML_INTERNAL_SECRET;
+    delete process.env.INTERNAL_SECRET;
+
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Feedback service not configured");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("masks Seaside storage failures behind the bridge error contract", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          detail: { message: "permission denied", correlation_id: "corr-client" },
+        }),
+        { status: 500 },
+      ),
+    );
+
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe("Feedback storage failed");
+    expect(JSON.stringify(body)).not.toContain("permission denied");
+    expect(body.details).toEqual({
+      correlationId: "corr-client",
+      service: "seaside",
+      status: 500,
+    });
+  });
+});

--- a/app/api/forecast-feedback/route.ts
+++ b/app/api/forecast-feedback/route.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  createValidationError,
+  withAuth,
+  type AuthenticatedContext,
+} from "@/lib/middleware/api-wrappers";
+import {
+  ForecastFeedbackClientPayloadSchema,
+  buildSeasideForecastFeedbackPayload,
+} from "@/lib/services/forecast/forecast-feedback";
+
+export const dynamic = "force-dynamic";
+
+type SeasideFeedbackResponse = {
+  ok?: boolean;
+  id?: string | null;
+  contract_version?: string;
+  correlation_id?: string | null;
+};
+
+function normalizedEnv(name: string): string | null {
+  const value = process.env[name];
+  if (!value) return null;
+  const normalized = value.replace(/\\n/g, "").trim();
+  return normalized ? normalized : null;
+}
+
+function readMlServiceUrl(): string {
+  return (
+    normalizedEnv("ML_SERVICE_URL") ?? "https://quiver-ml.fly.dev"
+  ).replace(/\/+$/, "");
+}
+
+function readMlInternalSecret(): string | null {
+  return normalizedEnv("ML_INTERNAL_SECRET") ?? normalizedEnv("INTERNAL_SECRET");
+}
+
+async function parseJsonResponse(
+  response: Response,
+): Promise<SeasideFeedbackResponse | null> {
+  try {
+    return (await response.json()) as SeasideFeedbackResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function forecastFeedbackHandler(
+  request: NextRequest,
+  { user }: AuthenticatedContext,
+): Promise<NextResponse> {
+  const secret = readMlInternalSecret();
+  if (!secret) {
+    return createErrorResponse("Feedback service not configured", undefined, 500);
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return createValidationError("Invalid feedback payload", {
+      body: "Request body must be valid JSON",
+    });
+  }
+
+  const validation = ForecastFeedbackClientPayloadSchema.safeParse(rawBody);
+  if (!validation.success) {
+    return createValidationError(
+      "Invalid feedback payload",
+      validation.error.flatten(),
+    );
+  }
+
+  const correlationId = validation.data.correlationId ?? randomUUID();
+  const requestId = validation.data.requestId ?? randomUUID();
+  const payload = buildSeasideForecastFeedbackPayload(validation.data, {
+    userId: user.id,
+    ingestPath: "quiver-api/forecast-feedback",
+    requestId,
+    correlationId,
+    clientSource: "quiver-web",
+    clientVersion:
+      normalizedEnv("VERCEL_GIT_COMMIT_SHA") ??
+      normalizedEnv("NEXT_PUBLIC_VERCEL_ENV"),
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`${readMlServiceUrl()}/internal/forecast-feedback`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": secret,
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    });
+  } catch {
+    return createErrorResponse(
+      "Feedback storage failed",
+      { correlationId, service: "seaside", status: "network_error" },
+      502,
+    );
+  }
+
+  const responseBody = await parseJsonResponse(response);
+  if (!response.ok || responseBody?.ok !== true) {
+    return createErrorResponse(
+      "Feedback storage failed",
+      { correlationId, service: "seaside", status: response.status },
+      502,
+    );
+  }
+
+  return createSuccessResponse({
+    id: responseBody.id ?? null,
+    contractVersion: responseBody.contract_version ?? payload.contract_version,
+    correlationId: responseBody.correlation_id ?? correlationId,
+  });
+}
+
+export const POST = withAuth(forecastFeedbackHandler, {
+  errorMessage: "Failed to submit forecast feedback",
+});

--- a/components/beach-detail/tabs/forecast-tab.tsx
+++ b/components/beach-detail/tabs/forecast-tab.tsx
@@ -40,6 +40,7 @@ import { DataErrorBoundary } from "@/components/error-boundaries";
 import { TideStatusStrip } from "@/components/beach-detail/tide-status-strip";
 import { TideChartSection } from "@/components/beach-detail/tide-chart-section";
 import { useAuth } from "@/context/auth-context";
+import { ForecastFeedbackCapture } from "@/components/forecast/forecast-feedback-capture";
 
 const ConditionsOverview = dynamic(
   () =>
@@ -502,6 +503,20 @@ export function ForecastTab({
                 </div>
               </div>
             </section>
+          )}
+
+          {user && currentForecast && (
+            <ForecastFeedbackCapture
+              beach={beach}
+              forecast={currentForecast}
+              forecastMetadata={forecastMetadata}
+              surfCall={surfCall}
+              beachTimezone={beachTimezone}
+              isCalibrated={beachIsCalibrated}
+              isDisplayStaleForecast={isDisplayStaleForecast}
+              forecastTimeLabel={currentForecastTimeLabel}
+              freshnessLabel={freshnessLabel}
+            />
           )}
 
           {/* Yesterday's Accuracy */}

--- a/components/forecast/forecast-feedback-capture.tsx
+++ b/components/forecast/forecast-feedback-capture.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import { Check, Loader2, Send, TrendingDown, TrendingUp } from "lucide-react";
+import type { Beach } from "@/types/database";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+import type { BeachForecastMetadata } from "@/hooks/use-beach-detail-data";
+import { useTrackEvent } from "@/hooks/use-track-event";
+import type { ForecastFeedbackClientPayload } from "@/lib/services/forecast/forecast-feedback";
+
+type FeedbackValue = "too_low" | "about_right" | "too_high";
+
+interface ForecastFeedbackCaptureProps {
+  beach: Beach;
+  forecast: EnhancedForecastEntity;
+  forecastMetadata?: BeachForecastMetadata | null;
+  surfCall?: SurfCallResult | null;
+  beachTimezone?: string | null;
+  isCalibrated: boolean;
+  isDisplayStaleForecast: boolean;
+  forecastTimeLabel?: string | null;
+  freshnessLabel?: string | null;
+}
+
+const FEEDBACK_OPTIONS: Array<{
+  value: FeedbackValue;
+  label: string;
+  Icon: typeof TrendingDown;
+}> = [
+  { value: "too_low", label: "Too low", Icon: TrendingDown },
+  { value: "about_right", label: "Right", Icon: Check },
+  { value: "too_high", label: "Too high", Icon: TrendingUp },
+];
+
+function compactNote(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseDateMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function forecastHorizonHours(
+  forecastAt: string,
+  issuedAt: string | null | undefined,
+): number | null {
+  const forecastMs = parseDateMs(forecastAt);
+  const issuedMs = parseDateMs(issuedAt);
+  if (forecastMs == null || issuedMs == null) return null;
+  const hours = Math.round((forecastMs - issuedMs) / (1000 * 60 * 60));
+  return hours >= 0 && hours <= 168 ? hours : null;
+}
+
+function buildPayload(args: {
+  beach: Beach;
+  forecast: EnhancedForecastEntity;
+  forecastMetadata?: BeachForecastMetadata | null;
+  surfCall?: SurfCallResult | null;
+  beachTimezone?: string | null;
+  isCalibrated: boolean;
+  isDisplayStaleForecast: boolean;
+  forecastTimeLabel?: string | null;
+  freshnessLabel?: string | null;
+  feedbackValue: FeedbackValue;
+  feedbackNote: string | null;
+  routePathname: string | null;
+}): ForecastFeedbackClientPayload {
+  const { beach, forecast, surfCall, forecastMetadata } = args;
+  const sourceContext = {
+    data_source: forecast.data_source ?? null,
+    model_version: forecast.ml_model_version ?? null,
+    is_ml_calibrated: forecast.is_ml_calibrated ?? null,
+    open_meteo_fetched_at: forecast.om_fetched_at ?? null,
+    metadata_source: forecastMetadata?.dataSource ?? null,
+    metadata_cached: forecastMetadata?.cached ?? null,
+    metadata_stale: forecastMetadata?.stale ?? null,
+  };
+  const calibrationContext = {
+    beach_is_calibrated: args.isCalibrated,
+    displayed_height_kind: args.isCalibrated ? "face_height" : "forecast_height",
+    ml_corrected_height_ft: forecast.ml_corrected_height ?? null,
+    confidence_score: forecast.confidence_score ?? null,
+  };
+  const surfCallContext = surfCall
+    ? {
+        verdict: surfCall.verdict,
+        score: surfCall.score,
+        forecast_confidence: surfCall.forecastConfidence,
+        why_sentence: surfCall.whySentence,
+        best_window_start: surfCall.bestWindowStart,
+        best_window_end: surfCall.bestWindowEnd,
+        peak_time: surfCall.peakTime,
+        wave_height: surfCall.waveHeight,
+        wind_speed: surfCall.windSpeed,
+        tide_phase: surfCall.tidePhase,
+        rideable_waves_per_hour: surfCall.rideableWavesPerHour,
+      }
+    : {};
+
+  return {
+    beachId: beach.id,
+    forecastAt: forecast.forecast_at,
+    windowStart: surfCall?.bestWindowStart ?? forecast.forecast_at,
+    windowEnd: surfCall?.bestWindowEnd ?? null,
+    issuedAt: forecast.created_at ?? null,
+    predictedAt: forecast.updated_at ?? null,
+    forecastHorizonHours: forecastHorizonHours(
+      forecast.forecast_at,
+      forecast.created_at,
+    ),
+    feedbackKind: "forecast_accuracy",
+    feedbackValue: args.feedbackValue,
+    feedbackNote: args.feedbackNote,
+    displayedContext: {
+      wave_height_ft: forecast.ml_corrected_height ?? forecast.wave_height,
+      raw_wave_height_ft: forecast.wave_height,
+      wave_period_s: forecast.wave_period ?? forecast.swell_1_period ?? null,
+      wave_direction: forecast.wave_direction ?? forecast.swell_1_direction ?? null,
+      primary_swell_height_ft: forecast.swell_1_height ?? null,
+      primary_swell_period_s: forecast.swell_1_period ?? null,
+      primary_swell_direction: forecast.swell_1_direction ?? null,
+      wind_speed: forecast.wind_speed ?? null,
+      wind_direction: forecast.wind_direction ?? null,
+      tide_status: forecast.tide_status ?? null,
+      tide_height_ft: forecast.tide_height ?? null,
+      display_time_label: args.forecastTimeLabel ?? null,
+      display_stale: args.isDisplayStaleForecast,
+      freshness_label: args.freshnessLabel ?? null,
+    },
+    sourceModelContext: sourceContext,
+    calibrationContext,
+    surfCallContext,
+    missingFlags: surfCall ? {} : { surf_call_context: true },
+    auditMetadata: {
+      surface: "forecast_tab",
+      route: args.routePathname,
+      beach_name: beach.name,
+      beach_slug: beach.slug,
+      timezone: args.beachTimezone ?? null,
+    },
+    clientSource: "quiver-web",
+  };
+}
+
+export function ForecastFeedbackCapture({
+  beach,
+  forecast,
+  forecastMetadata,
+  surfCall,
+  beachTimezone,
+  isCalibrated,
+  isDisplayStaleForecast,
+  forecastTimeLabel,
+  freshnessLabel,
+}: ForecastFeedbackCaptureProps) {
+  const routePathname = usePathname();
+  const { track } = useTrackEvent();
+  const [selectedValue, setSelectedValue] = useState<FeedbackValue | null>(
+    null,
+  );
+  const [note, setNote] = useState("");
+  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const selectedLabel = useMemo(
+    () =>
+      FEEDBACK_OPTIONS.find((option) => option.value === selectedValue)?.label ??
+      null,
+    [selectedValue],
+  );
+
+  const handleSubmit = async () => {
+    if (!selectedValue || isSubmitting) return;
+    setIsSubmitting(true);
+    setStatus("idle");
+    const payload = buildPayload({
+      beach,
+      forecast,
+      forecastMetadata,
+      surfCall,
+      beachTimezone,
+      isCalibrated,
+      isDisplayStaleForecast,
+      forecastTimeLabel,
+      freshnessLabel,
+      feedbackValue: selectedValue,
+      feedbackNote: compactNote(note),
+      routePathname,
+    });
+
+    try {
+      const response = await fetch("/api/forecast-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || body?.success !== true) {
+        throw new Error("Feedback submit failed");
+      }
+      setStatus("success");
+      setNote("");
+      track("forecast_interaction", {
+        beachId: beach.id,
+        metadata: {
+          action: "view_details",
+          slot: `feedback_${selectedValue}`,
+        },
+      });
+    } catch {
+      setStatus("error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-[8px] border-2 border-[#11100D] bg-[#F8F0DF] p-4 shadow-[3px_3px_0_#11100D]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="font-heading text-base font-black uppercase text-[#11100D]">
+            Did this forecast feel right?
+          </h3>
+          <p className="mt-1 text-sm font-medium text-[#5F5646]">
+            {selectedLabel
+              ? `${selectedLabel} selected`
+              : `${beach.name} · ${forecastTimeLabel ?? "latest slot"}`}
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 sm:min-w-[320px]">
+          {FEEDBACK_OPTIONS.map(({ value, label, Icon }) => {
+            const active = value === selectedValue;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => {
+                  setSelectedValue(value);
+                  setStatus("idle");
+                }}
+                className={`flex min-h-11 items-center justify-center gap-2 rounded-[8px] border-2 px-2 py-2 text-xs font-black uppercase transition ${
+                  active
+                    ? "border-[#11100D] bg-[#11100D] text-[#F4EBD8]"
+                    : "border-[#11100D] bg-[#F4EBD8] text-[#11100D] hover:bg-[#EFE5CF]"
+                }`}
+                aria-pressed={active}
+              >
+                <Icon className="h-4 w-4 shrink-0" />
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {selectedValue && (
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+          <textarea
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            maxLength={1000}
+            rows={2}
+            className="min-h-12 flex-1 rounded-[8px] border-2 border-[#11100D] bg-[#F4EBD8] px-3 py-2 text-sm font-medium text-[#11100D] outline-none focus:ring-2 focus:ring-[#0B3A75]"
+            placeholder="Add a detail"
+          />
+          <button
+            type="button"
+            onClick={() => {
+              void handleSubmit();
+            }}
+            disabled={isSubmitting}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-[8px] border-2 border-[#11100D] bg-[#F78E42] px-4 py-2 font-heading text-sm font-black uppercase text-[#11100D] shadow-[2px_2px_0_#11100D] transition hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[1px_1px_0_#11100D] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isSubmitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+            <span>Send</span>
+          </button>
+        </div>
+      )}
+
+      {status === "success" && (
+        <p className="mt-2 text-sm font-bold text-[#0B7A4B]">
+          Feedback saved.
+        </p>
+      )}
+      {status === "error" && (
+        <p className="mt-2 text-sm font-bold text-[#B42318]">
+          Feedback could not be saved.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/lib/services/forecast/forecast-feedback.ts
+++ b/lib/services/forecast/forecast-feedback.ts
@@ -1,0 +1,170 @@
+import { z } from "zod";
+
+export const FORECAST_FEEDBACK_CONTRACT_VERSION =
+  "forecast-feedback-context.v1";
+export const FORECAST_FEEDBACK_SCHEMA_VERSION = 1;
+
+const contextRecordSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .default({});
+
+const optionalContextRecordSchema = z
+  .record(z.string(), z.unknown())
+  .nullable()
+  .optional();
+
+const dateTimeSchema = z
+  .string()
+  .min(1)
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "Must be a parseable datetime",
+  });
+
+const optionalDateTimeSchema = z
+  .string()
+  .min(1)
+  .nullable()
+  .optional()
+  .refine((value) => value == null || !Number.isNaN(Date.parse(value)), {
+    message: "Must be a parseable datetime",
+  });
+
+export const ForecastFeedbackClientPayloadSchema = z.object({
+  beachId: z.string().min(1),
+  forecastAt: dateTimeSchema,
+  windowStart: optionalDateTimeSchema,
+  windowEnd: optionalDateTimeSchema,
+  issuedAt: optionalDateTimeSchema,
+  predictedAt: optionalDateTimeSchema,
+  forecastHorizonHours: z.number().int().min(0).max(168).nullable().optional(),
+  feedbackKind: z.enum([
+    "forecast_accuracy",
+    "surf_call",
+    "condition_report",
+    "other",
+  ]),
+  feedbackValue: z.string().min(1).max(120),
+  feedbackNote: z.string().max(1000).nullable().optional(),
+  displayedContext: contextRecordSchema,
+  sourceModelContext: contextRecordSchema,
+  calibrationContext: contextRecordSchema,
+  surfCallContext: contextRecordSchema,
+  missingFlags: contextRecordSchema,
+  auditMetadata: contextRecordSchema,
+  clientSource: z.string().min(1).max(80).nullable().optional(),
+  clientVersion: z.string().max(120).nullable().optional(),
+  sessionId: z.string().max(120).nullable().optional(),
+  anonymousClientId: z.string().max(120).nullable().optional(),
+  correlationId: z.string().max(120).nullable().optional(),
+  requestId: z.string().max(120).nullable().optional(),
+  extraContext: optionalContextRecordSchema,
+});
+
+export type ForecastFeedbackClientPayload = z.infer<
+  typeof ForecastFeedbackClientPayloadSchema
+>;
+
+export interface SeasideForecastFeedbackPayload {
+  user_id: string | null;
+  session_id: string | null;
+  anonymous_client_id: string | null;
+  beach_id: string;
+  forecast_at: string;
+  window_start: string | null;
+  window_end: string | null;
+  issued_at: string | null;
+  predicted_at: string | null;
+  forecast_horizon_hours: number | null;
+  feedback_kind: ForecastFeedbackClientPayload["feedbackKind"];
+  feedback_value: string;
+  feedback_note: string | null;
+  displayed_context: Record<string, unknown>;
+  source_model_context: Record<string, unknown>;
+  calibration_context: Record<string, unknown>;
+  surf_call_context: Record<string, unknown>;
+  missing_flags: Record<string, unknown>;
+  audit_metadata: Record<string, unknown>;
+  client_source: string;
+  client_version: string | null;
+  schema_version: number;
+  contract_version: string;
+  ingest_path: string;
+  request_id: string | null;
+  correlation_id: string | null;
+}
+
+interface BuildSeasidePayloadOptions {
+  userId: string | null;
+  ingestPath: string;
+  requestId: string;
+  correlationId: string;
+  clientSource: string;
+  clientVersion?: string | null;
+}
+
+function optionalString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function hasContext(value: Record<string, unknown>): boolean {
+  return Object.keys(value).length > 0;
+}
+
+export function buildSeasideForecastFeedbackPayload(
+  input: ForecastFeedbackClientPayload,
+  options: BuildSeasidePayloadOptions,
+): SeasideForecastFeedbackPayload {
+  const displayedContext = input.displayedContext ?? {};
+  const sourceModelContext = input.sourceModelContext ?? {};
+  const calibrationContext = input.calibrationContext ?? {};
+  const surfCallContext = input.surfCallContext ?? {};
+  const missingFlags: Record<string, unknown> = {
+    ...(input.missingFlags ?? {}),
+  };
+
+  if (!hasContext(displayedContext)) missingFlags.displayed_context = true;
+  if (!hasContext(sourceModelContext)) missingFlags.source_model_context = true;
+  if (!hasContext(calibrationContext)) missingFlags.calibration_context = true;
+  if (!hasContext(surfCallContext)) missingFlags.surf_call_context = true;
+
+  const clientSource =
+    optionalString(input.clientSource) ?? options.clientSource;
+  const clientVersion =
+    optionalString(input.clientVersion) ??
+    optionalString(options.clientVersion) ??
+    null;
+
+  return {
+    user_id: options.userId,
+    session_id: optionalString(input.sessionId),
+    anonymous_client_id: optionalString(input.anonymousClientId),
+    beach_id: input.beachId,
+    forecast_at: input.forecastAt,
+    window_start: input.windowStart ?? null,
+    window_end: input.windowEnd ?? null,
+    issued_at: input.issuedAt ?? null,
+    predicted_at: input.predictedAt ?? null,
+    forecast_horizon_hours: input.forecastHorizonHours ?? null,
+    feedback_kind: input.feedbackKind,
+    feedback_value: input.feedbackValue,
+    feedback_note: optionalString(input.feedbackNote),
+    displayed_context: displayedContext,
+    source_model_context: sourceModelContext,
+    calibration_context: calibrationContext,
+    surf_call_context: surfCallContext,
+    missing_flags: missingFlags,
+    audit_metadata: {
+      ...(input.auditMetadata ?? {}),
+      ...(input.extraContext ? { extra_context: input.extraContext } : {}),
+    },
+    client_source: clientSource,
+    client_version: clientVersion,
+    schema_version: FORECAST_FEEDBACK_SCHEMA_VERSION,
+    contract_version: FORECAST_FEEDBACK_CONTRACT_VERSION,
+    ingest_path: options.ingestPath,
+    request_id: optionalString(input.requestId) ?? options.requestId,
+    correlation_id: optionalString(input.correlationId) ?? options.correlationId,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the authenticated /api/forecast-feedback bridge for web and native clients.
- Renders forecast feedback capture on the beach forecast tab.
- Keeps the prod release scoped to forecast feedback files only.

## Verification
- PASS: yarn typecheck
- PASS: yarn test:unit __tests__/app/api/forecast-feedback-route.test.ts --runInBand
- PASS: npx eslint --max-warnings=0 app/api/forecast-feedback/route.ts components/beach-detail/tabs/forecast-tab.tsx components/forecast/forecast-feedback-capture.tsx lib/services/forecast/forecast-feedback.ts __tests__/app/api/forecast-feedback-route.test.ts
- PASS: VERCEL_ENV=production yarn build

## Release notes
- Production DB migration and Seaside service endpoint were already applied/wired before this web release.
- Direct push to prod is blocked by repository rules, so this PR targets prod.