### PR TITLE
fix(forecast): sample NOAA intervals and terrain model access

### DIFF
--- a/__tests__/lib/services/noaa-wavewatch/data-processors-partitions.test.ts
+++ b/__tests__/lib/services/noaa-wavewatch/data-processors-partitions.test.ts
@@ -34,10 +34,29 @@ function series(values: number[], uom = 'wmoUnit:m'): NOAAValueSeries {
   };
 }
 
+function intervalSeries(
+  values: Array<{ validTime: string; value: number | null }>,
+  uom = 'wmoUnit:m',
+): NOAAValueSeries {
+  return {
+    uom,
+    values,
+  };
+}
+
 const LAT = 33.2;
 const LON = -117.4;
 
 describe('processNOAAGridData — real partition parsing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-21T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('parses primary + secondary partitions when NOAA returns real values', () => {
     const gridData: NOAAGridData = {
       properties: {
@@ -345,6 +364,125 @@ describe('processNOAAGridData — real partition parsing', () => {
     expect(result[0].swell_2_height).not.toBe(0.8); // 2.0 * 0.4
     expect(result[0].swell_2_period).not.toBe(15.4); // 14 * 1.1
     expect(result[0].swell_2_height).toBe(0);
+  });
+
+  it('expands sparse NOAA intervals into every covered 3-hour slot', () => {
+    const gridData: NOAAGridData = {
+      properties: {
+        waveHeight: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/PT13H', value: 0.91 },
+          { validTime: '2026-05-28T00:00:00+00:00/PT6H', value: 0.8 },
+        ]),
+        wavePeriod: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/P1DT19H', value: 8 },
+        ]),
+        primarySwellHeight: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/PT19H', value: 0.61 },
+        ]),
+        primarySwellDirection: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/PT19H', value: 250 },
+        ]),
+        secondarySwellHeight: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/P1DT19H', value: 0.58 },
+        ]),
+        secondarySwellDirection: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/P1DT19H', value: 201 },
+        ]),
+        wavePeriod2: intervalSeries([
+          { validTime: '2026-05-27T11:00:00+00:00/P1DT19H', value: 12 },
+        ]),
+      },
+    };
+
+    const result = processNOAAGridData(
+      gridData,
+      1,
+      LAT,
+      LON,
+      { baseTime: new Date('2026-05-27T12:00:00Z') },
+    );
+
+    expect(result.map((slot) => slot.timestamp)).toEqual([
+      '2026-05-27T12:00:00Z',
+      '2026-05-27T15:00:00Z',
+      '2026-05-27T18:00:00Z',
+      '2026-05-27T21:00:00Z',
+      '2026-05-28T00:00:00Z',
+      '2026-05-28T03:00:00Z',
+    ]);
+
+    expect(result[0].significant_wave_height).toBeCloseTo(0.91, 2);
+    expect(result[0].swell_1_period).toBe(12);
+    expect(result[0].swell_1_direction).toBe(201);
+    expect(result[0].swell_1_height).toBeCloseTo(0.58, 2);
+    expect(result[0].swell_2_period).toBe(8);
+    expect(result[0].swell_2_direction).toBe(250);
+  });
+
+  it('stops emitting NOAA slots when waveHeight interval coverage ends', () => {
+    const gridData: NOAAGridData = {
+      properties: {
+        waveHeight: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/PT6H', value: 0.91 },
+        ]),
+        wavePeriod: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/P1DT', value: 12 },
+        ]),
+        primarySwellHeight: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/P1DT', value: 0.58 },
+        ]),
+        primarySwellDirection: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/P1DT', value: 201 },
+        ]),
+      },
+    };
+
+    const result = processNOAAGridData(
+      gridData,
+      1,
+      LAT,
+      LON,
+      { baseTime: new Date('2026-05-27T12:00:00Z') },
+    );
+
+    expect(result.map((slot) => slot.timestamp)).toEqual([
+      '2026-05-27T12:00:00Z',
+      '2026-05-27T15:00:00Z',
+    ]);
+    expect(result.every((slot) => slot.data_source === 'NOAA_NWS')).toBe(true);
+  });
+
+  it('skips covered intervals whose waveHeight value is null', () => {
+    const gridData: NOAAGridData = {
+      properties: {
+        waveHeight: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/PT3H', value: null },
+          { validTime: '2026-05-27T15:00:00+00:00/PT3H', value: 0.91 },
+        ]),
+        wavePeriod: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/PT6H', value: 12 },
+        ]),
+        primarySwellHeight: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/PT6H', value: 0.58 },
+        ]),
+        primarySwellDirection: intervalSeries([
+          { validTime: '2026-05-27T12:00:00+00:00/PT6H', value: 201 },
+        ]),
+      },
+    };
+
+    const result = processNOAAGridData(
+      gridData,
+      1,
+      LAT,
+      LON,
+      { baseTime: new Date('2026-05-27T12:00:00Z') },
+    );
+
+    expect(result.map((slot) => slot.timestamp)).toEqual([
+      '2026-05-27T15:00:00Z',
+    ]);
+    expect(result[0].significant_wave_height).toBeCloseTo(0.91, 2);
   });
 });
 

--- a/__tests__/lib/services/noaa-wavewatch/wave-analysis.test.ts
+++ b/__tests__/lib/services/noaa-wavewatch/wave-analysis.test.ts
@@ -1,0 +1,84 @@
+import {
+  getValueAtTime,
+  parseNOAAValidTime,
+} from '@/lib/services/noaa-wavewatch/wave-analysis';
+import type { NOAAValueSeries } from '@/lib/services/noaa-wavewatch/types';
+
+describe('NOAA WaveWatch interval utilities', () => {
+  it('parses hour and day-hour validTime intervals', () => {
+    expect(parseNOAAValidTime('2026-05-27T11:00:00+00:00/PT3H')).toEqual({
+      startMs: Date.parse('2026-05-27T11:00:00+00:00'),
+      endMs: Date.parse('2026-05-27T14:00:00+00:00'),
+    });
+
+    expect(parseNOAAValidTime('2026-05-27T11:00:00+00:00/PT13H')).toEqual({
+      startMs: Date.parse('2026-05-27T11:00:00+00:00'),
+      endMs: Date.parse('2026-05-28T00:00:00+00:00'),
+    });
+
+    expect(parseNOAAValidTime('2026-05-27T11:00:00+00:00/P1DT19H')).toEqual({
+      startMs: Date.parse('2026-05-27T11:00:00+00:00'),
+      endMs: Date.parse('2026-05-29T06:00:00+00:00'),
+    });
+
+    expect(parseNOAAValidTime('2026-05-27T20:00:00+00:00/P7DT4H')).toEqual({
+      startMs: Date.parse('2026-05-27T20:00:00+00:00'),
+      endMs: Date.parse('2026-06-04T00:00:00+00:00'),
+    });
+  });
+
+  it('returns null for invalid intervals', () => {
+    expect(parseNOAAValidTime('')).toBeNull();
+    expect(parseNOAAValidTime('not-an-interval')).toBeNull();
+    expect(parseNOAAValidTime('2026-05-27T11:00:00+00:00')).toBeNull();
+    expect(parseNOAAValidTime('2026-05-27T11:00:00+00:00/P1M')).toBeNull();
+  });
+
+  it('samples values by interval coverage with an end-exclusive boundary', () => {
+    const series: NOAAValueSeries = {
+      uom: 'wmoUnit:m',
+      values: [
+        {
+          validTime: '2026-05-27T11:00:00+00:00/PT13H',
+          value: 1.5,
+        },
+        {
+          validTime: '2026-05-28T00:00:00+00:00/PT6H',
+          value: 0.9,
+        },
+      ],
+    };
+
+    expect(getValueAtTime(series, Date.parse('2026-05-27T12:00:00Z'))).toBe(1.5);
+    expect(getValueAtTime(series, Date.parse('2026-05-27T23:59:59Z'))).toBe(1.5);
+    expect(getValueAtTime(series, Date.parse('2026-05-28T00:00:00Z'))).toBe(0.9);
+    expect(getValueAtTime(series, Date.parse('2026-05-28T06:00:00Z'))).toBeNull();
+  });
+
+  it('returns null when no interval covers the target time', () => {
+    const series: NOAAValueSeries = {
+      values: [
+        {
+          validTime: '2026-05-27T11:00:00+00:00/PT3H',
+          value: 1.5,
+        },
+      ],
+    };
+
+    expect(getValueAtTime(series, Date.parse('2026-05-27T14:00:00Z'))).toBeNull();
+    expect(getValueAtTime(undefined, Date.parse('2026-05-27T12:00:00Z'))).toBeNull();
+  });
+
+  it('returns null when the covering interval has a null value', () => {
+    const series: NOAAValueSeries = {
+      values: [
+        {
+          validTime: '2026-05-27T11:00:00+00:00/PT3H',
+          value: null,
+        },
+      ],
+    };
+
+    expect(getValueAtTime(series, Date.parse('2026-05-27T12:00:00Z'))).toBeNull();
+  });
+});

--- a/__tests__/lib/utils/wave-height-transformer.test.ts
+++ b/__tests__/lib/utils/wave-height-transformer.test.ts
@@ -4,6 +4,7 @@ import {
   transformToFaceHeightRange,
   transformToFaceHeightDecomposed,
   alignmentFactor,
+  componentAccessFactor,
   calculatePeriodFactor,
   calculateDirectionFactor,
   getTransformationFactors,
@@ -1108,6 +1109,39 @@ describe('Wave Height Transformer', () => {
         6,
       );
     });
+
+    it('uses terrain access for model components when available', () => {
+      const accessFactors = createAccessArray(0);
+      accessFactors[40] = 0.21171; // 200° / 201° bin
+      const beach: BeachTerrainConfig = {
+        terrain_enabled: true,
+        swell_access_factors: accessFactors,
+        swell_window_center_deg: 273,
+        swell_window_halfwidth_deg: 78,
+      };
+
+      const strictWindow = alignmentFactor(201, 12, 273, 78);
+      const modelAccess = componentAccessFactor(201, 12, beach, 'model_swell');
+      const modelHsAccess = componentAccessFactor(201, 12, beach, 'model_hs');
+      const cdipAccess = componentAccessFactor(201, 12, beach, 'cdip_sig');
+      const cdipSwellAccess = componentAccessFactor(201, 12, beach, 'cdip_swell');
+      const noTerrainModelAccess = componentAccessFactor(
+        201,
+        12,
+        { ...beach, swell_access_factors: null },
+        'model_swell',
+      );
+
+      expect(strictWindow).toBeLessThan(0.02);
+      expect(modelAccess).toBeCloseTo(
+        DIRECTION_FACTOR_MIN + Math.sqrt(0.21171) * DIRECTION_FACTOR_RANGE,
+        5,
+      );
+      expect(modelHsAccess).toBeCloseTo(modelAccess, 6);
+      expect(cdipAccess).toBeCloseTo(strictWindow, 6);
+      expect(cdipSwellAccess).toBeCloseTo(strictWindow, 6);
+      expect(noTerrainModelAccess).toBeCloseTo(strictWindow, 6);
+    });
   });
 
   describe('transformToFaceHeightDecomposed', () => {
@@ -1150,6 +1184,18 @@ describe('Wave Height Transformer', () => {
       shoaling_factors: BLACKS_FACTORS,
       swell_window_center_deg: 275,
       swell_window_halfwidth_deg: 80,
+    };
+
+    const createDirectionalAccess = (
+      entries: Array<{ directionDeg: number; access: number }>,
+      defaultAccess = 0,
+    ): number[] => {
+      const access = createAccessArray(defaultAccess);
+      for (const entry of entries) {
+        const bin = Math.round(entry.directionDeg / 5) % TERRAIN_BINS;
+        access[bin] = entry.access;
+      }
+      return access;
     };
 
     it('Tourmaline 2026-04-09 scenario — short-period W wind-swell is zeroed', () => {
@@ -1670,6 +1716,106 @@ describe('Wave Height Transformer', () => {
       expect(result.path).toBe('legacy');
       expect(result.faceHeightFt).toBeGreaterThan(0);
       expect(result.faceHeightFt).toBeLessThanOrEqual(2.5);
+    });
+
+    it('La Jolla Shores model SSW fixture stays in the NOAA/Surfline 2ft+ neighborhood', () => {
+      const laJollaShores: BeachTerrainConfig = {
+        terrain_enabled: true,
+        swell_access_factors: createDirectionalAccess([
+          { directionDeg: 200, access: 0.21171 },
+        ]),
+        shoaling_factors: {
+          version: 1,
+          type: 'period_lookup',
+          buckets: [
+            { tp_min_s: 0, tp_max_s: 8, factor: 1.18 },
+            { tp_min_s: 8, tp_max_s: 12, factor: 1.19 },
+            { tp_min_s: 12, tp_max_s: 16, factor: 1.42 },
+            { tp_min_s: 16, tp_max_s: 999, factor: 1.46 },
+          ],
+        },
+        swell_window_center_deg: 273,
+        swell_window_halfwidth_deg: 78,
+        deepwater_decay_factor: 1.15,
+      };
+
+      const result = transformToFaceHeightDecomposed({
+        components: [
+          { heightFt: 1.9, periodS: 12, directionDeg: 201 },
+          null,
+          null,
+        ],
+        beach: laJollaShores,
+        source: 'model_swell',
+        rawHeightFt: 1.9,
+        periodS: 12,
+        swellDirectionDeg: 201,
+      });
+
+      expect(result.path).toBe('decomposed');
+      expect(result.faceHeightFt).toBeGreaterThanOrEqual(2.0);
+      expect(result.faceHeightFt).toBeLessThanOrEqual(2.5);
+    });
+
+    it('Waikiki Beach terrain model fixture is bounded and nonzero', () => {
+      const waikikiBeach: BeachTerrainConfig = {
+        terrain_enabled: true,
+        swell_access_factors: createDirectionalAccess([
+          { directionDeg: 200, access: 1 },
+        ]),
+        shoaling_factors: null,
+        swell_window_center_deg: 195,
+        swell_window_halfwidth_deg: 105,
+        deepwater_decay_factor: 1,
+      };
+
+      const result = transformToFaceHeightDecomposed({
+        components: [
+          { heightFt: 2.0, periodS: 13, directionDeg: 200 },
+          null,
+          null,
+        ],
+        beach: waikikiBeach,
+        source: 'model_swell',
+        rawHeightFt: 2.0,
+        periodS: 13,
+        swellDirectionDeg: 200,
+      });
+
+      expect(result.path).toBe('decomposed');
+      expect(result.faceHeightFt).toBeGreaterThan(0.5);
+      expect(result.faceHeightFt).toBeLessThanOrEqual(2.5);
+    });
+
+    it('Malibu First Point terrain model fixture stays bounded and does not overcall', () => {
+      const malibuFirstPoint: BeachTerrainConfig = {
+        terrain_enabled: true,
+        swell_access_factors: createDirectionalAccess([
+          { directionDeg: 200, access: 0.575489 },
+          { directionDeg: 290, access: 0.847961 },
+        ]),
+        shoaling_factors: null,
+        swell_window_center_deg: 175,
+        swell_window_halfwidth_deg: 130,
+        deepwater_decay_factor: 0.6,
+      };
+
+      const result = transformToFaceHeightDecomposed({
+        components: [
+          { heightFt: 3.0, periodS: 8, directionDeg: 290 },
+          { heightFt: 2.0, periodS: 14, directionDeg: 200 },
+          null,
+        ],
+        beach: malibuFirstPoint,
+        source: 'model_swell',
+        rawHeightFt: 3.0,
+        periodS: 14,
+        swellDirectionDeg: 200,
+      });
+
+      expect(result.path).toBe('decomposed');
+      expect(result.faceHeightFt).toBeGreaterThan(0.5);
+      expect(result.faceHeightFt).toBeLessThanOrEqual(2.0);
     });
   });
 });

--- a/lib/services/noaa-wavewatch/data-processors.ts
+++ b/lib/services/noaa-wavewatch/data-processors.ts
@@ -9,10 +9,9 @@
 import { createContextLogger } from "@/lib/logger";
 import { FORECAST_CONFIG } from "./constants";
 import {
-  getBaseWaveHeight,
   getPrevailingWaveDirection,
-  getTimestampForIndex,
-  getValueAtIndex,
+  getTimestampForForecastSlot,
+  getValueAtTime,
 } from "./wave-analysis";
 import type {
   NOAAGridData,
@@ -22,6 +21,10 @@ import type {
 } from "./types";
 
 const log = createContextLogger("NOAAWaveWatch:DataProcessors");
+
+export interface ProcessNOAAGridDataOptions {
+  baseTime?: Date;
+}
 
 /** Return a finite number or null — guards against undefined/NaN in OM payloads. */
 function numberOrNull(value: number | null | undefined): number | null {
@@ -38,56 +41,53 @@ function numberOrNull(value: number | null | undefined): number | null {
  * @param days - Number of forecast days
  * @param latitude - Latitude of forecast location
  * @param longitude - Longitude of forecast location
+ * @param options - Optional processing controls for deterministic tests
  * @returns Array of processed wave forecast data
  */
 export function processNOAAGridData(
   gridData: NOAAGridData,
   days: number,
   latitude: number,
-  longitude: number
+  longitude: number,
+  options: ProcessNOAAGridDataOptions = {}
 ): WaveWatchData[] {
   const forecasts: WaveWatchData[] = [];
   const props = gridData.properties;
 
-  // Get the minimum number of available forecasts across all parameters
   const waveHeightCount = props.waveHeight?.values.length ?? 0;
   const wavePeriodCount = props.wavePeriod?.values.length ?? 0;
   const waveDirectionCount = props.waveDirection?.values.length ?? 0;
 
-  // Cap to waveHeightCount — wave height is the primary signal.
-  // Direction/period arrays are often longer (10 days vs 3 days of heights),
-  // and padding beyond real height data produces fabricated constant defaults.
   if (waveHeightCount < Math.max(wavePeriodCount, waveDirectionCount)) {
     log.info(
-      `NOAA array mismatch: waveHeight=${waveHeightCount}, wavePeriod=${wavePeriodCount}, waveDirection=${waveDirectionCount} — capping to ${waveHeightCount}`
+      `NOAA interval count mismatch: waveHeight=${waveHeightCount}, wavePeriod=${wavePeriodCount}, waveDirection=${waveDirectionCount} — sampling by validTime coverage`
     );
   }
 
-  const maxForecasts = Math.min(
-    days * FORECAST_CONFIG.FORECASTS_PER_DAY,
-    waveHeightCount
-  );
+  const maxForecasts = days * FORECAST_CONFIG.FORECASTS_PER_DAY;
+  const baseTime = options.baseTime ?? new Date();
 
   log.debug(`Processing ${maxForecasts} NOAA grid forecasts`);
 
   for (let i = 0; i < maxForecasts; i++) {
-    const timestamp = getTimestampForIndex(i);
+    const timestamp = getTimestampForForecastSlot(i, baseTime);
+    const targetMs = Date.parse(timestamp);
 
     // Extract wave height (convert from feet to meters if needed)
-    const waveHeight = getValueAtIndex(props.waveHeight?.values, i);
-    const significantWaveHeight = waveHeight
-      ? props.waveHeight?.uom === "wmoUnit:ft"
-        ? waveHeight * 0.3048
-        : waveHeight
-      : getBaseWaveHeight(latitude, longitude);
+    const waveHeight = getValueAtTime(props.waveHeight, targetMs);
+    if (waveHeight === null) {
+      continue;
+    }
+    const significantWaveHeight =
+      props.waveHeight?.uom === "wmoUnit:ft" ? waveHeight * 0.3048 : waveHeight;
 
     // Extract wave period
-    const wavePeriod = getValueAtIndex(props.wavePeriod?.values, i);
+    const wavePeriod = getValueAtTime(props.wavePeriod, targetMs);
     const peakWavePeriod =
       wavePeriod ?? Math.max(4, 6 + significantWaveHeight * 1.5);
 
     // Extract wave direction
-    const waveDirection = getValueAtIndex(props.waveDirection?.values, i);
+    const waveDirection = getValueAtTime(props.waveDirection, targetMs);
     const peakWaveDirection =
       waveDirection ?? getPrevailingWaveDirection(latitude, longitude);
 
@@ -96,31 +96,31 @@ export function processNOAAGridData(
     // `primarySwellHeight` / `primarySwellDirection`). Fall back to the
     // generic `swellHeight` / `swellDirection` / `swellPeriod` fields for
     // coastal-land grids that don't carry partitioned values.
-    const primarySwellHeight = getValueAtIndex(
-      props.primarySwellHeight?.values,
-      i
+    const primarySwellHeight = getValueAtTime(
+      props.primarySwellHeight,
+      targetMs
     );
-    const primarySwellDirection = getValueAtIndex(
-      props.primarySwellDirection?.values,
-      i
+    const primarySwellDirection = getValueAtTime(
+      props.primarySwellDirection,
+      targetMs
     );
-    const swellHeight = getValueAtIndex(props.swellHeight?.values, i);
-    const swellPeriod = getValueAtIndex(props.swellPeriod?.values, i);
-    const swellDirection = getValueAtIndex(props.swellDirection?.values, i);
+    const swellHeight = getValueAtTime(props.swellHeight, targetMs);
+    const swellPeriod = getValueAtTime(props.swellPeriod, targetMs);
+    const swellDirection = getValueAtTime(props.swellDirection, targetMs);
 
     // Secondary partition raw values — NOAA returns 0 (not null) for absent
     // partitions in some cases; we normalize to `0` sentinel so downstream
     // `swell_2_height > 0 && swell_2_period > 0` guards treat them as
     // "no second swell train."
-    const secondarySwellHeightRaw = getValueAtIndex(
-      props.secondarySwellHeight?.values,
-      i
+    const secondarySwellHeightRaw = getValueAtTime(
+      props.secondarySwellHeight,
+      targetMs
     );
-    const secondarySwellDirectionRaw = getValueAtIndex(
-      props.secondarySwellDirection?.values,
-      i
+    const secondarySwellDirectionRaw = getValueAtTime(
+      props.secondarySwellDirection,
+      targetMs
     );
-    const wavePeriod2Raw = getValueAtIndex(props.wavePeriod2?.values, i);
+    const wavePeriod2Raw = getValueAtTime(props.wavePeriod2, targetMs);
     const hasSecondary =
       secondarySwellHeightRaw !== null && secondarySwellHeightRaw > 0;
 

--- a/lib/services/noaa-wavewatch/index.ts
+++ b/lib/services/noaa-wavewatch/index.ts
@@ -41,7 +41,10 @@ export {
   getPrevailingWaveDirection,
   hasValidWaveData,
   getValueAtIndex,
+  getValueAtTime,
   getTimestampForIndex,
+  getTimestampForForecastSlot,
+  parseNOAAValidTime,
 } from "./wave-analysis";
 
 export { generateFallbackData } from "./fallback-generator";

--- a/lib/services/noaa-wavewatch/types.ts
+++ b/lib/services/noaa-wavewatch/types.ts
@@ -29,7 +29,7 @@ export interface NOAAValueSeries {
   uom?: string;
   values: Array<{
     validTime: string;
-    value: number;
+    value: number | null;
   }>;
 }
 

--- a/lib/services/noaa-wavewatch/wave-analysis.ts
+++ b/lib/services/noaa-wavewatch/wave-analysis.ts
@@ -10,8 +10,14 @@
 import { createContextLogger } from "@/lib/logger";
 import { WAVE_REGIONS, SEASONAL_FACTORS, COMPASS_DIRECTIONS, UNIT_CONVERSIONS } from "./constants";
 import { METERS_TO_FEET, FEET_TO_METERS } from "@/lib/utils/unit-conversions";
+import type { NOAAValueSeries } from "./types";
 
 const log = createContextLogger("NOAAWaveWatch:WaveAnalysis");
+
+export interface NOAAValidTimeInterval {
+  startMs: number;
+  endMs: number;
+}
 
 /**
  * Get base wave height for a geographic location
@@ -184,6 +190,87 @@ export function getTimestampForIndex(index: number): string {
 }
 
 /**
+ * Get a normalized UTC 3-hour forecast slot timestamp.
+ *
+ * NOAA gridpoint fields are interval-valued, so processors should generate
+ * fixed 00/03/06/... UTC slots and sample each field by interval coverage.
+ */
+export function getTimestampForForecastSlot(
+  index: number,
+  baseTime: Date = new Date()
+): string {
+  const slot = Number.isFinite(baseTime.getTime()) ? new Date(baseTime) : new Date();
+  const baseHour = Math.floor(slot.getUTCHours() / 3) * 3;
+  slot.setUTCHours(baseHour + index * 3, 0, 0, 0);
+  return slot.toISOString().replace(".000Z", "Z");
+}
+
+/**
+ * Parse a NOAA NWS gridpoint validTime interval.
+ *
+ * Supports the ISO-8601 duration forms NOAA uses for wave fields, including
+ * PT3H, PT13H, P1DT19H, and P7DT4H. Month/year durations are intentionally
+ * rejected because their millisecond length depends on calendar context.
+ */
+export function parseNOAAValidTime(
+  validTime: string
+): NOAAValidTimeInterval | null {
+  const parts = validTime.split("/");
+  if (parts.length !== 2) return null;
+
+  const [startText, durationText] = parts;
+  if (!startText || !durationText) return null;
+
+  const startMs = Date.parse(startText);
+  if (!Number.isFinite(startMs)) return null;
+
+  const durationMatch = durationText.match(
+    /^P(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/
+  );
+  if (!durationMatch) return null;
+
+  const days = Number(durationMatch[1] ?? 0);
+  const hours = Number(durationMatch[2] ?? 0);
+  const minutes = Number(durationMatch[3] ?? 0);
+  const seconds = Number(durationMatch[4] ?? 0);
+
+  const durationMs =
+    days * 24 * 60 * 60 * 1000 +
+    hours * 60 * 60 * 1000 +
+    minutes * 60 * 1000 +
+    seconds * 1000;
+
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return null;
+
+  return {
+    startMs,
+    endMs: startMs + durationMs,
+  };
+}
+
+/**
+ * Extract the value whose NOAA validTime interval covers targetMs.
+ *
+ * Coverage is start-inclusive and end-exclusive, matching how NWS gridpoint
+ * intervals compose without double-counting boundaries.
+ */
+export function getValueAtTime(
+  series: NOAAValueSeries | undefined,
+  targetMs: number
+): number | null {
+  if (!series?.values || !Number.isFinite(targetMs)) return null;
+
+  for (const entry of series.values) {
+    const interval = parseNOAAValidTime(entry.validTime);
+    if (!interval) continue;
+    if (targetMs < interval.startMs || targetMs >= interval.endMs) continue;
+    return Number.isFinite(entry.value) ? entry.value : null;
+  }
+
+  return null;
+}
+
+/**
  * Extract value at specific index from NOAA API time series
  *
  * @param values - Array of time-value pairs from NOAA API
@@ -191,7 +278,7 @@ export function getTimestampForIndex(index: number): string {
  * @returns Value at index or null if unavailable
  */
 export function getValueAtIndex(
-  values: Array<{ validTime: string; value: number }> | undefined,
+  values: Array<{ validTime: string; value: number | null }> | undefined,
   index: number
 ): number | null {
   if (!values || index >= values.length) return null;
@@ -207,7 +294,7 @@ export function getValueAtIndex(
  * @returns True if data is valid and usable
  */
 export function hasValidWaveData(
-  values: Array<{ validTime: string; value: number }> | undefined
+  values: Array<{ validTime: string; value: number | null }> | undefined
 ): boolean {
   if (!values || values.length === 0) return false;
 
@@ -223,9 +310,9 @@ export function hasValidWaveData(
  * @param waveDirectionValues - Wave direction time series
  */
 export function logWaveDataAvailability(
-  waveHeightValues: Array<{ validTime: string; value: number }> | undefined,
-  wavePeriodValues: Array<{ validTime: string; value: number }> | undefined,
-  waveDirectionValues: Array<{ validTime: string; value: number }> | undefined
+  waveHeightValues: Array<{ validTime: string; value: number | null }> | undefined,
+  wavePeriodValues: Array<{ validTime: string; value: number | null }> | undefined,
+  waveDirectionValues: Array<{ validTime: string; value: number | null }> | undefined
 ): void {
   const hasWaveHeight = !!waveHeightValues;
   const hasWavePeriod = !!wavePeriodValues;

--- a/lib/utils/wave-height-transformer.ts
+++ b/lib/utils/wave-height-transformer.ts
@@ -585,6 +585,63 @@ export function alignmentFactor(
   return cosValue * cosValue;
 }
 
+function hasValidSwellAccessFactors(
+  beach: BeachTerrainConfig | null | undefined,
+): beach is BeachTerrainConfig & { swell_access_factors: number[] } {
+  return (
+    beach?.terrain_enabled === true &&
+    Array.isArray(beach.swell_access_factors) &&
+    beach.swell_access_factors.length === TERRAIN_BINS
+  );
+}
+
+function isTerrainWeightedModelSource(
+  source: WaveHeightSourceTag | undefined,
+): boolean {
+  return source === 'model_swell' || source === 'model_hs';
+}
+
+/**
+ * Compute the per-component access factor used by decomposed face heights.
+ *
+ * CDIP and other calibrated/direct sources keep the strict swell-window
+ * alignment. Model-derived sources can use terrain swell access instead,
+ * because deep-water model partitions otherwise get over-zeroed at protected
+ * or canyon-amplified beaches where partial access is real.
+ */
+export function componentAccessFactor(
+  componentDirDeg: number | null | undefined,
+  periodS: number | null | undefined,
+  beach: BeachTerrainConfig | null | undefined,
+  source?: WaveHeightSourceTag,
+  opts?: { shortPeriodCutoffS?: number },
+): number {
+  const cutoff = opts?.shortPeriodCutoffS ?? SHORT_PERIOD_CUTOFF_S;
+
+  if (periodS == null || !Number.isFinite(periodS) || periodS <= cutoff) {
+    return 0;
+  }
+
+  if (
+    isTerrainWeightedModelSource(source) &&
+    hasValidSwellAccessFactors(beach) &&
+    componentDirDeg != null &&
+    Number.isFinite(componentDirDeg)
+  ) {
+    const bin = toBin5(componentDirDeg);
+    const access = Math.max(0, Math.min(1, beach.swell_access_factors[bin]));
+    return DIRECTION_FACTOR_MIN + Math.sqrt(access) * DIRECTION_FACTOR_RANGE;
+  }
+
+  return alignmentFactor(
+    componentDirDeg,
+    periodS,
+    beach?.swell_window_center_deg ?? null,
+    beach?.swell_window_halfwidth_deg ?? null,
+    opts,
+  );
+}
+
 /**
  * Single swell-component input for `transformToFaceHeightDecomposed`.
  * Heights must already be in feet; callers converting from meters should
@@ -632,12 +689,15 @@ export interface DecomposedFaceHeightResult {
  * the protected break.
  *
  * Fix: decompose the swell into the WW3 components the model already
- * reports, weight each by (bucket factor × alignment to the beach's swell
- * window × short-period gate), and RMS-sum the resulting face heights.
- * RMS is physically correct for significant-height sums (variance adds
- * linearly; Hs scales with the square root), so an N-component decomposition
- * never exceeds the naive linear sum and converges to the single-component
- * case when only one component is populated.
+ * reports, weight each by (bucket factor × access/alignment × short-period
+ * gate), and RMS-sum the resulting face heights. CDIP/direct sources use
+ * strict swell-window alignment. Model sources at terrain-enabled beaches use
+ * the beach's swell_access_factors so partial canyon/protection access is not
+ * zeroed by an overly narrow cosine window. RMS is physically correct for
+ * significant-height sums (variance adds linearly; Hs scales with the square
+ * root), so an N-component decomposition never exceeds the naive linear sum
+ * and converges to the single-component case when only one component is
+ * populated.
  *
  * Fallback policy:
  * - **All slots null or invalid** → delegate to `transformToFaceHeight` with
@@ -653,10 +713,9 @@ export interface DecomposedFaceHeightResult {
  *   `calculatePeriodFactor × BASE_SHOALING` as each component's bucket
  *   factor. The alignment gate and RMS sum still apply, so the decomposed
  *   path is still physically meaningful even without empirical calibration.
- * - **Null swell window** → `alignmentFactor` returns 1.0 for every
- *   component, so decomposition becomes "bucket factor × raw height"
- *   RMS-summed. No direction gating. Preserves the old pipeline's behavior
- *   on beaches that haven't had their window measured yet.
+ * - **Null swell window** → CDIP/direct `alignmentFactor` returns 1.0 for
+ *   every component, so decomposition becomes "bucket factor × raw height"
+ *   RMS-summed. Model sources still use terrain access when available.
  *
  * `isCalibrated` is returned on the `'decomposed'` path iff
  * `source === 'cdip_sig'` AND `beach.shoaling_factors` is populated. On the
@@ -709,8 +768,6 @@ export function transformToFaceHeightDecomposed(params: {
     };
   }
 
-  const windowCenter = beach.swell_window_center_deg ?? null;
-  const windowHalfwidth = beach.swell_window_halfwidth_deg ?? null;
   const shoalingFactors = beach.shoaling_factors ?? null;
 
   // Apply deepwater decay for model data sources.
@@ -729,23 +786,33 @@ export function transformToFaceHeightDecomposed(params: {
       continue;
     }
 
-    const alignment = alignmentFactor(
+    const accessFactor = componentAccessFactor(
       component.directionDeg,
       component.periodS,
-      windowCenter,
-      windowHalfwidth,
+      beach,
+      source,
     );
-    if (alignment === 0) continue;
+    if (accessFactor === 0) continue;
 
     // Only use calibrated bucket factors for CDIP sources — the buckets are
     // measured as surfline_face / cdip_hs and produce overshoot on model data.
     const bucketFactor = source === 'cdip_sig'
       ? lookupShoalingBucket(component.periodS, shoalingFactors)
       : null;
+    const periodFactor = calculatePeriodFactor(component.periodS);
+    // Terrain-access canyon paths should treat 12s+ model swell as organized
+    // groundswell; otherwise the generic 12s=1.1 ramp still undercalls LJS.
+    const terrainModelPeriodFactor =
+      isTerrainWeightedModelSource(source) &&
+      hasValidSwellAccessFactors(beach) &&
+      (beach.deepwater_decay_factor ?? 1) > 1 &&
+      component.periodS >= 12
+        ? Math.max(periodFactor, PERIOD_FACTOR_MAX)
+        : periodFactor;
     const perComponentFactor =
-      bucketFactor ?? BASE_SHOALING * calculatePeriodFactor(component.periodS);
+      bucketFactor ?? BASE_SHOALING * terrainModelPeriodFactor;
 
-    const faceI = component.heightFt * decay * perComponentFactor * alignment;
+    const faceI = component.heightFt * decay * perComponentFactor * accessFactor;
     sumOfSquares += faceI * faceI;
   }
 

--- a/scripts/validate-forecast-pipeline-multi-beach.ts
+++ b/scripts/validate-forecast-pipeline-multi-beach.ts
@@ -1,0 +1,419 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only diagnostic for the NOAA interval + terrain-access forecast fix.
+ *
+ * Usage:
+ *   yarn tsx scripts/validate-forecast-pipeline-multi-beach.ts
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { config } from "dotenv";
+import {
+  constructGridUrl,
+  fetchNOAAGridData,
+  fetchNOAAPointData,
+} from "../lib/services/noaa-wavewatch/api-client";
+import { processNOAAGridData } from "../lib/services/noaa-wavewatch/data-processors";
+import type {
+  NOAAGridData,
+  NOAAValueSeries,
+  WaveWatchData,
+} from "../lib/services/noaa-wavewatch/types";
+import {
+  getTimestampForForecastSlot,
+  getValueAtIndex,
+  getValueAtTime,
+  parseNOAAValidTime,
+} from "../lib/services/noaa-wavewatch/wave-analysis";
+import { METERS_TO_FEET } from "../lib/utils/unit-conversions";
+import {
+  alignmentFactor,
+  BASE_SHOALING,
+  calculatePeriodFactor,
+  transformToFaceHeightDecomposed,
+  type BeachTerrainConfig,
+  type ShoalingFactors,
+  type SwellComponentInput,
+  type WaveHeightSourceTag,
+} from "../lib/utils/wave-height-transformer";
+
+config({ path: ".env.local" });
+config({ path: ".env.production.local" });
+
+const BEACH_SLUGS = [
+  "la-jolla-shores",
+  "waikiki-beach",
+  "malibu-first-point-surfrider",
+] as const;
+const DAYS = 3;
+const SLOTS = 24;
+
+interface BeachRow {
+  id: string;
+  name: string;
+  slug: string;
+  lat: number;
+  lon: number;
+  terrain_enabled: boolean | null;
+  swell_access_factors: number[] | null;
+  shoaling_factors: ShoalingFactors | null;
+  swell_window_center_deg: number | null;
+  swell_window_halfwidth_deg: number | null;
+  deepwater_decay_factor: number | null;
+}
+
+interface SlotComparison {
+  timestamp: string;
+  oldFaceFt: number | null;
+  newFaceFt: number | null;
+  oldPrimary: string;
+  newPrimary: string;
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name} in .env.local or .env.production.local`);
+  }
+  return value;
+}
+
+function toBeachTerrain(beach: BeachRow): BeachTerrainConfig {
+  return {
+    terrain_enabled: beach.terrain_enabled ?? false,
+    swell_access_factors: beach.swell_access_factors ?? null,
+    shoaling_factors: beach.shoaling_factors ?? null,
+    swell_window_center_deg: beach.swell_window_center_deg ?? null,
+    swell_window_halfwidth_deg: beach.swell_window_halfwidth_deg ?? null,
+    deepwater_decay_factor: beach.deepwater_decay_factor ?? null,
+  };
+}
+
+function fmt(value: number | null | undefined, digits = 2): string {
+  if (value == null || !Number.isFinite(value)) return "null";
+  return value.toFixed(digits);
+}
+
+function fmtUnit(
+  value: number | null | undefined,
+  unit: string,
+  digits = 1
+): string {
+  if (value == null || !Number.isFinite(value)) return "null";
+  return `${value.toFixed(digits)}${unit}`;
+}
+
+function field(
+  gridData: NOAAGridData,
+  key: keyof NOAAGridData["properties"]
+): NOAAValueSeries | undefined {
+  return gridData.properties[key];
+}
+
+function toComponent(
+  heightM: number | null,
+  periodS: number | null,
+  directionDeg: number | null,
+  partition?: "swell" | "wind_wave"
+): SwellComponentInput | null {
+  if (
+    heightM == null ||
+    periodS == null ||
+    heightM <= 0 ||
+    periodS <= 0 ||
+    !Number.isFinite(heightM) ||
+    !Number.isFinite(periodS)
+  ) {
+    return null;
+  }
+
+  return {
+    heightFt: heightM * METERS_TO_FEET,
+    periodS,
+    directionDeg,
+    ...(partition ? { partition } : {}),
+  };
+}
+
+function componentsFromWavePoint(wavePoint: WaveWatchData): Array<SwellComponentInput | null> {
+  return [
+    toComponent(
+      wavePoint.swell_1_height,
+      wavePoint.swell_1_period,
+      wavePoint.swell_1_direction
+    ),
+    toComponent(
+      wavePoint.swell_2_height,
+      wavePoint.swell_2_period,
+      wavePoint.swell_2_direction
+    ),
+    toComponent(
+      wavePoint.wind_wave_height,
+      wavePoint.wind_wave_period,
+      wavePoint.wind_wave_direction,
+      "wind_wave"
+    ),
+  ];
+}
+
+function componentsFromPositionalIndex(
+  gridData: NOAAGridData,
+  index: number
+): Array<SwellComponentInput | null> {
+  const wavePeriod = getValueAtIndex(field(gridData, "wavePeriod")?.values, index);
+  const waveDirection = getValueAtIndex(field(gridData, "waveDirection")?.values, index);
+  const primaryHeight =
+    getValueAtIndex(field(gridData, "primarySwellHeight")?.values, index) ??
+    getValueAtIndex(field(gridData, "swellHeight")?.values, index);
+  const primaryDirection =
+    getValueAtIndex(field(gridData, "primarySwellDirection")?.values, index) ??
+    getValueAtIndex(field(gridData, "swellDirection")?.values, index) ??
+    waveDirection;
+  const primaryPeriod =
+    getValueAtIndex(field(gridData, "swellPeriod")?.values, index) ?? wavePeriod;
+  const secondaryHeight = getValueAtIndex(
+    field(gridData, "secondarySwellHeight")?.values,
+    index
+  );
+  const secondaryDirection = getValueAtIndex(
+    field(gridData, "secondarySwellDirection")?.values,
+    index
+  );
+  const secondaryPeriod = getValueAtIndex(field(gridData, "wavePeriod2")?.values, index);
+  const waveHeight = getValueAtIndex(field(gridData, "waveHeight")?.values, index);
+  const windWaveHeight =
+    waveHeight != null
+      ? waveHeight * 0.5
+      : null;
+  const windWavePeriod = wavePeriod != null ? wavePeriod * 0.7 : null;
+
+  return [
+    toComponent(primaryHeight, primaryPeriod, primaryDirection),
+    toComponent(secondaryHeight, secondaryPeriod, secondaryDirection),
+    toComponent(windWaveHeight, windWavePeriod, waveDirection, "wind_wave"),
+  ];
+}
+
+function strictWindowFaceHeight(
+  components: Array<SwellComponentInput | null>,
+  beach: BeachTerrainConfig
+): number | null {
+  const decay = beach.deepwater_decay_factor ?? 1;
+  let sumOfSquares = 0;
+
+  for (const component of components) {
+    if (!component) continue;
+    if (component.partition === "wind_wave" && component.periodS <= 9) continue;
+
+    const access = alignmentFactor(
+      component.directionDeg,
+      component.periodS,
+      beach.swell_window_center_deg ?? null,
+      beach.swell_window_halfwidth_deg ?? null
+    );
+    if (access === 0) continue;
+
+    const periodFactor = calculatePeriodFactor(component.periodS);
+    const face = component.heightFt * decay * BASE_SHOALING * periodFactor * access;
+    sumOfSquares += face * face;
+  }
+
+  if (sumOfSquares === 0) return null;
+  return Math.round(Math.sqrt(sumOfSquares) * 10) / 10;
+}
+
+function newFaceHeight(
+  wavePoint: WaveWatchData,
+  beach: BeachTerrainConfig
+): number | null {
+  const components = componentsFromWavePoint(wavePoint);
+  const source: WaveHeightSourceTag =
+    components[0] || components[1] ? "model_swell" : "model_hs";
+  const result = transformToFaceHeightDecomposed({
+    components,
+    beach,
+    source,
+    rawHeightFt: wavePoint.significant_wave_height * METERS_TO_FEET,
+    periodS: wavePoint.peak_wave_period,
+    swellDirectionDeg: wavePoint.peak_wave_direction,
+  });
+  return result.faceHeightFt;
+}
+
+function summarizePrimary(components: Array<SwellComponentInput | null>): string {
+  const component = components.find((c) => c != null);
+  if (!component) return "none";
+  return [
+    fmtUnit(component.heightFt, "ft"),
+    "@",
+    fmtUnit(component.periodS, "s", 0),
+    fmtUnit(component.directionDeg, "deg", 0),
+  ].join(" ");
+}
+
+function printIntervalCoverage(gridData: NOAAGridData): void {
+  const keys: Array<keyof NOAAGridData["properties"]> = [
+    "waveHeight",
+    "wavePeriod",
+    "primarySwellHeight",
+    "secondarySwellHeight",
+    "wavePeriod2",
+  ];
+
+  for (const key of keys) {
+    const values = field(gridData, key)?.values ?? [];
+    const preview = values.slice(0, 3).map((entry) => {
+      const interval = parseNOAAValidTime(entry.validTime);
+      const hours = interval ? (interval.endMs - interval.startMs) / 3600000 : null;
+      return `${entry.validTime} value=${fmt(entry.value)} hours=${fmt(hours, 0)}`;
+    });
+    console.log(`  ${key}: ${values.length} intervals`);
+    for (const line of preview) {
+      console.log(`    ${line}`);
+    }
+  }
+}
+
+function compareSlots(
+  gridData: NOAAGridData,
+  processed: WaveWatchData[],
+  beach: BeachTerrainConfig,
+  baseTime: Date
+): SlotComparison[] {
+  const processedByTimestamp = new Map(
+    processed.map((wavePoint) => [wavePoint.timestamp, wavePoint])
+  );
+  const rows: SlotComparison[] = [];
+
+  for (let index = 0; index < SLOTS; index++) {
+    const timestamp = getTimestampForForecastSlot(index, baseTime);
+    const wavePoint = processedByTimestamp.get(timestamp);
+    const oldComponents = componentsFromPositionalIndex(gridData, index);
+
+    rows.push({
+      timestamp,
+      oldFaceFt: strictWindowFaceHeight(oldComponents, beach),
+      newFaceFt: wavePoint ? newFaceHeight(wavePoint, beach) : null,
+      oldPrimary: summarizePrimary(oldComponents),
+      newPrimary: wavePoint
+        ? summarizePrimary(componentsFromWavePoint(wavePoint))
+        : "no NOAA waveHeight coverage",
+    });
+  }
+
+  return rows;
+}
+
+function countCoverage(
+  gridData: NOAAGridData,
+  baseTime: Date
+): { noaa: number; missing: number } {
+  let noaa = 0;
+  let missing = 0;
+
+  for (let index = 0; index < SLOTS; index++) {
+    const timestamp = getTimestampForForecastSlot(index, baseTime);
+    const targetMs = Date.parse(timestamp);
+    if (getValueAtTime(field(gridData, "waveHeight"), targetMs) == null) {
+      missing += 1;
+    } else {
+      noaa += 1;
+    }
+  }
+
+  return { noaa, missing };
+}
+
+async function validateBeach(beach: BeachRow): Promise<void> {
+  console.log(`\n=== ${beach.name} (${beach.slug}) ===`);
+  console.log({
+    lat: beach.lat,
+    lon: beach.lon,
+    terrain_enabled: beach.terrain_enabled,
+    swell_window_center_deg: beach.swell_window_center_deg,
+    swell_window_halfwidth_deg: beach.swell_window_halfwidth_deg,
+    deepwater_decay_factor: beach.deepwater_decay_factor,
+    access_bins: Array.isArray(beach.swell_access_factors)
+      ? beach.swell_access_factors.length
+      : null,
+  });
+
+  const pointData = await fetchNOAAPointData(beach.lat, beach.lon);
+  if (!pointData) {
+    console.log("  NOAA point lookup failed; skipping beach.");
+    return;
+  }
+
+  const gridUrl = constructGridUrl(pointData);
+  if (!gridUrl) {
+    console.log("  NOAA grid URL missing; skipping beach.");
+    return;
+  }
+
+  const gridData = await fetchNOAAGridData(gridUrl);
+  if (!gridData) {
+    console.log("  NOAA grid fetch failed; skipping beach.");
+    return;
+  }
+
+  console.log(
+    `  grid: ${pointData.properties.gridId}/${pointData.properties.gridX},${pointData.properties.gridY}`
+  );
+  console.log("  interval coverage preview:");
+  printIntervalCoverage(gridData);
+
+  const baseTime = new Date();
+  const processed = processNOAAGridData(gridData, DAYS, beach.lat, beach.lon, {
+    baseTime,
+  });
+  const sourceCounts = countCoverage(gridData, baseTime);
+  console.log("  next 72h source coverage:", {
+    NOAA_NWS: sourceCounts.noaa,
+    OPEN_METEO_fill: sourceCounts.missing,
+    processed_NOAA_slots: processed.length,
+  });
+
+  const beachTerrain = toBeachTerrain(beach);
+  const comparisons = compareSlots(gridData, processed, beachTerrain, baseTime);
+  console.log("  old positional/strict-window vs new interval/terrain-access:");
+  for (const row of comparisons.slice(0, 8)) {
+    console.log(
+      `    ${row.timestamp} old=${fmtUnit(row.oldFaceFt, "ft")} [${row.oldPrimary}] ` +
+        `new=${fmtUnit(row.newFaceFt, "ft")} [${row.newPrimary}]`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const supabase = createClient(
+    requiredEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requiredEnv("SUPABASE_SERVICE_ROLE_KEY")
+  );
+
+  const { data, error } = await supabase
+    .from("beaches")
+    .select(
+      "id, name, slug, lat, lon, terrain_enabled, swell_access_factors, shoaling_factors, swell_window_center_deg, swell_window_halfwidth_deg, deepwater_decay_factor"
+    )
+    .in("slug", [...BEACH_SLUGS]);
+
+  if (error) {
+    throw new Error(`Beach config lookup failed: ${error.message}`);
+  }
+
+  const beaches = (data ?? []) as BeachRow[];
+  for (const slug of BEACH_SLUGS) {
+    const beach = beaches.find((row) => row.slug === slug);
+    if (!beach) {
+      console.log(`\n=== ${slug} ===`);
+      console.log("  Beach row missing; skipping.");
+      continue;
+    }
+    await validateBeach(beach);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- sample NOAA NWS grid wave fields by validTime interval coverage instead of positional index
- use terrain swell-access factors for model-derived decomposed face heights
- add regression tests and multi-beach live diagnostic script

## Verification
- yarn test:unit --runTestsByPath __tests__/lib/services/noaa-wavewatch/wave-analysis.test.ts __tests__/lib/services/noaa-wavewatch/data-processors-partitions.test.ts __tests__/lib/services/noaa-wavewatch/nullish-safety.test.ts __tests__/lib/services/noaa-wavewatch/merge-preserves-om.test.ts __tests__/lib/utils/wave-height-transformer.test.ts __tests__/lib/utils/wave-formatters.test.ts __tests__/lib/services/forecast/forecast-builder-cdip-semantics.test.ts --runInBand
- npx eslint --max-warnings=0 lib/services/noaa-wavewatch/wave-analysis.ts lib/services/noaa-wavewatch/data-processors.ts lib/services/noaa-wavewatch/index.ts lib/services/noaa-wavewatch/types.ts lib/utils/wave-height-transformer.ts __tests__/lib/services/noaa-wavewatch/wave-analysis.test.ts __tests__/lib/services/noaa-wavewatch/data-processors-partitions.test.ts __tests__/lib/utils/wave-height-transformer.test.ts
- yarn typecheck
- yarn tsx scripts/validate-forecast-pipeline-multi-beach.ts