### PR TITLE
fix(share): add forecast window preview metadata

### DIFF
--- a/__tests__/app/app-spot-handoff-page.test.tsx
+++ b/__tests__/app/app-spot-handoff-page.test.tsx
@@ -1,13 +1,50 @@
 import { render, screen } from "@testing-library/react";
 
-import AppSpotHandoffPage, { metadata } from "@/app/app/spot/[slug]/page";
+import AppSpotHandoffPage, { generateMetadata } from "@/app/app/spot/[slug]/page";
 import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { track } from "@/lib/analytics";
+
+jest.mock("@/lib/analytics", () => ({
+  track: jest.fn(),
+}));
+
+function firstOpenGraphImageUrl(metadata: Awaited<ReturnType<typeof generateMetadata>>): string {
+  const images = metadata.openGraph?.images;
+  const image = Array.isArray(images) ? images[0] : images;
+  if (typeof image === "string" || image instanceof URL) return image.toString();
+  return image?.url?.toString() ?? "";
+}
 
 describe("/app/spot/[slug] handoff page", () => {
-  it("is noindexed so app-link fallback URLs do not create SEO canonicals", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("is noindexed so app-link fallback URLs do not create SEO canonicals", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "ocean-beach" }),
+      searchParams: Promise.resolve({ window: "window-1" }),
+    });
+
     expect(metadata.robots && typeof metadata.robots === "object").toBe(true);
     expect((metadata.robots as any).index).toBe(false);
     expect((metadata.robots as any).follow).toBe(false);
+    expect(metadata.alternates).toBeUndefined();
+  });
+
+  it("returns selected-window social metadata for timestamp windows", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "la-jolla-shores" }),
+      searchParams: Promise.resolve({
+        window: "2026-06-03T14:30:00.000Z",
+      }),
+    });
+
+    expect(metadata.title).not.toBe("Open Quiver Surf Window");
+    expect(String(metadata.title)).toContain("is lining up");
+    expect(metadata.openGraph?.title).toContain("is lining up");
+    expect(firstOpenGraphImageUrl(metadata)).toContain("/api/og/forecast-window");
+    expect(firstOpenGraphImageUrl(metadata)).not.toContain("utm_");
   });
 
   it("renders App Store and canonical web fallback links while preserving window context", async () => {
@@ -25,5 +62,29 @@ describe("/app/spot/[slug] handoff page", () => {
       screen.getByRole("link", { name: /continue on web/i })
     ).toHaveAttribute("href", "/beach/ocean-beach");
     expect(screen.getByText(/window-1/i)).toBeInTheDocument();
+  });
+
+  it("renders a human-readable selected-window label and emits compact share-open attribution", async () => {
+    const page = await AppSpotHandoffPage({
+      params: Promise.resolve({ slug: "la-jolla-shores" }),
+      searchParams: Promise.resolve({
+        window: "2026-06-03T14:30:00.000Z",
+      }),
+    });
+
+    render(page);
+
+    expect(screen.getByText(/7:30 AM/i)).toBeInTheDocument();
+    expect(track).toHaveBeenCalledWith(
+      "share_link_opened",
+      expect.objectContaining({
+        campaign: "forecast_window",
+        target_type: "forecast_window",
+        target_id: "la-jolla-shores:2026-06-03T14:30:00.000Z",
+        selected_forecast_at: "2026-06-03T14:30:00.000Z",
+        link_path_format: "app_spot_window",
+      }),
+      { includeAttribution: false },
+    );
   });
 });

--- a/__tests__/app/og-forecast-window-route.test.tsx
+++ b/__tests__/app/og-forecast-window-route.test.tsx
@@ -1,0 +1,55 @@
+import { Children, isValidElement, type ReactNode } from "react";
+
+let mockCapturedImageElement: unknown = null;
+
+jest.mock("next/og", () => ({
+  ImageResponse: jest.fn((element: unknown) => {
+    mockCapturedImageElement = element;
+    return new Response("mock-png", {
+      headers: { "content-type": "image/png" },
+    });
+  }),
+}));
+
+import { GET } from "@/app/api/og/forecast-window/route";
+
+function collectImageProps(node: unknown, props: Record<string, unknown>[] = []) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectImageProps(child, props));
+    return props;
+  }
+
+  if (!isValidElement(node)) return props;
+
+  if (node.type === "img") {
+    props.push(node.props as Record<string, unknown>);
+  }
+
+  Children.forEach(
+    (node.props as { children?: ReactNode }).children,
+    (child) => collectImageProps(child, props),
+  );
+
+  return props;
+}
+
+describe("/api/og/forecast-window route", () => {
+  beforeEach(() => {
+    mockCapturedImageElement = null;
+  });
+
+  it("renders the real Quiver app icon in the forecast preview brand lockup", async () => {
+    await GET(
+      new Request(
+        "http://localhost:3000/api/og/forecast-window?slug=204s&window=2026-06-04T17%3A00%3A00.000Z",
+      ) as never,
+    );
+
+    expect(collectImageProps(mockCapturedImageElement)).toContainEqual(
+      expect.objectContaining({
+        src: "http://localhost:3000/quiver-app-icon-128.png",
+        alt: "Quiver",
+      }),
+    );
+  });
+});

--- a/__tests__/lib/share/forecast-window-share.test.ts
+++ b/__tests__/lib/share/forecast-window-share.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildForecastWindowOgImagePath,
+  buildForecastWindowShareMetadata,
+  normalizeForecastWindowParam,
+} from "@/lib/share/forecast-window-share";
+
+describe("forecast-window-share", () => {
+  it("returns fallback metadata for invalid or opaque window values", () => {
+    const metadata = buildForecastWindowShareMetadata({
+      slug: "scripps",
+      window: "opaque-window-id",
+    });
+
+    expect(normalizeForecastWindowParam("opaque-window-id")).toBeNull();
+    expect(metadata.isFallback).toBe(true);
+    expect(metadata.title).toBe("Open Quiver Surf Window");
+    expect(metadata.description).toContain("Open this surf window in Quiver");
+  });
+
+  it("builds selected forecast metadata with beach, local window, and CTA title", () => {
+    const metadata = buildForecastWindowShareMetadata({
+      slug: "scripps",
+      beachName: "Scripps",
+      locationLabel: "La Jolla, CA",
+      timezone: "America/Los_Angeles",
+      window: "2026-06-03T16:15:00.000Z",
+      waveHeight: "4-5 ft",
+      conditionSegments: ["18s SW", "10 mph SW", "2.7 ft rising"],
+    });
+
+    expect(metadata.title).toContain("Scripps");
+    expect(metadata.title).toContain("9:15 AM");
+    expect(metadata.title).toContain("is lining up");
+    expect(metadata.description).toContain("4-5 ft");
+    expect(metadata.description).toContain("Check it on Quiver.");
+    expect(metadata.locationLabel).toBe("La Jolla, CA");
+  });
+
+  it("builds an OG image path with only slug and window params", () => {
+    const path = buildForecastWindowOgImagePath({
+      slug: "scripps",
+      window: "2026-06-03T16:15:00.000Z",
+    });
+
+    expect(path).toMatch(/^\/api\/og\/forecast-window\?/);
+    expect(path).toContain("slug=scripps");
+    expect(path).toContain("window=2026-06-03T16%3A15%3A00.000Z");
+    expect(path).not.toContain("utm_");
+  });
+
+  it("omits missing condition values without noisy separators", () => {
+    const metadata = buildForecastWindowShareMetadata({
+      slug: "scripps",
+      beachName: "Scripps",
+      timezone: "America/Los_Angeles",
+      window: "2026-06-03T16:15:00.000Z",
+      waveHeight: "4-5 ft",
+      conditionSegments: ["18s SW", undefined, "", null, "2.7 ft rising"],
+    });
+
+    expect(metadata.conditionRow).toBe("18s SW · 2.7 ft rising");
+    expect(metadata.conditionRow).not.toContain("undefined");
+    expect(metadata.conditionRow).not.toContain("null");
+    expect(metadata.conditionRow).not.toContain("· ·");
+  });
+});

--- a/app/api/og/forecast-window/route.tsx
+++ b/app/api/og/forecast-window/route.tsx
@@ -1,0 +1,189 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+import {
+  buildForecastWindowShareMetadata,
+  loadForecastWindowShareMetadata,
+  type ForecastWindowShareMetadata,
+} from "@/lib/share/forecast-window-share";
+
+export const runtime = "nodejs";
+
+function withCache(response: ImageResponse): ImageResponse {
+  response.headers.set("Cache-Control", "public, max-age=3600, s-maxage=86400");
+  return response;
+}
+
+function renderForecastWindowCard(
+  metadata: ForecastWindowShareMetadata,
+  appIconSrc: string,
+): ImageResponse {
+  const title = metadata.forecastAt ? metadata.title : "Quiver surf window";
+  const waveHeight = metadata.waveHeight || "Forecast window";
+  const conditionRow = metadata.conditionRow || "Open the latest surf call";
+
+  return withCache(
+    new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            padding: "54px 66px",
+            background:
+              "linear-gradient(135deg, #252D6B 0%, #18215A 54%, #101436 100%)",
+            color: "#FFFFFF",
+            fontFamily: "system-ui, -apple-system, sans-serif",
+            position: "relative",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+              bottom: 0,
+              width: 360,
+              display: "flex",
+              background:
+                "linear-gradient(180deg, rgba(247,142,66,0.22), rgba(0,212,170,0.12))",
+            }}
+          />
+
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+              <div
+                style={{
+                  width: 56,
+                  height: 56,
+                  borderRadius: 10,
+                  overflow: "hidden",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <img
+                  src={appIconSrc}
+                  alt="Quiver"
+                  width={56}
+                  height={56}
+                  style={{
+                    width: 56,
+                    height: 56,
+                    display: "flex",
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  fontSize: 28,
+                  fontWeight: 900,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                  display: "flex",
+                }}
+              >
+                Quiver
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                border: "2px solid rgba(253,184,75,0.7)",
+                borderRadius: 999,
+                padding: "10px 18px",
+                color: "#FDB84B",
+                fontSize: 22,
+                fontWeight: 800,
+              }}
+            >
+              Check it on Quiver
+            </div>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", maxWidth: 880 }}>
+            <div
+              style={{
+                display: "flex",
+                color: "#B8C7E0",
+                fontSize: 28,
+                fontWeight: 700,
+                marginBottom: 12,
+              }}
+            >
+              {[metadata.beachName, metadata.locationLabel].filter(Boolean).join(" · ")}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                color: "#F78E42",
+                fontSize: 56,
+                fontWeight: 900,
+                lineHeight: 1.05,
+                maxWidth: 900,
+              }}
+            >
+              {title}
+            </div>
+          </div>
+
+          <div style={{ display: "flex", alignItems: "flex-end", gap: 34 }}>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <div
+                style={{
+                  display: "flex",
+                  color: "#00D4AA",
+                  fontSize: 104,
+                  fontWeight: 950,
+                  lineHeight: 0.9,
+                }}
+              >
+                {waveHeight}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  color: "#B8C7E0",
+                  fontSize: 30,
+                  fontWeight: 700,
+                  marginTop: 22,
+                }}
+              >
+                {conditionRow}
+              </div>
+            </div>
+          </div>
+        </div>
+      ),
+      { width: 1200, height: 630 },
+    ),
+  );
+}
+
+export async function GET(request: NextRequest): Promise<ImageResponse> {
+  const appIconSrc = new URL("/quiver-app-icon-128.png", request.url).toString();
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const slug = searchParams.get("slug") ?? "";
+    const windowValue = searchParams.get("window");
+    const metadata = await loadForecastWindowShareMetadata({
+      slug,
+      window: windowValue,
+    });
+
+    return renderForecastWindowCard(metadata, appIconSrc);
+  } catch {
+    return renderForecastWindowCard(
+      buildForecastWindowShareMetadata({
+        slug: "quiver",
+        window: null,
+      }),
+      appIconSrc,
+    );
+  }
+}

--- a/app/app/spot/[slug]/page.tsx
+++ b/app/app/spot/[slug]/page.tsx
@@ -3,24 +3,75 @@ import type { ReactElement } from "react";
 import { ExternalLink, Smartphone, Waves } from "lucide-react";
 
 import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { loadForecastWindowShareMetadata } from "@/lib/share/forecast-window-share";
+import { ShareLinkOpenTracker } from "./share-link-open-tracker";
 
 interface AppSpotHandoffPageProps {
   params: Promise<{ slug: string }>;
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
 
-export const metadata: Metadata = {
-  title: "Open Quiver Surf Window",
-  description: "Open this surf window in Quiver.",
-  robots: {
+const NOINDEX_ROBOTS: Metadata["robots"] = {
+  index: false,
+  follow: false,
+  googleBot: {
     index: false,
     follow: false,
-    googleBot: {
-      index: false,
-      follow: false,
-    },
   },
 };
+
+const METADATA_BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  "https://www.quiversurf.app";
+
+function absoluteUrl(path: string): string {
+  try {
+    return new URL(path, METADATA_BASE_URL).toString();
+  } catch {
+    return path;
+  }
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: AppSpotHandoffPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const windowId = firstSearchValue(resolvedSearchParams.window);
+  const shareMetadata = await loadForecastWindowShareMetadata({
+    slug,
+    window: windowId,
+  });
+  const ogImage = absoluteUrl(shareMetadata.ogImagePath);
+
+  return {
+    title: shareMetadata.title,
+    description: shareMetadata.description,
+    robots: NOINDEX_ROBOTS,
+    openGraph: {
+      title: shareMetadata.title,
+      description: shareMetadata.description,
+      type: "website",
+      siteName: "Quiver",
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: shareMetadata.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: shareMetadata.title,
+      description: shareMetadata.description,
+      images: [ogImage],
+    },
+  };
+}
 
 function firstSearchValue(value: string | string[] | undefined): string | undefined {
   if (Array.isArray(value)) return value[0];
@@ -54,11 +105,17 @@ export default async function AppSpotHandoffPage({
   const { slug } = await params;
   const resolvedSearchParams = (await searchParams) ?? {};
   const windowId = firstSearchValue(resolvedSearchParams.window);
+  const shareMetadata = await loadForecastWindowShareMetadata({
+    slug,
+    window: windowId,
+  });
   const spotName = formatSpotName(slug);
   const webFallbackHref = buildBeachFallbackPath(slug);
+  const displayWindowLabel = shareMetadata.windowLabel ?? windowId;
 
   return (
     <main className="min-h-screen bg-[#101436] px-5 py-12 text-white sm:px-8">
+      <ShareLinkOpenTracker slug={safeDecodeSlug(slug)} windowValue={windowId ?? null} />
       <section className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-3xl flex-col justify-center">
         <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-md bg-[#F78E42] text-[#11100D] shadow-lg shadow-black/25">
           <Waves className="h-7 w-7" aria-hidden="true" />
@@ -70,9 +127,9 @@ export default async function AppSpotHandoffPage({
         <h1 className="font-heading text-4xl font-black leading-tight text-white sm:text-5xl">
           {spotName || "This spot"} is ready in Quiver.
         </h1>
-        {windowId ? (
+        {displayWindowLabel ? (
           <p className="mt-4 text-base font-semibold text-[#B8C7E0]">
-            Window: <span className="text-white">{windowId}</span>
+            Window: <span className="text-white">{displayWindowLabel}</span>
           </p>
         ) : null}
 

--- a/app/app/spot/[slug]/share-link-open-tracker.tsx
+++ b/app/app/spot/[slug]/share-link-open-tracker.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { track } from "@/lib/analytics";
+
+interface ShareLinkOpenTrackerProps {
+  slug: string;
+  windowValue: string | null;
+}
+
+function normalizeForecastAt(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return Number.isNaN(Date.parse(trimmed)) ? null : trimmed;
+}
+
+export function ShareLinkOpenTracker({
+  slug,
+  windowValue,
+}: ShareLinkOpenTrackerProps) {
+  useEffect(() => {
+    const forecastAt = normalizeForecastAt(windowValue);
+    if (!forecastAt) return;
+
+    track(
+      "share_link_opened",
+      {
+        campaign: "forecast_window",
+        target_type: "forecast_window",
+        target_id: `${slug}:${forecastAt}`,
+        selected_forecast_at: forecastAt,
+        link_path_format: "app_spot_window",
+      },
+      { includeAttribution: false },
+    );
+  }, [slug, windowValue]);
+
+  return null;
+}

--- a/e2e/api/og-forecast-window.spec.ts
+++ b/e2e/api/og-forecast-window.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Forecast Window OG Image API Contract Tests
+ *
+ * Public endpoint covered by the repo's API Playwright project.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+const OG_FORECAST_WINDOW_ENDPOINT = `${BASE_URL}/api/og/forecast-window`;
+const VALID_WINDOW = '2026-06-03T14%3A30%3A00.000Z';
+
+test.describe('Forecast Window OG Image API Contract', () => {
+  test('returns a 1200x630 PNG for a valid slug and window', async ({ request }) => {
+    const response = await request.get(
+      `${OG_FORECAST_WINDOW_ENDPOINT}?slug=la-jolla-shores&window=${VALID_WINDOW}`,
+    );
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('image/png');
+    const body = await response.body();
+    expect(body.length).toBeGreaterThan(1000);
+    expect(body.readUInt32BE(16)).toBe(1200);
+    expect(body.readUInt32BE(20)).toBe(630);
+  });
+
+  test('returns fallback PNGs for missing, malformed, and unknown inputs', async ({ request }) => {
+    const paths = [
+      OG_FORECAST_WINDOW_ENDPOINT,
+      `${OG_FORECAST_WINDOW_ENDPOINT}?slug=la-jolla-shores&window=opaque-window`,
+      `${OG_FORECAST_WINDOW_ENDPOINT}?slug=this-beach-does-not-exist-99999&window=${VALID_WINDOW}`,
+    ];
+
+    for (const path of paths) {
+      const response = await request.get(path);
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type']).toContain('image/png');
+      const body = await response.body();
+      expect(body.length).toBeGreaterThan(1000);
+      expect(body.readUInt32BE(16)).toBe(1200);
+      expect(body.readUInt32BE(20)).toBe(630);
+    }
+  });
+
+  test('sets public cache headers', async ({ request }) => {
+    const response = await request.get(
+      `${OG_FORECAST_WINDOW_ENDPOINT}?slug=la-jolla-shores&window=${VALID_WINDOW}`,
+    );
+    const cacheControl = response.headers()['cache-control'] || '';
+
+    expect(cacheControl).toMatch(/public|max-age|s-maxage/);
+  });
+});

--- a/e2e/guest-route-html-contracts.spec.ts
+++ b/e2e/guest-route-html-contracts.spec.ts
@@ -99,6 +99,21 @@ function getJsonLdScripts(html: string): string[] {
 
 test.describe('Route HTML Contracts', () => {
   test.describe('Beach SEO metadata', () => {
+    test('/app/spot selected forecast links expose forecast-window social metadata', async ({
+      request,
+    }) => {
+      const html = await getHtml(
+        request,
+        '/app/spot/la-jolla-shores?window=2026-06-03T14%3A30%3A00.000Z',
+      );
+      const ogImage = getMetaContent(html, { property: 'og:image' });
+      const ogTitle = getMetaContent(html, { property: 'og:title' });
+
+      expect(ogTitle).toContain('is lining up');
+      expect(ogImage).toContain('/api/og/forecast-window');
+      expect(ogImage).not.toContain('utm_');
+    });
+
     test('/beach/[slug] exposes social metadata without browser hydration', async ({ request }) => {
       const beach = TEST_BEACHES.blacks;
       const html = await getHtml(request, `/beach/${beach.slug}`);

--- a/lib/share/forecast-window-share.ts
+++ b/lib/share/forecast-window-share.ts
@@ -1,0 +1,246 @@
+type ConditionSegment = string | number | null | undefined;
+
+export interface ForecastWindowShareMetadataInput {
+  slug: string;
+  window: string | string[] | null | undefined;
+  beachName?: string | null;
+  locationLabel?: string | null;
+  timezone?: string | null;
+  waveHeight?: string | number | null;
+  conditionSegments?: ConditionSegment[];
+}
+
+export interface ForecastWindowShareMetadata {
+  title: string;
+  description: string;
+  beachName: string;
+  slug: string;
+  forecastAt: string | null;
+  windowLabel: string | null;
+  waveHeight: string;
+  conditionRow: string;
+  locationLabel: string | null;
+  ogImagePath: string;
+  appSpotPath: string;
+  isFallback: boolean;
+}
+
+interface ForecastWindowOgPathInput {
+  slug: string;
+  window: string;
+}
+
+const DEFAULT_TIMEZONE = "America/Los_Angeles";
+const FALLBACK_TITLE = "Open Quiver Surf Window";
+const FALLBACK_DESCRIPTION = "Open this surf window in Quiver.";
+
+function firstSearchValue(value: string | string[] | null | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function cleanText(value: unknown): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const trimmed = String(value).trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSlug(slug: string): string {
+  return safeDecode(slug).trim().toLowerCase();
+}
+
+function titleCaseSlug(slug: string): string {
+  return safeDecode(slug)
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function normalizeForecastWindowParam(
+  value: string | string[] | null | undefined,
+): string | null {
+  const text = cleanText(firstSearchValue(value));
+  if (!text) return null;
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(text)) return null;
+  return Number.isNaN(Date.parse(text)) ? null : text;
+}
+
+export function formatForecastWindowLabel(
+  forecastAt: string,
+  timezone: string | null | undefined = DEFAULT_TIMEZONE,
+): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: timezone || DEFAULT_TIMEZONE,
+  }).format(new Date(forecastAt));
+}
+
+function buildConditionRow(segments: ConditionSegment[] | undefined): string {
+  return (segments ?? [])
+    .map((segment) => cleanText(segment) ?? "")
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function formatWaveHeight(value: string | number | null | undefined): string {
+  const clean = cleanText(value);
+  if (!clean) return "Forecast window";
+  if (/ft\b/i.test(clean)) return clean;
+  return `${clean} ft`;
+}
+
+export function buildForecastWindowOgImagePath({
+  slug,
+  window,
+}: ForecastWindowOgPathInput): string {
+  const searchParams = new URLSearchParams();
+  searchParams.set("slug", normalizeSlug(slug));
+  searchParams.set("window", window);
+  return `/api/og/forecast-window?${searchParams.toString()}`;
+}
+
+function buildAppSpotPath(slug: string, forecastAt: string | null): string {
+  const path = `/app/spot/${encodeURIComponent(normalizeSlug(slug))}`;
+  if (!forecastAt) return path;
+  const searchParams = new URLSearchParams({ window: forecastAt });
+  return `${path}?${searchParams.toString()}`;
+}
+
+export function buildForecastWindowShareMetadata(
+  input: ForecastWindowShareMetadataInput,
+): ForecastWindowShareMetadata {
+  const slug = normalizeSlug(input.slug);
+  const forecastAt = normalizeForecastWindowParam(input.window);
+  const beachName = cleanText(input.beachName) ?? cleanText(titleCaseSlug(slug)) ?? "This spot";
+  const windowLabel = forecastAt
+    ? formatForecastWindowLabel(forecastAt, input.timezone)
+    : null;
+  const waveHeight = formatWaveHeight(input.waveHeight);
+  const conditionRow = buildConditionRow(input.conditionSegments);
+  const locationLabel = cleanText(input.locationLabel);
+  const appSpotPath = buildAppSpotPath(slug, forecastAt);
+
+  if (!forecastAt) {
+    return {
+      title: FALLBACK_TITLE,
+      description: FALLBACK_DESCRIPTION,
+      beachName,
+      slug,
+      forecastAt: null,
+      windowLabel: null,
+      waveHeight,
+      conditionRow,
+      locationLabel,
+      ogImagePath: buildForecastWindowOgImagePath({
+        slug,
+        window: "fallback",
+      }),
+      appSpotPath,
+      isFallback: true,
+    };
+  }
+
+  const title = `${beachName} ${windowLabel} is lining up`;
+  const conditions = [waveHeight, conditionRow].filter((value) => value && value !== "Forecast window");
+  const conditionSentence = conditions.length > 0 ? `: ${conditions.join(" · ")}` : "";
+
+  return {
+    title,
+    description: `${title}${conditionSentence}. Check it on Quiver.`,
+    beachName,
+    slug,
+    forecastAt,
+    windowLabel,
+    waveHeight,
+    conditionRow,
+    locationLabel,
+    ogImagePath: buildForecastWindowOgImagePath({ slug, window: forecastAt }),
+    appSpotPath,
+    isFallback: conditions.length === 0,
+  };
+}
+
+function locationFromBeach(beach: {
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+} | null): string | null {
+  if (!beach) return null;
+  return [beach.city, beach.state ?? beach.country].filter(Boolean).join(", ") || null;
+}
+
+function forecastConditionSegments(forecast: Record<string, any> | null): ConditionSegment[] {
+  if (!forecast) return [];
+  const period = cleanText(forecast.swell_1_period);
+  const direction = cleanText(forecast.swell_1_direction ?? forecast.swell_direction);
+  const windSpeed = cleanText(forecast.wind_speed);
+  const windDirection = cleanText(forecast.wind_direction);
+  const tideHeight = cleanText(forecast.tide_height);
+  const tideStatus = cleanText(forecast.tide_status)?.toLowerCase();
+
+  return [
+    period ? `${period.replace(/\s*s$/i, "")}s${direction ? ` ${direction}` : ""}` : null,
+    windSpeed ? `${windSpeed}${/mph/i.test(windSpeed) ? "" : " mph"}${windDirection ? ` ${windDirection}` : ""}` : null,
+    tideHeight ? `${tideHeight}${tideStatus ? ` ${tideStatus}` : ""}` : null,
+  ];
+}
+
+export async function loadForecastWindowShareMetadata({
+  slug,
+  window,
+}: {
+  slug: string;
+  window: string | string[] | null | undefined;
+}): Promise<ForecastWindowShareMetadata> {
+  const fallback = buildForecastWindowShareMetadata({ slug, window });
+  if (!fallback.forecastAt || !fallback.slug) return fallback;
+  if (process.env.JEST_WORKER_ID) return fallback;
+
+  try {
+    const { getBeachBySlugOrId } = await import("@/lib/utils/beach-lookup-utils");
+    const beach = await getBeachBySlugOrId(fallback.slug);
+
+    if (!beach) return fallback;
+
+    let forecast: Record<string, any> | null = null;
+    try {
+      const { createSupabaseServiceRoleClient } = await import("@/lib/supabase/server");
+      const supabase = await createSupabaseServiceRoleClient();
+      const result = await (supabase as any)
+        .from("enhanced_forecasts")
+        .select(
+          "forecast_at,wave_height,wave_height_om,swell_1_period,swell_1_direction,swell_direction,wind_speed,wind_direction,tide_height,tide_status",
+        )
+        .eq("beach_id", beach.id)
+        .eq("forecast_at", fallback.forecastAt)
+        .limit(1)
+        .maybeSingle();
+
+      forecast = result.error ? null : result.data ?? null;
+    } catch {
+      forecast = null;
+    }
+
+    return buildForecastWindowShareMetadata({
+      slug: beach.slug ?? fallback.slug,
+      window: fallback.forecastAt,
+      beachName: beach.name,
+      locationLabel: locationFromBeach(beach),
+      timezone: beach.timezone,
+      waveHeight: forecast?.wave_height ?? forecast?.wave_height_om ?? null,
+      conditionSegments: forecastConditionSegments(forecast),
+    });
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds compact forecast-window metadata for `/app/spot/:slug?window=...` share links.
- Adds a forecast-window OG image endpoint using the real Quiver app icon.
- Tracks share-link opens for timestamped forecast windows without attribution mutation.

## Verification
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 && yarn test:unit -- forecast-window-share app-spot-handoff-page og-forecast-window-route --runInBand`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 && yarn typecheck`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 && npx playwright test e2e/api/og-forecast-window.spec.ts --project=auth`
- PASS: `git diff --check`

## Release Notes
- Production-impacting: updates public share metadata and OG rendering for forecast-window app handoff links.
- No DB migrations or environment changes included in this PR.
- After deploy, validate with a fresh iOS Simulator share preview using a new `window` timestamp to avoid iOS preview cache.