### PR TITLE
fix(share): preserve forecast preview context

### DIFF
--- a/__tests__/app/app-spot-handoff-page.test.tsx
+++ b/__tests__/app/app-spot-handoff-page.test.tsx
@@ -47,6 +47,26 @@ describe("/app/spot/[slug] handoff page", () => {
     expect(firstOpenGraphImageUrl(metadata)).not.toContain("utm_");
   });
 
+  it("returns exact forecast-window CTA metadata from compact preview params", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: "204s" }),
+      searchParams: Promise.resolve({
+        window: "2026-06-04T22:30:00.000Z",
+        label: "3:30-6:00 PM",
+        conditions: "2-3 ft · 18s SSW · 7 mph SW · 3 ft, rising",
+      }),
+    });
+    const imageUrl = firstOpenGraphImageUrl(metadata);
+
+    expect(metadata.title).toBe("204s 3:30-6:00 PM is lining up");
+    expect(metadata.description).toBe(
+      "204s 3:30-6:00 PM is lining up: 2-3 ft · 18s SSW · 7 mph SW · 3 ft, rising. Check it on Quiver.",
+    );
+    expect(imageUrl).toContain("label=3%3A30-6%3A00");
+    expect(imageUrl).toContain("conditions=2-3");
+    expect(imageUrl).not.toContain("utm_");
+  });
+
   it("renders App Store and canonical web fallback links while preserving window context", async () => {
     const page = await AppSpotHandoffPage({
       params: Promise.resolve({ slug: "ocean-beach" }),
@@ -86,5 +106,20 @@ describe("/app/spot/[slug] handoff page", () => {
       }),
       { includeAttribution: false },
     );
+  });
+
+  it("renders the shared preview window range on the handoff page", async () => {
+    const page = await AppSpotHandoffPage({
+      params: Promise.resolve({ slug: "204s" }),
+      searchParams: Promise.resolve({
+        window: "2026-06-04T22:30:00.000Z",
+        label: "3:30-6:00 PM",
+        conditions: "2-3 ft · 18s SSW · 7 mph SW · 3 ft, rising",
+      }),
+    });
+
+    render(page);
+
+    expect(screen.getByText(/3:30-6:00 PM/i)).toBeInTheDocument();
   });
 });

--- a/__tests__/app/og-forecast-window-route.test.tsx
+++ b/__tests__/app/og-forecast-window-route.test.tsx
@@ -33,6 +33,27 @@ function collectImageProps(node: unknown, props: Record<string, unknown>[] = [])
   return props;
 }
 
+function collectText(node: unknown, text: string[] = []): string[] {
+  if (typeof node === "string" || typeof node === "number") {
+    text.push(String(node));
+    return text;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectText(child, text));
+    return text;
+  }
+
+  if (!isValidElement(node)) return text;
+
+  Children.forEach(
+    (node.props as { children?: ReactNode }).children,
+    (child) => collectText(child, text),
+  );
+
+  return text;
+}
+
 describe("/api/og/forecast-window route", () => {
   beforeEach(() => {
     mockCapturedImageElement = null;
@@ -51,5 +72,19 @@ describe("/api/og/forecast-window route", () => {
         alt: "Quiver",
       }),
     );
+  });
+
+  it("renders shared CTA preview copy instead of the fallback forecast-window card", async () => {
+    await GET(
+      new Request(
+        "http://localhost:3000/api/og/forecast-window?slug=204s&window=2026-06-04T22%3A30%3A00.000Z&label=3%3A30-6%3A00+PM&conditions=2-3+ft+%C2%B7+18s+SSW+%C2%B7+7+mph+SW+%C2%B7+3+ft%2C+rising",
+      ) as never,
+    );
+
+    const renderedText = collectText(mockCapturedImageElement).join(" ");
+    expect(renderedText).toContain("204s 3:30-6:00 PM is lining up");
+    expect(renderedText).toContain("2-3 ft");
+    expect(renderedText).toContain("18s SSW · 7 mph SW · 3 ft, rising");
+    expect(renderedText).not.toContain("Forecast window");
   });
 });

--- a/__tests__/lib/share/forecast-window-share.test.ts
+++ b/__tests__/lib/share/forecast-window-share.test.ts
@@ -36,15 +36,37 @@ describe("forecast-window-share", () => {
     expect(metadata.locationLabel).toBe("La Jolla, CA");
   });
 
-  it("builds an OG image path with only slug and window params", () => {
+  it("uses shared preview context for the exact CTA title and condition description", () => {
+    const metadata = buildForecastWindowShareMetadata({
+      slug: "204s",
+      beachName: "204s",
+      timezone: "America/Los_Angeles",
+      window: "2026-06-04T22:30:00.000Z",
+      windowLabel: "3:30-6:00 PM",
+      waveHeight: "2-3 ft",
+      conditionSegments: ["18s SSW", "7 mph SW", "3 ft, rising"],
+    } as never);
+
+    expect(metadata.title).toBe("204s 3:30-6:00 PM is lining up");
+    expect(metadata.description).toBe(
+      "204s 3:30-6:00 PM is lining up: 2-3 ft · 18s SSW · 7 mph SW · 3 ft, rising. Check it on Quiver.",
+    );
+    expect(metadata.windowLabel).toBe("3:30-6:00 PM");
+  });
+
+  it("builds an OG image path with share-preview params and no tracking params", () => {
     const path = buildForecastWindowOgImagePath({
       slug: "scripps",
       window: "2026-06-03T16:15:00.000Z",
-    });
+      windowLabel: "9:15-11:45 AM",
+      conditions: "4-5 ft · 18s SW · 10 mph SW · 2.7 ft rising",
+    } as never);
 
     expect(path).toMatch(/^\/api\/og\/forecast-window\?/);
     expect(path).toContain("slug=scripps");
     expect(path).toContain("window=2026-06-03T16%3A15%3A00.000Z");
+    expect(path).toContain("label=9%3A15-11%3A45+AM");
+    expect(path).toContain("conditions=4-5+ft");
     expect(path).not.toContain("utm_");
   });
 

--- a/app/api/og/forecast-window/route.tsx
+++ b/app/api/og/forecast-window/route.tsx
@@ -66,6 +66,7 @@ function renderForecastWindowCard(
                   justifyContent: "center",
                 }}
               >
+                {/* eslint-disable-next-line @next/next/no-img-element -- ImageResponse renders plain HTML, not Next image components. */}
                 <img
                   src={appIconSrc}
                   alt="Quiver"
@@ -105,7 +106,7 @@ function renderForecastWindowCard(
             </div>
           </div>
 
-          <div style={{ display: "flex", flexDirection: "column", maxWidth: 880 }}>
+          <div style={{ display: "flex", flexDirection: "column", maxWidth: 760 }}>
             <div
               style={{
                 display: "flex",
@@ -121,10 +122,10 @@ function renderForecastWindowCard(
               style={{
                 display: "flex",
                 color: "#F78E42",
-                fontSize: 56,
+                fontSize: 50,
                 fontWeight: 900,
-                lineHeight: 1.05,
-                maxWidth: 900,
+                lineHeight: 1.08,
+                maxWidth: 760,
               }}
             >
               {title}
@@ -174,6 +175,8 @@ export async function GET(request: NextRequest): Promise<ImageResponse> {
     const metadata = await loadForecastWindowShareMetadata({
       slug,
       window: windowValue,
+      windowLabel: searchParams.get("label"),
+      conditions: searchParams.get("conditions"),
     });
 
     return renderForecastWindowCard(metadata, appIconSrc);

--- a/app/app/spot/[slug]/page.tsx
+++ b/app/app/spot/[slug]/page.tsx
@@ -43,6 +43,8 @@ export async function generateMetadata({
   const shareMetadata = await loadForecastWindowShareMetadata({
     slug,
     window: windowId,
+    windowLabel: firstSearchValue(resolvedSearchParams.label),
+    conditions: firstSearchValue(resolvedSearchParams.conditions),
   });
   const ogImage = absoluteUrl(shareMetadata.ogImagePath);
 
@@ -108,6 +110,8 @@ export default async function AppSpotHandoffPage({
   const shareMetadata = await loadForecastWindowShareMetadata({
     slug,
     window: windowId,
+    windowLabel: firstSearchValue(resolvedSearchParams.label),
+    conditions: firstSearchValue(resolvedSearchParams.conditions),
   });
   const spotName = formatSpotName(slug);
   const webFallbackHref = buildBeachFallbackPath(slug);

--- a/e2e/guest-route-html-contracts.spec.ts
+++ b/e2e/guest-route-html-contracts.spec.ts
@@ -104,13 +104,19 @@ test.describe('Route HTML Contracts', () => {
     }) => {
       const html = await getHtml(
         request,
-        '/app/spot/la-jolla-shores?window=2026-06-03T14%3A30%3A00.000Z',
+        '/app/spot/204s?window=2026-06-04T22%3A30%3A00.000Z&label=3%3A30-6%3A00+PM&conditions=2-3+ft+%C2%B7+18s+SSW+%C2%B7+7+mph+SW+%C2%B7+3+ft%2C+rising',
       );
       const ogImage = getMetaContent(html, { property: 'og:image' });
       const ogTitle = getMetaContent(html, { property: 'og:title' });
+      const ogDescription = getMetaContent(html, { property: 'og:description' });
 
-      expect(ogTitle).toContain('is lining up');
+      expect(ogTitle).toBe('204s 3:30-6:00 PM is lining up');
+      expect(ogDescription).toBe(
+        '204s 3:30-6:00 PM is lining up: 2-3 ft · 18s SSW · 7 mph SW · 3 ft, rising. Check it on Quiver.',
+      );
       expect(ogImage).toContain('/api/og/forecast-window');
+      expect(ogImage).toContain('label=3%3A30-6%3A00');
+      expect(ogImage).toContain('conditions=2-3');
       expect(ogImage).not.toContain('utm_');
     });
 

--- a/lib/share/forecast-window-share.ts
+++ b/lib/share/forecast-window-share.ts
@@ -8,6 +8,8 @@ export interface ForecastWindowShareMetadataInput {
   timezone?: string | null;
   waveHeight?: string | number | null;
   conditionSegments?: ConditionSegment[];
+  windowLabel?: string | string[] | null;
+  conditions?: string | string[] | null;
 }
 
 export interface ForecastWindowShareMetadata {
@@ -28,11 +30,14 @@ export interface ForecastWindowShareMetadata {
 interface ForecastWindowOgPathInput {
   slug: string;
   window: string;
+  windowLabel?: string | null;
+  conditions?: string | null;
 }
 
 const DEFAULT_TIMEZONE = "America/Los_Angeles";
 const FALLBACK_TITLE = "Open Quiver Surf Window";
 const FALLBACK_DESCRIPTION = "Open this surf window in Quiver.";
+const MAX_PREVIEW_PARAM_LENGTH = 180;
 
 function firstSearchValue(value: string | string[] | null | undefined): string | null {
   if (Array.isArray(value)) return value[0] ?? null;
@@ -41,8 +46,14 @@ function firstSearchValue(value: string | string[] | null | undefined): string |
 
 function cleanText(value: unknown): string | null {
   if (typeof value !== "string" && typeof value !== "number") return null;
-  const trimmed = String(value).trim();
+  const trimmed = String(value).replace(/[\u0000-\u001F\u007F]/g, " ").replace(/\s+/g, " ").trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanPreviewParam(value: string | string[] | null | undefined): string | null {
+  const text = cleanText(firstSearchValue(value));
+  if (!text) return null;
+  return text.slice(0, MAX_PREVIEW_PARAM_LENGTH);
 }
 
 function safeDecode(value: string): string {
@@ -92,6 +103,30 @@ function buildConditionRow(segments: ConditionSegment[] | undefined): string {
     .join(" · ");
 }
 
+function previewConditionParts(value: string | string[] | null | undefined): {
+  waveHeight: string | null;
+  conditionSegments: string[] | null;
+  conditions: string | null;
+} {
+  const conditions = cleanPreviewParam(value);
+  if (!conditions) {
+    return { waveHeight: null, conditionSegments: null, conditions: null };
+  }
+
+  const segments = conditions
+    .split("·")
+    .map((segment) => cleanText(segment))
+    .filter((segment): segment is string => Boolean(segment));
+  const [firstSegment, ...remainingSegments] = segments;
+  const waveHeight = firstSegment && /\bft\b/i.test(firstSegment) ? firstSegment : null;
+
+  return {
+    waveHeight,
+    conditionSegments: waveHeight ? remainingSegments : segments,
+    conditions,
+  };
+}
+
 function formatWaveHeight(value: string | number | null | undefined): string {
   const clean = cleanText(value);
   if (!clean) return "Forecast window";
@@ -102,10 +137,16 @@ function formatWaveHeight(value: string | number | null | undefined): string {
 export function buildForecastWindowOgImagePath({
   slug,
   window,
+  windowLabel,
+  conditions,
 }: ForecastWindowOgPathInput): string {
   const searchParams = new URLSearchParams();
   searchParams.set("slug", normalizeSlug(slug));
   searchParams.set("window", window);
+  const labelParam = cleanPreviewParam(windowLabel);
+  const conditionsParam = cleanPreviewParam(conditions);
+  if (labelParam) searchParams.set("label", labelParam);
+  if (conditionsParam) searchParams.set("conditions", conditionsParam);
   return `/api/og/forecast-window?${searchParams.toString()}`;
 }
 
@@ -122,11 +163,15 @@ export function buildForecastWindowShareMetadata(
   const slug = normalizeSlug(input.slug);
   const forecastAt = normalizeForecastWindowParam(input.window);
   const beachName = cleanText(input.beachName) ?? cleanText(titleCaseSlug(slug)) ?? "This spot";
+  const previewLabel = forecastAt ? cleanPreviewParam(input.windowLabel) : null;
   const windowLabel = forecastAt
-    ? formatForecastWindowLabel(forecastAt, input.timezone)
+    ? previewLabel ?? formatForecastWindowLabel(forecastAt, input.timezone)
     : null;
-  const waveHeight = formatWaveHeight(input.waveHeight);
-  const conditionRow = buildConditionRow(input.conditionSegments);
+  const previewConditions = previewConditionParts(input.conditions);
+  const waveHeight = previewConditions.waveHeight ?? formatWaveHeight(input.waveHeight);
+  const conditionRow = buildConditionRow(
+    previewConditions.conditionSegments ?? input.conditionSegments,
+  );
   const locationLabel = cleanText(input.locationLabel);
   const appSpotPath = buildAppSpotPath(slug, forecastAt);
 
@@ -164,7 +209,12 @@ export function buildForecastWindowShareMetadata(
     waveHeight,
     conditionRow,
     locationLabel,
-    ogImagePath: buildForecastWindowOgImagePath({ slug, window: forecastAt }),
+    ogImagePath: buildForecastWindowOgImagePath({
+      slug,
+      window: forecastAt,
+      windowLabel: previewLabel,
+      conditions: previewConditions.conditions,
+    }),
     appSpotPath,
     isFallback: conditions.length === 0,
   };
@@ -198,11 +248,20 @@ function forecastConditionSegments(forecast: Record<string, any> | null): Condit
 export async function loadForecastWindowShareMetadata({
   slug,
   window,
+  windowLabel,
+  conditions,
 }: {
   slug: string;
   window: string | string[] | null | undefined;
+  windowLabel?: string | string[] | null;
+  conditions?: string | string[] | null;
 }): Promise<ForecastWindowShareMetadata> {
-  const fallback = buildForecastWindowShareMetadata({ slug, window });
+  const fallback = buildForecastWindowShareMetadata({
+    slug,
+    window,
+    windowLabel,
+    conditions,
+  });
   if (!fallback.forecastAt || !fallback.slug) return fallback;
   if (process.env.JEST_WORKER_ID) return fallback;
 
@@ -237,6 +296,8 @@ export async function loadForecastWindowShareMetadata({
       beachName: beach.name,
       locationLabel: locationFromBeach(beach),
       timezone: beach.timezone,
+      windowLabel,
+      conditions,
       waveHeight: forecast?.wave_height ?? forecast?.wave_height_om ?? null,
       conditionSegments: forecastConditionSegments(forecast),
     });


### PR DESCRIPTION
## Summary
- Preserves forecast-window range and condition context in compact share preview metadata.
- Uses shared preview params for `/app/spot/:slug` Open Graph/Twitter metadata and OG image rendering.
- Tightens the OG image title layout so the CTA card does not fall back or overflow.

## Verification
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn typecheck`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn test:unit -- forecast-window-share app-spot-handoff-page og-forecast-window-route --runInBand`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx eslint --max-warnings=0 lib/share/forecast-window-share.ts app/app/spot/[slug]/page.tsx app/api/og/forecast-window/route.tsx __tests__/lib/share/forecast-window-share.test.ts __tests__/app/app-spot-handoff-page.test.tsx __tests__/app/og-forecast-window-route.test.tsx e2e/guest-route-html-contracts.spec.ts`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx playwright test e2e/guest-route-html-contracts.spec.ts --project=guest --grep "app/spot selected forecast links expose forecast-window social metadata"`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx playwright test e2e/api/og-forecast-window.spec.ts --project=auth`
- PASS: `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn test:unit --bail=0`
- PASS: native local checks for paired app payload change: `npm test -- forecast-window-share distribution-share --runInBand` and `npm run typecheck`

## Release Notes
- Production-impacting: updates public share metadata and OG rendering for compact forecast-window links.
- No DB migrations or environment changes.
- Post-deploy validation: verify `www.quiversurf.app` metadata/OG image with a fresh timestamped URL, then validate the iOS Simulator share sheet.