### PR TITLE
fix(seo): surface product-led weekly report priorities

### DIFF
--- a/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
+++ b/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
@@ -193,6 +193,31 @@ describe("SEO workflow weekly report", () => {
     expect(report).toContain('Low-fit competitor keyword: "history of surfing"');
   });
 
+  it("does not label low-fit-only competitor keywords as product-fit", () => {
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-05-20T12:00:00Z",
+      recommendations: [],
+      missing: [],
+      dataforseo: {
+        generatedAt: "2026-05-20T12:00:00Z",
+        googleRankings: [],
+        asoRankings: [],
+        competitorKeywords: [{
+          competitor: "Lazy Surfer",
+          domain: "lazysurfer.app",
+          keyword: "history of surfing",
+          rank: 4,
+          searchVolume: 14800,
+        }],
+        missing: [],
+      },
+    });
+
+    expect(report).not.toContain("Product-fit competitor keyword opportunities");
+    expect(report).toContain("Top competitor keywords by volume");
+    expect(report).toContain('Low-fit competitor keyword: "history of surfing"');
+  });
+
   it("renders manual backlink import coverage without calling it missing data", () => {
     const report = renderWeeklySeoReport({
       generatedAt: "2026-05-20T12:00:00Z",

--- a/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
+++ b/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
@@ -114,7 +114,83 @@ describe("SEO workflow weekly report", () => {
     expect(report).toContain("DataForSEO ASO rank checks: 1/1");
     expect(report).toContain("DataForSEO is enabled");
     expect(report).toContain("DataForSEO Labs competitor keyword rows: 1 rows across 1 competitors");
+    expect(report).toContain("Product-fit competitor keyword opportunities by volume");
     expect(report).not.toContain("DataForSEO is not configured");
+  });
+
+  it("prioritizes product-led opportunities over commodity fact queries", () => {
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-05-20T12:00:00Z",
+      recommendations: [],
+      missing: [],
+      gsc: {
+        generatedAt: "2026-05-20T12:00:00Z",
+        siteUrl: "https://www.quiversurf.app",
+        dateRanges: {
+          last7d: { start: "2026-05-13", end: "2026-05-20" },
+          prior7d: { start: "2026-05-06", end: "2026-05-12" },
+          last28d: { start: "2026-04-22", end: "2026-05-20" },
+        },
+        last7d: [],
+        prior7d: [],
+        last28d: [],
+        sitemapPaths: [],
+        topQueries: [],
+        topPages: [{
+          page: "/water-temp/huntington-beach",
+          clicks: 20,
+          impressions: 4000,
+          position: 7,
+        }, {
+          page: "/best-time-to-surf/cocoa-beach",
+          clicks: 2,
+          impressions: 442,
+          position: 6.4,
+        }, {
+          page: "/dawn-patrol/san-francisco",
+          clicks: 2,
+          impressions: 55,
+          position: 9,
+        }],
+        byDevice: [],
+        byCountry: [],
+      },
+      dataforseo: {
+        generatedAt: "2026-05-20T12:00:00Z",
+        googleRankings: [],
+        asoRankings: [{
+          keyword: "surf session",
+          platform: "ios",
+          location: "United States",
+          depth: 100,
+          quiverRank: null,
+          topCompetitors: [{ app: "Surfmore", rank: 1 }],
+        }],
+        competitorKeywords: [{
+          competitor: "Lazy Surfer",
+          domain: "lazysurfer.app",
+          keyword: "history of surfing",
+          rank: 66,
+          searchVolume: 14800,
+        }, {
+          competitor: "Swellify",
+          domain: "swellify.app",
+          keyword: "swell period",
+          rank: 8,
+          searchVolume: 1200,
+        }],
+        missing: [],
+      },
+    });
+
+    expect(report).toContain("## Product-Led SEO Opportunities");
+    expect(report).toContain("Best-time planning: `/best-time-to-surf/cocoa-beach`");
+    expect(report).toContain("Dawn patrol planning: `/dawn-patrol/san-francisco`");
+    expect(report).toContain('ASO product wedge: "surf session"');
+    expect(report).toContain('Competitor-inspired content: "swell period"');
+    expect(report).toContain("## Do Not Chase");
+    expect(report).toContain("Commodity fact page: `/water-temp/huntington-beach`");
+    expect(report).toContain('Low-fit competitor keyword: "history of surfing"');
   });
 
   it("renders manual backlink import coverage without calling it missing data", () => {

--- a/lib/seo/agent-workflow/weekly-report.ts
+++ b/lib/seo/agent-workflow/weekly-report.ts
@@ -44,6 +44,14 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
     "",
     renderKeywordMovement(input.gsc, input.dataforseo, openRecommendations),
     "",
+    "## Product-Led SEO Opportunities",
+    "",
+    renderProductLedOpportunities(input.gsc, input.dataforseo),
+    "",
+    "## Do Not Chase",
+    "",
+    renderDoNotChase(input.gsc, input.dataforseo),
+    "",
     "## SEO Metadata",
     "",
     renderMetadataAudit(input.metadata),
@@ -352,10 +360,133 @@ function renderCompetitorKeywordCoverage(dataforseo?: DataForSeoExportInput): st
 
   return [
     `DataForSEO Labs competitor keyword rows: ${rows.length} rows across ${byCompetitor.size} competitors (${competitorSummary}).`,
-    topKeywords ? `Top actionable competitor keyword opportunities by volume: ${topKeywords}.` : "",
+    topKeywords ? `Product-fit competitor keyword opportunities by volume: ${topKeywords}.` : "",
     clusterSummary ? `Competitor keyword clusters: ${clusterSummary}.` : "",
     topPages ? `Competitor ranking pages with the broadest keyword footprint: ${topPages}.` : "",
   ].filter((row) => row.length > 0);
+}
+
+function renderProductLedOpportunities(
+  gsc: GscExportInput | undefined,
+  dataforseo: DataForSeoExportInput | undefined,
+): string {
+  const rows = [
+    ...productLedGscPages(gsc).map((page) =>
+      `- ${productLedLabel(page.page)}: \`${page.page}\` - ${page.impressions} impressions, ${page.clicks} clicks, avg position ${formatNumber(page.position)}. Improve the page around judgment, timing, local conditions, and app/session CTAs.`,
+    ),
+    ...productLedAsoKeywords(dataforseo).map((rank) => {
+      const quiver = rank.quiverRank === null ? "not top 100" : `rank ${rank.quiverRank}`;
+      const leader = rank.topCompetitors[0]?.app ? `; leader=${rank.topCompetitors[0].app}` : "";
+      return `- ASO product wedge: "${rank.keyword}" (${rank.platform}) - Quiver ${quiver}${leader}.`;
+    }),
+    ...productLedCompetitorKeywords(dataforseo).map((row) =>
+      `- Competitor-inspired content: "${row.keyword}" (${row.competitor}, vol ${row.searchVolume ?? "n/a"}, rank ${row.rank ?? "n/a"}) - use as education that leads into Quiver forecast/session workflows.`,
+    ),
+  ];
+
+  return rows.length
+    ? rows.slice(0, 12).join("\n")
+    : "- No product-led SEO opportunities in available inputs.";
+}
+
+function renderDoNotChase(
+  gsc: GscExportInput | undefined,
+  dataforseo: DataForSeoExportInput | undefined,
+): string {
+  const gscRows = (gsc?.topPages ?? [])
+    .filter((page) => isCommodityFactPhrase(page.page))
+    .slice()
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 5)
+    .map((page) =>
+      `- Commodity fact page: \`${page.page}\` - ${page.impressions} impressions but answer is mostly a fact box unless paired with surf timing/context.`,
+    );
+  const competitorRows = (dataforseo?.competitorKeywords ?? [])
+    .filter((row) => isLowFitCompetitorKeyword(row.keyword))
+    .slice()
+    .sort((a, b) => (b.searchVolume ?? 0) - (a.searchVolume ?? 0))
+    .slice(0, 5)
+    .map((row) =>
+      `- Low-fit competitor keyword: "${row.keyword}" (${row.competitor}, vol ${row.searchVolume ?? "n/a"}) - informational/trivia traffic, weak product intent.`,
+    );
+  const rows = [...gscRows, ...competitorRows];
+
+  return rows.length
+    ? rows.join("\n")
+    : "- No obvious commodity fact or low-fit trivia targets in available inputs.";
+}
+
+function productLedGscPages(gsc?: GscExportInput): GscExportInput["topPages"] {
+  return (gsc?.topPages ?? [])
+    .filter((page) => isProductLedSeoPath(page.page))
+    .slice()
+    .sort((a, b) => {
+      const productDelta = productLedScore(b.page) - productLedScore(a.page);
+      if (productDelta !== 0) return productDelta;
+      return b.impressions - a.impressions;
+    })
+    .slice(0, 8);
+}
+
+function productLedAsoKeywords(dataforseo?: DataForSeoExportInput): DataForSeoExportInput["asoRankings"] {
+  return (dataforseo?.asoRankings ?? [])
+    .filter((rank) => isProductLedKeyword(rank.keyword))
+    .slice()
+    .sort((a, b) => {
+      const delta = productLedScore(b.keyword) - productLedScore(a.keyword);
+      if (delta !== 0) return delta;
+      return (a.quiverRank ?? 999) - (b.quiverRank ?? 999);
+    })
+    .slice(0, 6);
+}
+
+function productLedCompetitorKeywords(dataforseo?: DataForSeoExportInput): DataForSeoExportInput["competitorKeywords"] {
+  return (dataforseo?.competitorKeywords ?? [])
+    .filter((row) => isProductLedKeyword(row.keyword) && !isLowFitCompetitorKeyword(row.keyword))
+    .slice()
+    .sort((a, b) => {
+      const delta = productLedScore(b.keyword) - productLedScore(a.keyword);
+      if (delta !== 0) return delta;
+      return (b.searchVolume ?? 0) - (a.searchVolume ?? 0);
+    })
+    .slice(0, 6);
+}
+
+function productLedLabel(path: string): string {
+  if (/dawn-patrol/i.test(path)) return "Dawn patrol planning";
+  if (/best-time-to-surf/i.test(path)) return "Best-time planning";
+  if (/longboard/i.test(path)) return "Board-fit planning";
+  return "Local surf decision";
+}
+
+function isProductLedSeoPath(path: string): boolean {
+  return /\/(best-time-to-surf|dawn-patrol|longboard)\//i.test(path) ||
+    /\/[a-z]{2}\/[^/]+\/[^/]+$/i.test(path);
+}
+
+function isProductLedKeyword(keyword: string): boolean {
+  return /(best time to surf|best tide|best wind|dawn patrol|surf session|surf journal|session log|surf tracker|custom spot|custom surf forecast|how to read.*surf forecast|swell period|swell height|surf height|wind swell|ground swell|beginner surf spots|surf forecast app|surf report app|surfline alternative|personal surf forecast)/i.test(keyword);
+}
+
+function isCommodityFactPhrase(value: string): boolean {
+  return /(water-temp|water temp|water temperature|ocean temp|ocean temperature|tide-chart|\/tides$)/i.test(value);
+}
+
+function isLowFitCompetitorKeyword(keyword: string): boolean {
+  return /(history|origin|invented|tom blake|free surfers|freesurf|surfer best)/i.test(keyword);
+}
+
+function productLedScore(value: string): number {
+  const text = value.toLowerCase();
+  let score = 0;
+  if (/(best-time-to-surf|best time to surf|best tide|best wind)/.test(text)) score += 5;
+  if (/(dawn-patrol|dawn patrol)/.test(text)) score += 5;
+  if (/(session|journal|tracker|log)/.test(text)) score += 4;
+  if (/(custom spot|custom surf forecast|personal surf forecast)/.test(text)) score += 4;
+  if (/(how to read|swell period|swell height|surf height|wind swell|ground swell)/.test(text)) score += 3;
+  if (/(longboard|board-fit|board)/.test(text)) score += 3;
+  if (/(water temp|water-temp|ocean temp|tide-chart|\/tides$|history|origin|invented)/.test(text)) score -= 5;
+  return score;
 }
 
 function classifyCompetitorKeyword(keyword: string): string {
@@ -393,4 +524,8 @@ function isActionableCompetitorKeyword(keyword: string): boolean {
 
 function sum(values: number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+function formatNumber(value: number | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? value.toFixed(1) : "n/a";
 }

--- a/lib/seo/agent-workflow/weekly-report.ts
+++ b/lib/seo/agent-workflow/weekly-report.ts
@@ -340,8 +340,23 @@ function renderCompetitorKeywordCoverage(dataforseo?: DataForSeoExportInput): st
     .sort((a, b) => b[1].rows - a[1].rows || b[1].volume - a[1].volume)
     .map(([competitor, value]) => `${competitor}=${value.rows}`)
     .join(", ");
-  const actionableRows = rows.filter((row) => isActionableCompetitorKeyword(row.keyword));
-  const topKeywords = (actionableRows.length ? actionableRows : rows)
+  const productFitRows = rows.filter((row) =>
+    isProductLedKeyword(row.keyword) && !isLowFitCompetitorKeyword(row.keyword)
+  );
+  const actionableRows = rows.filter((row) =>
+    isActionableCompetitorKeyword(row.keyword) && !isLowFitCompetitorKeyword(row.keyword)
+  );
+  const keywordRows = productFitRows.length
+    ? productFitRows
+    : actionableRows.length
+      ? actionableRows
+      : rows;
+  const keywordLabel = productFitRows.length
+    ? "Product-fit competitor keyword opportunities by volume"
+    : actionableRows.length
+      ? "Top actionable competitor keyword opportunities by volume"
+      : "Top competitor keywords by volume";
+  const topKeywords = keywordRows
     .slice()
     .sort((a, b) => (b.searchVolume ?? 0) - (a.searchVolume ?? 0))
     .slice(0, 5)
@@ -360,7 +375,7 @@ function renderCompetitorKeywordCoverage(dataforseo?: DataForSeoExportInput): st
 
   return [
     `DataForSEO Labs competitor keyword rows: ${rows.length} rows across ${byCompetitor.size} competitors (${competitorSummary}).`,
-    topKeywords ? `Product-fit competitor keyword opportunities by volume: ${topKeywords}.` : "",
+    topKeywords ? `${keywordLabel}: ${topKeywords}.` : "",
     clusterSummary ? `Competitor keyword clusters: ${clusterSummary}.` : "",
     topPages ? `Competitor ranking pages with the broadest keyword footprint: ${topPages}.` : "",
   ].filter((row) => row.length > 0);


### PR DESCRIPTION
## Summary
- Preserved the dirty local main worktree on remote safety branch `codex/safety-dirty-main-20260607` before resetting local main clean.
- Reconciled reviewed branch work against current `origin/main`; most reviewed branches were already represented or superseded.
- Integrated only the useful SEO weekly-report slice from `origin/codex/best-surf-calls-discovery`, adding product-led opportunity prioritization and a low-fit/commodity "Do Not Chase" section.
- Fixed review finding: low-fit-only competitor keyword exports now use neutral competitor coverage wording instead of being labeled product-fit.

## Branch Review Notes
- `origin/codex/personalization-match-route`: already represented on main; personalization API/libs/tests/migrations already present.
- `origin/codex/best-surf-calls-discovery`: partially integrated via a surgical weekly-report update; skipped `TODO.md`, `.planning/`, and stale broader branch diffs.
- `origin/feature/fix-signup-funnel`: already represented/superseded by the merged signup funnel work on main.
- `origin/release/socal-beginner-prod`: already represented by merged release work on main/prod.
- Likely squash-residue branches (`origin/fix/current-forecast-api`, `origin/fix/typecheck-beach-defaults-region-id`, `origin/feat/auto-enable-similarity-pro`, `origin/feat/similarity-alerts-hardening`): already represented on current main.

## Verification
- Safety branch: `source ~/.nvm/nvm.sh && nvm use 22 && yarn typecheck` passed.
- Safety branch: `source ~/.nvm/nvm.sh && nvm use 22 && yarn test:unit --bail=0` passed.
- Reconciliation branch: focused weekly-report Jest failed before implementation, then passed after implementation.
- Review-fix regression: low-fit-only competitor keyword test failed before the fix, then passed after the fix.
- Reconciliation branch: `source ~/.nvm/nvm.sh && nvm use 22 && PATH=/Users/stevenchandler/Desktop/dev/quiver/node_modules/.bin:$PATH npx eslint --max-warnings=0 lib/seo/agent-workflow/weekly-report.ts __tests__/lib/seo/agent-workflow/weekly-report.test.ts` passed.
- Reconciliation branch: `source ~/.nvm/nvm.sh && nvm use 22 && PATH=/Users/stevenchandler/Desktop/dev/quiver/node_modules/.bin:$PATH yarn typecheck` passed.
- Reconciliation branch: `source ~/.nvm/nvm.sh && nvm use 22 && NODE_OPTIONS="${NODE_OPTIONS:-} --disable-warning=DEP0040" NODE_PATH=/Users/stevenchandler/Desktop/dev/quiver/node_modules /Users/stevenchandler/Desktop/dev/quiver/node_modules/.bin/jest __tests__/lib/seo/agent-workflow/weekly-report.test.ts --runInBand` passed: 8 tests.
- Reconciliation branch, before the review-fix commit: `source ~/.nvm/nvm.sh && nvm use 22 && PATH=/Users/stevenchandler/Desktop/dev/quiver/node_modules/.bin:$PATH yarn test:unit --bail=0` passed: 947 suites passed, 15 skipped; 13,805 tests passed, 200 skipped, 1 todo.

## E2E
- Playwright not run. This branch only changes SEO report generation and its unit coverage; no UI/browser route behavior changed.

## Notes
- Local Jest emits existing Supabase env warnings and expected console noise; they did not fail the suite.
- No migrations, env changes, or production release steps.