### PR TITLE
[codex] Fix community nearby session filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ TypeScript, 2-space indentation, PascalCase components, camelCase variables/func
 - **API routes**: use `withAuth` from `lib/middleware/api-wrappers/` (40+ routes). Legacy routes using `lib/api-utils.ts` should migrate when edited. Also: `withErrorHandler`, `withRateLimit`, `withBotBlockingAndRateLimit`, `withFullProtection`, `validateUuidParam`, `requireOwnership`.
 - **Data fetching**: prefer `useDataFetcher` with a memoized fetch fn. Some hooks use SWR or TanStack Query — check existing patterns before adding new ones.
 - **Realtime**: subscribe in `useEffect`, return `() => supabase.removeChannel(channel)` cleanup.
-- **Coordinates**: prefer `lon`/`longitude` in new code. DB legacy fields are `center_lat`/`center_lng`. `beach.latitude` does NOT exist — use `beach.center_lat`/`beach.center_lng`. Component props use `latitude`/`longitude`.
+- **Coordinates**: prefer `lat`/`lon` for beach rows and `lon`/`longitude` in new API/component shapes. `beach.latitude` does NOT exist — use `beach.lat`/`beach.lon`.
 - **Timestamps**: use `forecast_at` (timestamptz). Adapter at `lib/utils/forecast-at-adapter.ts`. Query: `.gte("forecast_at", startISO).lt("forecast_at", endISO).order("forecast_at")`.
 - **User reference**: use `user_id`. Never `profile_id` — dropped Feb 2026. `sessions.profile_id` does not exist.
 
@@ -155,7 +155,7 @@ Never commit secrets. Don't hand-edit `types/database.generated.ts`. RLS on all 
 - Don't skip `withAuthenticatedAction` for protected server actions
 - Don't skip `withAuth` wrapper for authenticated API routes
 - Don't add monetization or non-growth features without direction
-- Don't assume `beach.latitude` exists (it's `beach.center_lat`)
+- Don't assume `beach.latitude` exists (it's `beach.lat`)
 - Don't use `lng` in new code (use `lon`)
 - Don't use `forecast_date` + `forecast_time` in new queries (use `forecast_at`)
 - Don't reference `sessions.profile_id` (dropped Feb 2026 — use `user_id`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ Always clean up channels — subscribe in `useEffect`, return `() => supabase.re
 
 ### Coordinate Naming
 
-**Never use `lng` in new code** — use `lon` or `longitude`. DB legacy fields are `center_lat`/`center_lng` (don't rename without migration). Component props use `latitude`/`longitude`. **Critical pitfall:** `beach.latitude` doesn't exist — use `beach.center_lat`/`beach.center_lng`.
+**Never use `lng` in new code** — use `lon` or `longitude`. Beach rows use `lat`/`lon`. **Critical pitfall:** `beach.latitude` doesn't exist — use `beach.lat`/`beach.lon`.
 Full guide: `docs/COORDINATE_CONVENTIONS.md`
 
 ### Forecast Timestamps
@@ -207,7 +207,7 @@ Before touching `lib/seo/meta.ts` or related SEO files, define the target patter
 - Don't skip `withAuthenticatedAction` for protected server actions
 - Don't skip `withAuth` wrapper for authenticated API routes
 - Don't add monetization or non-growth features without direction
-- Don't assume `beach.latitude` exists (it's `beach.center_lat`)
+- Don't assume `beach.latitude` exists (it's `beach.lat`)
 - Don't use `lng` in new code (use `lon`)
 - Don't use `forecast_date` + `forecast_time` in new queries (use `forecast_at`)
 - Don't reference `sessions.profile_id` (dropped Feb 2026 -- use `user_id`)

--- a/__tests__/api/sessions/public-sessions-route.test.ts
+++ b/__tests__/api/sessions/public-sessions-route.test.ts
@@ -54,6 +54,21 @@ jest.mock("@/lib/supabase/server", () => ({
 
 const { GET } = require("@/app/api/sessions/public/route");
 
+function createThenableChain(result: any) {
+  const chain: any = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    gte: jest.fn().mockReturnThis(),
+    lte: jest.fn().mockReturnThis(),
+    in: jest.fn().mockReturnThis(),
+    not: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    range: jest.fn().mockReturnThis(),
+    then: jest.fn((onResolve: any) => onResolve(result)),
+  };
+  return chain;
+}
+
 describe("/api/sessions/public", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -259,5 +274,97 @@ describe("/api/sessions/public", () => {
     ]);
     expect(likesChain.eq).toHaveBeenCalledWith("user_id", "current-user");
     expect(res.headers.get("cache-control")).toContain("no-store");
+  });
+
+  it("uses beach lat/lon columns for nearby filtering and applies those beach IDs to session queries", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    const nearbyChain = createThenableChain({
+      data: [{ id: "beach-1" }, { id: "beach-2" }],
+      error: null,
+    });
+    const countChain = createThenableChain({ count: 1, data: null, error: null });
+    const dataChain = createThenableChain({
+      data: [
+        {
+          id: "session-1",
+          user_id: "surfer-1",
+          beach_name: "Ocean Beach Pier",
+          beach_id: "beach-1",
+          arrival_time: "2026-06-11T13:05:00.000Z",
+          wave_quality: 4,
+          wave_height_ft: 3,
+          notes: "Fun morning",
+          description: null,
+          image_url: null,
+          likes_count: 0,
+          created_at: "2026-06-11T14:26:06.000Z",
+          duration_minutes: 60,
+          crowd_level: 2,
+          water_temp: null,
+          rating: 4,
+          beaches: { name: "Ocean Beach Pier" },
+          profiles: {
+            id: "surfer-1",
+            full_name: "Local Surfer",
+            avatar_url: null,
+          },
+          session_media: [],
+        },
+      ],
+      error: null,
+    });
+
+    const sessionChains = [countChain, dataChain];
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "beaches") return nearbyChain;
+      if (table === "sessions") return sessionChains.shift();
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const req = createMockRequest(
+      "GET",
+      "http://localhost:3000/api/sessions/public?lat=32.75&lon=-117.25&radius_miles=30&page=1&limit=10",
+    );
+    const res = await GET(req as any);
+    const payload = await expectSuccessResponse<any[]>(res, 200);
+
+    expect(payload.data).toHaveLength(1);
+    expect(nearbyChain.gte).toHaveBeenCalledWith("lat", expect.any(Number));
+    expect(nearbyChain.lte).toHaveBeenCalledWith("lat", expect.any(Number));
+    expect(nearbyChain.gte).toHaveBeenCalledWith("lon", expect.any(Number));
+    expect(nearbyChain.lte).toHaveBeenCalledWith("lon", expect.any(Number));
+    expect(nearbyChain.gte).not.toHaveBeenCalledWith("center_lat", expect.any(Number));
+    expect(nearbyChain.lte).not.toHaveBeenCalledWith("center_lng", expect.any(Number));
+    expect(countChain.in).toHaveBeenCalledWith("beach_id", ["beach-1", "beach-2"]);
+    expect(dataChain.in).toHaveBeenCalledWith("beach_id", ["beach-1", "beach-2"]);
+  });
+
+  it("throws when nearby beach lookup fails instead of silently returning an empty feed", async () => {
+    mockSupabaseClient.auth.getUser.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    const nearbyError = new Error("column beaches.center_lat does not exist");
+    const nearbyChain = createThenableChain({
+      data: null,
+      error: nearbyError,
+    });
+
+    mockSupabaseClient.from.mockImplementation((table: string) => {
+      if (table === "beaches") return nearbyChain;
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const req = createMockRequest(
+      "GET",
+      "http://localhost:3000/api/sessions/public?lat=32.75&lon=-117.25&page=1&limit=10",
+    );
+
+    await expect(GET(req as any)).rejects.toThrow("column beaches.center_lat does not exist");
   });
 });

--- a/app/api/sessions/public/route.ts
+++ b/app/api/sessions/public/route.ts
@@ -123,13 +123,15 @@ async function publicSessionsHandler(
     const latRange = radiusMiles / 69;
     const lonRange = radiusMiles / (69 * Math.cos((lat * Math.PI) / 180));
 
-    const { data: nearbyBeaches } = await supabase
+    const { data: nearbyBeaches, error: nearbyError } = await supabase
       .from("beaches")
       .select("id")
-      .gte("center_lat", lat - latRange)
-      .lte("center_lat", lat + latRange)
-      .gte("center_lng", lon - lonRange)
-      .lte("center_lng", lon + lonRange);
+      .gte("lat", lat - latRange)
+      .lte("lat", lat + latRange)
+      .gte("lon", lon - lonRange)
+      .lte("lon", lon + lonRange);
+
+    if (nearbyError) throw nearbyError;
 
     nearbyBeachIds = nearbyBeaches?.map((b) => b.id) ?? [];
     if (nearbyBeachIds.length === 0) {


### PR DESCRIPTION
## Summary
- Fix `/api/sessions/public` nearby filtering to query `beaches.lat` / `beaches.lon` instead of stale `center_lat` / `center_lng` columns.
- Throw on nearby beach lookup errors so schema drift fails loudly instead of silently returning an empty feed.
- Update active coordinate guidance in the web repo docs to use `beach.lat` / `beach.lon`.

## Root Cause
The public sessions route used columns that are not present on the live `beaches` table. The Supabase error from that beach lookup was ignored, which collapsed the nearby beach ID set to empty and made the Nearby feed return 0 sessions.

## Test Plan
- [x] `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn test:unit __tests__/api/sessions/public-sessions-route.test.ts --runInBand`
- [x] `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn typecheck`