### PR TITLE
fix(analytics): allow onboarding intro event

### DIFF
--- a/__tests__/api/events-taxonomy-characterization.test.ts
+++ b/__tests__/api/events-taxonomy-characterization.test.ts
@@ -21,11 +21,11 @@ import {
 import { EVENT_WEIGHTS } from "@/types/implicit-preferences";
 
 const CURRENT_EVENT_SET_HASHES = {
-  valid: "cac180da289bee4b7d19df2998d8856e2f9e622fd28bfe62b6b9057f92023fbe",
+  valid: "9da8656abb554c713d170bf7a413644bebe543c7eabbae8b26d10c2d759be427",
   anonymousAllowed:
-    "075066386791f1a86eb16b4e7966a6b9f90d00d14695b07065e69d4d788b97be",
+    "041f46e53eaf19d40bd24cc74d92b2f01f86c5dfeca0a1745e8bb3fbc851d5d7",
   preAuthOnly:
-    "f55c47e91fb773e725b6ef914a93099aeb5e963f3f7d88cc34bf4a0023e99367",
+    "8a7190af3042418d91c03cacb3f3be72cce78497cb86a5ba42fcd2dc62819d69",
 } as const;
 
 const PHASE_20_MEASUREMENT_EVENTS = [

--- a/__tests__/events-allowlist-onboarding-intro.test.ts
+++ b/__tests__/events-allowlist-onboarding-intro.test.ts
@@ -1,0 +1,21 @@
+import {
+  ANONYMOUS_ALLOWED_EVENTS,
+  PRE_AUTH_ONLY_EVENTS,
+  VALID_EVENTS,
+} from '@/app/api/events/route';
+
+const ONBOARDING_INTRO_EVENT = 'onboarding_intro_get_started';
+
+describe('onboarding intro event allowlist', () => {
+  it('accepts the get-started tap event', () => {
+    expect(VALID_EVENTS).toContain(ONBOARDING_INTRO_EVENT);
+  });
+
+  it('allows the get-started tap before auth', () => {
+    expect(ANONYMOUS_ALLOWED_EVENTS).toContain(ONBOARDING_INTRO_EVENT);
+  });
+
+  it('drops ghost signed-in fires for the pre-auth get-started tap', () => {
+    expect(PRE_AUTH_ONLY_EVENTS).toContain(ONBOARDING_INTRO_EVENT);
+  });
+});

--- a/lib/analytics/event-taxonomy.ts
+++ b/lib/analytics/event-taxonomy.ts
@@ -79,6 +79,7 @@ export const VALID_EVENTS = [
   'product_tour_skipped',
   'product_tour_step_viewed',
   'onboarding_started',
+  'onboarding_intro_get_started',
   'onboarding_step_viewed',
   'onboarding_step_completed',
   'onboarding_step_auto_skipped',
@@ -296,6 +297,8 @@ export const ANONYMOUS_ALLOWED_EVENTS: readonly EventType[] = [
   // an anonymous user. Authed fires are ghost-triggers and dropped server-side
   // via PRE_AUTH_ONLY_EVENTS.
   'signup_form_submitted', 'login_form_submitted',
+  // Native signed-out onboarding intro CTA.
+  'onboarding_intro_get_started',
   // Engagement signals from anonymous visitors
   'forecast_interaction', 'forecast_tab_click', 'horizon_strip_day_selected',
   'beach_search', 'beach_search_result_click', 'map_interaction', 'map_marker_click',
@@ -343,6 +346,8 @@ export const PRE_AUTH_ONLY_EVENTS: readonly EventType[] = [
   'login_form_submitted',
   'auth_modal_opened',
   'auth_modal_closed_without_action',
+  // Native signed-out onboarding intro CTA.
+  'onboarding_intro_get_started',
   // Anon alert capture (pre-auth only). Ghost-authed fires of these
   // events are silently dropped server-side. The post-auth siblings
   // (magic_link_clicked, signup_success) intentionally NOT here — they

--- a/supabase/migrations/20260612082818_allow_onboarding_intro_get_started_event.sql
+++ b/supabase/migrations/20260612082818_allow_onboarding_intro_get_started_event.sql
@@ -1,0 +1,50 @@
+-- Widen user_events.event_type CHECK to accept the native onboarding intro
+-- get-started conversion event.
+--
+-- Native fires onboarding_intro_get_started from the signed-out intro screen
+-- before routing into auth. Preserve the live CHECK expression dynamically so
+-- prior web/native event additions remain accepted.
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_check text;
+  candidate_events text[] := ARRAY[
+    'onboarding_intro_get_started'
+  ];
+  missing_events text[];
+BEGIN
+  SELECT regexp_replace(pg_get_constraintdef(oid), '^CHECK \((.*)\)$', '\1')
+    INTO current_check
+  FROM pg_constraint
+  WHERE conrelid = 'public.user_events'::regclass
+    AND conname = 'user_events_event_type_check';
+
+  IF current_check IS NULL THEN
+    RAISE EXCEPTION 'user_events_event_type_check constraint not found';
+  END IF;
+
+  SELECT array_agg(event_name)
+    INTO missing_events
+  FROM unnest(candidate_events) AS event_name
+  WHERE current_check NOT LIKE '%' || event_name || '%';
+
+  IF missing_events IS NULL OR array_length(missing_events, 1) IS NULL THEN
+    RAISE NOTICE 'onboarding_intro_get_started already present; no change.';
+    RETURN;
+  END IF;
+
+  ALTER TABLE public.user_events
+    DROP CONSTRAINT user_events_event_type_check;
+
+  EXECUTE format(
+    'ALTER TABLE public.user_events ADD CONSTRAINT user_events_event_type_check CHECK ((%s) OR event_type = ANY (%L::text[]))',
+    current_check,
+    missing_events
+  );
+END $$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/implicit-preferences.ts
+++ b/types/implicit-preferences.ts
@@ -96,6 +96,7 @@ export const EVENT_WEIGHTS: Record<ImplicitEventType, number> = {
   product_tour_skipped: 0,
   product_tour_step_viewed: 0,
   onboarding_started: 0,
+  onboarding_intro_get_started: 0,
   onboarding_step_viewed: 0,
   onboarding_step_completed: 0,
   onboarding_step_auto_skipped: 0,


### PR DESCRIPTION
Cherry-pick of ac312fc6 from codex/home-filter-parity (only this commit — the branch carries unrelated work).

Adds `onboarding_intro_get_started` to VALID_EVENTS (anonymous-allowed, pre-auth-only, zero preference weight) so the native onboarding intro's Get-started conversion event is accepted by /api/events. The characterization-test hash is re-derived against main's event set (main's VALID_EVENTS differs from the source branch; the anonymous/pre-auth hashes are unchanged and match exactly).

The DB constraint migration in this commit has already been applied to production (idempotent — re-runs no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)