### PR TITLE
chore(noaa): hard-disable GFS-Wave shadow capture

### DIFF
--- a/__tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts
+++ b/__tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts
@@ -1,4 +1,5 @@
 import {
+  GFS_WAVE_SHADOW_CAPTURE_DISABLED,
   GFS_WAVE_SHADOW_MODEL,
   buildGfsWaveShadowForecast,
   buildGfsWaveShadowRows,
@@ -53,12 +54,14 @@ describe("GFS-Wave shadow capture helpers", () => {
     }
   });
 
-  it("is off unless explicitly enabled", () => {
+  it("is hard-disabled even when the legacy env flag is enabled", () => {
+    expect(GFS_WAVE_SHADOW_CAPTURE_DISABLED).toBe(true);
+
     delete process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED;
     expect(isGfsWaveShadowCaptureEnabled()).toBe(false);
 
     process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED = "true";
-    expect(isGfsWaveShadowCaptureEnabled()).toBe(true);
+    expect(isGfsWaveShadowCaptureEnabled()).toBe(false);
   });
 
   it("classifies an all-zero wave_height payload as missing-source data", () => {

--- a/lib/services/noaa-wavewatch/gfs-wave-shadow.ts
+++ b/lib/services/noaa-wavewatch/gfs-wave-shadow.ts
@@ -11,6 +11,9 @@ const log = createContextLogger("GfsWaveShadow");
 export const GFS_WAVE_SHADOW_MODEL = "ncep_gfswave016";
 export const GFS_WAVE_SHADOW_SOURCE = "open_meteo";
 export const GFS_WAVE_SHADOW_TABLE = "gfs_wave_shadow_forecasts";
+// Disabled 2026-06-18 while mixed-swell promotion is paused. Re-enable only
+// with Seaside's DEFAULT_PROMOTION_ENABLED in mixed_swell_shadow.py.
+export const GFS_WAVE_SHADOW_CAPTURE_DISABLED = true;
 
 export type GfsWaveShadowCaptureStatus =
   | "ok"
@@ -105,6 +108,7 @@ function nullGfsValues(): Pick<
 }
 
 export function isGfsWaveShadowCaptureEnabled(): boolean {
+  if (GFS_WAVE_SHADOW_CAPTURE_DISABLED) return false;
   return process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED === "true";
 }
 


### PR DESCRIPTION
## Summary
- Hard-disable GFS-Wave shadow capture in code, even if the legacy env flag is toggled.
- Update the focused GFS-Wave shadow unit test to lock the disabled behavior.
- Add a cross-repo re-enable note tying this guard to Seaside mixed-swell promotion readiness.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn jest __tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts --runInBand` - passed, 10 tests.
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && npx eslint --max-warnings=0 lib/services/noaa-wavewatch/gfs-wave-shadow.ts __tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts` - passed.
- `source ~/.nvm/nvm.sh && nvm use 22 >/dev/null && yarn typecheck` - passed.

## Release Notes
- No DB migration.
- No new env var. Production capture is already off with `GFS_WAVE_SHADOW_CAPTURE_ENABLED=false`; this adds code-level defense in depth when deployed.
- No screenshots; no UI surface changed.