### PR TITLE
docs: note disabled CI gate + app-first flag no-op

### DIFF
--- a/components/landing-page/field-guide/quiver-field-guide-landing.tsx
+++ b/components/landing-page/field-guide/quiver-field-guide-landing.tsx
@@ -9,6 +9,9 @@ import type { FirstTouchPlatform } from "@/lib/analytics/web-context";
 
 interface QuiverFieldGuideLandingProps {
   platform: FirstTouchPlatform;
+  /** Defaults ON upstream and only tags analytics cohort; this does not gate
+   * whether the field-guide landing renders. Roll back by reverting deploy, not
+   * flipping APP_FIRST_LANDING_ENABLED. */
   appFirst?: boolean;
 }
 

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -58,13 +58,35 @@ This keeps both branches in sync without back-merging.
 
 ## CI Protection
 
-PRs targeting `prod` run the `prod-gate` workflow (`.github/workflows/prod-gate.yml`):
+The configured `prod-gate` workflow (`.github/workflows/prod-gate.yml`) is
+intended to gate PRs targeting `prod` with:
 - TypeScript type check
 - Lint
+- Unit tests
 - Build
 - Playwright smoke tests
 
-All checks must pass before merging to `prod`.
+When that workflow is enabled, all checks must pass before merging to `prod`.
+
+**Current CI reality (confirmed 2026-06-20):** GitHub reports the `Prod Gate`
+workflow as `disabled_manually` and its workflow metadata was last updated when
+Actions were disabled on 2026-05-06. This workflow currently does **not** run
+automatically on PRs, so a green or mergeable PR has **not** been gated by CI.
+When enabled, the workflow runs typecheck, lint, unit tests, build, and
+Playwright `@smoke`, but the smoke job targets `https://dev.quiversurf.app`
+rather than the PR's own deployment.
+
+Until Actions are re-enabled, contributors must treat local verification as the
+gate. Use Node 22 and run:
+
+```bash
+yarn typecheck
+yarn test:unit
+yarn build
+npx playwright test --grep @smoke --project=guest
+```
+
+Run the relevant smoke target for the deployment being validated.
 
 ## Naming Conventions
 

--- a/lib/flags/app-first-landing.ts
+++ b/lib/flags/app-first-landing.ts
@@ -1,7 +1,8 @@
 import "server-only";
 
-/** App-first landing restructure flag. Default ON; set
- * APP_FIRST_LANDING_ENABLED=false to roll back instantly. */
+/** Defaults ON and only tags the analytics cohort; it does not gate whether the
+ * field-guide landing renders. Roll back by reverting deploy, not flipping
+ * APP_FIRST_LANDING_ENABLED. */
 export function isAppFirstLandingEnabled(): boolean {
   return process.env.APP_FIRST_LANDING_ENABLED !== "false";
 }


### PR DESCRIPTION
## Summary
- Document the current `prod-gate` reality: GitHub reports `Prod Gate` as `disabled_manually`, disabled on 2026-05-06, and it does not automatically gate PRs while Actions remain disabled.
- Note that the configured smoke job targets `https://dev.quiversurf.app` rather than a PR deployment when the workflow is enabled.
- Correct the app-first flag comments to state that `APP_FIRST_LANDING_ENABLED` only tags analytics cohort and does not gate rendering of the field-guide landing.

## Verification
- `gh workflow list --all`
- `gh api repos/:owner/:repo/actions/workflows/237313893 --jq '{name, state, created_at, updated_at, path}'`
- `source ~/.nvm/nvm.sh && nvm use 22 && yarn install --frozen-lockfile`
- `source ~/.nvm/nvm.sh && nvm use 22 && node -v && yarn typecheck`
- `source ~/.nvm/nvm.sh && nvm use 22 && node -v && npx eslint --max-warnings=0 lib/flags/app-first-landing.ts components/landing-page/field-guide/quiver-field-guide-landing.tsx`
- `git diff --check`

## E2E
- No E2E tests added or run; this is docs/comment-only and does not change runtime behavior.