### PR TITLE
feat(notifications): morning home-break call + weekend-window push crons (disabled by default)

### DIFF
--- a/__tests__/api/cron/home-morning-call.test.ts
+++ b/__tests__/api/cron/home-morning-call.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+
+import { buildMorningCallCopy } from "@/app/api/cron/home-morning-call/route";
+import { isEligibleHomeBeachPushProfile } from "@/lib/cron/home-beach-push-runner";
+import { NOTIFICATION_REGISTRY } from "@/lib/notifications/registry";
+
+describe("home_morning_call registry contract", () => {
+  it("emits the pinned native push data shape", () => {
+    const def = (NOTIFICATION_REGISTRY as any).home_morning_call;
+
+    expect(def.channels).toEqual(["push"]);
+    expect(def.prefs.master.push).toBe("notif_push_enabled");
+    expect(def.prefs.perType.push).toBe("notif_reminders");
+
+    const out = def.buildPushPayload({
+      beach_id: "beach-1",
+      beach_name: "La Jolla",
+      verdict: "YES",
+      forecast_at: "2026-06-24T13:00:00.000Z",
+      title: "La Jolla: It's firing",
+      body: "3.5ft @ 11s. Clean offshore.",
+    });
+
+    expect(out).toMatchObject({
+      title: "La Jolla: It's firing",
+      body: "3.5ft @ 11s. Clean offshore.",
+      data: {
+        type: "home_morning_call",
+        beach_id: "beach-1",
+        verdict: "YES",
+        forecast_at: "2026-06-24T13:00:00.000Z",
+      },
+    });
+  });
+});
+
+describe("home_morning_call helpers", () => {
+  it("keeps only home-beach users with push and reminder prefs enabled", () => {
+    const allowlist = new Set<string>();
+
+    expect(
+      isEligibleHomeBeachPushProfile(
+        {
+          id: "user-1",
+          home_beach_id: "beach-1",
+          notif_push_enabled: null,
+          notif_reminders: null,
+        },
+        allowlist
+      )
+    ).toBe(true);
+
+    expect(
+      isEligibleHomeBeachPushProfile(
+        {
+          id: "user-1",
+          home_beach_id: null,
+          notif_push_enabled: null,
+          notif_reminders: null,
+        },
+        allowlist
+      )
+    ).toBe(false);
+
+    expect(
+      isEligibleHomeBeachPushProfile(
+        {
+          id: "user-1",
+          home_beach_id: "beach-1",
+          notif_push_enabled: false,
+          notif_reminders: null,
+        },
+        allowlist
+      )
+    ).toBe(false);
+
+    expect(
+      isEligibleHomeBeachPushProfile(
+        {
+          id: "user-1",
+          home_beach_id: "beach-1",
+          notif_push_enabled: null,
+          notif_reminders: false,
+        },
+        new Set(["other-user"])
+      )
+    ).toBe(false);
+  });
+
+  it("builds verdict-specific morning call copy", () => {
+    expect(
+      buildMorningCallCopy({
+        verdict: "YES",
+        beachName: "La Jolla",
+        waveHeight: "3-4 ft",
+        wavePeriod: "11s",
+        windDescription: "clean offshore",
+        whySentence: "Clean offshore with 3-4 ft swell energy.",
+      })
+    ).toEqual({
+      title: "La Jolla: It's firing",
+      body: "3-4 ft @ 11s. Clean offshore with 3-4 ft swell energy.",
+    });
+
+    expect(
+      buildMorningCallCopy({
+        verdict: "MAYBE",
+        beachName: "La Jolla",
+        waveHeight: "2 ft",
+        wavePeriod: null,
+        windDescription: null,
+        whySentence: "Rideable 2 ft surf - keep an eye on conditions.",
+      })
+    ).toEqual({
+      title: "La Jolla: Worth a look",
+      body: "2 ft. Rideable 2 ft surf - keep an eye on conditions.",
+    });
+
+    expect(
+      buildMorningCallCopy({
+        verdict: "NO",
+        beachName: "La Jolla",
+        waveHeight: null,
+        wavePeriod: null,
+        windDescription: null,
+        whySentence: "No viable surf window today.",
+      })
+    ).toEqual({
+      title: "La Jolla: Rest up today",
+      body: "No viable surf window today. Check the week before you drive.",
+    });
+  });
+});

--- a/__tests__/api/cron/weekend-window.test.ts
+++ b/__tests__/api/cron/weekend-window.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  buildWeekendWindowCopy,
+  getUpcomingWeekendKey,
+  isWeekendDaylightForecast,
+} from "@/app/api/cron/weekend-window/route";
+import { NOTIFICATION_REGISTRY } from "@/lib/notifications/registry";
+
+describe("weekend_window registry contract", () => {
+  it("emits the pinned native push data shape", () => {
+    const def = (NOTIFICATION_REGISTRY as any).weekend_window;
+
+    expect(def.channels).toEqual(["push"]);
+    expect(def.prefs.master.push).toBe("notif_push_enabled");
+    expect(def.prefs.perType.push).toBe("notif_reminders");
+
+    const out = def.buildPushPayload({
+      beach_id: "beach-1",
+      forecast_at: "2026-06-20T15:00:00.000Z",
+      window_local: "Sat 8am",
+      title: "Saturday's looking fun at La Jolla",
+      body: "Sat 8am: 3.5ft @ 10s · NW wind 6mph.",
+    });
+
+    expect(out).toMatchObject({
+      title: "Saturday's looking fun at La Jolla",
+      body: "Sat 8am: 3.5ft @ 10s · NW wind 6mph.",
+      data: {
+        type: "weekend_window",
+        beach_id: "beach-1",
+        forecast_at: "2026-06-20T15:00:00.000Z",
+        window_local: "Sat 8am",
+      },
+    });
+  });
+});
+
+describe("weekend_window helpers", () => {
+  it("keys the coming weekend by the user's local Saturday", () => {
+    expect(
+      getUpcomingWeekendKey(
+        new Date("2026-06-18T20:00:00.000Z"),
+        "America/Los_Angeles"
+      )
+    ).toBe("2026-06-20");
+
+    expect(
+      getUpcomingWeekendKey(
+        new Date("2026-06-20T20:00:00.000Z"),
+        "America/Los_Angeles"
+      )
+    ).toBe("2026-06-20");
+  });
+
+  it("keeps only Saturday or Sunday daylight forecasts for that weekend", () => {
+    const tz = "America/Los_Angeles";
+    const weekendKey = "2026-06-20";
+
+    expect(
+      isWeekendDaylightForecast("2026-06-20T15:00:00.000Z", tz, weekendKey)
+    ).toBe(true);
+    expect(
+      isWeekendDaylightForecast("2026-06-21T16:00:00.000Z", tz, weekendKey)
+    ).toBe(true);
+    expect(
+      isWeekendDaylightForecast("2026-06-19T15:00:00.000Z", tz, weekendKey)
+    ).toBe(false);
+    expect(
+      isWeekendDaylightForecast("2026-06-20T05:00:00.000Z", tz, weekendKey)
+    ).toBe(false);
+  });
+
+  it("builds weekend planning copy from the selected window", () => {
+    expect(
+      buildWeekendWindowCopy({
+        beachName: "La Jolla",
+        windowLocal: "Sat 8am",
+        waveHeightFt: 3.5,
+        wavePeriodS: 10,
+        windDirection: "NW",
+        windSpeedMph: 6,
+      })
+    ).toEqual({
+      title: "Saturday's looking fun at La Jolla",
+      body: "Sat 8am: 3.5ft @ 10s · NW wind 6mph.",
+    });
+  });
+});

--- a/__tests__/notifications/registry.test.ts
+++ b/__tests__/notifications/registry.test.ts
@@ -8,6 +8,18 @@
 import { NOTIFICATION_REGISTRY } from "@/lib/notifications/registry";
 
 describe("NOTIFICATION_REGISTRY — Phase 5h informational consolidation", () => {
+  it("home_morning_call and weekend_window are registered as push-only reminders", () => {
+    const registry = NOTIFICATION_REGISTRY as any;
+
+    for (const key of ["home_morning_call", "weekend_window"]) {
+      expect(registry[key].channels).toEqual(["push"]);
+      expect(registry[key].prefs.master.push).toBe("notif_push_enabled");
+      expect(registry[key].prefs.perType.push).toBe("notif_reminders");
+      expect(registry[key].quietHours.mode).toBe("defer");
+      expect(registry[key].suppressSelfNotify).toBe(false);
+    }
+  });
+
   it("forecast_alert restores push alongside in_app", () => {
     const def = NOTIFICATION_REGISTRY.forecast_alert as unknown as {
       channels: string[];

--- a/app/api/cron/home-morning-call/route.ts
+++ b/app/api/cron/home-morning-call/route.ts
@@ -1,0 +1,199 @@
+/**
+ * GET /api/cron/home-morning-call
+ *
+ * Morning home-break surf call push. Disabled by default and allowlist-gated
+ * for rollout. Auth: Authorization: Bearer <CRON_SECRET> or Vercel Cron header.
+ */
+
+import type { EnhancedForecastEntity } from "@/types/forecast";
+import {
+  runHomeBeachPushCron,
+  type HomeBeachPushSelectArgs,
+  type HomeBeachPushSelection,
+} from "@/lib/cron/home-beach-push-runner";
+import { withObservedCron } from "@/lib/cron/observability";
+import { getLocalDateString, getLocalHour } from "@/lib/utils/timezone-utils";
+import { resolveTodayHeadline } from "@/lib/services/forecast/today-headline";
+import {
+  computeSurfCall,
+  type SurfCallVerdict,
+} from "@/lib/utils/surf-call-logic";
+
+export const revalidate = 0;
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const CONTEXT_TAG = "[home-morning-call]";
+const NOTIFICATION_TYPE = "home_morning_call";
+const MORNING_START_HOUR = 5;
+const MORNING_END_HOUR = 12;
+const LOOKAHEAD_HOURS = 30;
+const SENTRY_MONITOR = {
+  slug: "home-morning-call",
+  schedule: "0 13 * * *",
+  maxRuntimeMinutes: 5,
+};
+
+interface HomeMorningCallPayload {
+  verdict: SurfCallVerdict;
+  beach_id: string;
+  beach_name: string;
+  forecast_at: string;
+  title: string;
+  body: string;
+}
+
+interface MorningCopyInput {
+  verdict: SurfCallVerdict;
+  beachName: string;
+  waveHeight: string | null;
+  wavePeriod: string | null;
+  windDescription: string | null;
+  whySentence: string | null;
+}
+
+function sentence(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function conditionLine(
+  waveHeight: string | null,
+  wavePeriod: string | null
+): string | null {
+  if (!waveHeight) return null;
+  if (!wavePeriod) return waveHeight;
+  return `${waveHeight} @ ${wavePeriod}`;
+}
+
+export function buildMorningCallCopy(input: MorningCopyInput): {
+  title: string;
+  body: string;
+} {
+  const condition = sentence(conditionLine(input.waveHeight, input.wavePeriod));
+  const why = sentence(input.whySentence ?? input.windDescription);
+
+  if (input.verdict === "YES") {
+    return {
+      title: `${input.beachName}: It's firing`,
+      body:
+        [condition, why].filter(Boolean).join(" ") ||
+        "Conditions look worth it today.",
+    };
+  }
+
+  if (input.verdict === "MAYBE") {
+    return {
+      title: `${input.beachName}: Worth a look`,
+      body:
+        [condition, why].filter(Boolean).join(" ") ||
+        "There may be a window today.",
+    };
+  }
+
+  return {
+    title: `${input.beachName}: Rest up today`,
+    body: `${why ?? "Flat or blown out today."} Check the week before you drive.`,
+  };
+}
+
+function normalizePeriod(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return /\bs\b/i.test(trimmed) ? trimmed : `${trimmed}s`;
+}
+
+function filterMorningForecasts(
+  forecasts: EnhancedForecastEntity[],
+  timezone: string,
+  now: Date
+): EnhancedForecastEntity[] {
+  const today = getLocalDateString(now, timezone);
+  return forecasts.filter((forecast) => {
+    if (!forecast.forecast_at) return false;
+    const forecastDate = new Date(forecast.forecast_at);
+    const hour = getLocalHour(forecastDate, timezone);
+    return (
+      getLocalDateString(forecastDate, timezone) === today &&
+      hour >= MORNING_START_HOUR &&
+      hour < MORNING_END_HOUR
+    );
+  });
+}
+
+function selectAndBuildMorningCall({
+  profile,
+  beach,
+  forecasts,
+  timezone,
+  now,
+}: HomeBeachPushSelectArgs): HomeBeachPushSelection<HomeMorningCallPayload> {
+  const morningForecasts = filterMorningForecasts(forecasts, timezone, now);
+  if (morningForecasts.length === 0) {
+    return { skipReason: "noForecast" };
+  }
+
+  const headline = resolveTodayHeadline({
+    forecasts: morningForecasts,
+    beach,
+    userPrefs: null,
+    horizonHours: 12,
+    now,
+  });
+  const window = headline?.window ?? null;
+  const call = computeSurfCall(window, morningForecasts, beach, {
+    isTomorrow: false,
+  });
+  const sourceForecast =
+    morningForecasts.find(
+      (forecast) => forecast.forecast_at === call.bestWindowStart
+    ) ??
+    morningForecasts.find(
+      (forecast) => forecast.forecast_at === headline?.display.forecastAt
+    ) ??
+    morningForecasts[0];
+  const copy = buildMorningCallCopy({
+    verdict: call.verdict,
+    beachName: beach.name,
+    waveHeight: call.waveHeight ?? sourceForecast.wave_height ?? null,
+    wavePeriod: normalizePeriod(sourceForecast.wave_period),
+    windDescription: call.windDescription,
+    whySentence: call.whySentence,
+  });
+  const localDate = getLocalDateString(now, timezone);
+  const forecastAt =
+    call.bestWindowStart ??
+    headline?.display.forecastAt ??
+    sourceForecast.forecast_at;
+
+  return {
+    payload: {
+      verdict: call.verdict,
+      beach_id: beach.id,
+      beach_name: beach.name,
+      forecast_at: forecastAt,
+      title: copy.title,
+      body: copy.body,
+    },
+    dedupeKey: `${NOTIFICATION_TYPE}:${profile.id}:${localDate}`,
+  };
+}
+
+async function _GET(request: Request): Promise<Response> {
+  return runHomeBeachPushCron<HomeMorningCallPayload>(request, {
+    contextTag: CONTEXT_TAG,
+    enabledEnv: "HOME_MORNING_CALL_ENABLED",
+    allowlistEnv: "HOME_MORNING_CALL_TEST_USER_IDS",
+    type: NOTIFICATION_TYPE,
+    lookaheadHours: LOOKAHEAD_HOURS,
+    selectAndBuild: selectAndBuildMorningCall,
+  });
+}
+
+export const GET = withObservedCron(
+  "/api/cron/home-morning-call",
+  _GET,
+  SENTRY_MONITOR
+);

--- a/app/api/cron/weekend-window/route.ts
+++ b/app/api/cron/weekend-window/route.ts
@@ -1,0 +1,251 @@
+/**
+ * GET /api/cron/weekend-window
+ *
+ * Weekend home-break planning push. Disabled by default and allowlist-gated
+ * for rollout. Auth: Authorization: Bearer <CRON_SECRET> or Vercel Cron header.
+ */
+
+import type { Beach } from "@/types/database";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+import {
+  runHomeBeachPushCron,
+  type HomeBeachPushSelectArgs,
+  type HomeBeachPushSelection,
+} from "@/lib/cron/home-beach-push-runner";
+import { withObservedCron } from "@/lib/cron/observability";
+import { getLocalDateString, getLocalHour } from "@/lib/utils/timezone-utils";
+import { scoreWindowWithComposite } from "@/lib/services/discovery/window-selector";
+
+export const revalidate = 0;
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const CONTEXT_TAG = "[weekend-window]";
+const NOTIFICATION_TYPE = "weekend_window";
+const LOOKAHEAD_HOURS = 10 * 24;
+const DAYLIGHT_START_HOUR = 6;
+const DAYLIGHT_END_HOUR = 19;
+const SURFABILITY_FLOOR = 60;
+const SENTRY_MONITOR = {
+  slug: "weekend-window",
+  schedule: "0 1 * * 5,6",
+  maxRuntimeMinutes: 5,
+};
+
+interface WeekendWindowPayload {
+  beach_id: string;
+  forecast_at: string;
+  window_local: string;
+  title: string;
+  body: string;
+}
+
+interface WeekendCopyInput {
+  beachName: string;
+  windowLocal: string;
+  waveHeightFt: number | null;
+  wavePeriodS: number | null;
+  windDirection?: string | null;
+  windSpeedMph?: number | null;
+}
+
+interface WeekendPick {
+  forecast: EnhancedForecastEntity;
+  score: number;
+}
+
+function localWeekday(date: Date, timezone: string): number {
+  const day = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    weekday: "short",
+  }).format(date);
+  const weekdays: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  return weekdays[day] ?? date.getUTCDay();
+}
+
+function addDaysToDateKey(dateKey: string, days: number): string {
+  const date = new Date(`${dateKey}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+export function getUpcomingWeekendKey(now: Date, timezone: string): string {
+  const localDate = getLocalDateString(now, timezone);
+  const weekday = localWeekday(now, timezone);
+  const daysUntilSaturday = weekday === 6 ? 0 : (6 - weekday + 7) % 7;
+  return addDaysToDateKey(localDate, daysUntilSaturday);
+}
+
+export function isWeekendDaylightForecast(
+  forecastAt: string,
+  timezone: string,
+  weekendKey: string
+): boolean {
+  const forecastDate = new Date(forecastAt);
+  const localDate = getLocalDateString(forecastDate, timezone);
+  const sundayKey = addDaysToDateKey(weekendKey, 1);
+  const hour = getLocalHour(forecastDate, timezone);
+
+  return (
+    (localDate === weekendKey || localDate === sundayKey) &&
+    hour >= DAYLIGHT_START_HOUR &&
+    hour < DAYLIGHT_END_HOUR
+  );
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+}
+
+function parseOptionalNumber(
+  value: string | number | null | undefined
+): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (!value) return null;
+  const parsed = parseFloat(value.replace(/[^\d.-]/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function fullDayName(windowLocal: string): string {
+  const prefix = windowLocal.split(/\s+/)[0];
+  const days: Record<string, string> = {
+    Sat: "Saturday",
+    Sun: "Sunday",
+  };
+  return days[prefix] ?? "Weekend";
+}
+
+export function buildWeekendWindowCopy(input: WeekendCopyInput): {
+  title: string;
+  body: string;
+} {
+  const wave =
+    input.waveHeightFt != null && input.wavePeriodS != null
+      ? `${formatNumber(input.waveHeightFt)}ft @ ${formatNumber(input.wavePeriodS)}s`
+      : input.waveHeightFt != null
+        ? `${formatNumber(input.waveHeightFt)}ft`
+        : "Surfable window";
+  const wind =
+    input.windDirection && input.windSpeedMph != null
+      ? ` · ${input.windDirection} wind ${formatNumber(input.windSpeedMph)}mph`
+      : "";
+
+  return {
+    title: `${fullDayName(input.windowLocal)}'s looking fun at ${input.beachName}`,
+    body: `${input.windowLocal}: ${wave}${wind}.`,
+  };
+}
+
+function formatWindowLocal(forecastAt: string, timezone: string): string {
+  try {
+    const date = new Date(forecastAt);
+    const day = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      weekday: "short",
+    }).format(date);
+    const hour = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "numeric",
+      hour12: true,
+    })
+      .format(date)
+      .toLowerCase()
+      .replace(/\s+/g, "");
+    return `${day} ${hour}`;
+  } catch {
+    return forecastAt;
+  }
+}
+
+function pickBestWeekendWindow(
+  forecasts: EnhancedForecastEntity[],
+  beach: Beach,
+  timezone: string,
+  weekendKey: string
+): WeekendPick | null {
+  let best: WeekendPick | null = null;
+
+  for (const forecast of forecasts) {
+    if (!isWeekendDaylightForecast(forecast.forecast_at, timezone, weekendKey)) {
+      continue;
+    }
+
+    const score = scoreWindowWithComposite(forecast, beach).total;
+    if (score < SURFABILITY_FLOOR) {
+      continue;
+    }
+
+    if (
+      !best ||
+      score > best.score ||
+      (score === best.score &&
+        forecast.forecast_at < best.forecast.forecast_at)
+    ) {
+      best = { forecast, score };
+    }
+  }
+
+  return best;
+}
+
+function selectAndBuildWeekendWindow({
+  profile,
+  beach,
+  forecasts,
+  timezone,
+  now,
+}: HomeBeachPushSelectArgs): HomeBeachPushSelection<WeekendWindowPayload> {
+  const weekendKey = getUpcomingWeekendKey(now, timezone);
+  const pick = pickBestWeekendWindow(forecasts, beach, timezone, weekendKey);
+  if (!pick) {
+    return { skipReason: "noSurfableWindow" };
+  }
+
+  const forecast = pick.forecast;
+  const windowLocal = formatWindowLocal(forecast.forecast_at, timezone);
+  const copy = buildWeekendWindowCopy({
+    beachName: beach.name,
+    windowLocal,
+    waveHeightFt: parseOptionalNumber(forecast.wave_height),
+    wavePeriodS: parseOptionalNumber(forecast.wave_period),
+    windDirection: forecast.wind_direction,
+    windSpeedMph: parseOptionalNumber(forecast.wind_speed),
+  });
+
+  return {
+    payload: {
+      beach_id: beach.id,
+      forecast_at: forecast.forecast_at,
+      window_local: windowLocal,
+      title: copy.title,
+      body: copy.body,
+    },
+    dedupeKey: `${NOTIFICATION_TYPE}:${profile.id}:${weekendKey}`,
+  };
+}
+
+async function _GET(request: Request): Promise<Response> {
+  return runHomeBeachPushCron<WeekendWindowPayload>(request, {
+    contextTag: CONTEXT_TAG,
+    enabledEnv: "WEEKEND_WINDOW_ENABLED",
+    allowlistEnv: "WEEKEND_WINDOW_TEST_USER_IDS",
+    type: NOTIFICATION_TYPE,
+    lookaheadHours: LOOKAHEAD_HOURS,
+    selectAndBuild: selectAndBuildWeekendWindow,
+  });
+}
+
+export const GET = withObservedCron(
+  "/api/cron/weekend-window",
+  _GET,
+  SENTRY_MONITOR
+);

--- a/lib/cron/home-beach-push-runner.ts
+++ b/lib/cron/home-beach-push-runner.ts
@@ -1,0 +1,283 @@
+import type { Beach } from "@/types/database";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+import type { NotificationType } from "@/lib/notifications/registry";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  handleApiError,
+  validateCronRequest,
+} from "@/lib/middleware/api-wrappers";
+import { enqueueNotification } from "@/lib/notifications/enqueue";
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+import { resolveBeachTimezone } from "@/lib/utils/timezone-utils";
+
+export interface HomeBeachPushProfileRow {
+  id: string;
+  home_beach_id: string | null;
+  timezone?: string | null;
+  notif_push_enabled?: boolean | null;
+  notif_reminders?: boolean | null;
+}
+
+export interface HomeBeachPushSelectArgs {
+  profile: HomeBeachPushProfileRow;
+  beach: Beach;
+  forecasts: EnhancedForecastEntity[];
+  timezone: string;
+  now: Date;
+}
+
+export type HomeBeachPushSelection<P extends object> =
+  | { payload: P; dedupeKey: string }
+  | { skipReason: string };
+
+interface HomeBeachPushRunnerOptions<P extends object> {
+  contextTag: string;
+  enabledEnv: string;
+  allowlistEnv: string;
+  type: NotificationType;
+  lookaheadHours: number;
+  selectAndBuild: (
+    args: HomeBeachPushSelectArgs
+  ) => HomeBeachPushSelection<P> | Promise<HomeBeachPushSelection<P>>;
+}
+
+interface HomeBeachPushRunSummary {
+  skipped: boolean;
+  reason?: string;
+  evaluated: number;
+  candidates: number;
+  sent: number;
+  duplicates: number;
+  testAllowlistActive: boolean;
+  skippedCounts: Record<string, number>;
+  errors: number;
+  durationMs: number;
+}
+
+function createSkippedCounts(): Record<string, number> {
+  return {
+    disabledPrefs: 0,
+    noHomeBeach: 0,
+    notInAllowlist: 0,
+    noBeach: 0,
+    noForecast: 0,
+    enqueueFailed: 0,
+  };
+}
+
+function increment(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+export function parseHomeBeachPushAllowlist(envName: string): Set<string> {
+  const raw = process.env[envName] ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean)
+  );
+}
+
+export function isEligibleHomeBeachPushProfile(
+  profile: HomeBeachPushProfileRow,
+  allowlist: Set<string>
+): boolean {
+  if (!profile.home_beach_id) return false;
+  if (profile.notif_push_enabled === false) return false;
+  if (profile.notif_reminders === false) return false;
+  if (allowlist.size > 0 && !allowlist.has(profile.id)) return false;
+  return true;
+}
+
+async function loadProfiles(supabase: any): Promise<HomeBeachPushProfileRow[]> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, home_beach_id, timezone, notif_push_enabled, notif_reminders")
+    .not("home_beach_id", "is", null);
+
+  if (error) {
+    throw new Error(`Failed to query profiles: ${error.message}`);
+  }
+  return (data ?? []) as HomeBeachPushProfileRow[];
+}
+
+async function loadBeaches(
+  supabase: any,
+  beachIds: string[]
+): Promise<Map<string, Beach>> {
+  if (beachIds.length === 0) return new Map();
+
+  const { data, error } = await supabase
+    .from("beaches")
+    .select("*")
+    .in("id", beachIds)
+    .is("deleted_at", null);
+
+  if (error) {
+    throw new Error(`Failed to query beaches: ${error.message}`);
+  }
+
+  const byId = new Map<string, Beach>();
+  for (const row of (data ?? []) as Beach[]) {
+    byId.set(row.id, row);
+  }
+  return byId;
+}
+
+async function loadForecasts(
+  supabase: any,
+  beachId: string,
+  now: Date,
+  lookaheadHours: number
+): Promise<EnhancedForecastEntity[]> {
+  const horizon = new Date(now.getTime() + lookaheadHours * 60 * 60 * 1000);
+  const { data, error } = await supabase
+    .from("enhanced_forecasts")
+    .select("*")
+    .eq("beach_id", beachId)
+    .gte("forecast_at", now.toISOString())
+    .lt("forecast_at", horizon.toISOString())
+    .order("forecast_at", { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to query forecasts for ${beachId}: ${error.message}`);
+  }
+  return (data ?? []) as EnhancedForecastEntity[];
+}
+
+export async function runHomeBeachPushCron<P extends object>(
+  request: Request,
+  options: HomeBeachPushRunnerOptions<P>
+): Promise<Response> {
+  const startedAt = Date.now();
+
+  try {
+    if (!validateCronRequest(request)) {
+      return createErrorResponse("Unauthorized", "Invalid cron authentication", 401);
+    }
+
+    const summary: HomeBeachPushRunSummary = {
+      skipped: false,
+      evaluated: 0,
+      candidates: 0,
+      sent: 0,
+      duplicates: 0,
+      testAllowlistActive: false,
+      skippedCounts: createSkippedCounts(),
+      errors: 0,
+      durationMs: 0,
+    };
+
+    if (process.env[options.enabledEnv] !== "true") {
+      summary.skipped = true;
+      summary.reason = "disabled";
+      summary.durationMs = Date.now() - startedAt;
+      return createSuccessResponse(summary);
+    }
+
+    const allowlist = parseHomeBeachPushAllowlist(options.allowlistEnv);
+    summary.testAllowlistActive = allowlist.size > 0;
+    const supabase = createSupabaseServiceRoleClient();
+    const profiles = await loadProfiles(supabase);
+    const eligibleProfiles: HomeBeachPushProfileRow[] = [];
+
+    for (const profile of profiles) {
+      summary.evaluated++;
+      if (!profile.home_beach_id) {
+        increment(summary.skippedCounts, "noHomeBeach");
+        continue;
+      }
+      if (
+        profile.notif_push_enabled === false ||
+        profile.notif_reminders === false
+      ) {
+        increment(summary.skippedCounts, "disabledPrefs");
+        continue;
+      }
+      if (allowlist.size > 0 && !allowlist.has(profile.id)) {
+        increment(summary.skippedCounts, "notInAllowlist");
+        continue;
+      }
+      eligibleProfiles.push(profile);
+    }
+
+    summary.candidates = eligibleProfiles.length;
+    const beachIds = Array.from(
+      new Set(
+        eligibleProfiles
+          .map((profile) => profile.home_beach_id)
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+    const beachesById = await loadBeaches(supabase, beachIds);
+    const now = new Date();
+
+    for (const profile of eligibleProfiles) {
+      try {
+        const beachId = profile.home_beach_id;
+        if (!beachId) continue;
+        const beach = beachesById.get(beachId);
+        if (!beach) {
+          increment(summary.skippedCounts, "noBeach");
+          continue;
+        }
+
+        const timezone = resolveBeachTimezone(profile.timezone ?? beach.timezone);
+        const forecasts = await loadForecasts(
+          supabase,
+          beachId,
+          now,
+          options.lookaheadHours
+        );
+        if (forecasts.length === 0) {
+          increment(summary.skippedCounts, "noForecast");
+          continue;
+        }
+
+        const selection = await options.selectAndBuild({
+          profile,
+          beach,
+          forecasts,
+          timezone,
+          now,
+        });
+        if ("skipReason" in selection) {
+          increment(summary.skippedCounts, selection.skipReason);
+          continue;
+        }
+
+        const enqueueResult = await enqueueNotification(
+          {
+            type: options.type,
+            recipientUserId: profile.id,
+            payload: selection.payload as Record<string, unknown>,
+            dedupeKey: selection.dedupeKey,
+          },
+          supabase
+        );
+
+        if (enqueueResult.enqueued) {
+          summary.sent++;
+          continue;
+        }
+        if (enqueueResult.reason === "duplicate") {
+          summary.duplicates++;
+          continue;
+        }
+
+        increment(summary.skippedCounts, "enqueueFailed");
+        summary.errors++;
+      } catch (profileError) {
+        console.error(`${options.contextTag} Error processing ${profile.id}:`, profileError);
+        summary.errors++;
+      }
+    }
+
+    summary.durationMs = Date.now() - startedAt;
+    return createSuccessResponse(summary);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/lib/notifications/registry.ts
+++ b/lib/notifications/registry.ts
@@ -73,6 +73,23 @@ const dailyCallStreakReminderSchema = z.object({
   streak: z.number().int().min(1),
 });
 
+const homeMorningCallSchema = z.object({
+  verdict: z.enum(["YES", "MAYBE", "NO"]),
+  beach_id: z.string().min(1),
+  beach_name: z.string().optional(),
+  forecast_at: z.string().nullable().optional(),
+  title: z.string().min(1),
+  body: z.string().min(1),
+});
+
+const weekendWindowSchema = z.object({
+  beach_id: z.string().min(1),
+  forecast_at: z.string().min(1),
+  window_local: z.string().optional(),
+  title: z.string().min(1),
+  body: z.string().min(1),
+});
+
 const weeklyStreakReminderSchema = z.object({
   streak: z.number().int().min(1),
 });
@@ -215,6 +232,23 @@ interface LogSessionNudgePayload {
 
 interface DailyCallStreakReminderPayload {
   streak: number;
+}
+
+interface HomeMorningCallPayload {
+  verdict: "YES" | "MAYBE" | "NO";
+  beach_id: string;
+  beach_name?: string;
+  forecast_at?: string | null;
+  title: string;
+  body: string;
+}
+
+interface WeekendWindowPayload {
+  beach_id: string;
+  forecast_at: string;
+  window_local?: string;
+  title: string;
+  body: string;
 }
 
 interface WeeklyStreakReminderPayload {
@@ -507,6 +541,50 @@ export const NOTIFICATION_REGISTRY = {
       }
     },
   } satisfies NotificationTypeDef<SimilarityMatchPayload>,
+
+  home_morning_call: {
+    type: "home_morning_call",
+    channels: ["push"],
+    prefs: {
+      master: { push: "notif_push_enabled" },
+      perType: { push: "notif_reminders" },
+    },
+    suppressSelfNotify: false,
+    quietHours: DEFAULT_QUIET,
+    validatePayload: (input) => homeMorningCallSchema.parse(input),
+    buildPushPayload: (p) => ({
+      title: p.title,
+      body: p.body,
+      data: {
+        type: "home_morning_call",
+        beach_id: p.beach_id,
+        verdict: p.verdict,
+        ...(p.forecast_at ? { forecast_at: p.forecast_at } : {}),
+      },
+    }),
+  } satisfies NotificationTypeDef<HomeMorningCallPayload>,
+
+  weekend_window: {
+    type: "weekend_window",
+    channels: ["push"],
+    prefs: {
+      master: { push: "notif_push_enabled" },
+      perType: { push: "notif_reminders" },
+    },
+    suppressSelfNotify: false,
+    quietHours: DEFAULT_QUIET,
+    validatePayload: (input) => weekendWindowSchema.parse(input),
+    buildPushPayload: (p) => ({
+      title: p.title,
+      body: p.body,
+      data: {
+        type: "weekend_window",
+        beach_id: p.beach_id,
+        forecast_at: p.forecast_at,
+        ...(p.window_local ? { window_local: p.window_local } : {}),
+      },
+    }),
+  } satisfies NotificationTypeDef<WeekendWindowPayload>,
 
   trial_ending: {
     type: "trial_ending",

--- a/vercel.json
+++ b/vercel.json
@@ -137,6 +137,14 @@
       "schedule": "0 13 * * *"
     },
     {
+      "path": "/api/cron/home-morning-call",
+      "schedule": "0 13 * * *"
+    },
+    {
+      "path": "/api/cron/weekend-window",
+      "schedule": "0 1 * * 5,6"
+    },
+    {
       "path": "/api/cron/condition-alert-deliver",
       "schedule": "0 * * * *"
     },


### PR DESCRIPTION
Implements plans **018** (morning home-break call) and **019** (weekend-window) plus **014** (D7 measurement spec/baseline).

## What
- Two new notification types — `home_morning_call`, `weekend_window` — added to the registry (no migration; `notification_events.type` is unconstrained).
- Two crons (`/api/cron/home-morning-call` @ `0 13 * * *`, `/api/cron/weekend-window` @ `0 1 * * 5,6`) sharing `lib/cron/home-beach-push-runner.ts` (profile/beach/forecast load, eligibility, enqueue+dedupe, summary).
- Reuses `computeSurfCall` for the verdict — no reimplemented scoring.

## Safety / rollout
- **Both ship DISABLED**: `HOME_MORNING_CALL_ENABLED` / `WEEKEND_WINDOW_ENABLED` must be `"true"`, and `*_TEST_USER_IDS` allowlist-gates the audience.
- No prod DB writes, migrations, or deploys in this PR.
- Enable allowlist-first, broaden only after post-launch D7 beats the **7.0%** baseline (target **19.5%**, = +8 D7 returners / 64 eligible).

## Contract (consumed by quiver-native PR for native tap routing)
- `home_morning_call` → `data: { type, beach_id, verdict, forecast_at? }` → routes to Home.
- `weekend_window` → `data: { type, beach_id, forecast_at, window_local? }` → routes to BeachDetail recommended window.

## Verification
- `yarn typecheck` ✓ · scoped `eslint --max-warnings=0` ✓ · `yarn test:unit` 20 tests ✓ · `vercel.json` valid JSON ✓
- Reviewed (advisor diff review + ponytail: shared runner extracted, ~-200 lines of duplication removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)