### PR TITLE
fix(forecast): align scoring invariants

### DIFF
--- a/__tests__/lib/domains/scoring/discovery-adapter.test.ts
+++ b/__tests__/lib/domains/scoring/discovery-adapter.test.ts
@@ -271,6 +271,24 @@ describe('Discovery Adapter', () => {
         expect(snapshot.windWave).toBeNull();
       });
 
+      it('normalizes wavePeriod to the dominant partition when stored wave_period is stale', () => {
+        const forecast = createForecast({
+          wave_height: '2',
+          wave_period: '14s',
+          swell_1_height: '1',
+          swell_1_period: '15s',
+          swell_1_direction: '270',
+          swell_2_height: '2',
+          swell_2_period: '4s',
+          swell_2_direction: '270',
+        });
+        const snapshot = forecastToSnapshot(forecast);
+
+        expect(snapshot.primarySwell?.periodS).toBe(4);
+        expect(snapshot.wavePeriod).toBe(4);
+        expect(snapshot.primarySwell?.periodS).toBe(snapshot.wavePeriod);
+      });
+
       it('exposes wind_wave separately when swell_1 is dominant', () => {
         const forecast = createForecast({
           wave_height: '4',

--- a/__tests__/lib/surf/terrain-scoring.test.ts
+++ b/__tests__/lib/surf/terrain-scoring.test.ts
@@ -33,6 +33,63 @@ describe('Terrain-Aware Scoring', () => {
       expect(score).toBeLessThanOrEqual(100)
     })
 
+    it('scores swell directions inside and near a non-wrapping window', () => {
+      const scoreAtCenter = computeHourScoreBreakdown({
+        waveDirectionDeg: 250,
+        wavePeriodS: 12,
+        windDirectionDeg: 270,
+        windSpeedMs: 3,
+        tideHeightM: 2.5 / 3.28084,
+        params: {
+          windOffshoreDeg: 270,
+          windCrossOkKts: 15,
+          swellWindowMinDeg: 190,
+          swellWindowMaxDeg: 310,
+          tidePreferredFtMin: 1,
+          tidePreferredFtMax: 4,
+        },
+      })
+
+      const scoreNearEdge = computeHourScoreBreakdown({
+        waveDirectionDeg: 300,
+        wavePeriodS: 12,
+        windDirectionDeg: 270,
+        windSpeedMs: 3,
+        tideHeightM: 2.5 / 3.28084,
+        params: {
+          windOffshoreDeg: 270,
+          windCrossOkKts: 15,
+          swellWindowMinDeg: 190,
+          swellWindowMaxDeg: 310,
+          tidePreferredFtMin: 1,
+          tidePreferredFtMax: 4,
+        },
+      })
+
+      expect(scoreAtCenter.swellDirScore).toBeCloseTo(1)
+      expect(scoreNearEdge.swellDirScore).toBeGreaterThan(0)
+    })
+
+    it('scores swell directions inside a wrap-around window', () => {
+      const scoreInsideWrap = computeHourScoreBreakdown({
+        waveDirectionDeg: 350,
+        wavePeriodS: 12,
+        windDirectionDeg: 270,
+        windSpeedMs: 3,
+        tideHeightM: 2.5 / 3.28084,
+        params: {
+          windOffshoreDeg: 270,
+          windCrossOkKts: 15,
+          swellWindowMinDeg: 300,
+          swellWindowMaxDeg: 60,
+          tidePreferredFtMin: 1,
+          tidePreferredFtMax: 4,
+        },
+      })
+
+      expect(scoreInsideWrap.swellDirScore).toBeGreaterThan(0)
+    })
+
     it('should handle missing terrain data gracefully', () => {
       const beachWithNullTerrain: BeachMeta = {
         ...baseBeach,
@@ -206,8 +263,6 @@ describe('Terrain-Aware Scoring', () => {
       const breakdown = computeHourScoreBreakdown(input)
 
       expect(breakdown.terrainFactorsApplied).toBe(true)
-      expect(breakdown.windExposure).toBeDefined()
-      expect(breakdown.swellAccess).toBeDefined()
       expect(breakdown.windExposure).toBe(0.5) // Partial shelter
       expect(breakdown.swellAccess).toBe(1.0) // Full access
     })

--- a/lib/domains/scoring/discovery-adapter.ts
+++ b/lib/domains/scoring/discovery-adapter.ts
@@ -83,7 +83,7 @@ export function beachToSpotProfile(beach: Beach): SpotProfile {
  */
 export function forecastToSnapshot(forecast: EnhancedForecastEntity): ConditionsSnapshot {
   const waveHeight = parseFloat(forecast.wave_height || '0');
-  const wavePeriod = parseFloat(forecast.wave_period?.replace('s', '') || '0');
+  const storedWavePeriod = parseFloat(forecast.wave_period?.replace('s', '') || '0');
 
   const windSpeed = parseFloat(forecast.wind_speed || '0');
   const windDirection = getDirectionDegrees(
@@ -103,6 +103,7 @@ export function forecastToSnapshot(forecast: EnhancedForecastEntity): Conditions
 
   const dominant = pickDominantSwell(partitions);
   const primarySwell = dominant ? toSwellComponent(dominant) : null;
+  const wavePeriod = dominant ? dominant.period : storedWavePeriod;
   const waveDirection = dominant ? dominant.direction : null;
 
   // `secondarySwell` carries the next-most-energetic non-dominant *swell*

--- a/lib/surf/scoring.ts
+++ b/lib/surf/scoring.ts
@@ -142,7 +142,10 @@ function computeSwellDirScore(
   const span = ((windowMaxDeg - windowMinDeg + 360) % 360);
   const min = windowMinDeg;
   const center = min + span / 2;
-  const offFromCenter = Math.abs(((normalizeDeg(waveDirectionDeg) - (center + 540)) % 360) - 180);
+  // Circular distance from the window center (0..180). Reuse angularDistance —
+  // the previous inline `(center + 540)` wrap math was wrong and returned a
+  // value >180 for every direction, zeroing swellDirScore even at window center.
+  const offFromCenter = angularDistance(waveDirectionDeg, center);
   const inside = Math.max(0, span / 2 - offFromCenter);
   // Fade to 0 in the next 30° beyond the window
   const beyond = Math.max(0, offFromCenter - span / 2);


### PR DESCRIPTION
## Summary
- Align forecast snapshots so `wavePeriod` follows the selected dominant partition instead of stale top-level storage.
- Fix swell direction relevance scoring for non-wrapping and wrap-around terrain windows.
- Add focused Jest coverage for the PR #344 QA blockers.

## Verification
- PASS: `DOTENV_CONFIG_PATH=/Users/stevenchandler/Desktop/dev/quiver/.env.local NODE_OPTIONS="-r dotenv/config" yarn jest __tests__/lib/domains/scoring/discovery-adapter.test.ts __tests__/lib/surf/terrain-scoring.test.ts __tests__/lib/domains/scoring/swell-alignment-scorer.test.ts __tests__/lib/domains/scoring/swell-interference-scorer.test.ts`
- PASS: `DOTENV_CONFIG_PATH=/Users/stevenchandler/Desktop/dev/quiver/.env.local NODE_OPTIONS="-r dotenv/config" yarn typecheck`
- PASS after removing redundant existing assertions: `DOTENV_CONFIG_PATH=/Users/stevenchandler/Desktop/dev/quiver/.env.local NODE_OPTIONS="-r dotenv/config" npx eslint --max-warnings=0 lib/domains/scoring/discovery-adapter.ts lib/surf/scoring.ts __tests__/lib/domains/scoring/discovery-adapter.test.ts __tests__/lib/surf/terrain-scoring.test.ts`

## Notes
- No DB migrations or env changes.
- E2E not run; this is forecast-domain unit coverage only.
