### PR TITLE
feat(map): custom spots — full feature (markers, forecast parity, detail route + anon gate, zine reskin)

### DIFF
--- a/__tests__/app/custom-spots-page.test.tsx
+++ b/__tests__/app/custom-spots-page.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from "@testing-library/react";
+import { notFound } from "next/navigation";
+import CustomSpotDetailPage, {
+  generateMetadata,
+} from "@/app/custom-spots/[id]/page";
+import { getEnhancedBeachForecasts } from "@/actions/forecast-actions";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+jest.mock("@/actions/forecast-actions", () => ({
+  getEnhancedBeachForecasts: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: jest.fn(),
+}));
+
+jest.mock("@/components/conditions/conditions-ticker", () => ({
+  ConditionsTicker: ({ beachName }: { beachName?: string }) => (
+    <div data-testid="conditions-ticker">{beachName}</div>
+  ),
+}));
+
+jest.mock("@/components/forecast/forecast-table", () => ({
+  MultiDayForecastTable: ({ forecasts }: { forecasts: unknown[] }) => (
+    <div data-testid="forecast-table">{forecasts.length} forecasts</div>
+  ),
+}));
+
+const publicSpot = {
+  id: "spot-public",
+  name: "Public Peak",
+  lat: 32.75,
+  lon: -117.25,
+  nearest_beach_id: "beach-1",
+  visibility: "public",
+  break_type: "reef",
+  facing_direction_deg: 270,
+  offshore_direction_deg: 90,
+  swell_window_min_deg: 190,
+  swell_window_max_deg: 260,
+  nearest_beach_distance_mi: 1.2,
+  user_id: "user-1",
+  created_at: "2026-06-25T00:00:00.000Z",
+  updated_at: "2026-06-25T00:00:00.000Z",
+  deleted_at: null,
+  exposure_level: null,
+  fingerprint_confidence: null,
+  fingerprint_updated_at: null,
+};
+
+const privateSpot = {
+  ...publicSpot,
+  id: "spot-private",
+  visibility: "private",
+};
+
+const nearestBeach = {
+  id: "beach-1",
+  name: "Ocean Beach",
+  city: "San Diego",
+  state: "CA",
+  country: "USA",
+  slug: "ocean-beach",
+  lat: 32.75,
+  lon: -117.25,
+  timezone: "America/Los_Angeles",
+  break_type: "beach",
+};
+
+const beachPhoto = {
+  image_url: "https://images.unsplash.com/photo-spot.jpg",
+  thumb_url: "https://images.unsplash.com/photo-spot-thumb.jpg",
+};
+
+const forecast = {
+  id: "forecast-1",
+  beach_id: "beach-1",
+  forecast_at: "2026-06-25T15:00:00.000Z",
+  forecast_date: "2026-06-25",
+  forecast_time: "15:00:00",
+  wave_height: "3-4 ft",
+  wave_period: "12s",
+  wave_direction: "WSW",
+  swell_1_height: "3",
+  swell_1_period: "12s",
+  swell_1_direction: "WSW",
+  wind_speed: "6 mph",
+  wind_direction: "E",
+  tide_height: "2 ft",
+  tide_status: "Rising",
+  water_temp: "64F",
+  confidence_score: 82,
+  data_source: "NOAA_NWS",
+  updated_at: "2026-06-25T12:00:00.000Z",
+};
+
+const mockSupabase = {
+  from: jest.fn(),
+};
+const tableResults = new Map<string, unknown>();
+
+function createQueryChain(data: unknown): any {
+  const chain: any = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    is: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    limit: jest.fn(() => chain),
+    maybeSingle: jest.fn(async () => ({ data, error: null })),
+  };
+  return chain;
+}
+
+function mockTableSingle(table: string, data: unknown): void {
+  tableResults.set(table, data);
+}
+
+describe("/custom-spots/[id] page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tableResults.clear();
+    mockSupabase.from.mockImplementation((table: string) =>
+      createQueryChain(tableResults.get(table) ?? null),
+    );
+    (createSupabaseServerClient as jest.Mock).mockResolvedValue(mockSupabase);
+    (getEnhancedBeachForecasts as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [forecast],
+    });
+  });
+
+  it("renders a public custom spot with borrowed forecast data", async () => {
+    mockTableSingle("custom_spots", publicSpot);
+    mockTableSingle("beaches", nearestBeach);
+    mockTableSingle("beach_photos", beachPhoto);
+
+    const page = await CustomSpotDetailPage({
+      params: Promise.resolve({ id: "spot-public" }),
+    });
+
+    render(page);
+
+    expect(
+      screen.getByRole("heading", { name: "Public Peak" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("custom-spot-zine-surface")).toBeInTheDocument();
+    expect(screen.getByAltText("Ocean Beach surf zone")).toHaveAttribute(
+      "src",
+      beachPhoto.thumb_url,
+    );
+    expect(screen.getByText("Borrowed from Ocean Beach")).toBeInTheDocument();
+    expect(screen.getByText(/Forecast borrowed from Ocean Beach/i)).toBeInTheDocument();
+    expect(screen.getByTestId("conditions-ticker")).toHaveTextContent(
+      "Public Peak",
+    );
+    expect(screen.getByTestId("forecast-table")).toHaveTextContent(
+      "1 forecasts",
+    );
+    expect(getEnhancedBeachForecasts).toHaveBeenCalledWith("beach-1", 10);
+  });
+
+  it("returns a true 404 when RLS hides or misses the custom spot", async () => {
+    mockTableSingle("custom_spots", null);
+
+    await expect(
+      CustomSpotDetailPage({
+        params: Promise.resolve({ id: "missing-or-private" }),
+      }),
+    ).rejects.toMatchObject({ digest: "NEXT_NOT_FOUND" });
+
+    expect(notFound).toHaveBeenCalled();
+    expect(getEnhancedBeachForecasts).not.toHaveBeenCalled();
+  });
+
+  it("noindexes private custom spots when the viewer can access metadata", async () => {
+    mockTableSingle("custom_spots", privateSpot);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: "spot-private" }),
+    });
+
+    expect((metadata.robots as any)?.index).toBe(false);
+    expect((metadata.robots as any)?.follow).toBe(false);
+    expect((metadata.robots as any)?.googleBot?.index).toBe(false);
+    expect((metadata.robots as any)?.googleBot?.follow).toBe(false);
+  });
+});

--- a/__tests__/components/map-view.test.tsx
+++ b/__tests__/components/map-view.test.tsx
@@ -12,6 +12,16 @@ let mockGeolocationLoading = false;
 let mockBeachLoading = false;
 let mockHomeBeach: { lat: number; lon: number } | null = null;
 let mockProfileLoading = false;
+const mockCustomSpots = [
+  {
+    id: "spot-1",
+    name: "Public Peak",
+    lat: 32.75,
+    lon: -117.25,
+    nearestBeachId: null,
+    visibility: "public",
+  },
+];
 
 jest.mock("next/navigation", () => ({
   usePathname: () => "/map",
@@ -64,6 +74,13 @@ jest.mock("@/hooks/use-beach-search", () => ({
   }),
 }));
 
+jest.mock("@/hooks/use-custom-spots", () => ({
+  useCustomSpots: () => ({
+    customSpots: mockCustomSpots,
+    loading: false,
+  }),
+}));
+
 const mockTrackMapEvent = jest.fn();
 const mockTrackQrRendered = jest.fn();
 
@@ -88,17 +105,20 @@ jest.mock("qrcode.react", () => ({
 jest.mock("@/components/map/map-content", () => ({
   MapContent: ({
     autoNavigateOnMarkerClick,
+    customSpots,
     loading,
     showSwellField,
     swellTimelineSteps,
   }: {
     autoNavigateOnMarkerClick?: boolean;
+    customSpots?: unknown[];
     loading?: boolean;
     showSwellField?: boolean;
     swellTimelineSteps?: string[];
   }) => (
     <div
       data-auto-navigate-on-marker-click={String(autoNavigateOnMarkerClick)}
+      data-custom-spot-count={String(customSpots?.length ?? 0)}
       data-loading={String(loading)}
       data-show-swell-field={String(showSwellField)}
       data-swell-timeline-steps={swellTimelineSteps?.join(",") ?? ""}
@@ -136,6 +156,10 @@ describe("MapView", () => {
     expect(screen.getByTestId("map-content")).toHaveAttribute(
       "data-show-swell-field",
       "true",
+    );
+    expect(screen.getByTestId("map-content")).toHaveAttribute(
+      "data-custom-spot-count",
+      "1",
     );
     expect(screen.queryByTestId("view-mode-list")).not.toBeInTheDocument();
   });

--- a/__tests__/components/map/interactive-map.test.tsx
+++ b/__tests__/components/map/interactive-map.test.tsx
@@ -1,0 +1,304 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockMarkerInstances: Array<{
+  addTo: jest.Mock;
+  remove: jest.Mock;
+  setLngLat: jest.Mock;
+}> = [];
+const mockRouterPush = jest.fn();
+const mockTrackSignupCtaClick = jest.fn();
+let mockUser: { id: string } | null = null;
+
+jest.mock("mapbox-gl", () => ({
+  Map: jest.fn(() => ({
+    on: jest.fn((event: string, callback: () => void) => {
+      if (event === "load") {
+        setTimeout(callback, 10);
+      }
+    }),
+    off: jest.fn(),
+    remove: jest.fn(),
+    getCenter: jest.fn(() => ({ lat: 32.7493, lng: -117.2511 })),
+    getZoom: jest.fn(() => 13),
+    getMaxZoom: jest.fn(() => 22),
+    getMinZoom: jest.fn(() => 0),
+    setCenter: jest.fn(),
+    setMaxBounds: jest.fn(),
+    setMaxZoom: jest.fn(),
+    setMinZoom: jest.fn(),
+    flyTo: jest.fn(),
+    easeTo: jest.fn(),
+    fitBounds: jest.fn(),
+    getBounds: jest.fn(() => ({
+      getWest: () => -117.3,
+      getSouth: () => 32.7,
+      getEast: () => -117.2,
+      getNorth: () => 32.8,
+    })),
+    getCanvasContainer: jest.fn(() => document.createElement("div")),
+    getLayer: jest.fn(() => undefined),
+    getStyle: jest.fn(() => ({ layers: [] })),
+    addLayer: jest.fn(),
+    addControl: jest.fn(),
+    removeLayer: jest.fn(),
+    triggerRepaint: jest.fn(),
+  })),
+  AttributionControl: jest.fn(() => ({ type: "attribution" })),
+  Marker: jest.fn(() => {
+    const marker = {
+      setLngLat: jest.fn().mockReturnThis(),
+      addTo: jest.fn().mockReturnThis(),
+      remove: jest.fn(),
+    };
+    mockMarkerInstances.push(marker);
+    return marker;
+  }),
+  Popup: jest.fn(() => ({
+    setLngLat: jest.fn().mockReturnThis(),
+    setDOMContent: jest.fn().mockReturnThis(),
+    addTo: jest.fn().mockReturnThis(),
+    remove: jest.fn(),
+  })),
+  accessToken: "",
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/map",
+  useRouter: () => ({ push: mockRouterPush, refresh: jest.fn() }),
+}));
+
+jest.mock("@/context/auth-context", () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+jest.mock("@/components/auth/unified-auth-modal", () => ({
+  UnifiedAuthModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="auth-modal" /> : null,
+}));
+
+jest.mock("@/lib/analytics/signup-conversion-tracking", () => ({
+  trackSignupCtaClick: (...args: unknown[]) =>
+    mockTrackSignupCtaClick(...args),
+}));
+
+jest.mock("@/hooks/use-track-event", () => ({
+  useTrackEvent: () => ({ track: jest.fn() }),
+}));
+
+jest.mock("@/lib/utils/request-cache", () => ({
+  createCachedMapFetch: jest.fn(() => jest.fn().mockResolvedValue({ data: [] })),
+}));
+
+jest.mock("@/lib/constants/ui", () => ({
+  CACHE_TTL: { MAP_NEARBY_BEACHES: 300000 },
+  API_BATCH_CONFIG: { BEACH_ID_BATCH_SIZE: 50 },
+}));
+
+jest.mock("@/lib/utils/map-utilities", () => ({
+  getOffshorePosition: jest.fn((lat: number, lon: number) => [
+    lon + 0.001,
+    lat + 0.001,
+  ]),
+  hasViewportChanged: jest.fn(() => true),
+}));
+
+describe("InteractiveMap", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarkerInstances.length = 0;
+    mockUser = null;
+  });
+
+  function getLastCustomSpotMarkerElement(id: string): HTMLElement {
+    const Marker = require("mapbox-gl").Marker;
+    const matchingCalls = Marker.mock.calls.filter(
+      ([options]: [{ element?: HTMLElement }]) =>
+        options.element?.getAttribute("data-custom-spot-id") === id,
+    );
+
+    return matchingCalls[matchingCalls.length - 1][0].element;
+  }
+
+  it("creates distinct custom spot markers and filters invalid coordinates", async () => {
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    const customSpots = [
+      {
+        id: "spot-1",
+        name: "Public Peak",
+        lat: 32.75,
+        lon: -117.25,
+        nearestBeachId: null,
+        visibility: "public",
+      },
+      {
+        id: "spot-2",
+        name: "Bad Coordinates",
+        lat: Number.NaN,
+        lon: -117.26,
+        nearestBeachId: null,
+        visibility: "public",
+      },
+    ];
+
+    render(<InteractiveMap beaches={[]} customSpots={customSpots} />);
+
+    await waitFor(() => {
+      const Marker = require("mapbox-gl").Marker;
+      expect(
+        Marker.mock.calls.some(
+          ([options]: [{ element?: HTMLElement }]) =>
+            options.element?.getAttribute("data-testid") ===
+            "custom-spot-marker",
+        ),
+      ).toBe(true);
+    });
+
+    const Marker = require("mapbox-gl").Marker;
+    const customMarkerIndex = Marker.mock.calls.findIndex(
+      ([options]: [{ element?: HTMLElement }]) =>
+        options.element?.getAttribute("data-custom-spot-id") === "spot-1",
+    );
+    const markerOptions = Marker.mock.calls[customMarkerIndex][0] as {
+      anchor?: string;
+      element?: HTMLElement;
+    };
+    const marker = mockMarkerInstances[customMarkerIndex];
+
+    expect(
+      Marker.mock.calls.some(
+        ([options]: [{ element?: HTMLElement }]) =>
+          options.element?.getAttribute("data-custom-spot-id") === "spot-2",
+      ),
+    ).toBe(false);
+    expect(markerOptions.anchor).toBe("center");
+    expect(markerOptions.element?.style.width).toBe("14px");
+    expect(markerOptions.element?.style.height).toBe("14px");
+    expect(markerOptions.element).toHaveAttribute(
+      "data-testid",
+      "custom-spot-marker",
+    );
+    expect(markerOptions.element).toHaveAttribute(
+      "data-custom-spot-id",
+      "spot-1",
+    );
+    expect(markerOptions.element).toHaveAttribute("title", "Public Peak");
+    expect(markerOptions.element?.style.background).toBe("rgb(255, 255, 255)");
+    expect(markerOptions.element?.style.borderWidth).toBe("2.5px");
+    expect(markerOptions.element?.style.borderStyle).toBe("solid");
+    expect(markerOptions.element?.style.borderColor).toBe("#f78e42");
+    expect(markerOptions.element?.style.cursor).toBe("pointer");
+    expect(marker.setLngLat).toHaveBeenCalledWith([-117.25, 32.75]);
+  });
+
+  it("opens the auth modal instead of navigating when an anonymous user clicks a custom spot", async () => {
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    const customSpots = [
+      {
+        id: "spot-1",
+        name: "Public Peak",
+        lat: 32.75,
+        lon: -117.25,
+        nearestBeachId: null,
+        visibility: "public",
+      },
+    ];
+
+    render(<InteractiveMap beaches={[]} customSpots={customSpots} />);
+
+    await waitFor(() => {
+      expect(getLastCustomSpotMarkerElement("spot-1")).toHaveAttribute(
+        "data-testid",
+        "custom-spot-marker",
+      );
+    });
+
+    const markerElement = getLastCustomSpotMarkerElement("spot-1");
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const stopPropagationSpy = jest.spyOn(event, "stopPropagation");
+
+    fireEvent(markerElement, event);
+
+    expect(stopPropagationSpy).toHaveBeenCalled();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockTrackSignupCtaClick).toHaveBeenCalledWith({
+      source: "custom-spot-spot-1",
+      cta_type: "custom_spot_marker",
+    });
+    expect(await screen.findByTestId("auth-modal")).toBeInTheDocument();
+  });
+
+  it("navigates to the custom spot detail route when an authenticated user clicks a custom spot", async () => {
+    mockUser = { id: "user-1" };
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    const customSpots = [
+      {
+        id: "spot-1",
+        name: "Public Peak",
+        lat: 32.75,
+        lon: -117.25,
+        nearestBeachId: null,
+        visibility: "public",
+      },
+    ];
+
+    render(<InteractiveMap beaches={[]} customSpots={customSpots} />);
+
+    await waitFor(() => {
+      expect(getLastCustomSpotMarkerElement("spot-1")).toHaveAttribute(
+        "data-testid",
+        "custom-spot-marker",
+      );
+    });
+
+    fireEvent.click(getLastCustomSpotMarkerElement("spot-1"));
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/custom-spots/spot-1");
+    expect(mockTrackSignupCtaClick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("auth-modal")).not.toBeInTheDocument();
+  });
+
+  it("uses the current user after auth state changes before a custom spot click", async () => {
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    const customSpots = [
+      {
+        id: "spot-1",
+        name: "Public Peak",
+        lat: 32.75,
+        lon: -117.25,
+        nearestBeachId: null,
+        visibility: "public",
+      },
+    ];
+    const { rerender } = render(
+      <InteractiveMap beaches={[]} customSpots={customSpots} />,
+    );
+
+    await waitFor(() => {
+      expect(getLastCustomSpotMarkerElement("spot-1")).toHaveAttribute(
+        "data-testid",
+        "custom-spot-marker",
+      );
+    });
+
+    mockUser = { id: "user-1" };
+    rerender(<InteractiveMap beaches={[]} customSpots={customSpots} />);
+
+    await waitFor(() => {
+      const Marker = require("mapbox-gl").Marker;
+      const matchingCalls = Marker.mock.calls.filter(
+        ([options]: [{ element?: HTMLElement }]) =>
+          options.element?.getAttribute("data-custom-spot-id") === "spot-1",
+      );
+      expect(matchingCalls.length).toBeGreaterThan(1);
+    });
+
+    fireEvent.click(getLastCustomSpotMarkerElement("spot-1"));
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/custom-spots/spot-1");
+    expect(mockTrackSignupCtaClick).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/map/map-content.test.tsx
+++ b/__tests__/components/map/map-content.test.tsx
@@ -7,6 +7,7 @@ let mockInteractiveMapMounts = 0;
 // Mock the dynamic import for InteractiveMap
 jest.mock("next/dynamic", () => () => {
   const InteractiveMapMock = ({
+    customSpots,
     initialCenter,
     onLocationClick,
     onBeachSelect,
@@ -18,6 +19,7 @@ jest.mock("next/dynamic", () => () => {
     return (
       <div
         data-testid="interactive-map"
+        data-custom-spot-count={String(customSpots?.length ?? 0)}
         data-initial-center={initialCenter?.join(",")}
         data-mount-id={mountId}
       >
@@ -113,6 +115,29 @@ describe("MapContent", () => {
     expect(screen.getByTestId("interactive-map")).toBeInTheDocument();
     expect(mapContainer.querySelector("[aria-hidden='true']")).toBeNull();
     expect(mapContainer).toBeInTheDocument();
+  });
+
+  it("should pass custom spots to the interactive map", () => {
+    render(
+      <MapContent
+        {...defaultProps}
+        customSpots={[
+          {
+            id: "spot-1",
+            name: "Public Peak",
+            lat: 32.75,
+            lon: -117.25,
+            nearestBeachId: null,
+            visibility: "public",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("interactive-map")).toHaveAttribute(
+      "data-custom-spot-count",
+      "1",
+    );
   });
 
   it("should recenter user location changes without remounting the map", () => {

--- a/app/custom-spots/[id]/page.tsx
+++ b/app/custom-spots/[id]/page.tsx
@@ -1,0 +1,371 @@
+import type { ReactElement } from "react";
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Compass, MapPin, Waves } from "lucide-react";
+import { ConditionsTicker } from "@/components/conditions/conditions-ticker";
+import { MultiDayForecastTable } from "@/components/forecast/forecast-table";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getEnhancedBeachForecasts } from "@/actions/forecast-actions";
+import { getCurrentForecast } from "@/lib/utils/current-forecast-utils";
+import { forecastToConditionsData } from "@/lib/mappers/conditions-mappers";
+import { buildBeachUrlWithTab } from "@/lib/utils/beach-url-utils";
+import type { Beach, Database } from "@/types/database";
+import type { EnhancedForecastEntity } from "@/types/forecast";
+
+export const dynamic = "force-dynamic";
+
+interface CustomSpotPageProps {
+  params: Promise<{ id: string }>;
+}
+
+type CustomSpotRow = Database["public"]["Tables"]["custom_spots"]["Row"];
+type BeachPhotoPreview = Pick<
+  Database["public"]["Tables"]["beach_photos"]["Row"],
+  "image_url" | "thumb_url"
+>;
+
+const PRIVATE_ROBOTS: Metadata["robots"] = {
+  index: false,
+  follow: false,
+  googleBot: {
+    index: false,
+    follow: false,
+  },
+};
+
+async function getVisibleCustomSpot(id: string): Promise<CustomSpotRow | null> {
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("custom_spots")
+    .select("*")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[CustomSpotDetailPage] Error fetching custom spot:", error);
+    return null;
+  }
+
+  return data as CustomSpotRow | null;
+}
+
+async function getNearestBeach(beachId: string | null): Promise<Beach | null> {
+  if (!beachId) return null;
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("beaches")
+    .select("*")
+    .eq("id", beachId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[CustomSpotDetailPage] Error fetching nearest beach:", error);
+    return null;
+  }
+
+  return data as Beach | null;
+}
+
+async function getBorrowedForecasts(
+  beachId: string | null,
+): Promise<EnhancedForecastEntity[]> {
+  if (!beachId) return [];
+
+  const result = await getEnhancedBeachForecasts(beachId, 10);
+  if (!result.success || !result.data) return [];
+
+  return result.data;
+}
+
+function normalizePhotoUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !/^https?:\/\//i.test(trimmed)) return null;
+
+  return trimmed;
+}
+
+async function getNearestBeachPhoto(
+  beachId: string | null,
+): Promise<string | null> {
+  if (!beachId) return null;
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("beach_photos")
+    .select("image_url, thumb_url")
+    .eq("beach_id", beachId)
+    .eq("approved", true)
+    .is("deleted_at", null)
+    .order("fetched_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[CustomSpotDetailPage] Error fetching nearest beach photo:", error);
+    return null;
+  }
+
+  const photo = data as BeachPhotoPreview | null;
+  return normalizePhotoUrl(photo?.thumb_url) ?? normalizePhotoUrl(photo?.image_url);
+}
+
+function formatNumber(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "Not set";
+  return `${Math.round(value)} deg`;
+}
+
+function formatSwellWindow(spot: CustomSpotRow): string {
+  if (spot.swell_window_min_deg == null || spot.swell_window_max_deg == null) {
+    return "Not set";
+  }
+
+  return `${Math.round(spot.swell_window_min_deg)}-${Math.round(
+    spot.swell_window_max_deg,
+  )} deg`;
+}
+
+function formatDistance(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "Nearest forecast spot";
+  return `${value.toFixed(1)} mi to nearest forecast spot`;
+}
+
+export async function generateMetadata(
+  props: CustomSpotPageProps,
+): Promise<Metadata> {
+  const { id } = await props.params;
+  const spot = await getVisibleCustomSpot(id);
+
+  if (!spot) {
+    return {
+      title: "Custom Spot",
+      robots: PRIVATE_ROBOTS,
+    };
+  }
+
+  return {
+    title: `${spot.name} Surf Forecast | Quiver`,
+    description: `Borrowed surf forecast and local conditions for ${spot.name}.`,
+    robots:
+      spot.visibility === "public"
+        ? { index: true, follow: true }
+        : PRIVATE_ROBOTS,
+  };
+}
+
+export default async function CustomSpotDetailPage(
+  props: CustomSpotPageProps,
+): Promise<ReactElement> {
+  const { id } = await props.params;
+  const spot = await getVisibleCustomSpot(id);
+
+  if (!spot) notFound();
+
+  const [nearestBeach, forecasts, heroPhotoUrl] = await Promise.all([
+    getNearestBeach(spot.nearest_beach_id),
+    getBorrowedForecasts(spot.nearest_beach_id),
+    getNearestBeachPhoto(spot.nearest_beach_id),
+  ]);
+  const currentForecast = getCurrentForecast(forecasts);
+  const beachTimezone = nearestBeach?.timezone ?? null;
+  const fullForecastHref = nearestBeach
+    ? buildBeachUrlWithTab(nearestBeach, "forecast")
+    : null;
+
+  return (
+    <ZineSurface
+      sectionLabel="Custom spot"
+      editionLabel="Borrowed forecast"
+      data-testid="custom-spot-zine-surface"
+    >
+      <main className="font-sans text-[#11100D]">
+        <nav className="mb-8">
+          <Link
+            href="/map"
+            className="inline-flex items-center gap-2 font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#11100D]/62 transition-colors hover:text-[#F78E42] hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Back to map
+          </Link>
+        </nav>
+
+        <header className="relative grid gap-8 lg:grid-cols-[minmax(0,1fr)_25rem] lg:items-end">
+          <div className="relative">
+            <QuiverSticker
+              sticker="orangeTape"
+              className="absolute -top-7 left-6 hidden w-36 rotate-[2deg] opacity-85 sm:block"
+            />
+            <div className="mb-5 flex flex-wrap items-center gap-3">
+              <span className="label-black">Custom spot</span>
+              <span className="border-2 border-[#11100D] bg-[#F78E42] px-3 py-1 font-mono text-[11px] font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.24)]">
+                {spot.visibility}
+              </span>
+            </div>
+            <h1 className="zine-h1 font-heading font-black uppercase leading-[0.88] tracking-normal text-[#11100D]">
+              {spot.name}
+            </h1>
+            <div className="mt-6 flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-xs uppercase tracking-[0.12em] text-[#11100D]/65">
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="h-4 w-4 text-[#11100D]" aria-hidden="true" />
+                {spot.lat.toFixed(4)}, {spot.lon.toFixed(4)}
+              </span>
+              {nearestBeach ? (
+                <>
+                  <span aria-hidden>/</span>
+                  <span>Forecast borrowed from {nearestBeach.name}</span>
+                </>
+              ) : null}
+            </div>
+          </div>
+
+          {nearestBeach && heroPhotoUrl ? (
+            <div className="polaroid rot-2">
+              <div className="photo">
+                <Image
+                  src={heroPhotoUrl}
+                  alt={`${nearestBeach.name} surf zone`}
+                  width={800}
+                  height={600}
+                  className="h-full w-full object-cover saturate-[0.78]"
+                  sizes="(min-width: 1024px) 400px, 100vw"
+                />
+                <div className="absolute inset-0 bg-[#F4EBD8]/10 mix-blend-screen" />
+                <QuiverSticker
+                  sticker="breakingWave"
+                  className="absolute -bottom-5 -right-4 w-28 -rotate-[2deg] drop-shadow-md"
+                />
+              </div>
+              <p className="cap">Borrowed from {nearestBeach.name}</p>
+            </div>
+          ) : (
+            <div className="torn torn-tb relative hidden min-h-48 border-2 border-[#11100D] bg-[#FBF6E8] p-6 lg:block">
+              <QuiverSticker
+                sticker="breakingWave"
+                className="absolute -right-4 -top-4 w-28 -rotate-[2deg] opacity-85"
+              />
+              <p className="max-w-xs font-heading text-2xl font-black uppercase leading-tight text-[#11100D]">
+                Forecast borrowed, photo pending.
+              </p>
+            </div>
+          )}
+        </header>
+
+        <section className="torn torn-tb mt-12 border-2 border-[#11100D] bg-[#FBF6E8]">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="circled bg-[#F78E42]/35 font-mono text-base">01</span>
+            <h2 className="font-heading text-2xl font-black uppercase leading-tight text-[#11100D]">
+              Current conditions
+            </h2>
+          </div>
+          {currentForecast ? (
+            <div className="overflow-hidden border-2 border-[#11100D] bg-[#FBF6E8] font-mono shadow-[2px_3px_0_rgba(17,16,13,0.18)] [&_span]:!text-[#11100D] [&_svg]:!text-[#11100D]">
+              <ConditionsTicker
+                data={forecastToConditionsData(currentForecast, nearestBeach)}
+                beachName={spot.name}
+                showFrequency={Boolean(nearestBeach)}
+                className="border-0 bg-[#FBF6E8] text-[#11100D]"
+              />
+            </div>
+          ) : (
+            <p className="font-mono text-sm uppercase tracking-[0.08em] text-[#11100D]/68">
+              Forecast data is not available for this custom spot yet.
+            </p>
+          )}
+        </section>
+
+        <div className="mt-8 grid gap-6 lg:grid-cols-[0.85fr_1.35fr]">
+          <section className="torn torn-tb border-2 border-[#11100D] bg-[#F0E5CC]">
+            <div className="mb-5 flex items-center gap-3">
+              <QuiverSticker
+                sticker="surfWax"
+                className="w-14 rotate-[3deg] drop-shadow-sm"
+              />
+              <h2 className="flex items-center gap-2 font-heading text-2xl font-black uppercase leading-tight text-[#11100D]">
+                <Compass className="h-5 w-5" aria-hidden="true" />
+                Spot setup
+              </h2>
+            </div>
+            <div className="space-y-3 text-sm">
+              <DetailRow
+                label="Break"
+                value={spot.break_type ?? "Not set"}
+                mono={false}
+              />
+              <DetailRow
+                label="Facing"
+                value={formatNumber(spot.facing_direction_deg)}
+              />
+              <DetailRow
+                label="Offshore"
+                value={formatNumber(spot.offshore_direction_deg)}
+              />
+              <DetailRow label="Swell window" value={formatSwellWindow(spot)} />
+              <DetailRow
+                label="Forecast source"
+                value={
+                  nearestBeach
+                    ? `${nearestBeach.name} (${formatDistance(
+                        spot.nearest_beach_distance_mi,
+                      )})`
+                    : "No nearest beach linked"
+                }
+              />
+            </div>
+          </section>
+
+          <section className="torn torn-tb border-2 border-[#11100D] bg-[#FBF6E8]">
+            <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+              <h2 className="flex items-center gap-2 font-heading text-2xl font-black uppercase leading-tight text-[#11100D]">
+                <Waves className="h-5 w-5" aria-hidden="true" />
+                Borrowed forecast
+              </h2>
+              {fullForecastHref ? (
+                <Link
+                  href={fullForecastHref}
+                  className="font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#11100D] underline decoration-[#F78E42] decoration-2 underline-offset-4 transition-colors hover:text-[#F78E42]"
+                >
+                  Full forecast
+                </Link>
+              ) : null}
+            </div>
+            <div className="overflow-x-auto border-2 border-[#11100D] bg-[#F4EBD8] p-3 font-mono shadow-[2px_3px_0_rgba(17,16,13,0.18)] [&_.bg-blue-100]:!bg-[#F78E42]/25 [&_.bg-card]:!bg-[#FBF6E8] [&_.bg-muted\\/30]:!bg-[#F0E5CC] [&_.bg-muted\\/50]:!bg-[#F0E5CC] [&_.border-border]:!border-[#11100D]/20 [&_.rounded-lg]:!rounded-none [&_.text-foreground]:!text-[#11100D] [&_.text-muted-foreground]:!text-[#11100D]/58 [&_.text-sky-500]:!text-[#11100D]">
+              <MultiDayForecastTable
+                forecasts={forecasts}
+                beachTimezone={beachTimezone}
+              />
+            </div>
+          </section>
+        </div>
+      </main>
+    </ZineSurface>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono = true,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}): ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-dashed border-[#11100D]/24 pb-2 last:border-b-0 last:pb-0">
+      <span className="font-mono text-xs font-bold uppercase tracking-[0.12em] text-[#11100D]/58">
+        {label}
+      </span>
+      <span
+        className={`text-right font-bold text-[#11100D] ${
+          mono ? "font-mono" : "font-sans"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -7,6 +7,7 @@ import { useGeolocation } from "@/hooks/use-geolocation";
 import { useBeachSearch } from "@/hooks/use-beach-search";
 import { MapToolbar } from "@/components/map/map-toolbar";
 import { Button } from "@/components/ui/button";
+import { useCustomSpots } from "@/hooks/use-custom-spots";
 import {
   MAP_REGION_PILLS,
   type MapRegionPill,
@@ -125,6 +126,7 @@ export function MapView() {
     toggleBreakType,
     clearAllFilters,
   } = useBeachSearch();
+  const { customSpots } = useCustomSpots();
 
   // Load nearby beaches when user location is available - prevent duplicate calls
   // Wait for geolocation to resolve before fetching to avoid using stale fallback coords
@@ -408,6 +410,7 @@ export function MapView() {
             focusCenter={mapFocusCenter}
             selectedBeach={selectedBeachForMap}
             filteredBeaches={filteredBeaches}
+            customSpots={customSpots}
             searchQuery={searchQuery}
             regionViewport={null}
             onGetUserLocation={handleUseMyLocation}

--- a/components/map/__tests__/custom-spot-marker-builder.test.ts
+++ b/components/map/__tests__/custom-spot-marker-builder.test.ts
@@ -1,0 +1,56 @@
+import { createCustomSpotMarkerElement } from "@/components/map/custom-spot-marker-builder";
+import { getConditionMarkerCall } from "@/components/map/map-marker-builder";
+import type { CustomSpot } from "@/hooks/use-custom-spots";
+
+const spot: CustomSpot = {
+  id: "spot-1",
+  name: "Public Peak",
+  lat: 32.75,
+  lon: -117.25,
+  nearestBeachId: "beach-1",
+  visibility: "public",
+};
+
+describe("createCustomSpotMarkerElement", () => {
+  it("renders the slice-1 orange-ring fallback without forecast data", () => {
+    const marker = createCustomSpotMarkerElement(spot);
+
+    expect(marker).toHaveAttribute("data-testid", "custom-spot-marker");
+    expect(marker).toHaveAttribute("data-custom-spot-id", "spot-1");
+    expect(marker).toHaveAttribute("title", "Public Peak");
+    expect(marker).not.toHaveAttribute("data-marker-gradient");
+    expect(marker.textContent).toBe("");
+    expect(marker.style.width).toBe("14px");
+    expect(marker.style.height).toBe("14px");
+    expect(marker.style.background).toBe("rgb(255, 255, 255)");
+    expect(marker.style.borderWidth).toBe("2.5px");
+    expect(marker.style.borderStyle).toBe("solid");
+    expect(marker.style.borderColor).toBe("#f78e42");
+    expect(marker.style.cursor).toBe("pointer");
+  });
+
+  it("renders borrowed forecast verdict color and wave label with the orange ring", () => {
+    const marker = createCustomSpotMarkerElement(spot, {
+      conditionSummary: "GOOD",
+      conditionScore: 82,
+      waveLabel: "3-4 ft",
+    });
+    const markerCall = getConditionMarkerCall({
+      conditionSummary: "GOOD",
+      conditionScore: 82,
+    });
+
+    expect(marker).toHaveAttribute("data-testid", "custom-spot-marker");
+    expect(marker).toHaveAttribute("data-custom-spot-id", "spot-1");
+    expect(marker).toHaveAttribute("data-condition-summary", "GOOD");
+    expect(marker).toHaveAttribute("data-condition-score", "82");
+    expect(marker).toHaveAttribute("data-marker-gradient", markerCall.gradient);
+    expect(marker).toHaveAttribute("data-wave-label", "3-4 ft");
+    expect(marker.textContent).toBe("3-4 ft");
+    expect(marker.style.borderWidth).toBe("2.5px");
+    expect(marker.style.borderStyle).toBe("solid");
+    expect(marker.style.borderColor).toBe("#f78e42");
+    expect(marker.style.color).toBe("rgb(255, 255, 255)");
+    expect(marker.style.cursor).toBe("pointer");
+  });
+});

--- a/components/map/custom-spot-marker-builder.ts
+++ b/components/map/custom-spot-marker-builder.ts
@@ -1,0 +1,84 @@
+import { getConditionMarkerCall } from "@/components/map/map-marker-builder";
+import type { ConditionSummary } from "@/components/map/map-beach-loader";
+import type { CustomSpot } from "@/hooks/use-custom-spots";
+
+const CUSTOM_SPOT_RING_COLOR = "#F78E42";
+
+export interface CustomSpotMarkerData {
+  conditionSummary?: ConditionSummary;
+  conditionScore?: number;
+  waveLabel?: string | null;
+}
+
+function hasUsableVerdict(data?: CustomSpotMarkerData): boolean {
+  if (!data) return false;
+  if (data.conditionSummary) return true;
+  return (
+    typeof data.conditionScore === "number" &&
+    Number.isFinite(data.conditionScore)
+  );
+}
+
+export function createCustomSpotMarkerElement(
+  spot: CustomSpot,
+  data?: CustomSpotMarkerData
+): HTMLElement {
+  const element = document.createElement("div");
+  element.setAttribute("data-testid", "custom-spot-marker");
+  element.setAttribute("data-custom-spot-id", spot.id);
+  element.setAttribute("title", spot.name);
+
+  if (!hasUsableVerdict(data)) {
+    element.style.cssText = `
+      pointer-events: auto;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: #FFFFFF;
+      border: 2.5px solid ${CUSTOM_SPOT_RING_COLOR};
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.28);
+      cursor: pointer;
+    `;
+    return element;
+  }
+
+  const conditionCall = getConditionMarkerCall({
+    conditionSummary: data?.conditionSummary,
+    conditionScore: data?.conditionScore,
+  });
+  const waveLabel = data?.waveLabel?.trim() || null;
+
+  element.setAttribute("data-condition-summary", conditionCall.summary);
+  element.setAttribute("data-marker-gradient", conditionCall.gradient);
+  if (typeof data?.conditionScore === "number") {
+    element.setAttribute("data-condition-score", String(data.conditionScore));
+  }
+  if (waveLabel) {
+    element.setAttribute("data-wave-label", waveLabel);
+    element.textContent = waveLabel;
+  }
+
+  element.style.cssText = `
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: ${waveLabel ? "30px" : "14px"};
+    width: ${waveLabel ? "auto" : "14px"};
+    height: ${waveLabel ? "18px" : "14px"};
+    padding: ${waveLabel ? "0 6px" : "0"};
+    border-radius: 9999px;
+    background: ${conditionCall.gradient};
+    border: 2.5px solid ${CUSTOM_SPOT_RING_COLOR};
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.32);
+    color: #FFFFFF;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    cursor: pointer;
+  `;
+
+  return element;
+}

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -15,7 +15,8 @@ import mapboxgl from "mapbox-gl";
 import { debounce } from "@/lib/utils/debounce";
 import type { Beach } from "@/types/database";
 import { useAuth } from "@/context/auth-context";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { UnifiedAuthModal } from "@/components/auth/unified-auth-modal";
 import { createCachedMapFetch } from "@/lib/utils/request-cache";
 import { hasViewportChanged as checkViewportChanged } from "@/lib/utils/map-utilities";
 import { CACHE_TTL } from "@/lib/constants/ui";
@@ -29,6 +30,7 @@ import {
   type MarkerBuilderDeps,
   type MapDisplayMode,
 } from "@/components/map/map-marker-builder";
+import { createCustomSpotMarkerElement } from "@/components/map/custom-spot-marker-builder";
 import {
   loadBeachesAndWaveHeights,
   type ConditionSummary,
@@ -63,6 +65,8 @@ import { SwellLayerSelector } from "@/components/map/swell-field/swell-layer-sel
 import { SwellForecastTimeline } from "@/components/map/swell-field/swell-forecast-timeline";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import type { ForecastDisplay } from "@/lib/services/forecast/today-headline";
+import type { CustomSpot } from "@/hooks/use-custom-spots";
+import { trackSignupCtaClick } from "@/lib/analytics/signup-conversion-tracking";
 
 // Mapbox CSS is imported globally in app/globals.css
 
@@ -152,6 +156,7 @@ interface InteractiveMapProps {
     zoom?: number;
   } | null;
   beaches?: Beach[]; // Filtered beaches to display on map (if provided, skips API fetch)
+  customSpots?: CustomSpot[];
   autoNavigateOnMarkerClick?: boolean; // Whether marker clicks auto-navigate to beach page (default: true)
   displayMode?: MapDisplayMode; // What data to show in markers: 'wave-height' (default) or 'water-temp'
   showSwellField?: boolean;
@@ -164,6 +169,7 @@ interface InteractiveMapProps {
 }
 
 const SAN_DIEGO: [number, number] = [32.7157, -117.1611];
+const EMPTY_CUSTOM_SPOTS: CustomSpot[] = [];
 
 interface MapConditionLegendProps {
   controls?: ReactNode;
@@ -257,6 +263,7 @@ export function InteractiveMap({
   className = "h-full w-full",
   regionViewport,
   beaches,
+  customSpots = EMPTY_CUSTOM_SPOTS,
   autoNavigateOnMarkerClick = true,
   displayMode = "wave-height",
   showSwellField = false,
@@ -301,6 +308,7 @@ export function InteractiveMap({
   // so we surface a small "no swell data" sticker. Defaults true to avoid a
   // flash before the first build.
   const [hasSwellData, setHasSwellData] = useState(true);
+  const [showAuth, setShowAuth] = useState(false);
   // One-time coastal-leash hint: the camera silently loses zoom-out when the
   // field's leash applies, so we flash a one-shot note the FIRST time it locks
   // per mount. Ref guards "shown once"; `showLeashHint` mounts it, `leashHintFading`
@@ -351,6 +359,7 @@ export function InteractiveMap({
   const { user } = useAuth();
   const { track } = useTrackEvent();
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     isMapReadyRef.current = isMapReady;
@@ -1377,7 +1386,7 @@ export function InteractiveMap({
     }
   }, [isMapReady, beaches, populateLocations]);
 
-  // Render individual beach markers
+  // Render individual beach markers and custom spot markers
   useEffect(() => {
     if (!isMapReady || !mapRef.current) return;
 
@@ -1412,7 +1421,61 @@ export function InteractiveMap({
       }
       markersRef.current[markerId] = marker;
     });
-  }, [beaches, isMapReady, waveHeightMap, buildWaveHeightBadge, cleanupMarkers]);
+
+    customSpots.forEach((spot) => {
+      if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lon)) {
+        return;
+      }
+
+      const markerId = `custom-${spot.id}`;
+      const nearestBeachId = spot.nearestBeachId;
+      const markerData = nearestBeachId
+        ? {
+            conditionSummary: conditionSummaryMap.get(nearestBeachId),
+            conditionScore: conditionScoreMap.get(nearestBeachId),
+            waveLabel: displayForecastMap.get(nearestBeachId)?.label ?? null,
+          }
+        : undefined;
+      const element = createCustomSpotMarkerElement(spot, markerData);
+      element.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (!user) {
+          trackSignupCtaClick({
+            source: `custom-spot-${spot.id}`,
+            cta_type: "custom_spot_marker",
+          });
+          setShowAuth(true);
+          return;
+        }
+
+        router.push(`/custom-spots/${spot.id}`);
+      });
+
+      const marker = new mapboxgl.Marker({
+        element,
+        anchor: "center",
+      }).setLngLat([spot.lon, spot.lat]);
+
+      if (mapRef.current?.getCanvasContainer()) {
+        marker.addTo(mapRef.current);
+      }
+      markersRef.current[markerId] = marker;
+    });
+  }, [
+    beaches,
+    customSpots,
+    isMapReady,
+    waveHeightMap,
+    displayForecastMap,
+    conditionScoreMap,
+    conditionSummaryMap,
+    buildWaveHeightBadge,
+    cleanupMarkers,
+    router,
+    user,
+  ]);
 
   const swellTimeline =
     showSwellField && onSwellTimelineChange && swellTimelineSteps.length > 0 ? (
@@ -1481,6 +1544,19 @@ export function InteractiveMap({
         >
           No swell data for this stretch
         </div>
+      )}
+      {showAuth && (
+        <UnifiedAuthModal
+          isOpen={showAuth}
+          onClose={() => setShowAuth(false)}
+          mode="signup"
+          contextMessage={{
+            title: "Save Custom Spots",
+            description: "Create an account to open and save custom surf spots.",
+          }}
+          source="custom-spot-marker"
+          returnTo={pathname ?? undefined}
+        />
       )}
     </div>
   );

--- a/components/map/map-content.tsx
+++ b/components/map/map-content.tsx
@@ -8,6 +8,7 @@ import { DataErrorBoundary } from "@/components/error-boundaries";
 import type { Beach } from "@/types/database";
 import { LocationTimeoutBanner } from "@/components/map/location-timeout-banner";
 import type { ForecastDisplay } from "@/lib/services/forecast/today-headline";
+import type { CustomSpot } from "@/hooks/use-custom-spots";
 
 const DEFAULT_MAP_CENTER = { lat: 32.7702, lon: -117.2525 } as const;
 
@@ -29,6 +30,7 @@ interface MapContentProps {
   focusCenter?: { lat: number; lon: number } | null;
   selectedBeach: Beach | null;
   filteredBeaches: Beach[];
+  customSpots?: CustomSpot[];
   searchQuery: string;
   regionViewport: {
     region: string;
@@ -77,6 +79,7 @@ export function MapContent({
   focusCenter,
   selectedBeach,
   filteredBeaches,
+  customSpots,
   searchQuery,
   regionViewport,
   onGetUserLocation,
@@ -213,6 +216,7 @@ export function MapContent({
             onMapClick={onMapClick ? () => onMapClick() : undefined}
             regionViewport={regionViewport}
             beaches={filteredBeaches}
+            customSpots={customSpots}
             onBoundsChange={onBoundsChange}
             onWaveHeightsChange={onWaveHeightsChange}
             onDisplayForecastsChange={onDisplayForecastsChange}

--- a/hooks/__tests__/use-custom-spots.test.ts
+++ b/hooks/__tests__/use-custom-spots.test.ts
@@ -1,0 +1,153 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { createClient } from "@/lib/supabase/client";
+import { useCustomSpots } from "@/hooks/use-custom-spots";
+
+jest.mock("@/lib/supabase/client", () => ({
+  createClient: jest.fn(),
+}));
+
+function setupSupabaseQuery(result: unknown) {
+  const is = jest.fn().mockResolvedValue(result);
+  const select = jest.fn(() => ({ is }));
+  const from = jest.fn(() => ({ select }));
+
+  (createClient as jest.Mock).mockReturnValue({ from });
+
+  return { from, select, is };
+}
+
+describe("useCustomSpots", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps custom spot rows and filters non-finite coordinates", async () => {
+    const query = setupSupabaseQuery({
+      data: [
+        {
+          id: "spot-1",
+          name: "Public Peak",
+          lat: 32.75,
+          lon: -117.25,
+          nearest_beach_id: "beach-1",
+          visibility: "public",
+          break_type: "reef",
+          facing_direction_deg: 270,
+          offshore_direction_deg: 90,
+          swell_window_min_deg: 210,
+          swell_window_max_deg: 300,
+          nearest_beach_distance_mi: 1.2,
+        },
+        {
+          id: "spot-2",
+          name: "Bad Lat",
+          lat: Number.NaN,
+          lon: -117.26,
+          nearest_beach_id: null,
+          visibility: "public",
+          break_type: null,
+          facing_direction_deg: null,
+          offshore_direction_deg: null,
+          swell_window_min_deg: null,
+          swell_window_max_deg: null,
+          nearest_beach_distance_mi: null,
+        },
+        {
+          id: "spot-3",
+          name: "Bad Lon",
+          lat: 32.76,
+          lon: Number.POSITIVE_INFINITY,
+          nearest_beach_id: null,
+          visibility: "private",
+          break_type: null,
+          facing_direction_deg: null,
+          offshore_direction_deg: null,
+          swell_window_min_deg: null,
+          swell_window_max_deg: null,
+          nearest_beach_distance_mi: null,
+        },
+        {
+          id: "spot-4",
+          name: "Private Bowl",
+          lat: 32.77,
+          lon: -117.27,
+          nearest_beach_id: null,
+          visibility: "private",
+          break_type: null,
+          facing_direction_deg: null,
+          offshore_direction_deg: null,
+          swell_window_min_deg: null,
+          swell_window_max_deg: null,
+          nearest_beach_distance_mi: null,
+        },
+      ],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useCustomSpots());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.customSpots).toEqual([
+      {
+        id: "spot-1",
+        name: "Public Peak",
+        lat: 32.75,
+        lon: -117.25,
+        nearestBeachId: "beach-1",
+        visibility: "public",
+        breakType: "reef",
+        facingDirectionDeg: 270,
+        offshoreDirectionDeg: 90,
+        swellWindowMinDeg: 210,
+        swellWindowMaxDeg: 300,
+        nearestBeachDistanceMi: 1.2,
+      },
+      {
+        id: "spot-4",
+        name: "Private Bowl",
+        lat: 32.77,
+        lon: -117.27,
+        nearestBeachId: null,
+        visibility: "private",
+        breakType: null,
+        facingDirectionDeg: null,
+        offshoreDirectionDeg: null,
+        swellWindowMinDeg: null,
+        swellWindowMaxDeg: null,
+        nearestBeachDistanceMi: null,
+      },
+    ]);
+    expect(query.from).toHaveBeenCalledWith("custom_spots");
+    expect(query.select).toHaveBeenCalledWith(
+      "id, name, lat, lon, nearest_beach_id, visibility, break_type, facing_direction_deg, offshore_direction_deg, swell_window_min_deg, swell_window_max_deg, nearest_beach_distance_mi",
+    );
+    expect(query.is).toHaveBeenCalledWith("deleted_at", null);
+  });
+
+  it("returns an empty list when the query errors", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    setupSupabaseQuery({
+      data: null,
+      error: { message: "RLS denied" },
+    });
+
+    const { result } = renderHook(() => useCustomSpots());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.customSpots).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Error fetching custom spots:",
+      { message: "RLS denied" },
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/hooks/use-custom-spots.ts
+++ b/hooks/use-custom-spots.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export interface CustomSpot {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  nearestBeachId: string | null;
+  visibility: string;
+  breakType?: string | null;
+  facingDirectionDeg?: number | null;
+  offshoreDirectionDeg?: number | null;
+  swellWindowMinDeg?: number | null;
+  swellWindowMaxDeg?: number | null;
+  nearestBeachDistanceMi?: number | null;
+}
+
+interface CustomSpotRow {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  nearest_beach_id: string | null;
+  visibility: string;
+  break_type: string | null;
+  facing_direction_deg: number | null;
+  offshore_direction_deg: number | null;
+  swell_window_min_deg: number | null;
+  swell_window_max_deg: number | null;
+  nearest_beach_distance_mi: number | null;
+}
+
+export function useCustomSpots(): {
+  customSpots: CustomSpot[];
+  loading: boolean;
+} {
+  const [customSpots, setCustomSpots] = useState<CustomSpot[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchCustomSpots(): Promise<void> {
+      try {
+        const supabase = createClient();
+        const { data, error } = await supabase
+          .from("custom_spots")
+          .select(
+            "id, name, lat, lon, nearest_beach_id, visibility, break_type, facing_direction_deg, offshore_direction_deg, swell_window_min_deg, swell_window_max_deg, nearest_beach_distance_mi",
+          )
+          .is("deleted_at", null);
+
+        if (error) {
+          console.error("Error fetching custom spots:", error);
+          if (isMounted) {
+            setCustomSpots([]);
+          }
+          return;
+        }
+
+        const rows = (data ?? []) as CustomSpotRow[];
+        const nextCustomSpots = rows
+          .filter(
+            (row) => Number.isFinite(row.lat) && Number.isFinite(row.lon),
+          )
+          .map((row) => ({
+            id: row.id,
+            name: row.name,
+            lat: row.lat,
+            lon: row.lon,
+            nearestBeachId: row.nearest_beach_id,
+            visibility: row.visibility,
+            breakType: row.break_type,
+            facingDirectionDeg: row.facing_direction_deg,
+            offshoreDirectionDeg: row.offshore_direction_deg,
+            swellWindowMinDeg: row.swell_window_min_deg,
+            swellWindowMaxDeg: row.swell_window_max_deg,
+            nearestBeachDistanceMi: row.nearest_beach_distance_mi,
+          }));
+
+        if (isMounted) {
+          setCustomSpots(nextCustomSpots);
+        }
+      } catch (error) {
+        console.error("Error fetching custom spots:", error);
+        if (isMounted) {
+          setCustomSpots([]);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchCustomSpots();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { customSpots, loading };
+}


### PR DESCRIPTION
Promotes the **complete custom-spots feature** from `feat/last-mile-legibility` as one clean slice (plans 029/030/041). This was on HOLD until slice 3 (detail route + anon gate) landed — now done, security-verified, and zine-reskinned.

## What it does
Public custom spots (and a logged-in user's own, via RLS `user_id = auth.uid() OR visibility = 'public'`) render on `/map` as orange-ringed dots that borrow their nearest beach's verdict color + wave label. Clicking opens `/custom-spots/[id]` (logged-in) or the sign-up modal (anonymous).

## Files
- `hooks/use-custom-spots.ts`, `components/map/custom-spot-marker-builder.ts` — markers + forecast parity
- `app/custom-spots/[id]/page.tsx` — RLS-safe server fetch (`createSupabaseServerClient`, **not** service-role), `notFound()` for any spot the viewer can't see, `noindex` on private, zine-reskinned (cream, nearest-beach hero photo, stickers)
- `components/map/interactive-map.tsx` — auth-gated marker click (anon → `UnifiedAuthModal` with `trackSignupCtaClick` guarded inside the `!user` branch; authed → `router.push`); current `user` in effect deps (no stale closure)

## Provenance & merge notes
Cherry-picked from `650537a2d` / `c8ab45e5a` / `59c78e719` / `6ce71ca59`, squashed. Conflicts were **additive-only** (kept both imports/mocks in map-view; dropped an orphaned `windParticleDensity` state that the off-main wind work owns). CHANGELOG left at `origin/main` (its 54× corruption on the legibility branch is a separate cleanup — main is clean).

## Verification
- `yarn typecheck` → 0
- `yarn test:unit` custom-spots / interactive-map / map-view → **43 passed**
- eslint clean on the hand-merged files
- Security boundary curl-proven earlier: anon GET of a private spot → 404, nonexistent → 404, public → 200 (page code unchanged by the merge)

**Suggest squash-merge.** Native deep-link / other slices not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)