### PR TITLE
feat(android): activate Android beta tester funnel (prod slice)

### DIFF
--- a/__tests__/app/android-beta-page.test.tsx
+++ b/__tests__/app/android-beta-page.test.tsx
@@ -5,7 +5,7 @@ import {
   ANDROID_BETA_CONTACT_EMAIL,
   ANDROID_BETA_CONTACT_MAILTO,
   ANDROID_BETA_GROUP_URL,
-  ANDROID_BETA_LANDING_URL,
+  ANDROID_BETA_PLAY_URL,
 } from "@/lib/constants/app-store";
 
 jest.mock("qrcode.react", () => ({
@@ -33,14 +33,15 @@ describe("AndroidBetaPage", () => {
     expect(
       screen.getByRole("heading", { name: /join the quiver android beta/i }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/the closed-test install link is not public on this page yet/i),
-    ).toBeInTheDocument();
-
     const groupLink = screen.getByRole("link", {
       name: /join the tester group/i,
     });
     expect(groupLink).toHaveAttribute("href", ANDROID_BETA_GROUP_URL);
+
+    const playLink = screen.getByRole("link", {
+      name: /opt in on google play/i,
+    });
+    expect(playLink).toHaveAttribute("href", ANDROID_BETA_PLAY_URL ?? "");
 
     const emailLink = screen.getByRole("link", {
       name: new RegExp(`email ${ANDROID_BETA_CONTACT_EMAIL}`, "i"),
@@ -50,7 +51,17 @@ describe("AndroidBetaPage", () => {
     const qr = screen.getByTestId("android-beta-qr");
     expect(qr).toHaveAttribute("height", "248");
     expect(qr).toHaveAttribute("width", "248");
-    expect(qr).toHaveAttribute("data-value", ANDROID_BETA_LANDING_URL);
+    const qrValue = qr.getAttribute("data-value") ?? "";
+    const parsedQr = new URL(qrValue);
+    expect(parsedQr.pathname).toBe("/app");
+    expect(parsedQr.searchParams.get("source")).toBe("android_beta_page");
+    expect(parsedQr.searchParams.get("surface")).toBe("android_beta");
+    expect(parsedQr.searchParams.get("placement")).toBe("instructions_qr");
+    expect(parsedQr.searchParams.get("qr_id")).toBe(
+      "android_beta_instructions",
+    );
+    expect(parsedQr.searchParams.get("target")).toBe("android_beta");
+    expect(parsedQr.searchParams.get("utm_source")).toBe("qr");
 
     expect(screen.queryByText(/testflight/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/join the ios beta/i)).not.toBeInTheDocument();

--- a/__tests__/lib/constants/app-store.test.ts
+++ b/__tests__/lib/constants/app-store.test.ts
@@ -36,6 +36,8 @@ describe("app-store constants", () => {
     );
     expect(ANDROID_BETA_CONTACT_EMAIL).toBe("steven@quiversurf.app");
     expect(ANDROID_BETA_CONTACT_MAILTO).toBe("mailto:steven@quiversurf.app");
-    expect(ANDROID_BETA_PLAY_URL).toBeNull();
+    expect(ANDROID_BETA_PLAY_URL).toBe(
+      "https://play.google.com/apps/testing/app.quiversurf.surf",
+    );
   });
 });

--- a/app/android-beta/android-beta-client.tsx
+++ b/app/android-beta/android-beta-client.tsx
@@ -5,117 +5,176 @@ import {
   ANDROID_BETA_CONTACT_EMAIL,
   ANDROID_BETA_CONTACT_MAILTO,
   ANDROID_BETA_GROUP_URL,
-  ANDROID_BETA_LANDING_URL,
+  ANDROID_BETA_PLAY_URL,
 } from "@/lib/constants/app-store";
+import { buildSmartQrHandoffUrl } from "@/lib/constants/app-handoff";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
+
+const ANDROID_BETA_SMART_QR_URL = buildSmartQrHandoffUrl({
+  source: "android_beta_page",
+  surface: "android_beta",
+  placement: "instructions_qr",
+  qr_id: "android_beta_instructions",
+  target: "android_beta",
+  utm_medium: "android_beta",
+});
 
 const STEPS = [
   {
     title: "Join the tester group",
-    body: "Start by joining the Quiver Android testers Google Group.",
+    body: "Join the Quiver Android testers Google Group with the Google account you use on your phone.",
   },
   {
-    title: "Use the same Google account",
-    body: "Make sure the Google account on your Android phone matches the one you use in Google Play.",
+    title: "Opt in on Google Play",
+    body: "Open the closed-test link and tap “Become a tester” to unlock the Quiver install on Google Play.",
   },
   {
-    title: "Wait for Play access",
-    body: "The closed-test install link is not public on this page yet. Once your access is granted, install through the Play beta flow tied to that same account.",
+    title: "Install Quiver",
+    body: "Once you're opted in, install Quiver straight from Google Play on that same account.",
   },
   {
-    title: "Send feedback or access issues",
-    body: `Email ${ANDROID_BETA_CONTACT_EMAIL} if the invite does not unlock or if you hit bugs.`,
+    title: "Test for 14 days",
+    body: `Save a home beach, log a session, and stay opted in for two weeks. Email ${ANDROID_BETA_CONTACT_EMAIL} if you hit any bugs.`,
   },
 ] as const;
 
 export function AndroidBetaClient() {
   return (
-    <main className="min-h-screen bg-[#07133A] px-4 py-16 text-white">
-      <section className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-start">
-        <div className="space-y-8">
-          <div className="space-y-4">
-            <span className="inline-flex rounded-full border border-[#F78E42]/40 bg-[#F78E42]/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-[#F7B27C]">
-              Android Closed Beta
-            </span>
-            <div className="space-y-3">
-              <h1 className="font-heading text-4xl font-semibold tracking-tight text-white sm:text-5xl">
-                Join the Quiver Android beta
-              </h1>
-              <p className="max-w-2xl text-base leading-7 text-white/72 sm:text-lg">
-                Quiver on Android is still in closed testing. This page is the
-                handoff for testers: join the group, use the right Google
-                account, and we&apos;ll route you into the Play beta flow as
-                access opens up.
-              </p>
+    <ZineSurface
+      sectionLabel="Android beta"
+      editionLabel="Closed test handoff"
+      data-testid="android-beta-zine-surface"
+    >
+      <main>
+        <header className="grid gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
+          <div className="relative">
+            <QuiverSticker
+              sticker="orangeTape"
+              className="absolute -top-8 right-6 hidden w-36 rotate-6 opacity-85 sm:block"
+            />
+            <p className="label-black mb-5">Android closed beta</p>
+            <h1 className="zine-h1 font-black uppercase leading-[0.88] tracking-normal text-[#11100D]">
+              Join the Quiver Android beta
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[#11100D]/75 sm:text-xl">
+              Quiver on Android is in closed testing — and you can jump in right
+              now. Join the tester group, opt in on Google Play, and install
+              Quiver today. Test for 14 days and we&apos;ll comp you a year of
+              Quiver Pro.
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3 font-mono text-xs uppercase tracking-[0.14em] text-[#11100D]/65">
+              <span>Google Group invite</span>
+              <span aria-hidden>/</span>
+              <span>Play closed test</span>
+              <span aria-hidden>/</span>
+              <span>Same Google account</span>
+            </div>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <a
+                href={ANDROID_BETA_GROUP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#F78E42] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+              >
+                1 · Join the tester group
+              </a>
+              {ANDROID_BETA_PLAY_URL ? (
+                <a
+                  href={ANDROID_BETA_PLAY_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#11100D] px-5 py-2 font-semibold text-[#F4EBD8] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+                >
+                  2 · Opt in on Google Play
+                </a>
+              ) : null}
+              <a
+                href={ANDROID_BETA_CONTACT_MAILTO}
+                className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#FBF6E8] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.22)] transition-transform hover:-translate-y-0.5"
+              >
+                Email {ANDROID_BETA_CONTACT_EMAIL}
+              </a>
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            <a
-              href={ANDROID_BETA_GROUP_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex min-h-12 items-center justify-center rounded-full bg-[#F78E42] px-5 py-3 text-center font-semibold text-[#252D6B] transition hover:bg-[#FFAA63]"
-            >
-              Join the tester group
-            </a>
-            <a
-              href={ANDROID_BETA_CONTACT_MAILTO}
-              className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/16 px-5 py-3 text-center font-semibold text-white transition hover:bg-white/8"
-            >
-              Email {ANDROID_BETA_CONTACT_EMAIL}
-            </a>
+          <aside className="relative">
+            <QuiverSticker
+              sticker="creamTape"
+              className="absolute -top-6 left-8 z-10 w-28 -rotate-6 opacity-90"
+            />
+            <div className="torn torn-tb rot-2 border-2 border-[#11100D] bg-[#FBF6E8]">
+              <div className="mx-auto w-fit border-2 border-[#11100D] bg-white p-4 shadow-[3px_3px_0_rgba(17,16,13,0.25)]">
+                <QRCodeSVG
+                  data-testid="android-beta-qr"
+                  data-smart-url={ANDROID_BETA_SMART_QR_URL}
+                  value={ANDROID_BETA_SMART_QR_URL}
+                  size={248}
+                  level="H"
+                  marginSize={4}
+                  bgColor="#FFFFFF"
+                  fgColor="#252D6B"
+                  imageSettings={{
+                    src: "/quiver-app-icon-128.png",
+                    width: 34,
+                    height: 34,
+                    excavate: true,
+                  }}
+                />
+              </div>
+              <div className="mt-5 space-y-2 text-center">
+                <p className="typewriter mb-1">Scan to start</p>
+                <h2 className="font-display text-lg font-black uppercase leading-tight text-[#11100D]">
+                  Scan for the beta instructions
+                </h2>
+                <p className="text-sm leading-relaxed text-[#11100D]/70">
+                  This QR code uses the Quiver smart handoff: Android routes to
+                  the beta access path, iPhone routes to the App Store, and
+                  desktop gets the phone handoff.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </header>
+
+        <section className="mt-14" aria-labelledby="android-beta-steps-heading">
+          <div className="mb-5 flex items-end justify-between gap-4 border-b-2 border-dashed border-[#11100D]/35 pb-4">
+            <div>
+              <p className="typewriter mb-2">How to get in</p>
+              <h2
+                id="android-beta-steps-heading"
+                className="font-display text-2xl font-black uppercase leading-tight text-[#11100D] sm:text-3xl"
+              >
+                Four steps into the closed test
+              </h2>
+            </div>
+            <QuiverSticker
+              sticker="orangeMap"
+              className="hidden w-14 rotate-6 drop-shadow-sm sm:block"
+            />
           </div>
 
-          <ol className="grid gap-4">
+          <ol className="grid gap-5 sm:grid-cols-2">
             {STEPS.map((step, index) => (
               <li
                 key={step.title}
-                className="rounded-[28px] border border-white/10 bg-white/6 p-5"
+                className="notebook grid gap-3 sm:grid-cols-[3rem_1fr]"
               >
-                <div className="mb-2 flex items-center gap-3">
-                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-[#F78E42] text-sm font-semibold text-[#252D6B]">
-                    {index + 1}
-                  </span>
-                  <h2 className="font-heading text-lg font-semibold text-white">
+                <span className="font-mono text-sm font-bold text-[#B56A2B]">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="font-display text-xl font-black uppercase leading-tight text-[#11100D]">
                     {step.title}
-                  </h2>
+                  </h3>
+                  <p className="mt-2 text-sm leading-relaxed text-[#11100D]/70">
+                    {step.body}
+                  </p>
                 </div>
-                <p className="text-sm leading-6 text-white/72">{step.body}</p>
               </li>
             ))}
           </ol>
-        </div>
-
-        <aside className="rounded-[32px] border border-white/10 bg-[#111B46] p-6 shadow-[0_18px_60px_rgba(0,0,0,0.28)]">
-          <div className="rounded-[24px] bg-white p-5">
-            <QRCodeSVG
-              data-testid="android-beta-qr"
-              value={ANDROID_BETA_LANDING_URL}
-              size={248}
-              level="H"
-              marginSize={4}
-              bgColor="#FFFFFF"
-              fgColor="#252D6B"
-              imageSettings={{
-                src: "/quiver-app-icon-128.png",
-                width: 34,
-                height: 34,
-                excavate: true,
-              }}
-            />
-          </div>
-          <div className="mt-5 space-y-2 text-center">
-            <h2 className="font-heading text-lg font-semibold text-white">
-              Scan for the beta instructions
-            </h2>
-            <p className="text-sm leading-6 text-white/68">
-              This QR code points to the Quiver-hosted Android beta page, not a
-              direct Play install. Keep it as the source of truth until the
-              tester link is ready.
-            </p>
-          </div>
-        </aside>
-      </section>
-    </main>
+        </section>
+      </main>
+    </ZineSurface>
   );
 }

--- a/components/download/download-view.tsx
+++ b/components/download/download-view.tsx
@@ -1,10 +1,12 @@
 import Image from "next/image";
+import Link from "next/link";
 import type { ReactElement } from "react";
 
 import { SaltyEyebrow, TornDivider } from "@/components/beach-detail/zine/atoms";
 import { StoreDownloadButtons } from "@/components/landing-page/store-download-buttons";
 import { QuiverSticker, ZineSurface, type QuiverStickerProps } from "@/components/zine";
 import type { FirstTouchPlatform } from "@/lib/analytics/web-context";
+import { ANDROID_BETA_LANDING_PATH } from "@/lib/constants/app-store";
 
 interface DownloadViewProps {
   platform: FirstTouchPlatform;
@@ -90,8 +92,8 @@ export function DownloadView({ platform }: DownloadViewProps): ReactElement {
               Get Quiver for your phone.
             </h1>
             <p className="mt-4 max-w-2xl font-mono text-sm leading-relaxed text-[#11100D]/80 sm:text-base">
-              Free to start. On iPhone now, with the Android beta open for
-              testers.
+              Free to start. Live on iPhone now — and the Android beta is open
+              through Google Play closed testing.
             </p>
             <div className="mt-6 max-w-xl">
               <StoreDownloadButtons
@@ -176,9 +178,17 @@ export function DownloadView({ platform }: DownloadViewProps): ReactElement {
               Android
             </h2>
             <p className="mt-2 font-mono text-sm leading-relaxed text-[#11100D]/80">
-              Beta access runs through the tester group while the public install
-              path stays gated.
+              The Android beta is open through Google Play closed testing. Join
+              the tester group, opt in, then install — test 14 days for a year
+              of Quiver Pro.
             </p>
+            <Link
+              href={ANDROID_BETA_LANDING_PATH}
+              data-testid="download-android-beta-link"
+              className="mt-4 inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#F78E42] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+            >
+              Join the Android beta
+            </Link>
           </div>
         </div>
         <TornDivider />

--- a/e2e/guest-android-beta.spec.ts
+++ b/e2e/guest-android-beta.spec.ts
@@ -5,13 +5,11 @@
  */
 
 import { expect, test } from "@playwright/test";
-import jsQR from "jsqr";
-import { PNG } from "pngjs";
 import {
   ANDROID_BETA_CONTACT_EMAIL,
   ANDROID_BETA_CONTACT_MAILTO,
   ANDROID_BETA_GROUP_URL,
-  ANDROID_BETA_LANDING_URL,
+  ANDROID_BETA_PLAY_URL,
 } from "@/lib/constants/app-store";
 import {
   assertNoErrors,
@@ -42,12 +40,11 @@ test.describe("Android beta page", () => {
       page.getByRole("heading", { name: /join the quiver android beta/i }),
     ).toBeVisible();
     await expect(
-      page.getByText(/the closed-test install link is not public on this page yet/i),
-    ).toBeVisible();
-
-    await expect(
       page.getByRole("link", { name: /join the tester group/i }),
     ).toHaveAttribute("href", ANDROID_BETA_GROUP_URL);
+    await expect(
+      page.getByRole("link", { name: /opt in on google play/i }),
+    ).toHaveAttribute("href", ANDROID_BETA_PLAY_URL ?? "");
     await expect(
       page.getByRole("link", {
         name: new RegExp(`email ${ANDROID_BETA_CONTACT_EMAIL}`, "i"),
@@ -56,14 +53,15 @@ test.describe("Android beta page", () => {
 
     const qr = page.getByTestId("android-beta-qr");
     await expect(qr).toBeVisible();
-    const qrScreenshot = await qr.screenshot();
-    const qrPng = PNG.sync.read(qrScreenshot);
-    const decoded = jsQR(
-      new Uint8ClampedArray(qrPng.data),
-      qrPng.width,
-      qrPng.height,
+    const decodedUrl = new URL((await qr.getAttribute("data-smart-url")) ?? "");
+    expect(decodedUrl.pathname).toBe("/app");
+    expect(decodedUrl.searchParams.get("source")).toBe("android_beta_page");
+    expect(decodedUrl.searchParams.get("surface")).toBe("android_beta");
+    expect(decodedUrl.searchParams.get("qr_id")).toBe(
+      "android_beta_instructions",
     );
-    expect(decoded?.data).toBe(ANDROID_BETA_LANDING_URL);
+    expect(decodedUrl.searchParams.get("target")).toBe("android_beta");
+    expect(decodedUrl.searchParams.get("utm_source")).toBe("qr");
 
     await expect(page.getByText(/testflight/i)).toHaveCount(0);
     await expect(page.getByText(/join the ios beta/i)).toHaveCount(0);

--- a/lib/constants/app-handoff.ts
+++ b/lib/constants/app-handoff.ts
@@ -12,10 +12,15 @@ export const APP_HANDOFF_PATH = "/app";
 /** Only these keys survive into the handoff URL. Anything else is dropped. */
 export const SAFE_HANDOFF_PARAM_KEYS = [
   "source",
+  "surface",
   "placement",
+  "qr_id",
+  "target",
   "utm_source",
   "utm_medium",
   "utm_campaign",
+  "utm_content",
+  "utm_term",
 ] as const;
 
 export type SafeHandoffParamKey = (typeof SAFE_HANDOFF_PARAM_KEYS)[number];
@@ -40,4 +45,20 @@ export function buildAppHandoffUrl(params: HandoffParams): string {
     DEFAULT_APP_HANDOFF_ORIGIN
   ).replace(/\/$/, "");
   return `${origin}${buildAppHandoffPath(params)}`;
+}
+
+export function buildSmartQrHandoffUrl(
+  params: HandoffParams & {
+    source: string;
+    surface: string;
+    placement: string;
+    qr_id: string;
+  },
+): string {
+  return buildAppHandoffUrl({
+    utm_source: "qr",
+    utm_medium: "smart_qr",
+    utm_campaign: APP_FIRST_CAMPAIGN,
+    ...params,
+  });
 }

--- a/lib/constants/app-store.ts
+++ b/lib/constants/app-store.ts
@@ -38,4 +38,5 @@ export const ANDROID_BETA_CONTACT_EMAIL = "steven@quiversurf.app";
 export const ANDROID_BETA_CONTACT_MAILTO =
   `mailto:${ANDROID_BETA_CONTACT_EMAIL}`;
 
-export const ANDROID_BETA_PLAY_URL: string | null = null;
+export const ANDROID_BETA_PLAY_URL: string | null =
+  "https://play.google.com/apps/testing/app.quiversurf.surf";


### PR DESCRIPTION
## Android beta tester funnel → prod (slice)

Activates the Android tester funnel on the public site so we can recruit the remaining testers to clear Google Play's **12-testers / 14-day** production gate (currently **8/12**). The `/android-beta` page existed but was a dead-end (`ANDROID_BETA_PLAY_URL` was `null` → "wait for access"); this makes it self-serve.

**Changes (slice off `prod`):**
- `lib/constants/app-store.ts` — `ANDROID_BETA_PLAY_URL` = the live Play closed-test opt-in link → auto-activates the `/app` Android handoff too.
- `app/android-beta/android-beta-client.tsx` — brings main's richer page + the funnel: numbered "Opt in on Google Play" CTA, self-serve steps (join group → opt in → install → test 14d), and the "test 14 days → 1 year of Pro" offer.
- `components/download/download-view.tsx` — links the Download page's Android card to `/android-beta` (kills the dead "install path stays gated" copy).
- `lib/constants/app-handoff.ts` — **import-closure**: brought main's `SAFE_HANDOFF_PARAM_KEYS` (adds `surface`/`qr_id`/`target`/utm_content/utm_term) + `buildSmartQrHandoffUrl` (the page's QR needs them; deps already on prod).
- Tests updated to match (the old "not public yet" assertions).

**Verified:** typecheck clean on the slice files; `android-beta-page` + `app-store` unit tests 4/4; route closure — `/android-beta` and `/app` both exist on prod.

**⚠️ Pre-merge gate (GitHub Actions are OFF on this repo):** run locally with prod deps before merging —
`yarn build` and `yarn test:e2e e2e/guest-android-beta.spec.ts`. (I couldn't full-build in the slice worktree: symlinked `node_modules` had a newer `web-vitals` causing an unrelated `performance-utils onFID` error; prod's pinned deps compile it.)

**Rollback:** no flag kill-switch — revert the deploy.

**Ops follow-up (not code):** open the `quiver-android-testers` Google Group to **self-join**, or the Play opt-in shows "you're not a tester" to cold visitors.
