### PR TITLE
feat(forecast): capture forecast feedback votes

### DIFF
--- a/__tests__/actions/forecast-verification-actions.test.ts
+++ b/__tests__/actions/forecast-verification-actions.test.ts
@@ -56,7 +56,7 @@ describe('Forecast Verification Actions', () => {
 
   describe('voteForecastAccuracy', () => {
     const voteInput: ForecastVoteInput = {
-      forecastId: 'forecast-123',
+      forecastId: '11111111-1111-4111-8111-111111111111',
       beachId: 'beach-456',
       wasAccurate: true,
       notes: 'Great forecast accuracy',
@@ -66,7 +66,7 @@ describe('Forecast Verification Actions', () => {
       const mockVote = {
         id: 'vote-123',
         user_id: 'test-user-id',
-        forecast_id: 'forecast-123',
+        forecast_id: '11111111-1111-4111-8111-111111111111',
         beach_id: 'beach-456',
         was_accurate: true,
         notes: 'Great forecast accuracy',
@@ -104,11 +104,78 @@ describe('Forecast Verification Actions', () => {
       expect(result.data?.isUpdate).toBe(false);
     });
 
+    it('resolves generated forecast ids to enhanced_forecasts rows before voting', async () => {
+      const realForecastId = '22222222-2222-4222-8222-222222222222';
+      const mockVote = {
+        id: 'vote-123',
+        user_id: 'test-user-id',
+        forecast_id: realForecastId,
+        beach_id: 'beach-456',
+        was_accurate: true,
+        notes: 'Great forecast accuracy',
+        created_at: new Date().toISOString(),
+      };
+
+      const forecastTable = {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: { id: realForecastId },
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      };
+      const votesTable = {
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              maybeSingle: jest.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockVote,
+              error: null,
+            }),
+          }),
+        }),
+      };
+
+      const mockSupabase = createMockSupabase();
+      (mockSupabase.from as jest.Mock).mockImplementation((table: string) => {
+        if (table === 'enhanced_forecasts') return forecastTable;
+        if (table === 'forecast_accuracy_votes') return votesTable;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+      useMockSupabase(mockSupabase);
+
+      const result = await voteForecastAccuracy({
+        ...voteInput,
+        forecastId: 'forecast-beach-456-1779621600000',
+        forecastAt: '2026-05-24T14:00:00.000Z',
+      } as ForecastVoteInput & { forecastAt: string });
+
+      expect(result.success).toBe(true);
+      expect(forecastTable.select).toHaveBeenCalledWith('id');
+      expect(votesTable.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ forecast_id: realForecastId }),
+      );
+      expect(result.data?.vote).toEqual(mockVote);
+    });
+
     it('should update an existing vote successfully', async () => {
       const existingVote = {
         id: 'vote-123',
         user_id: 'test-user-id',
-        forecast_id: 'forecast-123',
+        forecast_id: '11111111-1111-4111-8111-111111111111',
         beach_id: 'beach-456',
         was_accurate: false,
         notes: 'Old notes',

--- a/__tests__/app/api/forecast-feedback-route.test.ts
+++ b/__tests__/app/api/forecast-feedback-route.test.ts
@@ -6,6 +6,8 @@ import { NextRequest } from "next/server";
 import { POST } from "@/app/api/forecast-feedback/route";
 
 const mockUser = { id: "user-1" };
+const mockSupabase = { from: jest.fn() };
+const MOCK_FORECAST_ID = "22222222-2222-4222-8222-222222222222";
 
 jest.mock("@/lib/middleware/api-wrappers", () => {
   const actual = jest.requireActual("@/lib/api-utils");
@@ -14,11 +16,11 @@ jest.mock("@/lib/middleware/api-wrappers", () => {
       (
         handler: (
           request: NextRequest,
-          context: { user: typeof mockUser; supabase: Record<string, never> },
+          context: { user: typeof mockUser; supabase: typeof mockSupabase },
         ) => Promise<Response>,
       ) =>
       (request: NextRequest) =>
-        handler(request, { user: mockUser, supabase: {} }),
+        handler(request, { user: mockUser, supabase: mockSupabase }),
     createErrorResponse: actual.createErrorResponse,
     createSuccessResponse: actual.createSuccessResponse,
     createValidationError: actual.createValidationError,
@@ -26,6 +28,45 @@ jest.mock("@/lib/middleware/api-wrappers", () => {
 });
 
 const originalEnv = process.env;
+
+function mockForecastAccuracyVotePersistence() {
+  const enhancedMaybeSingle = jest.fn().mockResolvedValue({
+    data: { id: MOCK_FORECAST_ID },
+    error: null,
+  });
+  const enhancedForecastsTable = {
+    select: jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: enhancedMaybeSingle,
+        }),
+      }),
+    }),
+  };
+
+  const voteSingle = jest.fn().mockResolvedValue({
+    data: { id: "vote-row-1" },
+    error: null,
+  });
+  const forecastVotesTable = {
+    upsert: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        single: voteSingle,
+      }),
+    }),
+  };
+
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === "enhanced_forecasts") return enhancedForecastsTable;
+    if (table === "forecast_accuracy_votes") return forecastVotesTable;
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return {
+    enhancedForecastsTable,
+    forecastVotesTable,
+  };
+}
 
 function basePayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -63,6 +104,8 @@ function requestWithBody(body: unknown): NextRequest {
 describe("POST /api/forecast-feedback", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSupabase.from.mockReset();
+    mockForecastAccuracyVotePersistence();
     process.env = {
       ...originalEnv,
       ML_INTERNAL_SECRET: "test-secret",
@@ -128,6 +171,30 @@ describe("POST /api/forecast-feedback", () => {
     });
     expect(forwarded.displayed_context.wave_height_ft).toBe("2-3 ft");
     expect(forwarded.source_model_context.data_source).toBe("NOAA_NWS");
+  });
+
+  it("persists forecast-accuracy feedback into forecast_accuracy_votes", async () => {
+    const { forecastVotesTable } = mockForecastAccuracyVotePersistence();
+
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockSupabase.from).toHaveBeenCalledWith("enhanced_forecasts");
+    expect(mockSupabase.from).toHaveBeenCalledWith("forecast_accuracy_votes");
+    expect(forecastVotesTable.upsert).toHaveBeenCalledWith(
+      {
+        user_id: "user-1",
+        forecast_id: MOCK_FORECAST_ID,
+        beach_id: "11111111-1111-4111-8111-111111111111",
+        was_accurate: false,
+        actual_conditions: { wave_height_ft: "2-3 ft" },
+        notes: "Saw waist-high waves.",
+        photo_url: null,
+      },
+      { onConflict: "user_id,forecast_id" },
+    );
   });
 
   it("adds explicit missing flags for empty context groups before calling Seaside", async () => {

--- a/actions/forecast-verification-actions.ts
+++ b/actions/forecast-verification-actions.ts
@@ -1,12 +1,13 @@
 "use server";
 
 import { makeAuthenticatedAction } from "@/lib/server-action-utils";
-import type { Database } from "@/types/supabase";
+import type { Database, SupabaseServerClient } from "@/types/supabase";
 
 // Types
 export interface ForecastVoteInput {
   forecastId: string;
   beachId: string;
+  forecastAt?: string;
   wasAccurate: boolean;
   actualConditions?: {
     wave_height?: number;
@@ -41,6 +42,37 @@ export interface BeachAccuracyStats {
   recent_votes: ForecastVote[];
 }
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+async function resolveForecastId(
+  supabase: SupabaseServerClient,
+  input: ForecastVoteInput,
+): Promise<string> {
+  if (UUID_PATTERN.test(input.forecastId)) return input.forecastId;
+
+  if (!input.forecastAt) {
+    throw new Error("Forecast time is required for generated forecast IDs");
+  }
+
+  const { data, error } = await supabase
+    .from("enhanced_forecasts")
+    .select("id")
+    .eq("beach_id", input.beachId)
+    .eq("forecast_at", input.forecastAt)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to resolve forecast: ${error.message}`);
+  }
+
+  if (!data?.id) {
+    throw new Error("Forecast row not found");
+  }
+
+  return data.id;
+}
+
 /**
  * Submit or update a forecast accuracy vote
  * Users can vote once per forecast, subsequent calls update their vote
@@ -55,12 +87,14 @@ export const voteForecastAccuracy = makeAuthenticatedAction(
       throw new Error("wasAccurate must be a boolean value");
     }
 
+    const forecastId = await resolveForecastId(supabase, input);
+
     // Check if user has already voted on this forecast
     const { data: existingVote, error: fetchError } = await supabase
       .from("forecast_accuracy_votes")
       .select("*")
       .eq("user_id", user.id)
-      .eq("forecast_id", input.forecastId)
+      .eq("forecast_id", forecastId)
       .maybeSingle();
 
     if (fetchError) {
@@ -69,7 +103,7 @@ export const voteForecastAccuracy = makeAuthenticatedAction(
 
     const voteData = {
       user_id: user.id,
-      forecast_id: input.forecastId,
+      forecast_id: forecastId,
       beach_id: input.beachId,
       was_accurate: input.wasAccurate,
       actual_conditions: input.actualConditions || null,

--- a/app/api/forecast-feedback/route.ts
+++ b/app/api/forecast-feedback/route.ts
@@ -10,7 +10,9 @@ import {
 import {
   ForecastFeedbackClientPayloadSchema,
   buildSeasideForecastFeedbackPayload,
+  type ForecastFeedbackClientPayload,
 } from "@/lib/services/forecast/forecast-feedback";
+import type { Json } from "@/types/database.generated";
 
 export const dynamic = "force-dynamic";
 
@@ -19,6 +21,12 @@ type SeasideFeedbackResponse = {
   id?: string | null;
   contract_version?: string;
   correlation_id?: string | null;
+};
+
+const FORECAST_ACCURACY_VOTE_VALUES: Record<string, boolean> = {
+  about_right: true,
+  too_low: false,
+  too_high: false,
 };
 
 function normalizedEnv(name: string): string | null {
@@ -48,9 +56,67 @@ async function parseJsonResponse(
   }
 }
 
+function forecastAccuracyVoteValue(
+  input: ForecastFeedbackClientPayload,
+): boolean | null {
+  if (input.feedbackKind !== "forecast_accuracy") return null;
+  return FORECAST_ACCURACY_VOTE_VALUES[input.feedbackValue] ?? null;
+}
+
+function nonEmptyJsonRecordOrNull(
+  value: Record<string, unknown> | undefined,
+): Json | null {
+  if (!value || Object.keys(value).length === 0) return null;
+  return value as Json;
+}
+
+async function persistForecastAccuracyVote(
+  { user, supabase }: AuthenticatedContext,
+  input: ForecastFeedbackClientPayload,
+): Promise<void> {
+  const wasAccurate = forecastAccuracyVoteValue(input);
+  if (wasAccurate == null) return;
+
+  const { data: forecast, error: forecastError } = await supabase
+    .from("enhanced_forecasts")
+    .select("id")
+    .eq("beach_id", input.beachId)
+    .eq("forecast_at", input.forecastAt)
+    .maybeSingle();
+
+  if (forecastError) {
+    throw new Error("Forecast vote target lookup failed");
+  }
+
+  if (!forecast?.id) {
+    throw new Error("Forecast vote target not found");
+  }
+
+  const { error } = await supabase
+    .from("forecast_accuracy_votes")
+    .upsert(
+      {
+        user_id: user.id,
+        forecast_id: forecast.id,
+        beach_id: input.beachId,
+        was_accurate: wasAccurate,
+        actual_conditions: nonEmptyJsonRecordOrNull(input.displayedContext),
+        notes: input.feedbackNote?.trim() || null,
+        photo_url: null,
+      },
+      { onConflict: "user_id,forecast_id" },
+    )
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error("Forecast vote storage failed");
+  }
+}
+
 async function forecastFeedbackHandler(
   request: NextRequest,
-  { user }: AuthenticatedContext,
+  context: AuthenticatedContext,
 ): Promise<NextResponse> {
   const secret = readMlInternalSecret();
   if (!secret) {
@@ -76,8 +142,19 @@ async function forecastFeedbackHandler(
 
   const correlationId = validation.data.correlationId ?? randomUUID();
   const requestId = validation.data.requestId ?? randomUUID();
+
+  try {
+    await persistForecastAccuracyVote(context, validation.data);
+  } catch {
+    return createErrorResponse(
+      "Forecast vote storage failed",
+      { correlationId },
+      500,
+    );
+  }
+
   const payload = buildSeasideForecastFeedbackPayload(validation.data, {
-    userId: user.id,
+    userId: context.user.id,
     ingestPath: "quiver-api/forecast-feedback",
     requestId,
     correlationId,

--- a/lib/services/forecast/__tests__/log-display-prediction.test.ts
+++ b/lib/services/forecast/__tests__/log-display-prediction.test.ts
@@ -259,27 +259,14 @@ describe("logDisplayPredictions", () => {
     expect(upsertMock).toHaveBeenCalledTimes(1);
   });
 
-  it("drops rows missing Phase 0 replay provenance before writing", async () => {
+  it("logs no-source Flat rows with null raw input instead of fabricating output as input", async () => {
     await logDisplayPredictions([
       sampleRow({
-        beach_id: "beach-valid",
-        display_wave_source: "model_swell",
-        display_raw_input_height_m: 0.8,
-      }),
-      sampleRow({
-        beach_id: "beach-missing-source",
+        beach_id: "beach-flat",
         display_wave_source: null,
-        display_raw_input_height_m: 0.8,
-      }),
-      sampleRow({
-        beach_id: "beach-missing-raw-input",
-        display_wave_source: "model_swell",
         display_raw_input_height_m: null,
-      }),
-      sampleRow({
-        beach_id: "beach-negative-raw-input",
-        display_wave_source: "model_swell",
-        display_raw_input_height_m: -0.1,
+        raw_display_height_m: 0,
+        offset_corrected_display_height_m: 0,
       }),
     ]);
 
@@ -288,10 +275,74 @@ describe("logDisplayPredictions", () => {
     expect(payload).toHaveLength(1);
     expect(payload[0]).toEqual(
       expect.objectContaining({
+        beach_id: "beach-flat",
+        display_wave_source: null,
+        display_raw_input_height_m: null,
+        raw_display_height_m: 0,
+        offset_corrected_display_height_m: 0,
+      })
+    );
+  });
+
+  it("preserves the builder's true raw transform input for valid-source rows", async () => {
+    await logDisplayPredictions([
+      sampleRow({
         beach_id: "beach-valid",
         display_wave_source: "model_swell",
         display_raw_input_height_m: 0.8,
+        raw_display_height_m: 1.234,
+      }),
+    ]);
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    const payload = upsertMock.mock.calls[0][0];
+    expect(payload[0]).toEqual(
+      expect.objectContaining({
+        beach_id: "beach-valid",
+        display_wave_source: "model_swell",
+        display_raw_input_height_m: 0.8,
+        raw_display_height_m: 1.234,
       })
+    );
+  });
+
+  it("does not fabricate a missing raw transform input from the displayed output", async () => {
+    await logDisplayPredictions([
+      sampleRow({
+        beach_id: "beach-missing-raw-input",
+        display_wave_source: "model_swell",
+        display_raw_input_height_m: null,
+        raw_display_height_m: 1.234,
+      }),
+    ]);
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    const payload = upsertMock.mock.calls[0][0];
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toEqual(
+      expect.objectContaining({
+        beach_id: "beach-missing-raw-input",
+        raw_display_height_m: 1.234,
+        display_wave_source: "model_swell",
+        display_raw_input_height_m: null,
+      })
+    );
+  });
+
+  it("writes the caller's EF display value into the sidecar displayed-value column", async () => {
+    const efDisplayHeightM = 1.456;
+
+    await logDisplayPredictions([
+      sampleRow({
+        raw_display_height_m: 1.789,
+        offset_corrected_display_height_m: efDisplayHeightM,
+        display_raw_input_height_m: 0.91,
+      }),
+    ]);
+
+    const payload = upsertMock.mock.calls[0][0];
+    expect(payload[0].offset_corrected_display_height_m).toBe(
+      efDisplayHeightM
     );
   });
 
@@ -316,15 +367,15 @@ describe("logDisplayPredictions", () => {
     ).toEqual([...WAVE_HEIGHT_SOURCE_TAGS]);
   });
 
-  it("skips the insert when every row is missing Phase 0 replay provenance", async () => {
+  it("skips the insert when every row has invalid sidecar provenance values", async () => {
     await logDisplayPredictions([
       sampleRow({
-        display_wave_source: null,
-        display_raw_input_height_m: 0.8,
+        display_wave_source: "unknown-source" as never,
+        display_raw_input_height_m: null,
       }),
       sampleRow({
         display_wave_source: "model_swell",
-        display_raw_input_height_m: null,
+        display_raw_input_height_m: Number.NaN,
       }),
       sampleRow({
         display_wave_source: "model_swell",

--- a/lib/services/forecast/log-display-prediction.ts
+++ b/lib/services/forecast/log-display-prediction.ts
@@ -185,13 +185,16 @@ export async function logDisplayPredictions(
   try {
     const supabase = createServiceRoleClient();
 
-    const validRows = rows.filter(hasPhase0ReplayProvenance);
+    const validRows = rows.filter(hasValidSidecarProvenanceValues);
     const skippedRows = rows.length - validRows.length;
     if (skippedRows > 0) {
-      log.warn("logDisplayPredictions: skipped rows missing replay provenance", {
-        rowCount: rows.length,
-        skippedRows,
-      });
+      log.warn(
+        "logDisplayPredictions: skipped rows with invalid sidecar provenance",
+        {
+          rowCount: rows.length,
+          skippedRows,
+        }
+      );
     }
     if (validRows.length === 0) {
       return;
@@ -314,6 +317,10 @@ export async function logDisplayPredictions(
   }
 }
 
+function nonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function shouldFallbackToLegacyConflictTarget(error: {
   code?: string;
   message?: string;
@@ -337,12 +344,13 @@ function shouldFallbackToLegacyConflictTarget(error: {
   );
 }
 
-function hasPhase0ReplayProvenance(row: DisplayPredictionRow): boolean {
-  return (
-    row.display_wave_source != null &&
-    WAVE_HEIGHT_SOURCE_TAG_SET.has(row.display_wave_source) &&
-    typeof row.display_raw_input_height_m === "number" &&
-    Number.isFinite(row.display_raw_input_height_m) &&
-    row.display_raw_input_height_m >= 0
-  );
+function hasValidSidecarProvenanceValues(row: DisplayPredictionRow): boolean {
+  const hasValidWaveSource =
+    row.display_wave_source == null ||
+    WAVE_HEIGHT_SOURCE_TAG_SET.has(row.display_wave_source);
+  const hasValidRawInput =
+    row.display_raw_input_height_m == null ||
+    nonNegativeFiniteNumber(row.display_raw_input_height_m);
+
+  return hasValidWaveSource && hasValidRawInput;
 }


### PR DESCRIPTION
## Summary
- Promotes only Phase A forecast-feedback capture from main commit `1c8147a00` onto `prod`.
- Persists forecast-accuracy feedback into `forecast_accuracy_votes` while preserving the existing Seaside ML feedback forwarder.
- Updates the forecast verification action to resolve generated forecast IDs to `enhanced_forecasts` rows before voting.
- Relaxes display-prediction sidecar provenance handling so valid null sidecar values are logged instead of fabricated.

## Scope
Changed exactly these six files from `1c8147a00`:
- `actions/forecast-verification-actions.ts`
- `app/api/forecast-feedback/route.ts`
- `lib/services/forecast/log-display-prediction.ts`
- `__tests__/actions/forecast-verification-actions.test.ts`
- `__tests__/app/api/forecast-feedback-route.test.ts`
- `lib/services/forecast/__tests__/log-display-prediction.test.ts`

No migrations, env changes, new routes, new modules, or feature flags.

## Import / Route Closure
- `yarn typecheck` passed after reinstalling dependencies with the `prod` lockfile.
- No extra dependency files were added; import graph closed with the original six-file slice only.
- Slice changes no `app/**/page.tsx` files.
- `app/api/forecast-feedback/route.ts` already exists on `origin/prod`.
- Grep of the six slice files found no internal navigation link targets to validate.

## Verification
- PASS: `yarn install --frozen-lockfile`
- PASS: `yarn test:unit --runTestsByPath lib/services/forecast/__tests__/log-display-prediction.test.ts __tests__/app/api/forecast-feedback-route.test.ts __tests__/actions/forecast-verification-actions.test.ts` (3 suites, 73 tests)
- PASS: `yarn typecheck`
- PASS: `npx eslint --max-warnings=0 actions/forecast-verification-actions.ts app/api/forecast-feedback/route.ts lib/services/forecast/log-display-prediction.ts`
- PASS: `yarn build`

## Rollback / Release Note
There is no feature flag for this slice. Rollback is reverting the production deploy/commit, not flipping a flag.

Do not merge or deploy from Codex. After a human merges and Vercel deploys, verify the live prod route per the `vercel-deploy-verify` workflow because prod deploys do not post GitHub check-runs.