### PR TITLE
fix(sentry): restore prod cron monitor environment

### DIFF
--- a/__tests__/lib/monitoring/sentry-config.test.ts
+++ b/__tests__/lib/monitoring/sentry-config.test.ts
@@ -35,13 +35,13 @@ describe("sentry-config", () => {
       ).toBe("preview");
     });
 
-    it("uses the production Sentry environment for the Vercel production runtime", () => {
+    it("uses the Vercel production Sentry environment for the Vercel production runtime", () => {
       expect(
         getSentryRuntimeEnvironment({
           NODE_ENV: "production",
           VERCEL_ENV: "production",
         })
-      ).toBe("production");
+      ).toBe("vercel-production");
       expect(
         isSentryRuntimeEnabled({
           NODE_ENV: "production",

--- a/lib/monitoring/sentry-config.ts
+++ b/lib/monitoring/sentry-config.ts
@@ -89,7 +89,7 @@ export function getSentryRuntimeEnvironment(
 ): QuiverSentryEnvironment {
   const vercelEnv = env.NEXT_PUBLIC_VERCEL_ENV || env.VERCEL_ENV;
 
-  if (vercelEnv === "production") return "production";
+  if (vercelEnv === "production") return "vercel-production";
   if (vercelEnv === "preview") return "preview";
   if (vercelEnv) return "development";
 


### PR DESCRIPTION
## Summary
- Restores Vercel production Sentry runtime classification to `vercel-production` so existing cron monitors receive check-ins again.
- Updates the regression test to pin Vercel production to the monitor environment.

## Root cause
The June 12 environment mapping change sent new cron check-ins to `production` while Sentry cron monitors remained scoped to `vercel-production`, causing missed-check-in alerts even though most cron routes were running.

## Validation
- `DOTENV_CONFIG_PATH=/Users/stevenchandler/Desktop/dev/quiver/.env.local NODE_OPTIONS="-r dotenv/config ${NODE_OPTIONS:-}" yarn test:unit --runTestsByPath __tests__/lib/monitoring/sentry-config.test.ts --runInBand`
- `yarn typecheck`
- `npx eslint --max-warnings=0 lib/monitoring/sentry-config.ts __tests__/lib/monitoring/sentry-config.test.ts`

## Follow-up
- `forecast-alerts` is retired in code but still active in Sentry. Disable/delete that monitor after prod deploy.