### PR TITLE
feat(partner): attributed partner QR landing + printable flyer (prod slice)

### DIFF
--- a/__tests__/app/p/partner-flyer-page.test.tsx
+++ b/__tests__/app/p/partner-flyer-page.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { createMockSupabaseClient } from "@/test-utils/api-test-helpers";
+
+const mockSupabaseClient = createMockSupabaseClient();
+const mockRedirect = jest.fn((target: string) => {
+  throw new Error(`NEXT_REDIRECT:${target}`);
+});
+
+jest.mock("next/navigation", () => ({
+  redirect: (target: string) => mockRedirect(target),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: jest.fn(() => mockSupabaseClient),
+}));
+
+jest.mock("qrcode.react", () => ({
+  QRCodeSVG: ({
+    value,
+    "data-testid": dataTestId,
+  }: {
+    value: string;
+    "data-testid"?: string;
+  }) => <svg data-testid={dataTestId} data-value={value} />,
+}));
+
+import PartnerFlyerPage, { metadata } from "@/app/p/[partnerCode]/flyer/page";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const SITE_URL = "https://www.quiversurf.app";
+
+function renderPartnerFlyerPage(partnerCode: string) {
+  return PartnerFlyerPage({ params: Promise.resolve({ partnerCode }) });
+}
+
+async function expectRedirect(
+  promise: Promise<unknown>,
+  target: string,
+): Promise<void> {
+  await expect(promise).rejects.toThrow(`NEXT_REDIRECT:${target}`);
+  expect(mockRedirect).toHaveBeenCalledWith(target);
+}
+
+function mockPartnerProfile(
+  profile: {
+    id: string;
+    full_name: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  } | null,
+) {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: profile, error: null }),
+  };
+  mockSupabaseClient.from.mockReturnValueOnce(chain as any);
+  return chain;
+}
+
+describe("/p/[partnerCode]/flyer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  it("is noindexed for operator print views", () => {
+    expect(metadata.robots && typeof metadata.robots === "object").toBe(true);
+    expect((metadata.robots as any).index).toBe(false);
+    expect((metadata.robots as any).follow).toBe(false);
+  });
+
+  it("renders a print flyer with the shop label and canonical partner QR", async () => {
+    const chain = mockPartnerProfile({
+      id: "partner-id",
+      full_name: "Pacific Surf Company",
+      display_name: "Pacific Surf Co",
+      avatar_url: "https://example.com/shop.jpg",
+    });
+
+    render(await renderPartnerFlyerPage("surf12"));
+
+    expect(chain.eq).toHaveBeenCalledWith("referral_code", "SURF12");
+    expect(
+      screen.getByRole("heading", { name: /scan for the surf call/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Pacific Surf Co/i)).toBeInTheDocument();
+
+    const qr = screen.getByTestId("partner-flyer-qr");
+    expect(qr).toHaveAttribute(
+      "data-value",
+      `${SITE_URL}/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12`,
+    );
+  });
+
+  it("redirects invalid partner codes without querying the DB", async () => {
+    await expectRedirect(renderPartnerFlyerPage("ab"), "/");
+
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/p/partner-page.test.ts
+++ b/__tests__/app/p/partner-page.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment node
+ */
+
+import type { ReactElement } from "react";
+import { createMockSupabaseClient } from "@/test-utils/api-test-helpers";
+
+const mockSupabaseClient = createMockSupabaseClient();
+const mockRedirect = jest.fn((target: string) => {
+  throw new Error(`NEXT_REDIRECT:${target}`);
+});
+
+jest.mock("next/navigation", () => ({
+  redirect: (target: string) => mockRedirect(target),
+}));
+
+jest.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: jest.fn(() => mockSupabaseClient),
+}));
+
+import PartnerPage from "@/app/p/[partnerCode]/page";
+import { PartnerQrLandingClient } from "@/app/p/[partnerCode]/partner-qr-landing-client";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const SITE_URL = "https://www.quiversurf.app";
+
+function renderPartnerPage(partnerCode: string) {
+  return PartnerPage({ params: Promise.resolve({ partnerCode }) });
+}
+
+async function expectRedirect(
+  promise: Promise<unknown>,
+  target: string,
+): Promise<void> {
+  await expect(promise).rejects.toThrow(`NEXT_REDIRECT:${target}`);
+  expect(mockRedirect).toHaveBeenCalledWith(target);
+}
+
+function mockPartnerProfile(
+  profile: {
+    id: string;
+    full_name: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+  } | null,
+) {
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockResolvedValue({ data: profile, error: null }),
+  };
+  mockSupabaseClient.from.mockReturnValueOnce(chain as any);
+  return chain;
+}
+
+describe("/p/[partnerCode]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_SITE_URL = SITE_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  it("redirects invalid partner codes to home without querying the DB", async () => {
+    await expectRedirect(renderPartnerPage("ab"), "/");
+
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+  });
+
+  it("redirects codes with wildcard characters to home", async () => {
+    await expectRedirect(renderPartnerPage("%_"), "/");
+
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+  });
+
+  it("renders the landing for a valid code resolving a known partner", async () => {
+    const chain = mockPartnerProfile({
+      id: "partner-id",
+      full_name: "Pacific Surf Company",
+      display_name: "Pacific Surf Co",
+      avatar_url: "https://example.com/shop.jpg",
+    });
+
+    const result = (await renderPartnerPage("surf12")) as ReactElement;
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith("referral_code", "SURF12");
+    expect(result.type).toBe(PartnerQrLandingClient);
+    expect(result.props).toEqual(
+      expect.objectContaining({
+        partnerCode: "SURF12",
+        partnerName: "Pacific Surf Co",
+        qrUrl: `${SITE_URL}/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12`,
+        appSchemeUrl: "quiver://p/SURF12",
+        startPath: "/?ref=SURF12&utm_source=partner_qr&utm_content=SURF12",
+      }),
+    );
+  });
+
+  it("still renders the landing for a valid code with no matching partner (best-effort attribution)", async () => {
+    mockPartnerProfile(null);
+
+    const result = (await renderPartnerPage("SURF12")) as ReactElement;
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result.type).toBe(PartnerQrLandingClient);
+    expect(result.props).toEqual(
+      expect.objectContaining({
+        partnerCode: "SURF12",
+        partnerName: null,
+        qrUrl: `${SITE_URL}/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12`,
+        appSchemeUrl: "quiver://p/SURF12",
+        startPath: "/?ref=SURF12&utm_source=partner_qr&utm_content=SURF12",
+      }),
+    );
+  });
+});

--- a/__tests__/app/p/partner-qr-landing-client.test.tsx
+++ b/__tests__/app/p/partner-qr-landing-client.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PartnerQrLandingClient } from "@/app/p/[partnerCode]/partner-qr-landing-client";
+
+jest.mock("@/lib/utils/visitor-id", () => ({
+  getVisitorId: () => "12345678-1234-1234-1234-123456789012",
+}));
+
+jest.mock("@/lib/utils/browser-session-id", () => ({
+  getBrowserSessionId: () => "browser-session-1",
+}));
+
+jest.mock("@/components/pricing/android-waitlist-cta", () => ({
+  AndroidWaitlistCta: ({ children, onClickTrack }: any) => (
+    <button type="button" onClick={onClickTrack}>
+      {children}
+    </button>
+  ),
+}));
+
+const defaultProps = {
+  partnerCode: "SURF12",
+  partnerName: "Pacific Surf Co",
+  qrUrl:
+    "https://www.quiversurf.app/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12",
+  appSchemeUrl: "quiver://p/SURF12",
+  startPath: "/?ref=SURF12&utm_source=partner_qr&utm_content=SURF12",
+  utm: {
+    utm_source: "partner_qr",
+    utm_medium: "partner_qr",
+    utm_campaign: "partner_access",
+    utm_content: "SURF12",
+  },
+};
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: userAgent,
+    configurable: true,
+  });
+}
+
+function latestEventBody(): any {
+  const calls = (fetch as jest.Mock).mock.calls;
+  const body = calls[calls.length - 1]?.[1]?.body;
+  return JSON.parse(body);
+}
+
+function eventBody(eventType: string): any {
+  const calls = (fetch as jest.Mock).mock.calls;
+  const match = calls
+    .map((call) => JSON.parse(call[1]?.body))
+    .find((body) => body.eventType === eventType);
+  if (!match) {
+    throw new Error(`Missing event ${eventType}`);
+  }
+  return match;
+}
+
+function clickWithoutNavigation(element: HTMLElement): void {
+  element.addEventListener("click", (event) => event.preventDefault(), {
+    once: true,
+  });
+  fireEvent.click(element);
+}
+
+describe("PartnerQrLandingClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as any;
+  });
+
+  it("renders a QR whose value equals the passed qrUrl", () => {
+    const { container } = render(<PartnerQrLandingClient {...defaultProps} />);
+    const svg = container.querySelector("svg[data-smart-url]");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute("data-smart-url", defaultProps.qrUrl);
+  });
+
+  it("links App Store clicks with a per-partner campaign token", () => {
+    render(<PartnerQrLandingClient {...defaultProps} />);
+
+    const appStoreUrl = new URL(
+      screen.getByRole("link", { name: /open app store/i }).getAttribute("href") ??
+        "",
+    );
+
+    expect(appStoreUrl.searchParams.get("ct")).toBe("partner_SURF12");
+    expect(appStoreUrl.searchParams.get("mt")).toBe("8");
+  });
+
+  it("fires app_handoff_qr_rendered and invite_link_opened on mount with partner metadata", async () => {
+    render(<PartnerQrLandingClient {...defaultProps} />);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+
+    expect(eventBody("invite_link_opened")).toEqual(
+      expect.objectContaining({
+        eventType: "invite_link_opened",
+        sessionId: "12345678-1234-1234-1234-123456789012",
+        metadata: expect.objectContaining({
+          surface: "partner_landing",
+          partner_code: "SURF12",
+          browser_session_id: "browser-session-1",
+          platform: "desktop",
+          utm_source: "partner_qr",
+          utm_content: "SURF12",
+        }),
+      }),
+    );
+    expect(eventBody("app_handoff_qr_rendered")).toEqual(
+      expect.objectContaining({
+        eventType: "app_handoff_qr_rendered",
+        metadata: expect.objectContaining({
+          source: "partner_landing",
+          surface: "partner_landing",
+          partner_code: "SURF12",
+          utm_source: "partner_qr",
+          utm_content: "SURF12",
+        }),
+      }),
+    );
+  });
+
+  it("tracks App Store and web fallback CTA clicks by destination type", async () => {
+    render(<PartnerQrLandingClient {...defaultProps} />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+
+    clickWithoutNavigation(
+      screen.getByRole("link", { name: /open app store/i }),
+    );
+    expect(latestEventBody()).toEqual(
+      expect.objectContaining({
+        eventType: "invite_app_store_clicked",
+        metadata: expect.objectContaining({
+          partner_code: "SURF12",
+          destination_type: "app_store",
+        }),
+      }),
+    );
+
+    clickWithoutNavigation(
+      screen.getByRole("link", { name: /continue on web/i }),
+    );
+    expect(latestEventBody()).toEqual(
+      expect.objectContaining({
+        eventType: "invite_continue_web_clicked",
+        metadata: expect.objectContaining({
+          partner_code: "SURF12",
+          destination_type: "web_signup",
+        }),
+      }),
+    );
+  });
+
+  it("fires invite_open_app_clicked with the quiver://p scheme href", async () => {
+    render(<PartnerQrLandingClient {...defaultProps} />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+
+    const openApp = screen.getByRole("link", { name: /already have the app/i });
+    expect(openApp).toHaveAttribute("href", "quiver://p/SURF12");
+
+    clickWithoutNavigation(openApp);
+    expect(latestEventBody()).toEqual(
+      expect.objectContaining({
+        eventType: "invite_open_app_clicked",
+        metadata: expect.objectContaining({
+          partner_code: "SURF12",
+          destination_type: "app_scheme",
+        }),
+      }),
+    );
+  });
+
+  it("shows Android waitlist CTA and tracks it as a partner destination", async () => {
+    setUserAgent("Mozilla/5.0 (Linux; Android 14)");
+    render(<PartnerQrLandingClient {...defaultProps} />);
+
+    const androidCta = await screen.findByRole("button", {
+      name: /join android waitlist/i,
+    });
+    fireEvent.click(androidCta);
+
+    expect(latestEventBody()).toEqual(
+      expect.objectContaining({
+        eventType: "invite_app_store_clicked",
+        metadata: expect.objectContaining({
+          platform: "android",
+          destination_type: "android_waitlist",
+          partner_code: "SURF12",
+        }),
+      }),
+    );
+  });
+});

--- a/__tests__/middleware.integration.test.ts
+++ b/__tests__/middleware.integration.test.ts
@@ -260,6 +260,16 @@ describe("Middleware Integration Tests", () => {
       );
     });
 
+    it("should not rewrite partner flyer URLs as international city pages", async () => {
+      const request = createMockRequest("/p/SURF12/flyer");
+
+      const response = await middleware(request);
+
+      expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+      expect(response.headers.get("location")).toBeNull();
+      expect(response.status).not.toBe(301);
+    });
+
     it("should not rewrite 4-segment international beach URLs", async () => {
       const request = createMockRequest("/mexico/baja-california/rosarito/teresas");
 

--- a/app/p/[partnerCode]/flyer/page.tsx
+++ b/app/p/[partnerCode]/flyer/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  buildPartnerQrUrl,
+  isValidPartnerCode,
+} from "@/lib/partner/partner-qr-url";
+import { fetchPartnerByReferralCode } from "@/lib/partner/partner-profile";
+
+interface PartnerFlyerPageProps {
+  params: Promise<{ partnerCode: string }>;
+}
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+function partnerFlyerSiteUrl(): string {
+  return process.env.NEXT_PUBLIC_SITE_URL || "https://www.quiversurf.app";
+}
+
+export default async function PartnerFlyerPage({
+  params,
+}: PartnerFlyerPageProps): Promise<ReactElement> {
+  const { partnerCode } = await params;
+
+  if (!isValidPartnerCode(partnerCode)) {
+    redirect("/");
+  }
+
+  const code = partnerCode.toUpperCase();
+  const siteUrl = partnerFlyerSiteUrl();
+  const supabase = await createSupabaseServerClient();
+  const partner = await fetchPartnerByReferralCode(supabase, code);
+  const partnerLabel = partner?.name?.trim() || "A Quiver partner";
+  const qrUrl = buildPartnerQrUrl({ partnerCode: code, siteUrl });
+
+  return (
+    <main className="partner-flyer zine-tab min-h-screen bg-[#252D6B] px-4 py-8 text-[#11100D] print:bg-white print:p-0">
+      <style>{`
+        @page {
+          size: 8.5in 11in;
+          margin: 0.35in;
+        }
+
+        @media print {
+          body > footer,
+          nav,
+          [data-radix-toast-viewport],
+          [data-sonner-toaster],
+          .partner-flyer-print-hint {
+            display: none !important;
+          }
+
+          .partner-flyer-sheet {
+            min-height: 10.3in !important;
+            box-shadow: none !important;
+            transform: none !important;
+          }
+        }
+      `}</style>
+
+      <section className="partner-flyer-sheet mx-auto flex min-h-[10.3in] w-full max-w-[8.5in] flex-col overflow-hidden border-[3px] border-[#11100D] bg-[#F4EBD8] shadow-[12px_14px_0_rgba(17,16,13,0.35)] print:min-h-[10.3in] print:max-w-none print:border-0">
+        <div className="partner-flyer-print-hint border-b-2 border-[#11100D] bg-[#F78E42] px-5 py-2 text-center font-heading text-xs font-black uppercase tracking-[0.12em] text-[#11100D]">
+          Print on US Letter, scale 100%, portrait
+        </div>
+
+        <div className="grid flex-1 grid-rows-[auto_1fr_auto] gap-6 px-7 py-8 sm:px-10">
+          <header className="flex items-start justify-between gap-5">
+            <div>
+              <p className="font-mono text-xs font-bold uppercase tracking-[0.18em]">
+                Quiver x local surf call
+              </p>
+              <p className="mt-2 inline-block -rotate-1 bg-[#11100D] px-3 py-1 font-heading text-sm font-black uppercase tracking-[0.1em] text-[#F4EBD8]">
+                {partnerLabel}
+              </p>
+            </div>
+            <div className="rotate-3 border-2 border-[#11100D] bg-[#F78E42] px-3 py-2 text-right font-heading text-xs font-black uppercase leading-tight tracking-[0.1em] shadow-[3px_3px_0_#11100D]">
+              Know
+              <br />
+              before
+              <br />
+              you go
+            </div>
+          </header>
+
+          <div className="grid items-center gap-8 md:grid-cols-[minmax(0,1fr)_2.35in]">
+            <div>
+              <h1 className="font-heading text-[clamp(3.25rem,9vw,6.35rem)] font-black uppercase leading-[0.86] tracking-normal">
+                Scan for
+                <br />
+                the surf call
+              </h1>
+              <p className="mt-6 max-w-[5.8in] text-[clamp(1.2rem,2.4vw,1.65rem)] font-bold leading-tight">
+                Check the tide, wind, swell, and local call before you load the
+                board.
+              </p>
+              <div className="mt-7 grid max-w-[5.4in] gap-3 border-y-2 border-[#11100D] py-4 font-mono text-sm font-bold uppercase tracking-[0.08em] sm:grid-cols-3">
+                <span>Dawn patrol</span>
+                <span>Lunch window</span>
+                <span>After-work run</span>
+              </div>
+            </div>
+
+            <div className="justify-self-center">
+              <div className="-rotate-2 border-[3px] border-[#11100D] bg-white p-3 shadow-[6px_7px_0_rgba(17,16,13,0.32)]">
+                <QRCodeSVG
+                  value={qrUrl}
+                  data-testid="partner-flyer-qr"
+                  size={216}
+                  level="H"
+                  marginSize={4}
+                  bgColor="#FFFFFF"
+                  fgColor="#11100D"
+                />
+              </div>
+              <p className="mt-4 max-w-[2.25in] text-center font-heading text-sm font-black uppercase leading-tight tracking-[0.08em]">
+                Open camera, scan, make the call
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 border-t-[3px] border-[#11100D] pt-5 sm:grid-cols-[1fr_auto] sm:items-end">
+            <p className="max-w-[5.8in] text-base font-semibold leading-snug">
+              Quiver gives surfers a quick read on what matters: wave height,
+              period, wind, tide, and session notes from the crew.
+            </p>
+            <p className="justify-self-start rounded-sm border-2 border-[#11100D] px-3 py-2 font-mono text-xs font-bold uppercase tracking-[0.12em] sm:justify-self-end">
+              {code}
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/p/[partnerCode]/page.tsx
+++ b/app/p/[partnerCode]/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from "next/navigation";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import {
+  buildPartnerAppSchemeUrl,
+  buildPartnerQrUrl,
+  isValidPartnerCode,
+} from "@/lib/partner/partner-qr-url";
+import { fetchPartnerByReferralCode } from "@/lib/partner/partner-profile";
+import { PartnerQrLandingClient } from "./partner-qr-landing-client";
+
+interface PartnerPageProps {
+  params: Promise<{ partnerCode: string }>;
+}
+
+/**
+ * /p/[partnerCode]
+ *
+ * Attributed partner-QR landing. A partner (surf shop / instructor / business)
+ * prints this URL as a QR; a surfer scans it and lands here to install Quiver.
+ * Attribution rides on `utm_content=<partnerCode>`, threaded into the landing's
+ * anonymous-allowed handoff events — reusing the existing referrals spine, no
+ * schema change.
+ *
+ * Server component; read-only, no cookie mutation.
+ */
+export default async function PartnerPage({ params }: PartnerPageProps) {
+  const { partnerCode } = await params;
+
+  if (!isValidPartnerCode(partnerCode)) {
+    redirect("/");
+  }
+
+  const code = partnerCode.toUpperCase();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
+  const supabase = await createSupabaseServerClient();
+  const partner = await fetchPartnerByReferralCode(supabase, code);
+
+  const qrUrl = buildPartnerQrUrl({ partnerCode: code, siteUrl });
+
+  return (
+    <PartnerQrLandingClient
+      partnerCode={code}
+      partnerName={partner?.name ?? null}
+      qrUrl={qrUrl}
+      appSchemeUrl={buildPartnerAppSchemeUrl(code)}
+      startPath={`/?ref=${code}&utm_source=partner_qr&utm_content=${code}`}
+      utm={{
+        utm_source: "partner_qr",
+        utm_medium: "partner_qr",
+        utm_campaign: "partner_access",
+        utm_content: code,
+      }}
+    />
+  );
+}

--- a/app/p/[partnerCode]/partner-qr-landing-client.tsx
+++ b/app/p/[partnerCode]/partner-qr-landing-client.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { ArrowRight, ExternalLink, Smartphone } from "lucide-react";
+import { AndroidWaitlistCta } from "@/components/pricing/android-waitlist-cta";
+import {
+  IOS_APP_STORE_CTA,
+  iosAppStoreUrlWithCampaign,
+} from "@/lib/constants/app-store";
+import { trackAppHandoffQrRendered } from "@/lib/analytics/app-handoff-tracking";
+import { getBrowserSessionId } from "@/lib/utils/browser-session-id";
+import { getVisitorId } from "@/lib/utils/visitor-id";
+
+type PartnerLandingPlatform = "ios" | "android" | "desktop";
+
+interface PartnerLandingUtm {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+}
+
+interface PartnerQrLandingClientProps {
+  partnerCode: string;
+  partnerName: string | null;
+  qrUrl: string;
+  appSchemeUrl: string;
+  startPath: string;
+  utm: PartnerLandingUtm;
+}
+
+// Reuses the anonymous-allowed invite/app-handoff event family. No new literals.
+type PartnerEventType =
+  | "invite_link_opened"
+  | "invite_open_app_clicked"
+  | "invite_app_store_clicked"
+  | "invite_continue_web_clicked";
+
+type PartnerDestinationType =
+  | "app_store"
+  | "app_scheme"
+  | "web_signup"
+  | "android_waitlist";
+
+type PartnerMetadataOverride = Record<
+  string,
+  string | number | boolean | undefined
+>;
+
+function detectPlatform(): PartnerLandingPlatform {
+  if (typeof navigator === "undefined") return "desktop";
+
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (/iphone|ipad|ipod/.test(userAgent)) return "ios";
+  if (/android/.test(userAgent)) return "android";
+  return "desktop";
+}
+
+export function PartnerQrLandingClient({
+  partnerCode,
+  partnerName,
+  qrUrl,
+  appSchemeUrl,
+  startPath,
+  utm,
+}: PartnerQrLandingClientProps): ReactElement {
+  const [platform, setPlatform] = useState<PartnerLandingPlatform>("desktop");
+  const trackedOpen = useRef(false);
+  const trackedQr = useRef(false);
+  const browserSessionId = useMemo(() => getBrowserSessionId(), []);
+
+  const commonMetadata = useMemo(
+    () => ({
+      surface: "partner_landing",
+      partner_code: partnerCode,
+      browser_session_id: browserSessionId,
+      platform,
+      ...utm,
+    }),
+    [browserSessionId, partnerCode, platform, utm],
+  );
+
+  const trackPartnerEvent = useCallback(
+    (
+      eventType: PartnerEventType,
+      destinationType?: PartnerDestinationType,
+      metadataOverrides: PartnerMetadataOverride = {},
+    ) => {
+      if (typeof window === "undefined") return;
+
+      try {
+        fetch("/api/events", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            eventType,
+            metadata: {
+              ...commonMetadata,
+              ...metadataOverrides,
+              ...(destinationType ? { destination_type: destinationType } : {}),
+            },
+            sessionId: getVisitorId(),
+            viewportWidth: window.innerWidth,
+          }),
+          keepalive: true,
+        }).catch(() => {});
+      } catch {
+        // Tracking must never block the CTA navigation.
+      }
+    },
+    [commonMetadata],
+  );
+
+  useEffect(() => {
+    const detectedPlatform = detectPlatform();
+    setPlatform(detectedPlatform);
+    if (trackedOpen.current) return;
+    trackedOpen.current = true;
+    trackPartnerEvent("invite_link_opened", undefined, {
+      platform: detectedPlatform,
+    });
+    if (!trackedQr.current) {
+      trackedQr.current = true;
+      trackAppHandoffQrRendered({
+        source: "partner_landing",
+        surface: "partner_landing",
+        placement: "desktop_partner_qr",
+        platform: detectedPlatform,
+        destination_type: "partner_deep_link",
+        destination_url: qrUrl,
+        qr_id: "partner_desktop_qr",
+        target: "partner",
+        partner_code: partnerCode,
+        ...utm,
+      });
+    }
+    // trackPartnerEvent identity changes with platform; run once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [partnerCode, qrUrl]);
+
+  const isAndroid = platform === "android";
+  const partnerLabel = partnerName?.trim() || "A Quiver partner";
+  const appStoreUrl = iosAppStoreUrlWithCampaign(
+    `partner_${partnerCode.toUpperCase()}`,
+  );
+  const leadCopy = isAndroid
+    ? "Android access is waitlist-first for now. Join the Android waitlist or continue on web to start with Quiver."
+    : platform === "desktop"
+      ? "Scan the code with your phone camera, or open this page on your iPhone to install Quiver. Already have the app? Open it from here."
+      : "Install Quiver from the App Store to check the surf and log your sessions. If Quiver is already installed, open it from this page.";
+
+  return (
+    <main className="min-h-screen bg-[#252D6B] text-white">
+      <section className="mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center px-5 py-10 sm:px-8 lg:px-10">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_320px] lg:items-center">
+          <div className="space-y-7">
+            <div>
+              <p className="text-sm font-semibold uppercase text-[#FDB84B]">
+                Quiver
+              </p>
+              <h1 className="font-heading text-4xl font-bold leading-tight sm:text-5xl">
+                {partnerLabel} wants you on Quiver.
+              </h1>
+            </div>
+
+            <p className="max-w-2xl text-lg leading-8 text-white/78">
+              {leadCopy}
+            </p>
+
+            <div className="flex flex-col gap-3 sm:max-w-md">
+              {isAndroid ? (
+                <AndroidWaitlistCta
+                  source="partner_landing"
+                  surface="partner_landing"
+                  placement="primary_android"
+                  onClickTrack={() =>
+                    trackPartnerEvent(
+                      "invite_app_store_clicked",
+                      "android_waitlist",
+                    )
+                  }
+                  className="inline-flex min-h-12 items-center justify-center rounded-full bg-[#F78E42] px-5 py-3 text-center font-semibold text-[#252D6B] transition hover:bg-[#FFAA63] disabled:cursor-not-allowed disabled:opacity-70"
+                >
+                  Join Android waitlist
+                </AndroidWaitlistCta>
+              ) : (
+                <a
+                  href={appStoreUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    trackPartnerEvent("invite_app_store_clicked", "app_store", {
+                      attribution_scope: "app_store_click_only",
+                    })
+                  }
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full bg-[#F78E42] px-5 py-3 text-center font-semibold text-[#252D6B] transition hover:bg-[#FFAA63]"
+                >
+                  <Smartphone className="h-4 w-4" aria-hidden="true" />
+                  {IOS_APP_STORE_CTA}
+                </a>
+              )}
+
+              {!isAndroid ? (
+                <a
+                  href={appSchemeUrl}
+                  onClick={() =>
+                    trackPartnerEvent("invite_open_app_clicked", "app_scheme")
+                  }
+                  className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full border border-white/16 px-5 py-3 text-center font-semibold text-white transition hover:bg-white/10"
+                >
+                  Already have the app? Open Quiver
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                </a>
+              ) : null}
+
+              <a
+                href={startPath}
+                onClick={() =>
+                  trackPartnerEvent("invite_continue_web_clicked", "web_signup")
+                }
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-full px-5 py-3 text-center font-semibold text-white/82 transition hover:bg-white/8"
+              >
+                Continue on web
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+
+          <div className="hidden rounded-lg border border-white/12 bg-white/8 p-5 shadow-2xl shadow-black/25 lg:block">
+            <div className="rounded-md bg-white p-4">
+              <QRCodeSVG
+                value={qrUrl}
+                data-smart-url={qrUrl}
+                size={248}
+                level="H"
+                marginSize={4}
+                bgColor="#FFFFFF"
+                fgColor="#252D6B"
+                imageSettings={{
+                  src: "/quiver-app-icon-128.png",
+                  width: 34,
+                  height: 34,
+                  excavate: true,
+                }}
+              />
+            </div>
+            <p className="mt-4 text-center text-sm font-medium text-white/72">
+              Scan with your phone camera to get Quiver.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/e2e/partner-qr-flow.spec.ts
+++ b/e2e/partner-qr-flow.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Partner QR Flow E2E
+ *
+ * Covers the anonymous partner-QR landing at /p/[partnerCode]. The landing has
+ * no auth or email-token dependency — any valid code renders an attributed
+ * install page whose QR + CTAs drive the app handoff. Invalid codes redirect
+ * home. Attribution rides on utm_content and the anonymous-allowed handoff
+ * event family (no schema change).
+ *
+ * @project guest
+ */
+
+import { test, expect } from './fixtures/auth-fixture';
+import {
+  setupErrorDetection,
+  assertNoErrors,
+  type ErrorCapture,
+} from './utils/error-detection';
+
+const PARTNER_CODE = 'SURF12';
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+test.describe('Partner QR landing flow', () => {
+  let errorCapture: ErrorCapture;
+
+  test.beforeEach(async ({ page }) => {
+    errorCapture = setupErrorDetection(page);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await assertNoErrors(page, errorCapture, {
+      context: 'Partner QR landing flow',
+    });
+  });
+
+  test('guest valid partner code renders the QR landing and fires attributed handoff event', async ({
+    page,
+  }, testInfo) => {
+    skipWhen(testInfo.project.name !== 'guest', 'Guest project only');
+
+    const handoffEvent = page.waitForRequest(
+      (request) =>
+        request.url().includes('/api/events') &&
+        request.method() === 'POST' &&
+        isPartnerQrRenderedBody(request.postData()),
+      { timeout: 15_000 },
+    );
+
+    await page.goto(`/p/${PARTNER_CODE}?utm_source=partner_qr`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(
+      page.getByRole('heading', { name: /wants you on quiver/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByRole('link', { name: /open app store/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /already have the app/i }),
+    ).toHaveAttribute('href', `quiver://p/${PARTNER_CODE}`);
+    await expect(
+      page.getByRole('link', { name: /continue on web/i }),
+    ).toBeVisible();
+
+    // Desktop viewport shows the scannable QR carrying the attributed URL.
+    await expect(page.locator('svg[data-smart-url]')).toHaveAttribute(
+      'data-smart-url',
+      new RegExp(`/p/${PARTNER_CODE}\\?.*ref=${PARTNER_CODE}.*utm_content=${PARTNER_CODE}`),
+    );
+
+    const request = await handoffEvent;
+    const body = JSON.parse(request.postData() || '{}');
+    expect(body.metadata).toEqual(
+      expect.objectContaining({
+        surface: 'partner_landing',
+        partner_code: PARTNER_CODE,
+      }),
+    );
+  });
+
+  test('guest invalid partner code redirects home cleanly', async ({
+    page,
+  }, testInfo) => {
+    skipWhen(testInfo.project.name !== 'guest', 'Guest project only');
+
+    await page.goto('/p/ab', { waitUntil: 'domcontentloaded' });
+
+    const finalUrl = new URL(page.url());
+    expect(finalUrl.pathname).toBe('/');
+  });
+
+  test('guest valid partner code renders the printable flyer route', async ({
+    page,
+  }, testInfo) => {
+    skipWhen(testInfo.project.name !== 'guest', 'Guest project only');
+
+    const response = await page.goto(`/p/${PARTNER_CODE}/flyer`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByRole('heading', { name: /scan for\s+the surf call/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('partner-flyer-qr')).toBeVisible();
+    await expect(page.getByText(PARTNER_CODE, { exact: true })).toBeVisible();
+  });
+
+  test('guest partner ref sets the referral cookie for signup credit', async ({
+    page,
+    context,
+  }, testInfo) => {
+    skipWhen(testInfo.project.name !== 'guest', 'Guest project only');
+
+    await context.addCookies([
+      {
+        name: 'qvr_referral_code',
+        value: 'OLD999',
+        url: BASE_URL,
+        sameSite: 'Lax',
+        expires: Math.floor(Date.now() / 1000) + 60 * 60,
+      },
+    ]);
+
+    await page.goto(`/p/${PARTNER_CODE}?ref=${PARTNER_CODE}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Referral code cookies are intentionally last-touch: a fresh valid ?ref=
+    // overwrites an existing qvr_referral_code, while UTM cookies stay first-touch.
+    const cookies = await context.cookies(BASE_URL);
+    expect(cookies).toContainEqual(
+      expect.objectContaining({
+        name: 'qvr_referral_code',
+        value: PARTNER_CODE,
+      }),
+    );
+  });
+});
+
+function isPartnerQrRenderedBody(postData: string | null): boolean {
+  if (!postData) return false;
+  try {
+    const body = JSON.parse(postData);
+    return (
+      body.eventType === 'app_handoff_qr_rendered' &&
+      body.metadata?.surface === 'partner_landing'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function skipWhen(condition: boolean, reason: string) {
+  // eslint-disable-next-line playwright/no-skipped-test -- spec is registered in the guest project; skip in others.
+  test.skip(condition, reason);
+}

--- a/lib/partner/__tests__/partner-qr-url.test.ts
+++ b/lib/partner/__tests__/partner-qr-url.test.ts
@@ -1,0 +1,66 @@
+import {
+  buildPartnerAppSchemeUrl,
+  buildPartnerQrUrl,
+  isValidPartnerCode,
+} from "@/lib/partner/partner-qr-url";
+
+describe("isValidPartnerCode", () => {
+  it("accepts 4-12 alphanumeric codes (case-insensitive)", () => {
+    expect(isValidPartnerCode("SURF12")).toBe(true);
+    expect(isValidPartnerCode("surf12")).toBe(true);
+    expect(isValidPartnerCode("ABCD")).toBe(true);
+    expect(isValidPartnerCode("A1B2C3D4E5F6")).toBe(true);
+  });
+
+  it("rejects codes with wildcard/special chars, empty, or too short/long", () => {
+    expect(isValidPartnerCode("%_")).toBe(false);
+    expect(isValidPartnerCode("")).toBe(false);
+    expect(isValidPartnerCode("ab")).toBe(false);
+    expect(isValidPartnerCode("SURF-12")).toBe(false);
+    expect(isValidPartnerCode("A1B2C3D4E5F6G")).toBe(false);
+    expect(isValidPartnerCode(" SURF12 ")).toBe(false);
+  });
+});
+
+describe("buildPartnerQrUrl", () => {
+  it("builds a deterministic absolute attributed URL, uppercasing the code", () => {
+    expect(
+      buildPartnerQrUrl({
+        partnerCode: "surf12",
+        siteUrl: "https://www.quiversurf.app",
+      }),
+    ).toBe(
+      "https://www.quiversurf.app/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12",
+    );
+  });
+
+  it("trims a trailing slash on siteUrl", () => {
+    expect(
+      buildPartnerQrUrl({
+        partnerCode: "SURF12",
+        siteUrl: "https://www.quiversurf.app/",
+      }),
+    ).toBe(
+      "https://www.quiversurf.app/p/SURF12?ref=SURF12&utm_source=partner_qr&utm_medium=partner_qr&utm_campaign=partner_access&utm_content=SURF12",
+    );
+  });
+
+  it("includes ref for the referral cookie while UTM params remain first-touch attribution", () => {
+    const url = new URL(
+      buildPartnerQrUrl({
+        partnerCode: "surf12",
+        siteUrl: "https://www.quiversurf.app",
+      }),
+    );
+
+    expect(url.searchParams.get("ref")).toBe("SURF12");
+    expect(url.searchParams.get("utm_source")).toBe("partner_qr");
+    expect(url.searchParams.get("utm_content")).toBe("SURF12");
+  });
+});
+
+describe("buildPartnerAppSchemeUrl", () => {
+  it("builds the quiver:// deep-link scheme, uppercasing the code", () => {
+    expect(buildPartnerAppSchemeUrl("surf12")).toBe("quiver://p/SURF12");
+  });
+});

--- a/lib/partner/partner-profile.ts
+++ b/lib/partner/partner-profile.ts
@@ -1,0 +1,30 @@
+import type { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export interface ResolvedPartner {
+  id: string;
+  name: string | null;
+}
+
+type SupabaseServerClient = Awaited<
+  ReturnType<typeof createSupabaseServerClient>
+>;
+
+export async function fetchPartnerByReferralCode(
+  supabase: SupabaseServerClient,
+  code: string,
+): Promise<ResolvedPartner | null> {
+  // Partner === a user whose referral_code is printed on the QR. Best-effort:
+  // an unknown code still renders the public landing/flyer.
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, display_name, full_name, avatar_url")
+    .eq("referral_code", code)
+    .maybeSingle();
+
+  if (error || !data) return null;
+
+  return {
+    id: data.id,
+    name: data.display_name || data.full_name || null,
+  };
+}

--- a/lib/partner/partner-qr-url.ts
+++ b/lib/partner/partner-qr-url.ts
@@ -1,0 +1,52 @@
+/**
+ * Partner QR URL builder + code validator.
+ *
+ * A "partner" is a user whose `referral_code` (or signed invite JWT) is printed
+ * on a QR. The partner's human-readable label rides on UTM params, which the
+ * landing threads into event metadata. Zero schema change — attribution reuses
+ * the existing referrals spine.
+ *
+ * Pure module: no I/O, no side effects.
+ */
+
+/**
+ * Validate a partner code. Mirrors the referral-code guard in
+ * `actions/referral-actions.ts` (`/^[A-Z0-9]{4,12}$/i`) to prevent SQL wildcard
+ * injection (`%`/`_` are `ilike` wildcards) and keep partner === referral codes.
+ */
+export function isValidPartnerCode(code: string): boolean {
+  return /^[A-Z0-9]{4,12}$/i.test(code);
+}
+
+interface BuildPartnerQrUrlArgs {
+  partnerCode: string;
+  siteUrl: string;
+}
+
+/**
+ * Build the absolute, attributed partner landing URL. Deterministic param order
+ * via `URLSearchParams`; uppercases the code; trims a trailing slash on siteUrl
+ * (mirrors `buildAbsoluteInviteUrl` in `app/invite/[token]/page.tsx`).
+ */
+export function buildPartnerQrUrl({
+  partnerCode,
+  siteUrl,
+}: BuildPartnerQrUrlArgs): string {
+  const code = partnerCode.toUpperCase();
+  const search = new URLSearchParams({
+    ref: code,
+    utm_source: "partner_qr",
+    utm_medium: "partner_qr",
+    utm_campaign: "partner_access",
+    utm_content: code,
+  });
+  return `${siteUrl.replace(/\/$/, "")}/p/${code}?${search.toString()}`;
+}
+
+/**
+ * Build the `quiver://` app-scheme deep link for an already-installed app
+ * (mirrors `appSchemeUrl` in `invite-landing-client.tsx`).
+ */
+export function buildPartnerAppSchemeUrl(partnerCode: string): string {
+  return `quiver://p/${partnerCode.toUpperCase()}`;
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -118,6 +118,7 @@ export default defineConfig({
         'e2e/guest-*.spec.ts',
         'e2e/prod-readonly/guest-*.spec.ts',
         'e2e/invite-flow.spec.ts',
+        'e2e/partner-qr-flow.spec.ts',
         'e2e/email-core-loop/**/*.spec.ts',
       ],
       use: {

--- a/proxy.ts
+++ b/proxy.ts
@@ -50,6 +50,7 @@ const INTERNATIONAL_RESERVED_SEGMENTS = new Set([
   "sessions",
   "share",
   "spots",
+  "p",
   "s",
   "user",
   "error",


### PR DESCRIPTION
Targeted slice of main a3aed0d54 — partner QR flywheel only.

- /p/[partnerCode] landing: QR + attributed CTAs (ct= App Store campaign token, ref= referral credit)
- /p/[partnerCode]/flyer: printable US-Letter zine flyer (noindex), QR encodes the prod URL
- proxy.ts: reserve "p" segment (without this both routes are swallowed by /[intent]/[city]/[beachSlug] — verified live on www via x-matched-path)
- tests: 3 unit suites + middleware regression + guest e2e (4/4)

Gates (CI disabled — run locally): typecheck ✓, unit 50/50 ✓, prod build + both routes 200 ✓, e2e 4/4 ✓.
No migrations (referrals infra + event constraint already applied). No flag — rollback = revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)