### PR TITLE
fix(forecast): patch socal south swell trust

### DIFF
--- a/__tests__/lib/services/forecast/forecast-builder-cdip-semantics.test.ts
+++ b/__tests__/lib/services/forecast/forecast-builder-cdip-semantics.test.ts
@@ -76,6 +76,12 @@ const CALIBRATED_SHOALING = {
   ],
 };
 
+const LOW_LONG_PERIOD_SHOALING = {
+  version: 1 as const,
+  type: "period_lookup" as const,
+  buckets: [{ tp_min_s: 15, tp_max_s: 999, factor: 0.36 }],
+};
+
 const BLACKS_SHOALING = {
   version: 1 as const,
   type: "period_lookup" as const,
@@ -169,7 +175,12 @@ function makeBlacksSpikeWaveData(nowIso: string) {
   };
 }
 
-function makeCdipBuoyData(nowIso: string, sigHeightFt: number, periodS = 14) {
+function makeCdipBuoyData(
+  nowIso: string,
+  sigHeightFt: number,
+  periodS = 14,
+  directionDeg = 270,
+) {
   return {
     stationId: "220",
     stationName: "Mission Bay West",
@@ -180,7 +191,7 @@ function makeCdipBuoyData(nowIso: string, sigHeightFt: number, periodS = 14) {
         timestamp: nowIso,
         significantWaveHeight: sigHeightFt,
         peakWavePeriod: periodS,
-        peakWaveDirection: 270,
+        peakWaveDirection: directionDeg,
       },
     ],
   };
@@ -426,6 +437,38 @@ describe("ForecastBuilder CDIP height semantics", () => {
     expect(prov?.raw_value_ft).toBeCloseTo(cdipHsFt, 2);
   });
 
+  test("Rincon-style low long-period CDIP bucket renders from generic path with quarantine debug", async () => {
+    const builder = makeBuilder();
+
+    const forecasts = await builder.buildForecasts({
+      beach: makeBeach({
+        name: "Rincon",
+        shoaling_factors: LOW_LONG_PERIOD_SHOALING as unknown as Beach["shoaling_factors"],
+      }),
+      waveData: makeWaveData(FROZEN_NOW_ISO),
+      tideData: null,
+      weatherData: [],
+      buoyData: null,
+      cdipData: makeCdipBuoyData(FROZEN_NOW_ISO, 4.2, 18, 205) as never,
+      ioosWaterTempC: null,
+      coopsWaterTempC: null,
+    });
+    expectConsoleWarnings([CALIBRATION_COVERAGE_WARNING]);
+
+    const prov = forecasts[0].raw_forecast?.wave_height_provenance;
+    expect(extractFt(forecasts[0].wave_height)).toBeGreaterThan(4.5);
+    expect(prov).toEqual(
+      expect.objectContaining({
+        source: "cdip_sig",
+        transform_path: "scalar_generic",
+        components_used: false,
+        calibrated_shoaling_fired: false,
+        calibration_bucket_quarantined: true,
+      }),
+    );
+    expect(prov?.calibration_bucket_quarantined).toBe(true);
+  });
+
   test("NOAA-only (no CDIP): wave_height uses decomposed component path", async () => {
     const builder = makeBuilder();
 
@@ -570,6 +613,37 @@ describe("ForecastBuilder CDIP height semantics", () => {
     );
     expect(prov?.cdip_rejection?.raw_cdip_hs).toBeCloseTo(8.0, 2);
     expect(prov?.cdip_rejection?.raw_model_hs).toBeCloseTo(3.28, 1);
+  });
+
+  test("CDIP is retained when model total Hs corroborates a low primary partition", async () => {
+    const builder = makeBuilder();
+    const wave = makeWaveData(FROZEN_NOW_ISO);
+    wave.forecast[0].swell_1_height = 1.0; // ≈3.28 ft primary partition
+    wave.forecast[0].significant_wave_height = 2.6; // ≈8.53 ft total sea state
+
+    const forecasts = await builder.buildForecasts({
+      beach: makeBeach({
+        shoaling_factors: CALIBRATED_SHOALING as unknown as Beach["shoaling_factors"],
+      }),
+      waveData: wave,
+      tideData: null,
+      weatherData: [],
+      buoyData: null,
+      cdipData: makeCdipBuoyData(FROZEN_NOW_ISO, 8.0) as never,
+      ioosWaterTempC: null,
+      coopsWaterTempC: null,
+    });
+
+    const prov = forecasts[0].raw_forecast?.wave_height_provenance;
+    expect(prov).toEqual(
+      expect.objectContaining({
+        source: "cdip_sig",
+        transform_path: "scalar_calibrated",
+        calibrated_shoaling_fired: true,
+      }),
+    );
+    expect(prov?.cdip_rejection).toBeUndefined();
+    expect(extractFt(forecasts[0].wave_height)).toBe(15);
   });
 
   test("fresh CDIP drives now and +3h slots, while +6h remains model-backed", async () => {

--- a/__tests__/lib/services/forecast/forecast-builder-nowcast-anchor.test.ts
+++ b/__tests__/lib/services/forecast/forecast-builder-nowcast-anchor.test.ts
@@ -256,6 +256,37 @@ describe("ForecastBuilder nowcast anchor output", () => {
     };
   }
 
+  function makeSouthOcNearTermSawtoothWaveData(nowIso: string) {
+    const base = Date.parse(nowIso);
+    const makePoint = (hoursAhead: number) => {
+      const forecastAt = new Date(base + hoursAhead * 60 * 60 * 1000).toISOString();
+      return {
+        timestamp: forecastAt,
+        forecast_at: forecastAt,
+        significant_wave_height: 0.65,
+        peak_wave_period: 16,
+        peak_wave_direction: 203,
+        swell_1_height: 0.62,
+        swell_1_period: 16,
+        swell_1_direction: 203,
+        swell_2_height: 0.2,
+        swell_2_period: 11,
+        swell_2_direction: 250,
+        wind_wave_height: 0.2,
+        wind_wave_period: 6,
+        wind_wave_direction: 270,
+        data_source: "NOAA_NWS" as const,
+      };
+    };
+
+    return {
+      lat: 33.38,
+      lng: -117.59,
+      data_source: "NOAA_NWS" as const,
+      forecast: [makePoint(0), makePoint(3), makePoint(6)],
+    };
+  }
+
   function makeSouthOcAlreadyHigherWaveData(nowIso: string) {
     return {
       lat: 33.38,
@@ -478,6 +509,52 @@ describe("ForecastBuilder nowcast anchor output", () => {
     expect(result[0].raw_forecast?.wave_height_provenance?.south_oc_sano_guardrail?.branch).toBe(
       "trestles_calibrated_anchor",
     );
+  });
+
+  test("South OC guardrail prevents Lower Trestles near-term sawtooth rows", async () => {
+    const nowIso = new Date().toISOString();
+    const builder = makeBuilder();
+
+    const result = await builder.buildForecasts({
+      beach: makeTestBeach([SOUTH_OC_SANO_SHADOW_GUARDRAIL_FEATURE_FLAG], {
+        slug: "lower-trestles",
+        name: "Lower Trestles",
+        lat: 33.3844,
+        lon: -117.5934,
+        center_lat: 33.3844,
+        center_lng: -117.5934,
+        swell_window_center_deg: 220,
+        swell_window_halfwidth_deg: 105,
+        deepwater_decay_factor: 0.6,
+        shoaling_factors: {
+          version: 1,
+          type: "period_lookup",
+          buckets: [{ tp_min_s: 16, tp_max_s: 999, factor: 1.62 }],
+        },
+      }),
+      waveData: makeSouthOcNearTermSawtoothWaveData(nowIso),
+      tideData: null,
+      weatherData: [],
+      buoyData: null,
+      cdipData: null,
+      ioosWaterTempC: null,
+      coopsWaterTempC: null,
+      southOcSanoShadowZoneSnapshot: makeSouthOcSnapshot(nowIso),
+    });
+    expectConsoleWarnings([CALIBRATION_COVERAGE_WARNING]);
+
+    const nearTerm = result.slice(0, 3);
+    const heights = nearTerm.map((forecast) => extractFt(forecast.wave_height));
+    expect(heights).toHaveLength(3);
+    expect(Math.min(...heights)).toBeGreaterThan(4.5);
+    expect(Math.max(...heights) - Math.min(...heights)).toBeLessThan(1);
+    expect(
+      nearTerm.every(
+        (forecast) =>
+          forecast.raw_forecast?.wave_height_provenance?.south_oc_sano_guardrail
+            ?.branch === "trestles_calibrated_anchor",
+      ),
+    ).toBe(true);
   });
 
   test("South OC guardrail lifts Church via calibrated Trestles anchor provenance", async () => {

--- a/__tests__/lib/services/forecast/south-oc-sano-shadow-guardrail.test.ts
+++ b/__tests__/lib/services/forecast/south-oc-sano-shadow-guardrail.test.ts
@@ -175,6 +175,52 @@ describe("resolveSouthOcSanoShadowGuardrail", () => {
     expect(result.metadata.branch).toBe("trestles_calibrated_anchor");
   });
 
+  test("applies to active confirmed nearshore south swell through now plus six hours", () => {
+    const snapshot = buildSouthOcSanoShadowZoneSnapshot(
+      [
+        makeObservation({ stationId: "46277", heightM: 1.0 }),
+        makeObservation({ stationId: "46275", heightM: 0.96 }),
+      ],
+      NOW_MS,
+    );
+
+    const result = resolveSouthOcSanoShadowGuardrail({
+      beach: makeBeach("lower-trestles"),
+      snapshot,
+      forecastAtMs: NOW_MS + 6 * 60 * 60 * 1000,
+      nowMs: NOW_MS,
+    });
+
+    expect(result.kind).toBe("trestles_calibrated_anchor");
+  });
+
+  test("does not apply before now minus thirty minutes or after now plus six hours", () => {
+    const snapshot = buildSouthOcSanoShadowZoneSnapshot(
+      [
+        makeObservation({ stationId: "46277", heightM: 1.0 }),
+        makeObservation({ stationId: "46275", heightM: 0.96 }),
+      ],
+      NOW_MS,
+    );
+
+    expect(
+      resolveSouthOcSanoShadowGuardrail({
+        beach: makeBeach("lower-trestles"),
+        snapshot,
+        forecastAtMs: NOW_MS - 31 * 60 * 1000,
+        nowMs: NOW_MS,
+      }),
+    ).toMatchObject({ kind: "noop", reason: "outside_nowcast_window" });
+    expect(
+      resolveSouthOcSanoShadowGuardrail({
+        beach: makeBeach("lower-trestles"),
+        snapshot,
+        forecastAtMs: NOW_MS + 6 * 60 * 60 * 1000 + 1,
+        nowMs: NOW_MS,
+      }),
+    ).toMatchObject({ kind: "noop", reason: "outside_nowcast_window" });
+  });
+
   test("returns a non-cluster anchor floor for flagged South OC beaches outside Trestles cluster", () => {
     const snapshot = buildSouthOcSanoShadowZoneSnapshot(
       [
@@ -227,7 +273,7 @@ describe("resolveSouthOcSanoShadowGuardrail", () => {
       resolveSouthOcSanoShadowGuardrail({
         beach: makeBeach("lower-trestles"),
         snapshot: confirmed,
-        forecastAtMs: NOW_MS + 2 * 60 * 60 * 1000,
+        forecastAtMs: NOW_MS + 7 * 60 * 60 * 1000,
         nowMs: NOW_MS,
       }).kind,
     ).toBe("noop");

--- a/__tests__/lib/utils/wave-height-transformer.test.ts
+++ b/__tests__/lib/utils/wave-height-transformer.test.ts
@@ -972,6 +972,67 @@ describe('Wave Height Transformer', () => {
       expect(result.isCalibrated).toBe(false);
     });
 
+    it('quarantines low long-period CDIP buckets and uses the generic path', () => {
+      const rinconStyleFactors: ShoalingFactors = {
+        version: 1,
+        type: 'period_lookup',
+        buckets: [{ tp_min_s: 15, tp_max_s: 999, factor: 0.36 }],
+      };
+
+      const result = transformToFaceHeightWithMetadata({
+        rawHeightFt: 4.2,
+        periodS: 18,
+        swellDirectionDeg: 205,
+        beach: { shoaling_factors: rinconStyleFactors },
+        source: 'cdip_sig',
+      });
+
+      expect(result.faceHeightFt).toBe(5.0);
+      expect(result.faceHeightFt).toBeGreaterThan(4.2 * 0.36);
+      expect(result.isCalibrated).toBe(false);
+      expect(result.calibrationBucketQuarantined).toBe(true);
+    });
+
+    it('keeps normal calibrated behavior for long-period CDIP buckets at or above threshold', () => {
+      const trustedFactors: ShoalingFactors = {
+        version: 1,
+        type: 'period_lookup',
+        buckets: [{ tp_min_s: 15, tp_max_s: 999, factor: 1.2 }],
+      };
+
+      const result = transformToFaceHeightWithMetadata({
+        rawHeightFt: 4.2,
+        periodS: 18,
+        swellDirectionDeg: 205,
+        beach: { shoaling_factors: trustedFactors },
+        source: 'cdip_sig',
+      });
+
+      expect(result.faceHeightFt).toBe(5.0);
+      expect(result.isCalibrated).toBe(true);
+      expect(result.calibrationBucketQuarantined).toBeUndefined();
+    });
+
+    it('does not quarantine model sources even when a matching bucket is low', () => {
+      const lowFactors: ShoalingFactors = {
+        version: 1,
+        type: 'period_lookup',
+        buckets: [{ tp_min_s: 15, tp_max_s: 999, factor: 0.36 }],
+      };
+
+      const result = transformToFaceHeightWithMetadata({
+        rawHeightFt: 4.2,
+        periodS: 18,
+        swellDirectionDeg: 205,
+        beach: { shoaling_factors: lowFactors },
+        source: 'model_swell',
+      });
+
+      expect(result.faceHeightFt).toBe(5.0);
+      expect(result.isCalibrated).toBe(false);
+      expect(result.calibrationBucketQuarantined).toBeUndefined();
+    });
+
     it('returns isCalibrated false for cdip_swell with factors', () => {
       const result = transformToFaceHeightWithMetadata({
         rawHeightFt: 1.7,

--- a/lib/services/forecast/forecast-builder.ts
+++ b/lib/services/forecast/forecast-builder.ts
@@ -1053,6 +1053,9 @@ export class ForecastBuilder {
         transform_path: waveHeightDebug.transformPath,
         components_used: waveHeightDebug.componentsUsed,
         calibrated_shoaling_fired: waveHeightDebug.calibratedShoalingFired,
+        ...(waveHeightDebug.calibrationBucketQuarantined
+          ? { calibration_bucket_quarantined: true }
+          : {}),
         ...(waveHeightDebug.cdipRejection
           ? {
               cdip_rejection: {
@@ -1113,6 +1116,13 @@ export class ForecastBuilder {
             }
           : {}),
       },
+      ...(waveHeightDebug.calibrationBucketQuarantined
+        ? {
+            wave_height_debug: {
+              calibrationBucketQuarantined: true,
+            },
+          }
+        : {}),
       ...(isFirstOfDay && tideData && tideData.tides && tideData.tides.length > 0
         ? {
             tide_schedule: tideData.tides

--- a/lib/services/forecast/south-oc-sano-shadow-guardrail.ts
+++ b/lib/services/forecast/south-oc-sano-shadow-guardrail.ts
@@ -16,7 +16,8 @@ const MIN_CONFIRMED_PERIOD_S = 15;
 const MIN_SOUTH_DIRECTION_DEG = 175;
 const MAX_SOUTH_DIRECTION_DEG = 220;
 const MAX_NEARSHORE_TO_OFFSHORE_RATIO = 1.8;
-const NOWCAST_WINDOW_MS = 1.5 * 60 * 60 * 1000;
+const WINDOW_PAST_MS = 30 * 60 * 1000;
+const WINDOW_FUTURE_MS = 6 * 60 * 60 * 1000;
 
 export const SOUTH_OC_SANO_SHADOW_STATION_IDS = [
   GREEN_BEACH_OFFSHORE,
@@ -303,7 +304,10 @@ export function resolveSouthOcSanoShadowGuardrail(args: {
   if (!slug || !ZONE_SLUGS.has(slug)) {
     return { kind: "noop", reason: "out_of_zone", snapshot: args.snapshot };
   }
-  if (Math.abs(args.forecastAtMs - args.nowMs) > NOWCAST_WINDOW_MS) {
+  if (
+    args.forecastAtMs < args.nowMs - WINDOW_PAST_MS ||
+    args.forecastAtMs > args.nowMs + WINDOW_FUTURE_MS
+  ) {
     return { kind: "noop", reason: "outside_nowcast_window", snapshot: args.snapshot };
   }
 

--- a/lib/utils/wave-formatters.ts
+++ b/lib/utils/wave-formatters.ts
@@ -444,7 +444,11 @@ export function selectWaveHeightSource(
   // Prefer CDIP significant height when available and within reasonable range
   if (cdipSig !== undefined && cdipSig <= MAX_TRUSTED_CDIP_FT) {
     // If we also have model swell and CDIP is a large outlier, defer to model
-    if (modelSwell !== undefined && cdipSig > modelSwell * CDIP_OUTLIER_THRESHOLD) {
+    if (
+      modelSwell !== undefined &&
+      cdipSig > modelSwell * CDIP_OUTLIER_THRESHOLD &&
+      !isCdipCorroboratedByModelHs(cdipSig, modelHs)
+    ) {
       return {
         heightFt: modelSwell,
         source: 'model_swell',
@@ -506,6 +510,14 @@ export function selectWaveHeightSource(
   }
 
   return null;
+}
+
+function isCdipCorroboratedByModelHs(
+  cdipSigFt: number,
+  modelHsFt: number | undefined,
+): boolean {
+  return modelHsFt !== undefined &&
+    cdipSigFt <= modelHsFt * CDIP_OUTLIER_THRESHOLD;
 }
 
 // ============================================================================
@@ -643,6 +655,8 @@ export function toFaceHeightFeetDecomposed(
  * - `componentsUsed`: true when the decomposed branch RMS-summed components.
  * - `calibratedShoalingFired`: true when the empirical bucket lookup hit
  *   (only possible when source is `cdip_sig` and the beach has factors).
+ * - `calibrationBucketQuarantined`: true when a low long-period CDIP bucket
+ *   was skipped and the generic transformer path rendered the row instead.
  * - `cdipRejection`: present when `selectWaveHeightSource` rejected CDIP as
  *   an outlier and fell back to model/NDBC. Records the why for traceability.
  */
@@ -652,6 +666,7 @@ export interface WaveHeightDebugInfo {
   transformPath: 'scalar_calibrated' | 'scalar_generic' | 'decomposed' | null;
   componentsUsed: boolean;
   calibratedShoalingFired: boolean;
+  calibrationBucketQuarantined?: boolean;
   handoffDiscontinuityFt?: number;
   handoffBlend?: ForecastHandoffBlendMetadata;
   cdipRejection?: {
@@ -715,6 +730,9 @@ export function toFaceHeightFeetDecomposedWithDebug(
       transformPath,
       componentsUsed: result.path === 'decomposed',
       calibratedShoalingFired: result.isCalibrated,
+      ...(result.calibrationBucketQuarantined
+        ? { calibrationBucketQuarantined: true }
+        : {}),
       ...(source.cdipRejection ? { cdipRejection: source.cdipRejection } : {}),
     },
   };

--- a/lib/utils/wave-height-transformer.ts
+++ b/lib/utils/wave-height-transformer.ts
@@ -363,6 +363,7 @@ export function transformToFaceHeight(params: TransformParams): number {
 export interface FaceHeightWithMetadata {
   faceHeightFt: number;
   isCalibrated: boolean;
+  calibrationBucketQuarantined?: boolean;
 }
 
 /**
@@ -413,6 +414,8 @@ export function transformToFaceHeightWithMetadata(
     return { faceHeightFt: 0, isCalibrated: false };
   }
 
+  let calibrationBucketQuarantined = false;
+
   // Short-circuit: empirically calibrated per-beach shoaling lookup.
   // GATED on source === 'cdip_sig' because the bucket factor is measured as
   // `surfline_face_ft / cdip_hs_ft` — applying it to a model-derived height
@@ -422,11 +425,15 @@ export function transformToFaceHeightWithMetadata(
   if (canUseCalibratedShoaling(source, allowCalibratedShoaling)) {
     const bucketFactor = lookupShoalingBucket(periodS, beach?.shoaling_factors);
     if (bucketFactor != null) {
-      const shadow = calibratedShadowFactor(swellDirectionDeg, beach);
-      return {
-        faceHeightFt: Math.round(rawHeightFt * bucketFactor * shadow * 10) / 10,
-        isCalibrated: true,
-      };
+      if (shouldQuarantineCalibratedShoalingBucket(source, periodS, bucketFactor)) {
+        calibrationBucketQuarantined = true;
+      } else {
+        const shadow = calibratedShadowFactor(swellDirectionDeg, beach);
+        return {
+          faceHeightFt: Math.round(rawHeightFt * bucketFactor * shadow * 10) / 10,
+          isCalibrated: true,
+        };
+      }
     }
   }
 
@@ -448,6 +455,7 @@ export function transformToFaceHeightWithMetadata(
   return {
     faceHeightFt: Math.round(faceHeight * 10) / 10,
     isCalibrated: false,
+    ...(calibrationBucketQuarantined ? { calibrationBucketQuarantined } : {}),
   };
 }
 
@@ -520,6 +528,8 @@ export const SHORT_PERIOD_CUTOFF_S = 8;
 export const WIND_WAVE_FACE_HEIGHT_CUTOFF_S = 9;
 
 const LONG_PERIOD_SOUTH_SWELL_FLOOR_MIN_PERIOD_S = 15;
+export const CALIBRATION_BUCKET_QUARANTINE_MIN_PERIOD_S = 15;
+export const CALIBRATION_BUCKET_QUARANTINE_MAX_FACTOR = 0.8;
 const LONG_PERIOD_SOUTH_SWELL_FLOOR_MIN_ACCESS = 0.02;
 const SOUTH_SWELL_FLOOR_MIN_DIRECTION_DEG = 160;
 const SOUTH_SWELL_FLOOR_MAX_DIRECTION_DEG = 230;
@@ -700,6 +710,18 @@ function canUseCalibratedShoaling(
     (source === 'nowcast_anchor' && allowCalibratedShoaling === true);
 }
 
+function shouldQuarantineCalibratedShoalingBucket(
+  source: WaveHeightSourceTag | undefined,
+  periodS: number | null | undefined,
+  bucketFactor: number,
+): boolean {
+  return source === 'cdip_sig' &&
+    periodS != null &&
+    Number.isFinite(periodS) &&
+    periodS >= CALIBRATION_BUCKET_QUARANTINE_MIN_PERIOD_S &&
+    bucketFactor < CALIBRATION_BUCKET_QUARANTINE_MAX_FACTOR;
+}
+
 function shouldApplyDeepwaterDecay(
   source: WaveHeightSourceTag | undefined,
 ): boolean {
@@ -795,15 +817,15 @@ export interface SwellComponentInput {
  *   to what the existing transform would return — this path exists so
  *   callers can log/telemetry which rows decomposed vs which didn't.
  *
- * `isCalibrated` is `true` only when both conditions hold: `source ===
- * 'cdip_sig'` and `beach.shoaling_factors` is populated. Mirrors the
- * semantics of `transformToFaceHeightWithMetadata` so downstream consumers
- * can treat the two metadata flags identically.
+ * `isCalibrated` is `true` only when at least one empirical bucket factor was
+ * actually applied. Mirrors `transformToFaceHeightWithMetadata` so downstream
+ * consumers can treat the two metadata flags identically.
  */
 export interface DecomposedFaceHeightResult {
   faceHeightFt: number;
   isCalibrated: boolean;
   path: 'decomposed' | 'legacy';
+  calibrationBucketQuarantined?: boolean;
 }
 
 /**
@@ -846,10 +868,10 @@ export interface DecomposedFaceHeightResult {
  *   every component, so decomposition becomes "bucket factor × raw height"
  *   RMS-summed. Model sources still use terrain access when available.
  *
- * `isCalibrated` is returned on the `'decomposed'` path iff
- * `source === 'cdip_sig'` AND `beach.shoaling_factors` is populated. On the
- * `'legacy'` path it mirrors whatever `transformToFaceHeightWithMetadata`
- * would have returned for the raw Hs input.
+ * `isCalibrated` is returned on the `'decomposed'` path iff at least one
+ * empirical bucket factor was actually applied. On the `'legacy'` path it
+ * mirrors whatever `transformToFaceHeightWithMetadata` would have returned
+ * for the raw Hs input.
  */
 export function transformToFaceHeightDecomposed(params: {
   components: Array<SwellComponentInput | null>;
@@ -897,6 +919,9 @@ export function transformToFaceHeightDecomposed(params: {
       faceHeightFt: legacy.faceHeightFt,
       isCalibrated: legacy.isCalibrated,
       path: 'legacy',
+      ...(legacy.calibrationBucketQuarantined
+        ? { calibrationBucketQuarantined: true }
+        : {}),
     };
   }
 
@@ -910,6 +935,8 @@ export function transformToFaceHeightDecomposed(params: {
     : 1.0;
 
   let sumOfSquares = 0;
+  let calibrationBucketQuarantined = false;
+  let calibratedBucketUsed = false;
   for (const component of populated) {
     if (
       component.partition === 'wind_wave' &&
@@ -932,9 +959,24 @@ export function transformToFaceHeightDecomposed(params: {
 
     // Only use calibrated bucket factors for CDIP sources — the buckets are
     // measured as surfline_face / cdip_hs and produce overshoot on model data.
-    const bucketFactor = canUseCalibratedShoaling(source, allowCalibratedShoaling)
+    const rawBucketFactor = canUseCalibratedShoaling(source, allowCalibratedShoaling)
       ? lookupShoalingBucket(component.periodS, shoalingFactors)
       : null;
+    const bucketFactor =
+      rawBucketFactor != null &&
+      shouldQuarantineCalibratedShoalingBucket(
+        source,
+        component.periodS,
+        rawBucketFactor,
+      )
+        ? null
+        : rawBucketFactor;
+    if (rawBucketFactor != null && bucketFactor == null) {
+      calibrationBucketQuarantined = true;
+    }
+    if (bucketFactor != null) {
+      calibratedBucketUsed = true;
+    }
     const periodFactor = calculatePeriodFactor(component.periodS);
     // Terrain-access canyon paths should treat 12s+ model swell as organized
     // groundswell; otherwise the generic 12s=1.1 ramp still undercalls LJS.
@@ -963,6 +1005,9 @@ export function transformToFaceHeightDecomposed(params: {
       faceHeightFt: legacy.faceHeightFt,
       isCalibrated: legacy.isCalibrated,
       path: 'legacy',
+      ...(legacy.calibrationBucketQuarantined
+        ? { calibrationBucketQuarantined: true }
+        : {}),
     };
   }
 
@@ -971,11 +1016,8 @@ export function transformToFaceHeightDecomposed(params: {
 
   return {
     faceHeightFt: rounded,
-    // Calibrated iff the short-circuit would have fired for the combined
-    // reading: source is CDIP sig AND the beach has a lookup table. Per-
-    // component bucket misses don't invalidate the beach-level claim.
-    isCalibrated: canUseCalibratedShoaling(source, allowCalibratedShoaling) &&
-      shoalingFactors != null,
+    isCalibrated: calibratedBucketUsed,
     path: 'decomposed',
+    ...(calibrationBucketQuarantined ? { calibrationBucketQuarantined } : {}),
   };
 }

--- a/types/forecast.ts
+++ b/types/forecast.ts
@@ -248,6 +248,8 @@ export interface EnhancedForecastEntity {
     tide_station?: TideStationInfo;
     /** Per-row wave_height provenance (source, transform path, etc.). */
     wave_height_provenance?: WaveHeightProvenance;
+    /** Optional internal wave-height debug metadata. */
+    wave_height_debug?: WaveHeightDebugMetadata;
   } | null;
 }
 
@@ -541,6 +543,8 @@ export interface WaveHeightProvenance {
   components_used: boolean;
   /** True when the per-beach `shoaling_factors` lookup actually fired. */
   calibrated_shoaling_fired: boolean;
+  /** True when a low long-period CDIP bucket was skipped for this row. */
+  calibration_bucket_quarantined?: boolean;
   /** Last CDIP face height minus first following model face height at the source handoff. */
   handoff_discontinuity_ft?: number;
   /** Optional default-off boundary blend applied to model rows after a CDIP handoff. */
@@ -581,6 +585,10 @@ export interface WaveHeightProvenance {
   };
 }
 
+export interface WaveHeightDebugMetadata {
+  calibrationBucketQuarantined?: boolean;
+}
+
 // Enhanced Forecast with Raw Data
 export interface EnhancedForecastWithRawData extends EnhancedForecastEntity {
   raw_forecast?: {
@@ -602,5 +610,7 @@ export interface EnhancedForecastWithRawData extends EnhancedForecastEntity {
     tide_station?: TideStationInfo;
     /** Per-row wave_height provenance metadata (source, transform path, etc.). */
     wave_height_provenance?: WaveHeightProvenance;
+    /** Optional internal wave-height debug metadata. */
+    wave_height_debug?: WaveHeightDebugMetadata;
   };
 }


### PR DESCRIPTION
## Summary
- quarantine suspect low long-period CDIP shoaling buckets and emit raw debug metadata
- extend South OC/SanO shadow guardrail to now -30m through now +6h
- add transformer, guardrail, and ForecastBuilder regression tests for Rincon/Lower Trestles cases

## Verification
- yarn test:unit --runTestsByPath __tests__/lib/utils/wave-height-transformer.test.ts __tests__/lib/services/forecast/south-oc-sano-shadow-guardrail.test.ts __tests__/lib/services/forecast/forecast-builder-nowcast-anchor.test.ts __tests__/lib/services/forecast/forecast-builder-cdip-semantics.test.ts
- yarn typecheck

## Notes
- Code-only deploy; no production forecast rows regenerated or mutated.