### PR TITLE
feat(session): ship session fallback and app bridge to prod

### DIFF
--- a/__tests__/app/og-share-card-routes.test.tsx
+++ b/__tests__/app/og-share-card-routes.test.tsx
@@ -26,12 +26,12 @@ describe("install-style OG share cards", () => {
     mockCapturedOptions = null;
   });
 
-  it("renders session share cards with the install-card anatomy and QR attribution", async () => {
+  it("renders session share cards with the session-card anatomy and share footer", async () => {
     const { GET } = await import("@/app/api/og/session/route");
 
     const response = await GET(
       new Request(
-        "http://localhost:3000/api/og/session?beach=Ocean+Beach&rating=Epic&stars=5&size=Chest-Head&board=Fish&windLabel=Offshore&windSpeed=7+mph&tagline=Clean+morning+waves&shareUrl=https%3A%2F%2Fwww.quiversurf.app%2Fsessions%2Fsession-abc",
+        "http://localhost:3000/api/og/session?beach=Ocean+Beach&rating=Epic&stars=5&size=Chest-Head&board=Fish&windLabel=Offshore&windSpeed=7+mph&tagline=Clean+morning+waves&bg=https%3A%2F%2Fcdn.quiversurf.app%2Fsession.jpg&shareUrl=https%3A%2F%2Fwww.quiversurf.app%2Fsessions%2Fsession-abc",
       ) as never,
     );
 
@@ -39,17 +39,19 @@ describe("install-style OG share cards", () => {
     expect(mockCapturedOptions).toEqual(expect.objectContaining({ width: 1080, height: 1920 }));
     expect(capturedProps()).toEqual(
       expect.objectContaining({
-        baseUrl: "http://localhost:3000",
-        title: "Get Quiver",
-        subtitle: expect.stringContaining("Ocean Beach session"),
+        beach: "Ocean Beach",
+        rating: "Epic",
+        stars: 5,
+        size: "Chest-Head",
+        board: "Fish",
+        windLabel: "Offshore",
+        windSpeed: "7 mph",
+        tagline: "Clean morning waves",
+        bg: "https://cdn.quiversurf.app/session.jpg",
         footer: expect.stringContaining("quiversurf.app/sessions/session-abc"),
+        qrImageSrc: expect.stringContaining("data:image/svg+xml"),
       }),
     );
-    const qrValue = new URL(String(capturedProps().qrValue));
-    expect(qrValue.pathname).toBe("/app");
-    expect(qrValue.searchParams.get("surface")).toBe("og_session_card");
-    expect(qrValue.searchParams.get("qr_id")).toBe("session_share_card");
-    expect(qrValue.searchParams.get("utm_source")).toBe("qr");
   });
 
   it("renders surf-call share cards with the install-card anatomy and QR attribution", async () => {

--- a/__tests__/app/sessions/email-app-bridge.test.tsx
+++ b/__tests__/app/sessions/email-app-bridge.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  buildSessionEmailWebSignInUrl,
+  buildSessionNativeAppUrl,
+  EmailSessionAppBridge,
+  isSessionEmailAppBridgeRequest,
+} from "@/app/sessions/new/email-app-bridge";
+
+describe("email session app bridge", () => {
+  const emailParams = new URLSearchParams({
+    entrySource: "email",
+    utm_source: "manual_test",
+    utm_medium: "email",
+    utm_campaign: "email_attribution_validation",
+    email_type: "manual_attribution_test",
+    message_instance_id: "manual-email-attribution-20260708-1015",
+    beachId: "mission-beach",
+  });
+
+  it("detects email-attributed session links", () => {
+    expect(isSessionEmailAppBridgeRequest(emailParams)).toBe(true);
+    expect(isSessionEmailAppBridgeRequest(new URLSearchParams("mode=log"))).toBe(false);
+    expect(
+      isSessionEmailAppBridgeRequest(new URLSearchParams("utm_campaign=launch"))
+    ).toBe(false);
+  });
+
+  it("builds a native sessions/new URL with attribution preserved", () => {
+    const appUrl = buildSessionNativeAppUrl(emailParams);
+    const url = new URL(appUrl);
+
+    expect(url.protocol).toBe("quiver:");
+    expect(url.hostname).toBe("sessions");
+    expect(url.pathname).toBe("/new");
+    expect(url.searchParams.get("entrySource")).toBe("email");
+    expect(url.searchParams.get("native_handoff")).toBe("web_email_bridge");
+    expect(url.searchParams.get("email_type")).toBe("manual_attribution_test");
+    expect(url.searchParams.get("message_instance_id")).toBe(
+      "manual-email-attribution-20260708-1015"
+    );
+    expect(url.searchParams.get("beachId")).toBe("mission-beach");
+  });
+
+  it("builds a web sign-in fallback that preserves the session redirect", () => {
+    const signInUrl = buildSessionEmailWebSignInUrl(emailParams);
+    const url = new URL(signInUrl, "https://www.quiversurf.app");
+
+    expect(url.pathname).toBe("/auth/sign-in");
+    expect(url.searchParams.get("redirectTo")).toContain("/sessions/new?");
+    expect(url.searchParams.get("redirectTo")).toContain("email_type=manual_attribution_test");
+  });
+
+  it("renders app and web fallback CTAs for unauthenticated email clicks", () => {
+    render(
+      <EmailSessionAppBridge
+        appUrl="quiver://sessions/new?entrySource=email"
+        signInUrl="/auth/sign-in?redirectTo=%2Fsessions%2Fnew"
+        isAuthenticated={false}
+        onContinueWeb={jest.fn()}
+        autoAttempt={false}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: /open quiver app/i })
+    ).toHaveAttribute("href", "quiver://sessions/new?entrySource=email");
+    expect(
+      screen.getByRole("link", { name: /continue on web/i })
+    ).toHaveAttribute("href", "/auth/sign-in?redirectTo=%2Fsessions%2Fnew");
+  });
+
+  it("lets authenticated web users continue to the web session form", () => {
+    const onContinueWeb = jest.fn();
+
+    render(
+      <EmailSessionAppBridge
+        appUrl="quiver://sessions/new?entrySource=email"
+        signInUrl="/auth/sign-in?redirectTo=%2Fsessions%2Fnew"
+        isAuthenticated
+        onContinueWeb={onContinueWeb}
+        autoAttempt={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /continue on web/i }));
+    expect(onContinueWeb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/session-detail-view.gating.test.tsx
+++ b/__tests__/components/session-detail-view.gating.test.tsx
@@ -15,18 +15,17 @@ jest.mock("@/context/auth-context", () => ({
   })),
 }));
 
-jest.mock("@/components/ui/public-content-gate", () => ({
-  PublicContentGate: ({
-    ctaTitle,
+jest.mock("@/components/app-store/ios-app-store-cta", () => ({
+  IosAppStoreCta: ({
     children,
+    className,
   }: {
-    ctaTitle: string;
     children: React.ReactNode;
+    className?: string;
   }) => (
-    <div>
-      <div>{ctaTitle}</div>
-      <div>{children}</div>
-    </div>
+    <a href="https://apps.apple.com/us/app/surf-forecast-quiver/id6759300320" className={className}>
+      {children}
+    </a>
   ),
 }));
 
@@ -45,12 +44,33 @@ jest.mock("next/link", () => {
 });
 
 describe("SessionDetailView (gating)", () => {
-  it("shows an auth gate when logged out (instead of spinning forever)", () => {
-    render(<SessionDetailView id="session-1" />);
-    expect(
-      screen.getByText("Log in to view session details")
-    ).toBeInTheDocument();
+  it("shows a shared-session app fallback when logged out", () => {
+    render(
+      <SessionDetailView
+        id="session-1"
+        sharedPreview={{
+          beachName: "Ocean Beach",
+          userName: "Sam",
+          rating: 4,
+          dateText: "Jul 3, 2026",
+          title: "Sam's session at Ocean Beach",
+          subtitle: "4/5 stars · Jul 3, 2026 · Logged session",
+          imageUrl: "https://cdn.quiversurf.app/session.jpg",
+          shareImageUrl: "https://www.quiversurf.app/api/og/session?beach=Ocean+Beach",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Shared session")).toBeInTheDocument();
+    expect(screen.getByText("Sam's session at Ocean Beach")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open App Store" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("apps.apple.com"),
+    );
+    expect(screen.getByRole("link", { name: "Download options" })).toHaveAttribute(
+      "href",
+      "/download",
+    );
   });
 });
-
 

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -134,6 +134,27 @@ describe("Middleware", () => {
     expect(mockRedirect).not.toHaveBeenCalled();
   });
 
+  test("allows /sessions/new email attribution bridge when unauthenticated", async () => {
+    const search =
+      "?entrySource=email&utm_medium=email&email_type=manual_attribution_test&message_instance_id=manual-email-attribution-20260708-1015";
+    const request: any = {
+      nextUrl: {
+        pathname: "/sessions/new",
+        search,
+        searchParams: new URLSearchParams(search.slice(1)),
+      },
+      url: `http://localhost/sessions/new${search}`,
+      method: "GET",
+      headers: new Headers(),
+      cookies: { get: () => undefined, getAll: () => [] },
+    };
+
+    await middleware(request);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
   test("allows unauthenticated access to beach detail page (public for SEO)", async () => {
     const request: any = { nextUrl: { pathname: "/beach/blacks-beach" }, url: "http://localhost/beach/blacks-beach", method: "GET", headers: new Headers(), cookies: { get: () => undefined, getAll: () => [] } };
     await middleware(request);

--- a/app/api/og/session/route.tsx
+++ b/app/api/og/session/route.tsx
@@ -4,7 +4,6 @@ import { type NextRequest } from "next/server";
 import { buildSmartQrHandoffUrl } from "@/lib/constants/app-handoff";
 import {
   createQrCodeDataUri,
-  PortraitInstallShareCard,
   SHARE_CARD_COLORS,
 } from "@/app/api/og/_components/install-share-card";
 
@@ -62,6 +61,21 @@ function formatShareUrl(value: string): string {
   }
 }
 
+interface SessionShareCardProps {
+  beach: string;
+  rating: string;
+  stars: number;
+  size: string;
+  board: string;
+  date: string;
+  windLabel: string;
+  windSpeed: string;
+  tagline: string;
+  footer: string;
+  bg: string;
+  qrImageSrc: string;
+}
+
 function buildSessionSubtitle(params: {
   beach: string;
   rating: string;
@@ -87,9 +101,307 @@ function buildSessionSubtitle(params: {
   );
 }
 
+function SessionShareCard({
+  beach,
+  rating,
+  stars,
+  size,
+  board,
+  date,
+  windLabel,
+  windSpeed,
+  tagline,
+  footer,
+  bg,
+  qrImageSrc,
+}: SessionShareCardProps) {
+  const detailCards = [
+    { label: "Waves", value: size || "Logged" },
+    { label: "Board", value: board || "Quiver" },
+    {
+      label: "Wind",
+      value: [windSpeed, windLabel].filter(Boolean).join(" ") || "Session notes",
+    },
+  ];
+  const clampedStars = Math.max(0, Math.min(5, Math.round(stars)));
+  const subtitle = buildSessionSubtitle({
+    beach,
+    rating,
+    size,
+    board,
+    windLabel,
+    windSpeed,
+    tagline,
+  });
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: SHARE_CARD_COLORS.paper,
+        color: SHARE_CARD_COLORS.ink,
+        fontFamily: "SpaceGrotesk, system-ui, sans-serif",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: 1080,
+          display: "flex",
+          background: SHARE_CARD_COLORS.navy,
+          overflow: "hidden",
+        }}
+      >
+        {bg ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={bg}
+            alt=""
+            width={1080}
+            height={1080}
+            style={{
+              width: 1080,
+              height: 1080,
+              objectFit: "cover",
+              display: "flex",
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "rgba(255,255,255,0.78)",
+              fontSize: 84,
+              fontWeight: 900,
+            }}
+          >
+            Quiver
+          </div>
+        )}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: 0,
+            display: "flex",
+            background: "rgba(17,16,13,0.28)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: 72,
+            right: 72,
+            bottom: 72,
+            display: "flex",
+            flexDirection: "column",
+            gap: 22,
+          }}
+        >
+          <div
+            style={{
+              alignSelf: "flex-start",
+              display: "flex",
+              borderRadius: 999,
+              background: SHARE_CARD_COLORS.orange,
+              color: SHARE_CARD_COLORS.navy,
+              padding: "16px 26px",
+              fontSize: 34,
+              fontWeight: 900,
+              letterSpacing: 2,
+              textTransform: "uppercase",
+            }}
+          >
+            {rating} session
+          </div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              color: "#FFFFFF",
+              textShadow: "0 6px 24px rgba(0,0,0,0.35)",
+            }}
+          >
+            <div style={{ display: "flex", fontSize: 92, fontWeight: 900 }}>
+              {beach}
+            </div>
+            <div style={{ display: "flex", fontSize: 38, fontWeight: 700 }}>
+              {date || "Logged on Quiver"}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 34,
+          padding: "56px 72px 64px",
+          flex: 1,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 58,
+              color: SHARE_CARD_COLORS.orange,
+              letterSpacing: 2,
+            }}
+          >
+            {"★".repeat(clampedStars)}
+            {"☆".repeat(5 - clampedStars)}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 34,
+              fontWeight: 800,
+              color: SHARE_CARD_COLORS.muted,
+            }}
+          >
+            {rating}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 40,
+            lineHeight: 1.28,
+            fontWeight: 700,
+            color: SHARE_CARD_COLORS.ink,
+          }}
+        >
+          {tagline || subtitle}
+        </div>
+
+        <div style={{ display: "flex", gap: 18 }}>
+          {detailCards.map((card) => (
+            <div
+              key={card.label}
+              style={{
+                display: "flex",
+                flex: 1,
+                flexDirection: "column",
+                gap: 12,
+                borderRadius: 28,
+                background: "#F4EBD8",
+                border: "2px solid #E5D4B3",
+                padding: 24,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 24,
+                  fontWeight: 900,
+                  color: SHARE_CARD_COLORS.muted,
+                  letterSpacing: 3,
+                  textTransform: "uppercase",
+                }}
+              >
+                {card.label}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 34,
+                  fontWeight: 900,
+                  color: SHARE_CARD_COLORS.ink,
+                  lineHeight: 1.08,
+                }}
+              >
+                {card.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          style={{
+            marginTop: "auto",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 30,
+            borderTop: "2px solid #E7EAF1",
+            paddingTop: 30,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+              flex: 1,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                fontSize: 28,
+                fontWeight: 900,
+                color: SHARE_CARD_COLORS.navy,
+              }}
+            >
+              Open this session on Quiver
+            </div>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 24,
+                fontWeight: 700,
+                color: SHARE_CARD_COLORS.muted,
+              }}
+            >
+              {footer}
+            </div>
+          </div>
+          <div
+            style={{
+              width: 148,
+              height: 148,
+              borderRadius: 22,
+              background: "#FFFFFF",
+              border: "2px solid #E7EAF1",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 12,
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={qrImageSrc}
+              alt=""
+              width={124}
+              height={124}
+              style={{ width: 124, height: 124, display: "flex" }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export async function GET(request: NextRequest): Promise<ImageResponse> {
   try {
-    const origin = new URL(request.url).origin;
     const { searchParams } = new URL(request.url);
 
     const beach = truncate(searchParams.get("beach") || "Your surf session", 38);
@@ -99,6 +411,9 @@ export async function GET(request: NextRequest): Promise<ImageResponse> {
     const windLabel = truncate(searchParams.get("windLabel") || "", 28);
     const windSpeed = truncate(searchParams.get("windSpeed") || "", 18);
     const tagline = truncate(searchParams.get("tagline") || "", 64);
+    const date = truncate(searchParams.get("date") || "", 32);
+    const bg = searchParams.get("bg") || "";
+    const stars = Number(searchParams.get("stars") || 4);
     const footer = truncate(
       searchParams.get("shareUrl")
         ? `Open this session at ${formatShareUrl(searchParams.get("shareUrl") || "")}`
@@ -118,21 +433,19 @@ export async function GET(request: NextRequest): Promise<ImageResponse> {
 
     const response = new ImageResponse(
       (
-        <PortraitInstallShareCard
-          baseUrl={origin}
-          qrValue={qrValue}
-          qrImageSrc={qrImageSrc}
-          title="Get Quiver"
-          subtitle={buildSessionSubtitle({
-            beach,
-            rating,
-            size,
-            board,
-            windLabel,
-            windSpeed,
-            tagline,
-          })}
+        <SessionShareCard
+          beach={beach}
+          rating={rating}
+          stars={Number.isFinite(stars) ? stars : 4}
+          size={size}
+          board={board}
+          date={date}
+          windLabel={windLabel}
+          windSpeed={windSpeed}
+          tagline={tagline}
           footer={footer}
+          bg={bg}
+          qrImageSrc={qrImageSrc}
         />
       ),
       { width: 1080, height: 1920 },

--- a/app/sessions/[id]/page.tsx
+++ b/app/sessions/[id]/page.tsx
@@ -10,12 +10,57 @@ import { format } from "date-fns";
 const baseUrl =
   process.env.NEXT_PUBLIC_SITE_URL || "https://www.quiversurf.app";
 
+async function getSharedSessionPreview(id: string) {
+  const result = await getSessionMetadata(id);
+  if (!result.success || !result.data) return null;
+
+  const session = result.data;
+  const beach = session.beach as unknown as { name: string } | null;
+  const user = session.user as unknown as {
+    full_name: string;
+    username: string;
+  } | null;
+  const beachName = beach?.name || session.beach_name || "Unknown Beach";
+  const userName = user?.full_name || user?.username || "A surfer";
+  const rating =
+    typeof session.rating === "number" ? session.rating : Number(session.rating);
+  const safeRating = Number.isFinite(rating) ? rating : null;
+  const dateText = session.arrival_time
+    ? format(new Date(session.arrival_time), "MMM d, yyyy")
+    : null;
+  const photoUrl =
+    (session as { featured_photo_url?: string | null }).featured_photo_url ||
+    session.image_url ||
+    null;
+  const shareImageUrl = buildSessionShareImageUrl(
+    session as unknown as SessionWithDetails,
+  );
+
+  return {
+    beachName,
+    userName,
+    rating: safeRating,
+    dateText,
+    title: `${userName}'s session at ${beachName}`,
+    subtitle: [
+      safeRating ? `${safeRating}/5 stars` : null,
+      dateText,
+      session.status === "planned" ? "Planned session" : "Logged session",
+    ]
+      .filter(Boolean)
+      .join(" · "),
+    imageUrl: photoUrl ?? shareImageUrl,
+    shareImageUrl,
+  };
+}
+
 export default async function SessionDetailPage(
   props: {
     params: Promise<{ id: string }>;
   }
 ) {
   const params = await props.params;
+  const sharedPreview = await getSharedSessionPreview(params.id);
   return (
     <div className="flex flex-col min-h-screen">
       {/* Breadcrumb Structured Data for SEO */}
@@ -27,7 +72,7 @@ export default async function SessionDetailPage(
         ]}
       />
 
-      <SessionDetailView id={params.id} />
+      <SessionDetailView id={params.id} sharedPreview={sharedPreview} />
     </div>
   );
 }

--- a/app/sessions/new/NewSessionClientPage.tsx
+++ b/app/sessions/new/NewSessionClientPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { SessionScrollForm } from "@/components/session-forms/SessionScrollForm";
@@ -14,6 +14,12 @@ import { FormErrorBoundary } from "@/components/error-boundaries";
 import { PostSessionShare } from "@/components/session/post-session-share";
 import { ShareSheet } from "@/components/share/share-sheet";
 import { useNearestBeach } from "@/hooks/use-nearest-beach";
+import {
+  buildSessionEmailWebSignInUrl,
+  buildSessionNativeAppUrl,
+  EmailSessionAppBridge,
+  isSessionEmailAppBridgeRequest,
+} from "./email-app-bridge";
 import { useSessionSubmission } from "./useSessionSubmission";
 
 interface NewSessionPageContentProps {
@@ -133,7 +139,12 @@ function NewSessionPageContent({
 
 function NewSessionPageWrapper() {
   const searchParams = useSearchParams();
+  const { isAuthenticated } = useAuth();
+  const [continueOnWeb, setContinueOnWeb] = useState(false);
   const parseResult = parseSessionWizardParams(searchParams);
+  const emailBridgeSearchParams = new URLSearchParams(searchParams.toString());
+  const shouldShowEmailBridge =
+    !continueOnWeb && isSessionEmailAppBridgeRequest(emailBridgeSearchParams);
 
   const mode: SessionFormMode = "log";
   let initialFormState: Partial<SessionFormState> | undefined;
@@ -168,6 +179,17 @@ function NewSessionPageWrapper() {
     }
 
     initialFormState = parseResult.defaults as Partial<SessionFormState>;
+  }
+
+  if (shouldShowEmailBridge) {
+    return (
+      <EmailSessionAppBridge
+        appUrl={buildSessionNativeAppUrl(emailBridgeSearchParams)}
+        signInUrl={buildSessionEmailWebSignInUrl(emailBridgeSearchParams)}
+        isAuthenticated={isAuthenticated}
+        onContinueWeb={() => setContinueOnWeb(true)}
+      />
+    );
   }
 
   return (

--- a/app/sessions/new/email-app-bridge.tsx
+++ b/app/sessions/new/email-app-bridge.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect } from "react";
+
+const EMAIL_BRIDGE_KEYS = [
+  "email_type",
+  "message_instance_id",
+];
+
+function firstParam(searchParams: URLSearchParams, key: string): string | null {
+  const value = searchParams.get(key);
+  return value && value.trim().length > 0 ? value : null;
+}
+
+export function isSessionEmailAppBridgeRequest(
+  searchParams: URLSearchParams
+): boolean {
+  if (firstParam(searchParams, "entrySource") === "email") return true;
+  if (firstParam(searchParams, "utm_source") === "email") return true;
+  if (firstParam(searchParams, "utm_medium") === "email") return true;
+  return EMAIL_BRIDGE_KEYS.some((key) => firstParam(searchParams, key) !== null);
+}
+
+export function buildSessionNativeAppUrl(searchParams: URLSearchParams): string {
+  const nativeParams = new URLSearchParams(searchParams.toString());
+  nativeParams.set("entrySource", "email");
+  nativeParams.set("native_handoff", "web_email_bridge");
+  return `quiver://sessions/new?${nativeParams.toString()}`;
+}
+
+export function buildSessionEmailWebSignInUrl(
+  searchParams: URLSearchParams
+): string {
+  const redirectTo = `/sessions/new?${searchParams.toString()}`;
+  const signInParams = new URLSearchParams({ redirectTo });
+  return `/auth/sign-in?${signInParams.toString()}`;
+}
+
+function isMobileUserAgent(userAgent: string): boolean {
+  return /Android|iPhone|iPad|iPod/i.test(userAgent);
+}
+
+interface EmailSessionAppBridgeProps {
+  appUrl: string;
+  signInUrl: string;
+  isAuthenticated: boolean;
+  onContinueWeb: () => void;
+  autoAttempt?: boolean;
+}
+
+export function EmailSessionAppBridge({
+  appUrl,
+  signInUrl,
+  isAuthenticated,
+  onContinueWeb,
+  autoAttempt = true,
+}: EmailSessionAppBridgeProps) {
+  useEffect(() => {
+    if (!autoAttempt || typeof window === "undefined") return;
+    if (!isMobileUserAgent(window.navigator.userAgent)) return;
+
+    const storageKey = `quiver-email-app-bridge:${appUrl}`;
+    if (window.sessionStorage.getItem(storageKey) === "attempted") return;
+
+    window.sessionStorage.setItem(storageKey, "attempted");
+    const timeoutId = window.setTimeout(() => {
+      const link = document.createElement("a");
+      link.href = appUrl;
+      link.rel = "noreferrer";
+      link.click();
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [appUrl, autoAttempt]);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-5 py-10 text-white">
+      <div className="mx-auto flex min-h-[70vh] max-w-md flex-col justify-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.18em] text-orange-300">
+          Quiver
+        </p>
+        <h1 className="mt-3 text-3xl font-bold leading-tight">
+          Open this session in the app
+        </h1>
+        <p className="mt-4 text-base leading-7 text-white/72">
+          This link came from email. If Quiver is installed, open the app to log
+          the session with attribution intact.
+        </p>
+
+        <div className="mt-8 flex flex-col gap-3">
+          <a
+            href={appUrl}
+            className="inline-flex min-h-12 items-center justify-center rounded-full bg-orange-400 px-5 py-3 text-center font-semibold text-slate-950 transition hover:bg-orange-300"
+          >
+            Open Quiver app
+          </a>
+
+          {isAuthenticated ? (
+            <button
+              type="button"
+              onClick={onContinueWeb}
+              className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/16 px-5 py-3 text-center font-semibold text-white transition hover:bg-white/10"
+            >
+              Continue on web
+            </button>
+          ) : (
+            <a
+              href={signInUrl}
+              className="inline-flex min-h-12 items-center justify-center rounded-full border border-white/16 px-5 py-3 text-center font-semibold text-white transition hover:bg-white/10"
+            >
+              Continue on web
+            </a>
+          )}
+        </div>
+
+        <p className="mt-5 text-sm leading-6 text-white/50">
+          If nothing happens, tap Open Quiver app once more.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/components/session-detail-view.tsx
+++ b/components/session-detail-view.tsx
@@ -23,7 +23,6 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/auth-context";
 import type { SessionWithDetails } from "@/types/database";
-import { PublicContentGate } from "@/components/ui/public-content-gate";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -48,6 +47,7 @@ import { ShareSheet } from "@/components/share";
 import { buildSessionShareSheetData } from "@/lib/share/session-share";
 import { getWaveTypeLabel } from "@/components/ui/wave-type-selector";
 import { formatSessionTideSnapshot } from "@/lib/services/session-tide-snapshot";
+import { IosAppStoreCta } from "@/components/app-store/ios-app-store-cta";
 
 const RIP_CURRENT_LABELS: Record<string, string> = {
   none: "None",
@@ -74,11 +74,23 @@ const SessionPhotoGallery = dynamic(
   }
 );
 
-interface SessionDetailViewProps {
-  id: string;
+interface SharedSessionPreview {
+  beachName: string;
+  userName: string;
+  rating: number | null;
+  dateText: string | null;
+  title: string;
+  subtitle: string;
+  imageUrl: string | null;
+  shareImageUrl: string;
 }
 
-export function SessionDetailView({ id }: SessionDetailViewProps) {
+interface SessionDetailViewProps {
+  id: string;
+  sharedPreview?: SharedSessionPreview | null;
+}
+
+export function SessionDetailView({ id, sharedPreview = null }: SessionDetailViewProps) {
   const router = useRouter();
   const { user, isLoading } = useAuth();
   const [session, setSession] = useState<SessionWithDetails | null>(null);
@@ -88,6 +100,10 @@ export function SessionDetailView({ id }: SessionDetailViewProps) {
   const [shareOpen, setShareOpen] = useState(false);
   const [sessionPhotos, setSessionPhotos] = useState<SessionPhoto[]>([]);
   const [photosLoading, setPhotosLoading] = useState(false);
+  const sharedPreviewStars =
+    sharedPreview?.rating != null
+      ? Math.max(0, Math.min(5, Math.round(sharedPreview.rating)))
+      : null;
 
   useEffect(() => {
     async function loadSession() {
@@ -144,40 +160,74 @@ export function SessionDetailView({ id }: SessionDetailViewProps) {
   // Gate the detail page for logged-out users (avoid infinite loading state).
   if (!user && !isLoading) {
     return (
-      <PublicContentGate
-        ctaTitle="Log in to view session details"
-        ctaDescription="See the full session breakdown, photos, and comments."
-        blurLevel="lg"
-        source="session-detail"
-        className="flex-1"
-      >
-        <div className="flex-1 flex flex-col">
-          <header className="sticky top-0 z-10 bg-background border-b">
-            <div className="container flex items-center h-16 px-4">
-              <Link href="/sessions" className="mr-2">
-                <ArrowLeft className="h-5 w-5" />
-              </Link>
-              <h1 className="text-xl font-bold">Session Details</h1>
-            </div>
-          </header>
-          <main className="flex-1 container px-4 py-6 space-y-4">
-            <Card>
-              <CardContent className="p-6 space-y-2">
-                <div className="h-4 w-2/3 bg-muted rounded" />
-                <div className="h-4 w-1/2 bg-muted rounded" />
-                <div className="h-40 w-full bg-muted rounded" />
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-6 space-y-2">
-                <div className="h-4 w-3/4 bg-muted rounded" />
-                <div className="h-4 w-full bg-muted rounded" />
-                <div className="h-4 w-5/6 bg-muted rounded" />
-              </CardContent>
-            </Card>
-          </main>
-        </div>
-      </PublicContentGate>
+      <div className="flex-1 flex flex-col bg-[#F4EBD8] text-[#11100D]">
+        <header className="sticky top-0 z-10 border-b border-[#E5D4B3] bg-[#F4EBD8]/95 backdrop-blur">
+          <div className="container flex items-center h-16 px-4">
+            <Link href="/sessions" className="mr-2" aria-label="Back to sessions">
+              <ArrowLeft className="h-5 w-5" />
+            </Link>
+            <h1 className="text-xl font-bold">Session Details</h1>
+          </div>
+        </header>
+        <main className="flex-1 container px-4 py-6">
+          <Card className="mx-auto max-w-md overflow-hidden border-[#E5D4B3] bg-white shadow-sm">
+            {sharedPreview?.imageUrl ? (
+              <div className="aspect-[4/5] w-full overflow-hidden bg-[#252D6B]">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={sharedPreview.imageUrl}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            ) : null}
+            <CardContent className="space-y-5 p-6">
+              <div className="space-y-2">
+                <p className="text-xs font-bold uppercase tracking-[0.2em] text-[#8A5E00]">
+                  Shared session
+                </p>
+                <h2 className="text-2xl font-black leading-tight">
+                  {sharedPreview?.title ?? "Open this session in Quiver"}
+                </h2>
+                <p className="text-sm font-semibold text-[#4A463C]">
+                  {sharedPreview?.subtitle ??
+                    "See the beach, conditions, photos, and session notes in the app."}
+                </p>
+              </div>
+
+              {sharedPreviewStars != null ? (
+                <div
+                  aria-label={`${sharedPreviewStars} out of 5 stars`}
+                  className="text-2xl text-[#F78E42]"
+                >
+                  {"★".repeat(sharedPreviewStars)}
+                  {"☆".repeat(5 - sharedPreviewStars)}
+                </div>
+              ) : null}
+
+              <div className="rounded-2xl border border-[#E5D4B3] bg-[#F4EBD8] p-4 text-sm font-semibold text-[#4A463C]">
+                Quiver opens shared session links directly in the app when it is installed.
+                If it is not installed, download it and return to this link.
+              </div>
+
+              <div className="space-y-3">
+                <Button asChild className="w-full bg-[#F78E42] text-[#252D6B] hover:bg-[#D06C2E]">
+                  <IosAppStoreCta
+                    source="session_share"
+                    surface="session_detail_fallback"
+                    placement="primary_app_store"
+                  >
+                    Open App Store
+                  </IosAppStoreCta>
+                </Button>
+                <Button asChild variant="outline" className="w-full border-[#E5D4B3]">
+                  <Link href="/download">Download options</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </main>
+      </div>
     );
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -413,9 +413,17 @@ export async function proxy(request: NextRequest) {
     pathname,
     request.method
   );
+  const sessionSearchParams = request.nextUrl.searchParams;
   const isEmailSessionFallback =
     pathname === "/sessions/new" &&
-    request.nextUrl.searchParams?.has("token") === true;
+    (
+      sessionSearchParams?.has("token") === true ||
+      sessionSearchParams?.get("entrySource") === "email" ||
+      sessionSearchParams?.get("utm_source") === "email" ||
+      sessionSearchParams?.get("utm_medium") === "email" ||
+      sessionSearchParams?.has("email_type") === true ||
+      sessionSearchParams?.has("message_instance_id") === true
+    );
 
   // Skip middleware for API routes, static files, etc.
   if (routeClassification.type === "skip") {


### PR DESCRIPTION
## Summary

Ships the approved sessions work to prod only:

- Adds a logged-out shared-session fallback for `/sessions/[id]` so shared links show session context and App Store/download CTAs instead of hanging behind auth.
- Updates `/api/og/session` to render richer install-style session share cards with QR handoff.
- Adds an email attribution bridge for `/sessions/new` so mobile email clicks can open `quiver://sessions/new` while preserving attribution, with web sign-in/continue fallback.
- Allows unauthenticated `/sessions/new` email/token fallback requests through proxy.

## Scope

Cherry-picked from main:

- `12a14da30 feat(session): add shared session fallback`
- `36ba51fc4 fix(email): bridge session links to native app`

No DB migrations. No env changes. No map/discover/partner/forecast-accuracy changes included.

## Verification

- PASS `yarn install --frozen-lockfile`
- PASS `yarn test:unit --runTestsByPath __tests__/app/sessions/email-app-bridge.test.tsx __tests__/middleware.test.ts __tests__/app/og-share-card-routes.test.tsx __tests__/components/session-detail-view.gating.test.tsx`
- PASS `npx eslint --max-warnings=0 app/sessions/[id]/page.tsx app/sessions/new/NewSessionClientPage.tsx app/sessions/new/email-app-bridge.tsx components/session-detail-view.tsx app/api/og/session/route.tsx proxy.ts __tests__/app/sessions/email-app-bridge.test.tsx __tests__/middleware.test.ts __tests__/app/og-share-card-routes.test.tsx __tests__/components/session-detail-view.gating.test.tsx`
- PASS `yarn typecheck`
- PASS `VERCEL_ENV=preview yarn build`
- PASS `npx playwright test --list e2e/sessions.spec.ts --project=auth` (4 tests registered)
- PASS `npx playwright test e2e/sessions.spec.ts --project=auth` (3 passed, 1 skipped because the test account had no session detail link)
- PASS `yarn test:unit --bail=0` (1075 suites passed, 14 skipped; 14889 tests passed, 193 skipped, 1 todo)

## Release Notes

Prod-impacting surface: web session detail/share pages, session OG image route, `/sessions/new` email deeplink handling, proxy auth bypass for email session fallback.
