### PR TITLE
fix(android-beta): capture tester email before handoff

### DIFF
--- a/__tests__/app/android-beta-page.test.tsx
+++ b/__tests__/app/android-beta-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import AndroidBetaPage, { metadata } from "@/app/android-beta/page";
 import {
@@ -20,28 +21,148 @@ jest.mock("qrcode.react", () => ({
   ),
 }));
 
+jest.mock("@/lib/utils/visitor-id", () => ({
+  getVisitorId: jest.fn(() => "00000000-0000-4000-8000-000000000001"),
+}));
+
 describe("AndroidBetaPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global as any).fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      ),
+    );
+  });
+
   it("exports Android beta metadata", () => {
     expect(metadata.title).toBe("Quiver Android Beta");
     expect(metadata.description).toMatch(/closed beta/i);
     expect(metadata.alternates?.canonical).toBe("/android-beta");
   });
 
-  it("renders the closed-beta instructions and QR destination", () => {
+  it("captures an email before revealing the closed-beta links", async () => {
+    const user = userEvent.setup();
     render(<AndroidBetaPage />);
 
     expect(
       screen.getByRole("heading", { name: /join the quiver android beta/i }),
     ).toBeInTheDocument();
-    const groupLink = screen.getByRole("link", {
+    expect(
+      screen.queryByRole("link", { name: /join the tester group/i }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByLabelText(/email for android beta access/i),
+      "SURFER@example.com",
+    );
+    await user.click(screen.getByRole("button", { name: /get beta steps/i }));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/android-beta/leads",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "surfer@example.com",
+          sessionId: "00000000-0000-4000-8000-000000000001",
+          source: "android_beta_page",
+          surface: "android_beta",
+          placement: "hero_email_capture",
+        }),
+      }),
+    );
+
+    const groupLink = await screen.findByRole("link", {
       name: /join the tester group/i,
     });
     expect(groupLink).toHaveAttribute("href", ANDROID_BETA_GROUP_URL);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /saved surfer@example\.com/i,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /use a different email/i }),
+    );
+    expect(
+      screen.queryByRole("link", { name: /join the tester group/i }),
+    ).not.toBeInTheDocument();
+    const emailInput = screen.getByLabelText(/email for android beta access/i);
+    expect(emailInput).toHaveValue("SURFER@example.com");
+
+    jest.clearAllMocks();
+    await user.clear(emailInput);
+    await user.type(emailInput, "corrected@example.com");
+    await user.click(screen.getByRole("button", { name: /get beta steps/i }));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/android-beta/leads",
+      expect.objectContaining({
+        body: JSON.stringify({
+          email: "corrected@example.com",
+          sessionId: "00000000-0000-4000-8000-000000000001",
+          source: "android_beta_page",
+          surface: "android_beta",
+          placement: "hero_email_capture",
+        }),
+      }),
+    );
+
+    jest.clearAllMocks();
+    const correctedGroupLink = await screen.findByRole("link", {
+      name: /join the tester group/i,
+    });
+    await user.click(correctedGroupLink);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/events",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          eventType: "cta_click",
+          sessionId: "00000000-0000-4000-8000-000000000001",
+          viewportWidth: window.innerWidth,
+          metadata: {
+            cta_family: "android_waitlist",
+            platform: "android",
+            source: "android_beta_page",
+            surface: "android_beta",
+            placement: "google_group",
+            destination_type: "google_group",
+            destination_status: "outbound",
+          },
+        }),
+        keepalive: true,
+      }),
+    );
 
     const playLink = screen.getByRole("link", {
       name: /opt in on google play/i,
     });
     expect(playLink).toHaveAttribute("href", ANDROID_BETA_PLAY_URL ?? "");
+    jest.clearAllMocks();
+    await user.click(playLink);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/events",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          eventType: "cta_click",
+          sessionId: "00000000-0000-4000-8000-000000000001",
+          viewportWidth: window.innerWidth,
+          metadata: {
+            cta_family: "android_waitlist",
+            platform: "android",
+            source: "android_beta_page",
+            surface: "android_beta",
+            placement: "google_play",
+            destination_type: "google_play",
+            destination_status: "outbound",
+          },
+        }),
+        keepalive: true,
+      }),
+    );
 
     const emailLink = screen.getByRole("link", {
       name: new RegExp(`email ${ANDROID_BETA_CONTACT_EMAIL}`, "i"),

--- a/app/android-beta/android-beta-client.tsx
+++ b/app/android-beta/android-beta-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, type FormEvent } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import {
   ANDROID_BETA_CONTACT_EMAIL,
@@ -9,6 +10,7 @@ import {
 } from "@/lib/constants/app-store";
 import { buildSmartQrHandoffUrl } from "@/lib/constants/app-handoff";
 import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { getVisitorId } from "@/lib/utils/visitor-id";
 
 const ANDROID_BETA_SMART_QR_URL = buildSmartQrHandoffUrl({
   source: "android_beta_page",
@@ -38,7 +40,96 @@ const STEPS = [
   },
 ] as const;
 
+type CaptureStatus = "idle" | "saving" | "saved" | "error";
+
+const BETA_CAPTURE_SOURCE = "android_beta_page";
+const BETA_CAPTURE_SURFACE = "android_beta";
+const BETA_CAPTURE_PLACEMENT = "hero_email_capture";
+
+function trackAndroidBetaOutboundClick(destinationType: string): void {
+  try {
+    fetch("/api/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        eventType: "cta_click",
+        sessionId: getVisitorId(),
+        viewportWidth: window.innerWidth,
+        metadata: {
+          cta_family: "android_waitlist",
+          platform: "android",
+          source: BETA_CAPTURE_SOURCE,
+          surface: BETA_CAPTURE_SURFACE,
+          placement: destinationType,
+          destination_type: destinationType,
+          destination_status: "outbound",
+        },
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // Tracking must never block the handoff.
+  }
+}
+
 export function AndroidBetaClient() {
+  const [email, setEmail] = useState("");
+  const [capturedEmail, setCapturedEmail] = useState<string | null>(null);
+  const [status, setStatus] = useState<CaptureStatus>("idle");
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  async function handleSubmit(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+    if (status === "saving") return;
+
+    setStatus("saving");
+    setInlineError(null);
+    const normalizedEmail = email.trim().toLowerCase();
+
+    try {
+      const response = await fetch("/api/android-beta/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: normalizedEmail,
+          sessionId: getVisitorId(),
+          source: BETA_CAPTURE_SOURCE,
+          surface: BETA_CAPTURE_SURFACE,
+          placement: BETA_CAPTURE_PLACEMENT,
+        }),
+      });
+      const result = (await response.json().catch(() => null)) as {
+        success?: boolean;
+        error?: string;
+      } | null;
+
+      if (!response.ok || !result?.success) {
+        setInlineError(
+          result?.error === "invalid_email"
+            ? "Enter a valid email address."
+            : "Could not save your email. Try again.",
+        );
+        setStatus("error");
+        return;
+      }
+
+      setCapturedEmail(normalizedEmail);
+      setStatus("saved");
+    } catch {
+      setInlineError("Could not save your email. Try again.");
+      setStatus("error");
+    }
+  }
+
+  function handleEditEmail(): void {
+    setStatus("idle");
+    setInlineError(null);
+  }
+
+  const hasCapturedEmail = status === "saved" && Boolean(capturedEmail);
+
   return (
     <ZineSurface
       sectionLabel="Android beta"
@@ -58,9 +149,10 @@ export function AndroidBetaClient() {
             </h1>
             <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[#11100D]/75 sm:text-xl">
               Quiver on Android is in closed testing — and you can jump in right
-              now. Join the tester group, opt in on Google Play, and install
-              Quiver today. Test for 14 days and we&apos;ll comp you a year of
-              Quiver Pro.
+              now. Enter the Google Play email you will use on your phone, then
+              join the tester group, opt in on Google Play, and install Quiver
+              today. Test for 14 days and we&apos;ll comp you a year of Quiver
+              Pro.
             </p>
             <div className="mt-7 flex flex-wrap gap-3 font-mono text-xs uppercase tracking-[0.14em] text-[#11100D]/65">
               <span>Google Group invite</span>
@@ -69,32 +161,108 @@ export function AndroidBetaClient() {
               <span aria-hidden>/</span>
               <span>Same Google account</span>
             </div>
-            <div className="mt-8 flex flex-wrap gap-3">
-              <a
-                href={ANDROID_BETA_GROUP_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#F78E42] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+
+            {hasCapturedEmail ? (
+              <div className="mt-7 rounded-[14px_6px_16px_6px] border-2 border-[#11100D] bg-[#7BDCB5] px-4 py-3 text-[#11100D] shadow-[2px_3px_0_rgba(17,16,13,0.25)]">
+                <p
+                  className="break-words font-mono text-sm font-bold tracking-[0.08em]"
+                  role="status"
+                >
+                  Saved {capturedEmail}. Use the same Google account for the
+                  next two steps.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleEditEmail}
+                  className="mt-2 font-mono text-xs font-bold uppercase tracking-[0.12em] underline decoration-2 underline-offset-4"
+                >
+                  Use a different email
+                </button>
+              </div>
+            ) : (
+              <form
+                onSubmit={handleSubmit}
+                className="mt-8 grid max-w-xl gap-3 rounded-[18px_8px_20px_10px] border-2 border-[#11100D] bg-[#FBF6E8] p-4 shadow-[3px_4px_0_rgba(17,16,13,0.24)] sm:grid-cols-[minmax(0,1fr)_auto]"
+                noValidate
               >
-                1 · Join the tester group
-              </a>
-              {ANDROID_BETA_PLAY_URL ? (
+                <label
+                  htmlFor="android-beta-email"
+                  className="font-mono text-xs font-bold uppercase tracking-[0.16em] text-[#11100D]/65 sm:col-span-2"
+                >
+                  Google Play email for Android beta access
+                </label>
+                <input
+                  id="android-beta-email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(event) => {
+                    setEmail(event.target.value);
+                    if (inlineError) setInlineError(null);
+                    if (status === "error") setStatus("idle");
+                  }}
+                  placeholder="you@email.com"
+                  className="min-h-12 min-w-0 rounded-md border-2 border-[#11100D] bg-white px-3 font-sans text-base font-semibold text-[#11100D] placeholder:text-[#11100D]/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#FBF6E8]"
+                  aria-describedby={
+                    inlineError ? "android-beta-email-error" : undefined
+                  }
+                />
+                <button
+                  type="submit"
+                  disabled={status === "saving"}
+                  className="inline-flex min-h-12 items-center justify-center rounded-full border-2 border-[#11100D] bg-[#F78E42] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70 disabled:hover:translate-y-0"
+                >
+                  {status === "saving" ? "Saving..." : "Get beta steps"}
+                </button>
+                <p className="text-sm leading-relaxed text-[#11100D]/70 sm:col-span-2">
+                  Use the Gmail or Google account that opens Play Store on your
+                  Android phone. That is the account Google checks for closed
+                  testing.
+                </p>
+                {inlineError ? (
+                  <p
+                    id="android-beta-email-error"
+                    className="font-sans text-sm font-semibold text-[#B5452C] sm:col-span-2"
+                    role="alert"
+                  >
+                    {inlineError}
+                  </p>
+                ) : null}
+              </form>
+            )}
+
+            {hasCapturedEmail ? (
+              <div className="mt-8 flex flex-wrap gap-3">
                 <a
-                  href={ANDROID_BETA_PLAY_URL}
+                  href={ANDROID_BETA_GROUP_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#11100D] px-5 py-2 font-semibold text-[#F4EBD8] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+                  onClick={() => trackAndroidBetaOutboundClick("google_group")}
+                  className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#F78E42] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
                 >
-                  2 · Opt in on Google Play
+                  1 · Join the tester group
                 </a>
-              ) : null}
-              <a
-                href={ANDROID_BETA_CONTACT_MAILTO}
-                className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#FBF6E8] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.22)] transition-transform hover:-translate-y-0.5"
-              >
-                Email {ANDROID_BETA_CONTACT_EMAIL}
-              </a>
-            </div>
+                {ANDROID_BETA_PLAY_URL ? (
+                  <a
+                    href={ANDROID_BETA_PLAY_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => trackAndroidBetaOutboundClick("google_play")}
+                    className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#11100D] px-5 py-2 font-semibold text-[#F4EBD8] shadow-[2px_2px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5"
+                  >
+                    2 · Opt in on Google Play
+                  </a>
+                ) : null}
+                <a
+                  href={ANDROID_BETA_CONTACT_MAILTO}
+                  onClick={() => trackAndroidBetaOutboundClick("email_contact")}
+                  className="inline-flex min-h-11 items-center rounded-full border-2 border-[#11100D] bg-[#FBF6E8] px-5 py-2 font-semibold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.22)] transition-transform hover:-translate-y-0.5"
+                >
+                  Email {ANDROID_BETA_CONTACT_EMAIL}
+                </a>
+              </div>
+            ) : null}
           </div>
 
           <aside className="relative">

--- a/e2e/guest-android-beta.spec.ts
+++ b/e2e/guest-android-beta.spec.ts
@@ -4,7 +4,7 @@
  * @project guest
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import {
   ANDROID_BETA_CONTACT_EMAIL,
   ANDROID_BETA_CONTACT_MAILTO,
@@ -19,6 +19,16 @@ import {
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
+async function clickOutboundLinkAndClosePopup(
+  page: Page,
+  name: RegExp,
+): Promise<void> {
+  const popupPromise = page.waitForEvent("popup");
+  await page.getByRole("link", { name }).click();
+  const popup = await popupPromise;
+  await popup.close();
+}
+
 test.describe("Android beta page", () => {
   let errorCapture: ErrorCapture;
 
@@ -32,13 +42,87 @@ test.describe("Android beta page", () => {
     });
   });
 
-  test("renders the group-gated beta instructions and QR", async ({ page }) => {
+  test("captures an email before showing the group-gated beta instructions and QR", async ({
+    page,
+  }) => {
+    const capturedLeadEmails: string[] = [];
+    let groupClickTracked = false;
+    let playClickTracked = false;
+
+    await page.route("**/api/android-beta/leads", async (route) => {
+      const body = route.request().postDataJSON() as {
+        email?: string;
+        source?: string;
+        surface?: string;
+        placement?: string;
+      };
+      expect(body.email).toMatch(/^(surfer|corrected)@example\.com$/);
+      expect(body.source).toBe("android_beta_page");
+      expect(body.surface).toBe("android_beta");
+      expect(body.placement).toBe("hero_email_capture");
+      capturedLeadEmails.push(body.email ?? "");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, emailSent: true }),
+      });
+    });
+    await page.route("**/api/events", async (route) => {
+      const body = route.request().postDataJSON() as {
+        eventType?: string;
+        metadata?: {
+          cta_family?: string;
+          destination_type?: string;
+          source?: string;
+        };
+      };
+      if (
+        body.eventType === "cta_click" &&
+        body.metadata?.cta_family === "android_waitlist" &&
+        body.metadata.source === "android_beta_page"
+      ) {
+        if (body.metadata.destination_type === "google_group") {
+          groupClickTracked = true;
+        }
+        if (body.metadata.destination_type === "google_play") {
+          playClickTracked = true;
+        }
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
     await page.goto("/android-beta");
     await page.waitForLoadState("load");
 
     await expect(
       page.getByRole("heading", { name: /join the quiver android beta/i }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /join the tester group/i }),
+    ).toHaveCount(0);
+    await page
+      .getByLabel(/google play email for android beta access/i)
+      .fill("SURFER@example.com");
+    await page.getByRole("button", { name: /get beta steps/i }).click();
+
+    await expect(page.getByRole("status")).toContainText(
+      /saved surfer@example\.com/i,
+    );
+    await page.getByRole("button", { name: /use a different email/i }).click();
+    await expect(
+      page.getByRole("link", { name: /join the tester group/i }),
+    ).toHaveCount(0);
+    await page
+      .getByLabel(/google play email for android beta access/i)
+      .fill("corrected@example.com");
+    await page.getByRole("button", { name: /get beta steps/i }).click();
+    await expect(page.getByRole("status")).toContainText(
+      /saved corrected@example\.com/i,
+    );
     await expect(
       page.getByRole("link", { name: /join the tester group/i }),
     ).toHaveAttribute("href", ANDROID_BETA_GROUP_URL);
@@ -50,6 +134,8 @@ test.describe("Android beta page", () => {
         name: new RegExp(`email ${ANDROID_BETA_CONTACT_EMAIL}`, "i"),
       }),
     ).toHaveAttribute("href", ANDROID_BETA_CONTACT_MAILTO);
+    await clickOutboundLinkAndClosePopup(page, /join the tester group/i);
+    await clickOutboundLinkAndClosePopup(page, /opt in on google play/i);
 
     const qr = page.getByTestId("android-beta-qr");
     await expect(qr).toBeVisible();
@@ -65,5 +151,11 @@ test.describe("Android beta page", () => {
 
     await expect(page.getByText(/testflight/i)).toHaveCount(0);
     await expect(page.getByText(/join the ios beta/i)).toHaveCount(0);
+    expect(capturedLeadEmails).toEqual([
+      "surfer@example.com",
+      "corrected@example.com",
+    ]);
+    await expect.poll(() => groupClickTracked).toBe(true);
+    await expect.poll(() => playClickTracked).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Ship the Android beta handoff fix as a scoped production PR.

User-visible changes:
- `/android-beta` now captures the tester's Google Play email before exposing Google Group / Play opt-in links.
- Users can correct the captured email before continuing.
- Google Group, Play opt-in, and contact-email outbound clicks are tracked after capture.

## Touched Surface

Production:
- `app/android-beta/android-beta-client.tsx`

Tests:
- `__tests__/app/android-beta-page.test.tsx`
- `e2e/guest-android-beta.spec.ts`

This branch is based on `origin/prod` and contains only this Android beta commit.

## Verification

Run from the scoped prod-based worktree:
- `yarn install --frozen-lockfile` - passed
- `yarn test:unit --runTestsByPath __tests__/app/android-beta-page.test.tsx __tests__/api/android-beta-leads.test.ts __tests__/components/pricing/android-waitlist-cta.test.tsx` - passed, 3 suites / 14 tests
- `npx eslint --max-warnings=0 app/android-beta/android-beta-client.tsx __tests__/app/android-beta-page.test.tsx e2e/guest-android-beta.spec.ts` - passed
- `npx playwright test --list e2e/guest-android-beta.spec.ts --project=guest` - passed, 1 test registered
- `yarn typecheck` - passed
- `git diff --check origin/prod..HEAD -- app/android-beta/android-beta-client.tsx __tests__/app/android-beta-page.test.tsx e2e/guest-android-beta.spec.ts` - passed
- `npx playwright test e2e/guest-android-beta.spec.ts --project=guest` - passed, 1 test
- `VERCEL_ENV=preview yarn build` - passed

Warnings observed:
- Playwright/build local server emitted existing Sentry deprecation warnings and FORCE_COLOR/NO_COLOR warnings.
- Next warned about multiple lockfiles because the validation ran from a local git worktree under `.worktrees/`; build passed.

## Release Notes / Risk

- No DB migrations.
- No new env vars.
- Production behavior change: Android beta visitors must submit an email before seeing outbound tester links.
- Residual product risk: users can still drop after email capture, but they are now recoverable through captured lead data.
