### PR TITLE
feat(recommendations): add feedback loop tracking

### DIFF
--- a/__tests__/actions/session-actions-create-logged.test.ts
+++ b/__tests__/actions/session-actions-create-logged.test.ts
@@ -18,6 +18,7 @@ function createSupabaseMock() {
     from: jest.fn().mockReturnThis() as MockFn,
     select: jest.fn().mockReturnThis() as MockFn,
     insert: jest.fn().mockReturnThis() as MockFn,
+    upsert: jest.fn().mockReturnThis() as MockFn,
     update: jest.fn().mockReturnThis() as MockFn,
     eq: jest.fn().mockReturnThis() as MockFn,
     is: jest.fn().mockReturnThis() as MockFn,
@@ -178,6 +179,88 @@ describe("createLoggedSession personalization recompute", () => {
         process.env.ALLOW_E2E_MUTATIONS_DEV = originalAllowE2E;
       }
     }
+  });
+
+  it("persists recommendation attribution and emits session_created metadata", async () => {
+    mockSupabase.single.mockReset();
+    mockSupabase.single.mockResolvedValue({
+      data: {
+        id: "session-123",
+        beach_id: "beach-123",
+        beach_name: "HB Cliffs",
+        duration_minutes: 90,
+        rating: 2,
+        recommendation_id: "beach:beach-123:2026-07-09T14:00:00.000Z",
+        arrival_time: "2026-07-09 14:00:00+00",
+      },
+      error: null,
+    });
+    mockServiceRoleSupabase.upsert.mockResolvedValue({ error: null });
+
+    const result = await createLoggedSession({
+      beach_id: "beach-123",
+      beach_name: "HB Cliffs",
+      arrival_time: "2026-07-09 14:00:00+00",
+      rating: 2,
+      recommendation_id: "beach:beach-123:2026-07-09T14:00:00.000Z",
+      recommendation_call_accuracy: "wrong",
+      forecast_wave_height_ft: 4,
+      forecast_tide_status: "rising",
+      wave_height_correct: false,
+      tide_status_correct: true,
+      recommendation_context: {
+        recommendationId: "beach:beach-123:2026-07-09T14:00:00.000Z",
+        surface: "home_hero",
+        rank: 1,
+        score: 88,
+        windowStart: "2026-07-09T14:00:00.000Z",
+        windowEnd: "2026-07-09T17:00:00.000Z",
+        mode: "log",
+        timeSlot: "dawn-patrol",
+      },
+    } as any);
+
+    await flushFireAndForget();
+
+    expect(result.success).toBe(true);
+    expect(mockSupabase.from).toHaveBeenCalledWith("sessions");
+    expect(mockSupabase.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recommendation_id: "beach:beach-123:2026-07-09T14:00:00.000Z",
+        recommendation_call_accuracy: "wrong",
+        forecast_wave_height_ft: 4,
+        forecast_tide_status: "rising",
+        wave_height_correct: false,
+        tide_status_correct: true,
+      })
+    );
+    expect(mockSupabase.insert).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        recommendation_context: expect.any(Object),
+      })
+    );
+    expect(mockSupabase.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_type: "session_created",
+        metadata: expect.objectContaining({
+          session_id: "session-123",
+          recommendation_id: "beach:beach-123:2026-07-09T14:00:00.000Z",
+        }),
+      })
+    );
+    expect(mockServiceRoleSupabase.from).toHaveBeenCalledWith(
+      "recommendation_session_contexts"
+    );
+    expect(mockServiceRoleSupabase.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: "user-123",
+        session_id: "session-123",
+        recommendation_id: "beach:beach-123:2026-07-09T14:00:00.000Z",
+        source_surface: "home_hero",
+        ranking_position: 1,
+      }),
+      { onConflict: "user_id,session_id,recommendation_id" }
+    );
   });
 
   it("keeps session creation successful when preference recompute fails", async () => {

--- a/__tests__/api/recommendation-impressions.test.ts
+++ b/__tests__/api/recommendation-impressions.test.ts
@@ -1,0 +1,156 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+
+if (typeof (globalThis as any).Response?.json !== "function") {
+  (globalThis as any).Response.json = (data: any, init?: ResponseInit) =>
+    new Response(JSON.stringify(data), {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        ...(init?.headers || {}),
+      },
+    });
+}
+
+const mockUser = { id: "user-1" };
+const upsertSpy = jest.fn();
+const insertSpy = jest.fn();
+let upsertError: { message: string } | null = null;
+let insertError: { message: string } | null = null;
+let insertedImpressionKeys: Array<{ impression_key: string }> | null = [
+  {
+    impression_key:
+      "user-1:beach:beach-1:2026-07-09T14:00:00.000Z:home_hero:2026-07-09T14:00:00.000Z",
+  },
+];
+
+function buildSupabase() {
+  return {
+    from(table: string) {
+      if (table === "recommendation_impressions") {
+        return {
+          upsert(payload: Record<string, unknown>[], options: Record<string, unknown>) {
+            upsertSpy(payload, options);
+            return {
+              select(columns: string) {
+                expect(columns).toBe("impression_key");
+                return Promise.resolve({
+                  data: insertedImpressionKeys,
+                  error: upsertError,
+                });
+              },
+            };
+          },
+        };
+      }
+
+      if (table === "user_events") {
+        return {
+          insert(payload: Record<string, unknown>[]) {
+            insertSpy(payload);
+            return Promise.resolve({ data: null, error: insertError });
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+jest.mock("@/lib/middleware/api-wrappers", () => ({
+  withAuth: (handler: any) => (request: NextRequest) =>
+    handler(request, { user: mockUser, supabase: buildSupabase() }),
+}));
+
+import { POST } from "@/app/api/recommendation-impressions/route";
+
+const payload = {
+  impressions: [
+    {
+      recommendationId: "beach:beach-1:2026-07-09T14:00:00.000Z",
+      beachId: "22222222-2222-4222-8222-222222222222",
+      rank: 1,
+      score: 88,
+      windowStart: "2026-07-09T14:00:00.000Z",
+      windowEnd: "2026-07-09T17:00:00.000Z",
+      mode: "log",
+      timeSlot: "dawn-patrol",
+      surface: "home_hero",
+    },
+  ],
+};
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/recommendation-impressions", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("/api/recommendation-impressions", () => {
+  beforeEach(() => {
+    upsertSpy.mockClear();
+    insertSpy.mockClear();
+    upsertError = null;
+    insertError = null;
+    insertedImpressionKeys = [
+      {
+        impression_key:
+          "user-1:beach:beach-1:2026-07-09T14:00:00.000Z:home_hero:2026-07-09T14:00:00.000Z",
+      },
+    ];
+  });
+
+  it("upserts impressions and emits matching user_events", async () => {
+    const response = await POST(request(payload));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(upsertSpy).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          user_id: "user-1",
+          recommendation_id: "beach:beach-1:2026-07-09T14:00:00.000Z",
+          beach_id: "22222222-2222-4222-8222-222222222222",
+          surface: "home_hero",
+          impression_key:
+            "user-1:beach:beach-1:2026-07-09T14:00:00.000Z:home_hero:2026-07-09T14:00:00.000Z",
+        }),
+      ],
+      { onConflict: "impression_key", ignoreDuplicates: true }
+    );
+    expect(insertSpy).toHaveBeenCalledWith([
+      expect.objectContaining({
+        user_id: "user-1",
+        event_type: "recommendation_impression",
+        beach_id: "22222222-2222-4222-8222-222222222222",
+      }),
+    ]);
+  });
+
+  it("rejects malformed payloads", async () => {
+    const response = await POST(
+      request({ impressions: [{ ...payload.impressions[0], rank: 0 }] })
+    );
+
+    expect(response.status).toBe(400);
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not emit duplicate user_events when the impression already exists", async () => {
+    insertedImpressionKeys = [];
+
+    const response = await POST(request(payload));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/session-forms/ConditionsSection.recommendation.test.tsx
+++ b/__tests__/components/session-forms/ConditionsSection.recommendation.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ConditionsSection } from "@/components/session-forms/ConditionsSection";
+import type { SessionFormState } from "@/hooks/use-session-form";
+
+jest.mock("@/hooks/use-session-forecast", () => ({
+  useSessionForecast: jest.fn(() => ({
+    forecastData: {
+      wave_height: 4,
+      wind_speed: 8,
+      wind_direction: "NW",
+      water_temp: 64,
+      tide_height: 2.4,
+      tide_status: "rising",
+      isNightSession: false,
+    },
+    loading: false,
+    error: null,
+  })),
+}));
+
+jest.mock("@/hooks/use-session-tide-snapshot", () => ({
+  useSessionTideSnapshot: jest.fn(() => ({
+    tideSnapshot: {
+      tideStatus: "rising",
+    },
+  })),
+}));
+
+jest.mock("@/lib/services/session-tide-snapshot", () => ({
+  formatSessionTideSnapshot: jest.fn(() => "Rising"),
+}));
+
+const baseState: SessionFormState = {
+  selectedBeach: "HB Cliffs",
+  selectedBeachId: "beach-1",
+  selectedDate: "2026-07-09",
+  selectedTime: "07:00",
+  selectedBoard: "",
+  duration: "60m",
+  waveQuality: "",
+  waterTemp: "",
+  crowdLevel: "",
+  parkingEase: "",
+  overallRating: "",
+  notes: "",
+  photos: [],
+  waveCharacteristics: [],
+  waveTypes: [],
+  isPublic: true,
+  isMuted: false,
+  selectedGoals: [],
+  skillRatings: {},
+  sessionDecomposition: null,
+};
+
+describe("ConditionsSection recommendation feedback", () => {
+  it("hides tide height and marks wave height edited for suggested logs", () => {
+    const updateField = jest.fn();
+
+    render(
+      <ConditionsSection
+        formState={{
+          ...baseState,
+          recommendationId: "beach:beach-1:2026-07-09T14:00:00.000Z",
+          waveHeight: 4,
+          tideStatus: "rising",
+        }}
+        updateField={updateField}
+      />
+    );
+
+    expect(screen.queryByLabelText("Tide Height (ft)")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Wave Height (ft)"), {
+      target: { value: "3" },
+    });
+
+    expect(updateField).toHaveBeenCalledWith("waveHeight", 3);
+    expect(updateField).toHaveBeenCalledWith("waveHeightEdited", true);
+  });
+});

--- a/__tests__/hooks/use-recommendation-impression.test.tsx
+++ b/__tests__/hooks/use-recommendation-impression.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useAuth } from "@/context/auth-context";
+import { useRecommendationImpression } from "@/hooks/use-recommendation-impression";
+import type { RecommendationImpressionInput } from "@/lib/recommendations/impressions";
+
+jest.mock("@/context/auth-context", () => ({
+  useAuth: jest.fn(),
+}));
+
+type ObserverCallback = IntersectionObserverCallback;
+
+let observerCallbacks: ObserverCallback[] = [];
+const observeSpy = jest.fn();
+const disconnectSpy = jest.fn();
+
+class MockIntersectionObserver {
+  constructor(callback: ObserverCallback) {
+    observerCallbacks.push(callback);
+  }
+
+  observe = observeSpy;
+  disconnect = disconnectSpy;
+  unobserve = jest.fn();
+  takeRecords = jest.fn(() => []);
+  root = null;
+  rootMargin = "";
+  thresholds = [0, 0.5, 1];
+}
+
+function makeImpression(
+  id: string,
+  beachId: string,
+  surface: RecommendationImpressionInput["surface"] = "home_hero"
+): RecommendationImpressionInput {
+  return {
+    recommendationId: `beach:${id}:2026-07-09T14:00:00.000Z`,
+    beachId,
+    rank: 1,
+    score: 88,
+    windowStart: "2026-07-09T14:00:00.000Z",
+    windowEnd: "2026-07-09T17:00:00.000Z",
+    mode: "log",
+    timeSlot: "dawn-patrol",
+    surface,
+  };
+}
+
+const impression: RecommendationImpressionInput = makeImpression(
+  "beach-1",
+  "22222222-2222-4222-8222-222222222222"
+);
+const batchImpressionA: RecommendationImpressionInput = makeImpression(
+  "beach-batch-a",
+  "33333333-3333-4333-8333-333333333333",
+  "home_top_spots"
+);
+const batchImpressionB: RecommendationImpressionInput = makeImpression(
+  "beach-batch-b",
+  "44444444-4444-4444-8444-444444444444",
+  "home_top_spots"
+);
+
+function ImpressionProbe({
+  value = impression,
+}: {
+  value?: RecommendationImpressionInput;
+}) {
+  const ref = useRecommendationImpression<HTMLDivElement>(value);
+  return <div ref={ref} data-testid="probe" />;
+}
+
+function visible(callback: ObserverCallback | undefined, ratio: number): void {
+  callback?.(
+    [{ isIntersecting: ratio > 0, intersectionRatio: ratio } as IntersectionObserverEntry],
+    {} as IntersectionObserver
+  );
+}
+
+function latestObserver(): ObserverCallback | undefined {
+  return observerCallbacks[observerCallbacks.length - 1];
+}
+
+describe("useRecommendationImpression", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    observeSpy.mockClear();
+    disconnectSpy.mockClear();
+    observerCallbacks = [];
+    (useAuth as jest.Mock).mockReturnValue({ user: { id: "user-1" } });
+    (global as any).IntersectionObserver = MockIntersectionObserver;
+    global.fetch = jest.fn(async () => new Response(JSON.stringify({ success: true }))) as any;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("logs after 50% visibility for 500ms and de-dupes remounts", async () => {
+    const { unmount } = render(<ImpressionProbe />);
+
+    expect(observeSpy).toHaveBeenCalled();
+    act(() => {
+      visible(latestObserver(), 0.49);
+      jest.advanceTimersByTime(500);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    act(() => {
+      visible(latestObserver(), 0.5);
+      jest.advanceTimersByTime(500);
+      jest.runOnlyPendingTimers();
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    unmount();
+    render(<ImpressionProbe />);
+    act(() => {
+      visible(latestObserver(), 1);
+      jest.advanceTimersByTime(500);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("batches visible impressions into one request", () => {
+    render(
+      <>
+        <ImpressionProbe value={batchImpressionA} />
+        <ImpressionProbe value={batchImpressionB} />
+      </>
+    );
+
+    act(() => {
+      visible(observerCallbacks[0], 0.5);
+      visible(observerCallbacks[1], 0.5);
+      jest.advanceTimersByTime(500);
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body)).toEqual({
+      impressions: [batchImpressionA, batchImpressionB],
+    });
+  });
+
+  it("does not log impressions without an authenticated user", () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: null });
+
+    render(<ImpressionProbe />);
+
+    expect(observeSpy).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/use-session-conditions-prefill.test.tsx
+++ b/__tests__/hooks/use-session-conditions-prefill.test.tsx
@@ -18,6 +18,14 @@ jest.mock("@/hooks/use-session-forecast", () => ({
   })),
 }));
 
+jest.mock("@/hooks/use-session-tide-snapshot", () => ({
+  useSessionTideSnapshot: jest.fn(() => ({
+    tideSnapshot: {
+      tideStatus: "rising",
+    },
+  })),
+}));
+
 function makeFormState(overrides: Partial<SessionFormState> = {}): SessionFormState {
   return {
     selectedBeach: "Ocean Beach",
@@ -65,5 +73,27 @@ describe("useSessionConditionsPrefill", () => {
 
     expect(updateField).not.toHaveBeenCalledWith("tideHeight", expect.anything());
     expect(updateField).not.toHaveBeenCalledWith("tideStatus", expect.anything());
+  });
+
+  it("stores forecast prefill values for recommendation-attributed logs", async () => {
+    const updateField = jest.fn();
+
+    renderHook(() =>
+      useSessionConditionsPrefill(
+        "log",
+        makeFormState({
+          recommendationId: "beach:beach-1:2026-06-10T14:00:00.000Z",
+        }),
+        updateField
+      )
+    );
+
+    await waitFor(() => {
+      expect(updateField).toHaveBeenCalledWith("forecastWaveHeightFt", 3.5);
+      expect(updateField).toHaveBeenCalledWith("forecastTideStatus", "rising");
+      expect(updateField).toHaveBeenCalledWith("tideStatus", "rising");
+    });
+
+    expect(updateField).not.toHaveBeenCalledWith("tideHeight", expect.anything());
   });
 });

--- a/__tests__/lib/recommendations/attribution.test.ts
+++ b/__tests__/lib/recommendations/attribution.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildRecommendationImpressionInput,
+  buildRecommendationLogUrl,
+} from "@/lib/recommendations/attribution";
+import type { SurfDiscoveryRecommendation } from "@/types/personalization";
+
+const makeRecommendation = (): SurfDiscoveryRecommendation =>
+  ({
+    recommendationId: "beach:123:2026-07-08T15:00:00.000Z",
+    kind: "beach",
+    beach: {
+      id: "8f7b6110-0b6f-4ba0-8ec7-59f45ce1b7ac",
+      name: "Ocean Beach",
+    },
+    forecast: {
+      forecast_at: "2026-07-08T15:00:00.000Z",
+    },
+    window: {
+      start: new Date("2026-07-08T15:00:00.000Z"),
+      end: new Date("2026-07-08T17:00:00.000Z"),
+    },
+    score: 82,
+  }) as SurfDiscoveryRecommendation;
+
+describe("recommendation attribution", () => {
+  it("keeps known time slots on impression inputs", () => {
+    const input = buildRecommendationImpressionInput({
+      recommendation: makeRecommendation(),
+      rank: 1,
+      surface: "home_hero",
+      timeSlot: "morning",
+    });
+
+    expect(input.timeSlot).toBe("morning");
+  });
+
+  it("omits unknown time slots from impression inputs", () => {
+    const input = buildRecommendationImpressionInput({
+      recommendation: makeRecommendation(),
+      rank: 1,
+      surface: "home_hero",
+      timeSlot: "after-dark",
+    });
+
+    expect(input.timeSlot).toBeUndefined();
+  });
+
+  it("normalizes null time slots on impression inputs", () => {
+    const input = buildRecommendationImpressionInput({
+      recommendation: makeRecommendation(),
+      rank: 1,
+      surface: "home_hero",
+      timeSlot: null,
+    });
+
+    expect(input.timeSlot).toBeUndefined();
+  });
+
+  it("preserves provided time slots on log URLs", () => {
+    const url = buildRecommendationLogUrl({
+      recommendation: makeRecommendation(),
+      rank: 1,
+      surface: "home_hero",
+      timeSlot: "after-dark",
+    });
+
+    expect(url).toContain("recommendation_time_slot=after-dark");
+  });
+});

--- a/__tests__/lib/utils/session-data-builder.test.ts
+++ b/__tests__/lib/utils/session-data-builder.test.ts
@@ -182,6 +182,83 @@ describe("session-data-builder", () => {
       expect(payload.rip_current_observed).toBe("strong");
     });
 
+    it("maps recommendation attribution and call feedback fields", () => {
+      const payload = buildSessionPayload(
+        {
+          selectedBeach: "HB Cliffs",
+          selectedBeachId: "beach-hb",
+          recommendationId: "beach:beach-hb:2026-07-09T14:00:00.000Z",
+          recommendationCallAccuracy: "wrong",
+          recommendationSurface: "home_hero",
+          recommendationRank: 1,
+          recommendationScore: 91,
+          recommendationWindowStart: "2026-07-09T14:00:00.000Z",
+          recommendationWindowEnd: "2026-07-09T17:00:00.000Z",
+          recommendationTimeSlot: "dawn-patrol",
+          forecastWaveHeightFt: 4,
+          forecastTideStatus: "rising",
+          waveHeight: 3,
+          tideStatus: "falling",
+          waveHeightEdited: true,
+          tideStatusEdited: true,
+        },
+        userId
+      );
+
+      expect(payload.recommendation_id).toBe(
+        "beach:beach-hb:2026-07-09T14:00:00.000Z"
+      );
+      expect(payload.recommendation_call_accuracy).toBe("wrong");
+      expect(payload.forecast_wave_height_ft).toBe(4);
+      expect(payload.forecast_tide_status).toBe("rising");
+      expect(payload.wave_height_correct).toBe(false);
+      expect(payload.tide_status_correct).toBe(false);
+      expect(payload.recommendation_context).toEqual({
+        recommendationId: "beach:beach-hb:2026-07-09T14:00:00.000Z",
+        surface: "home_hero",
+        rank: 1,
+        score: 91,
+        windowStart: "2026-07-09T14:00:00.000Z",
+        windowEnd: "2026-07-09T17:00:00.000Z",
+        mode: "log",
+        timeSlot: "dawn-patrol",
+      });
+    });
+
+    it("marks unchanged recommendation prefill fields as correct", () => {
+      const payload = buildSessionPayload(
+        {
+          selectedBeach: "HB Cliffs",
+          recommendationId: "beach:hb:2026-07-09T14:00:00.000Z",
+          forecastWaveHeightFt: 4,
+          forecastTideStatus: "rising",
+          waveHeight: 4,
+          tideStatus: "rising",
+        },
+        userId
+      );
+
+      expect(payload.wave_height_correct).toBe(true);
+      expect(payload.tide_status_correct).toBe(true);
+    });
+
+    it("omits tide height for recommendation-attributed logs", () => {
+      const payload = buildSessionPayload(
+        {
+          selectedBeach: "HB Cliffs",
+          recommendationId: "beach:hb:2026-07-09T14:00:00.000Z",
+          tideHeight: 2.6,
+          tideStatus: "rising",
+          forecastTideStatus: "rising",
+        },
+        userId
+      );
+
+      expect(payload.tide_height_ft).toBeUndefined();
+      expect(payload.tide_status).toBe("rising");
+      expect(payload.tide_status_correct).toBe(true);
+    });
+
     it("normalizes omitted observed rip current value to null", () => {
       const payload = buildSessionPayload({ selectedBeach: "Trestles" }, userId);
 

--- a/__tests__/lib/utils/session-utils.test.ts
+++ b/__tests__/lib/utils/session-utils.test.ts
@@ -124,4 +124,46 @@ describe("session-utils", () => {
     expect((result as any).rip_current_observed).toBe("light");
     expect(result.goals).toBeUndefined();
   });
+
+  test("transformSessionFormStateToDbSchema omits tide height for recommendation logs", () => {
+    const result = transformSessionFormStateToDbSchema({
+      selectedBeach: "HB Cliffs",
+      selectedBeachId: "beach-1",
+      selectedDate: "2026-07-09",
+      selectedTime: "07:00",
+      selectedBoard: "",
+      duration: "60m",
+      waveQuality: "",
+      waterTemp: "",
+      crowdLevel: "",
+      parkingEase: "",
+      overallRating: "",
+      notes: "",
+      photos: [],
+      waveCharacteristics: [],
+      waveTypes: [],
+      waveHeight: 4,
+      windSpeed: undefined,
+      windDirection: undefined,
+      forecastAccuracy: undefined,
+      recommendationId: "beach:beach-1:2026-07-09T14:00:00.000Z",
+      forecastWaveHeightFt: 4,
+      forecastTideStatus: "rising",
+      waveHeightEdited: false,
+      tideStatusEdited: false,
+      tideHeight: 2.4,
+      tideStatus: "rising",
+      ripCurrentObserved: undefined,
+      isPublic: true,
+      isMuted: false,
+      selectedGoals: [],
+      skillRatings: {},
+      sessionDecomposition: null,
+    } as any);
+
+    expect((result as any).tide_height_ft).toBeUndefined();
+    expect((result as any).tide_status).toBe("rising");
+    expect((result as any).wave_height_correct).toBe(true);
+    expect((result as any).tide_status_correct).toBe(true);
+  });
 });

--- a/__tests__/lib/utils/session-wizard-params.test.ts
+++ b/__tests__/lib/utils/session-wizard-params.test.ts
@@ -291,6 +291,38 @@ describe('buildSessionWizardUrl', () => {
     expect(data.forecastFeedbackValue).toBe('too_high');
   });
 
+  it('should round-trip recommendation attribution params', () => {
+    const url = buildSessionWizardUrl({
+      ...validParams,
+      recommendationId: 'beach:123e4567-e89b-12d3-a456-426614174000:2026-07-09T14:00:00.000Z',
+      recommendationSurface: 'home_hero',
+      recommendationRank: 1,
+      recommendationScore: 87.5,
+      recommendationTimeSlot: 'dawn-patrol',
+      recommendationWindowStart: new Date('2026-07-09T14:00:00.000Z'),
+      recommendationWindowEnd: new Date('2026-07-09T17:00:00.000Z'),
+    });
+
+    const result = parseSessionWizardParams(
+      new URLSearchParams(url.split('?')[1]),
+    );
+    const data = expectSuccessfulParse(result);
+
+    expect(data.recommendationId).toBe(
+      'beach:123e4567-e89b-12d3-a456-426614174000:2026-07-09T14:00:00.000Z',
+    );
+    expect(data.recommendationSurface).toBe('home_hero');
+    expect(data.recommendationRank).toBe(1);
+    expect(data.recommendationScore).toBe(87.5);
+    expect(data.recommendationTimeSlot).toBe('dawn-patrol');
+    expect(data.recommendationWindowStart?.toISOString()).toBe(
+      '2026-07-09T14:00:00.000Z',
+    );
+    expect(data.recommendationWindowEnd?.toISOString()).toBe(
+      '2026-07-09T17:00:00.000Z',
+    );
+  });
+
   it('should throw when asked to serialize an invalid start time', () => {
     expect(() =>
       buildSessionWizardUrl({
@@ -405,6 +437,29 @@ describe('extractFormState', () => {
         forecastFeedbackValue: 'too_high',
       }).forecastAccuracy,
     ).toBe('inaccurate');
+  });
+
+  it('should carry recommendation attribution into form state', () => {
+    const formState = extractFormState({
+      ...validParams,
+      recommendationId: 'beach:abc:2026-07-09T14:00:00.000Z',
+      recommendationSurface: 'discover_list',
+      recommendationRank: 2,
+      recommendationScore: 76,
+      recommendationTimeSlot: 'afternoon',
+      recommendationWindowStart: new Date('2026-07-09T14:00:00.000Z'),
+      recommendationWindowEnd: new Date('2026-07-09T17:00:00.000Z'),
+    });
+
+    expect(formState).toMatchObject({
+      recommendationId: 'beach:abc:2026-07-09T14:00:00.000Z',
+      recommendationSurface: 'discover_list',
+      recommendationRank: 2,
+      recommendationScore: 76,
+      recommendationTimeSlot: 'afternoon',
+      recommendationWindowStart: '2026-07-09T14:00:00.000Z',
+      recommendationWindowEnd: '2026-07-09T17:00:00.000Z',
+    });
   });
 });
 

--- a/__tests__/migrations/recommendation-feedback-loop.test.ts
+++ b/__tests__/migrations/recommendation-feedback-loop.test.ts
@@ -1,0 +1,45 @@
+import fs from "fs";
+import path from "path";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260709090000_recommendation_feedback_loop.sql"
+);
+
+describe("recommendation feedback loop migration", () => {
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  it("creates recommendation_impressions with RLS, keys, and policies", () => {
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS public.recommendation_impressions");
+    expect(sql).toContain("recommendation_id text NOT NULL");
+    expect(sql).toContain("beach_id uuid NOT NULL");
+    expect(sql).toContain("impression_key text NOT NULL");
+    expect(sql).toContain("recommendation_impressions_key_idx");
+    expect(sql).toContain("ALTER TABLE public.recommendation_impressions ENABLE ROW LEVEL SECURITY");
+    expect(sql).toContain("recommendation_impressions_insert_own");
+    expect(sql).toContain("recommendation_impressions_select_own");
+    expect(sql).toContain("recommendation_impressions_service_role_all");
+  });
+
+  it("adds recommendation attribution and feedback columns to sessions", () => {
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS recommendation_id text");
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS recommendation_call_accuracy text");
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS forecast_wave_height_ft numeric");
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS forecast_tide_status text");
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS wave_height_correct boolean");
+    expect(sql).toContain("ADD COLUMN IF NOT EXISTS tide_status_correct boolean");
+    expect(sql).toContain("sessions_recommendation_call_accuracy_check");
+    expect(sql).toContain("'right', 'partly', 'wrong', 'not_sure'");
+    expect(sql).toContain("recommendation_session_contexts_source_surface_check");
+    expect(sql).toContain("'discover_list'");
+    expect(sql).toContain("'home_top_spots'");
+  });
+
+  it("widens event taxonomy and creates forward-looking reporting view", () => {
+    expect(sql).toContain("recommendation_impression");
+    expect(sql).toContain("CREATE OR REPLACE VIEW public.recommendation_feedback_summary");
+    expect(sql).toContain("WITH (security_invoker = true)");
+    expect(sql).toContain("public.recommendation_impressions ri");
+    expect(sql).toContain("s.recommendation_id = ri.recommendation_id");
+  });
+});

--- a/__tests__/setup/typed-mocks.ts
+++ b/__tests__/setup/typed-mocks.ts
@@ -301,6 +301,16 @@ export function createMockProfile(overrides: Partial<Profile> = {}): Profile {
  * Creates a mock Session with required fields
  */
 export function createMockSession(overrides: Partial<Session> = {}): Session {
+  const {
+    forecast_tide_status = null,
+    forecast_wave_height_ft = null,
+    recommendation_call_accuracy = null,
+    recommendation_id = null,
+    tide_status_correct = null,
+    wave_height_correct = null,
+    ...restOverrides
+  } = overrides;
+
   return {
     id: `session-${Date.now()}`,
     user_id: "test-user-123",
@@ -328,6 +338,8 @@ export function createMockSession(overrides: Partial<Session> = {}): Session {
     wind_speed_mph: null,
     parking_ease: null,
     forecast_accuracy: null,
+    forecast_tide_status,
+    forecast_wave_height_ft,
     goals: [],
     invitee_ids: [],
     image_url: null,
@@ -342,10 +354,14 @@ export function createMockSession(overrides: Partial<Session> = {}): Session {
     wave_characteristics: null,
     source: null,
     custom_spot_id: null,
+    recommendation_call_accuracy,
+    recommendation_id,
     session_decomposition: null,
     session_board_fit: null,
     session_skill_fit: null,
-    ...overrides,
+    tide_status_correct,
+    wave_height_correct,
+    ...restOverrides,
   };
 }
 

--- a/actions/session-actions.ts
+++ b/actions/session-actions.ts
@@ -42,6 +42,16 @@ async function trackXPOptional(action: string, entityId?: string, entityType?: s
 type SessionInput = Partial<SessionInsert>;
 type SessionInputWithFeedbackContext = SessionInput & {
   forecast_feedback_context_id?: string;
+  recommendation_context?: {
+    recommendationId: string;
+    surface?: string;
+    rank?: number;
+    score?: number;
+    windowStart?: string;
+    windowEnd?: string;
+    mode?: string;
+    timeSlot?: string;
+  };
 };
 type BoardInput = Omit<Board, "id" | "created_at" | "updated_at" | "user_id">;
 
@@ -322,6 +332,7 @@ export async function createLoggedSession(data: SessionFormState | SessionInputW
 
     const {
       forecast_feedback_context_id,
+      recommendation_context,
       ...rest
     } = data as SessionInputWithFeedbackContext;
     let forecastFeedbackContextId = forecast_feedback_context_id;
@@ -460,6 +471,58 @@ export async function createLoggedSession(data: SessionFormState | SessionInputW
       }
     }
 
+    if (recommendation_context?.recommendationId) {
+      try {
+        const contextScore = Number.isFinite(recommendation_context.score)
+          ? Number(recommendation_context.score)
+          : 0;
+        const windowStart =
+          recommendation_context.windowStart ?? session.arrival_time;
+        const windowEnd =
+          recommendation_context.windowEnd ??
+          recommendation_context.windowStart ??
+          session.arrival_time;
+
+        const { error: recommendationContextError } =
+          await createSupabaseServiceRoleClient()
+            .from("recommendation_session_contexts")
+            .upsert(
+              {
+                user_id: user.id,
+                session_id: session.id,
+                recommendation_id: recommendation_context.recommendationId,
+                source_surface:
+                  recommendation_context.surface ?? "discover_list",
+                beach_id: session.beach_id,
+                beach_name: session.beach_name ?? cleaned.beach_name ?? null,
+                window_start: windowStart,
+                window_end: windowEnd,
+                forecast_at: windowStart,
+                condition_score: contextScore,
+                personal_match_score: Math.min(contextScore / 10, 10),
+                overall_score: contextScore,
+                reason_type: "session_log",
+                recommendation_state: "ready_today",
+                ranking_position: recommendation_context.rank ?? 1,
+                fallback_horizon_hours: null,
+              },
+              { onConflict: "user_id,session_id,recommendation_id" }
+            );
+
+        if (recommendationContextError) {
+          console.warn(
+            "[createLoggedSession] recommendation context link failed:",
+            recommendationContextError,
+          );
+        }
+      } catch (error) {
+        console.warn(
+          "[createLoggedSession] recommendation context link failed:",
+          error,
+        );
+      }
+    }
+
     // Fire-and-forget: emit to user_events for retention analytics.
     void (async () => {
       const { error: evtErr } = await writeClient.from("user_events").insert({
@@ -471,6 +534,10 @@ export async function createLoggedSession(data: SessionFormState | SessionInputW
           session_id: session.id,
           duration_minutes: session.duration_minutes ?? null,
           rating: session.rating ?? null,
+          recommendation_id:
+            (session as any).recommendation_id ??
+            (cleaned as any).recommendation_id ??
+            null,
         },
       });
       if (evtErr) console.warn("[createLoggedSession] user_events insert failed:", evtErr);

--- a/app/api/recommendation-impressions/route.ts
+++ b/app/api/recommendation-impressions/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/middleware/api-wrappers";
+import {
+  RecommendationImpressionsRequestSchema,
+  toRecommendationImpressionEventRow,
+  toRecommendationImpressionRow,
+} from "@/lib/recommendations/impressions";
+
+export const dynamic = "force-dynamic";
+
+export const POST = withAuth(async (
+  request: NextRequest,
+  { user, supabase }
+) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const parsed = RecommendationImpressionsRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Invalid recommendation impression payload" },
+      { status: 400 }
+    );
+  }
+
+  const rows = parsed.data.impressions.map((impression) =>
+    toRecommendationImpressionRow(user.id, impression)
+  );
+  const untypedSupabase = supabase as unknown as {
+    from: (table: string) => {
+      upsert?: (
+        payload: Record<string, unknown>[],
+        options: Record<string, unknown>
+      ) => {
+        select: (
+          columns: string
+        ) => Promise<{
+          data: Array<{ impression_key: string }> | null;
+          error: { message: string } | null;
+        }>;
+      };
+      insert?: (
+        payload: Record<string, unknown>[]
+      ) => Promise<{ error: { message: string } | null }>;
+    };
+  };
+
+  const impressionResult = await untypedSupabase
+    .from("recommendation_impressions")
+    .upsert!(rows, {
+      onConflict: "impression_key",
+      ignoreDuplicates: true,
+    })
+    .select("impression_key");
+
+  if (impressionResult.error) {
+    return NextResponse.json(
+      { success: false, error: impressionResult.error.message },
+      { status: 500 }
+    );
+  }
+
+  const insertedKeys = new Set(
+    (impressionResult.data ?? []).map((row) => row.impression_key)
+  );
+  const eventRows = parsed.data.impressions
+    .map((impression) => toRecommendationImpressionEventRow(user.id, impression))
+    .filter((row) => {
+      const impressionKey = (row.metadata as { impression_key?: string })
+        .impression_key;
+      return impressionKey ? insertedKeys.has(impressionKey) : false;
+    });
+
+  if (eventRows.length === 0) {
+    return NextResponse.json({ success: true });
+  }
+
+  const eventResult = await untypedSupabase
+    .from("user_events")
+    .insert!(eventRows);
+
+  if (eventResult.error) {
+    return NextResponse.json(
+      { success: false, error: eventResult.error.message },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+});

--- a/components/discover/beach-discovery-card.tsx
+++ b/components/discover/beach-discovery-card.tsx
@@ -26,12 +26,14 @@ import { track } from "@/lib/analytics";
 import { useTrackEvent } from "@/hooks/use-track-event";
 import { FavoriteButton } from "@/components/favorite-button";
 import { useAuth } from "@/context/auth-context";
+import { buildRecommendationImpressionInput } from "@/lib/recommendations/attribution";
+import { useRecommendationImpression } from "@/hooks/use-recommendation-impression";
 
 
 interface BeachDiscoveryCardProps {
   recommendation: SurfDiscoveryRecommendation;
   rank: number;
-  onLogSession: (beachId: string) => void;
+  onLogSession: (recommendation: SurfDiscoveryRecommendation, rank: number) => void;
   /** Optional personalized board-wave matching feedback from matchBoardToWaves() */
   boardReasoning?: string;
 }
@@ -63,6 +65,13 @@ export function BeachDiscoveryCard({
 
   const { user } = useAuth();
   const { track: trackEvent } = useTrackEvent();
+  const impressionRef = useRecommendationImpression<HTMLDivElement>(
+    buildRecommendationImpressionInput({
+      recommendation,
+      rank,
+      surface: "discover_list",
+    })
+  );
 
   // Fetch personalized score for this beach
   const personalization = useBeachPersonalization({
@@ -113,6 +122,7 @@ export function BeachDiscoveryCard({
 
   return (
     <Card
+      ref={impressionRef}
       className={cn(
         "w-full hover:shadow-lg transition-shadow",
         rank === 1 && "border-2 border-blue-500"
@@ -263,7 +273,7 @@ export function BeachDiscoveryCard({
                   match_quality: matchQuality,
                 },
               });
-              onLogSession(beach.id);
+              onLogSession(recommendation, rank);
             }}
           >
             Log Session

--- a/components/discover/beach-discovery-list.tsx
+++ b/components/discover/beach-discovery-list.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2, Search, AlertCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { SurfDiscoveryRecommendation, SurfDiscoveryResponse } from "@/types/personalization";
+import { buildRecommendationLogUrl } from "@/lib/recommendations/attribution";
 
 interface BeachDiscoveryListProps {
   /** Maximum results to fetch (only used when discoveryData is not provided) */
@@ -66,24 +67,17 @@ export function BeachDiscoveryList({
   const error = discoveryData !== undefined ? externalError : fetchError;
   const hasRecommendations = discovery ? discovery.recommendations.length > 0 : fetchHasRecommendations;
 
-  const handleLogSession = (beachId: string) => {
-    // Find the recommendation to get complete data including time window
-    const recommendation = discovery?.recommendations.find(r => r.beach.id === beachId);
-
-    if (!recommendation) {
-      console.warn(`Beach ${beachId} not found in recommendations`);
-      // Fallback to basic route
-      router.push(`/sessions/new?beach=${beachId}`);
-      return;
-    }
-
-    // Build URL with prefill parameters
-    const params = new URLSearchParams({
-      beach: recommendation.beach.id,
-      beachName: recommendation.beach.name,
-    });
-
-    router.push(`/sessions/new?${params.toString()}`);
+  const handleLogSession = (
+    recommendation: SurfDiscoveryRecommendation,
+    rank: number
+  ) => {
+    router.push(
+      buildRecommendationLogUrl({
+        recommendation,
+        rank,
+        surface: "discover_list",
+      })
+    );
   };
 
   // Loading state

--- a/components/home-screen/compact-spot-card.tsx
+++ b/components/home-screen/compact-spot-card.tsx
@@ -11,6 +11,12 @@ import { formatDistanceDisplay } from "@/lib/utils/distance-utils";
 import { formatTimeWindowCompact, formatTimeCasual } from "@/lib/utils/date-time";
 import type { SurfDiscoveryRecommendation } from "@/types/personalization";
 import { track } from "@/lib/analytics";
+import type {
+  RecommendationImpressionInput,
+  RecommendationImpressionSurface,
+} from "@/lib/recommendations/impressions";
+import { buildRecommendationImpressionInput } from "@/lib/recommendations/attribution";
+import { useRecommendationImpression } from "@/hooks/use-recommendation-impression";
 
 /**
  * Short variants for condition badge labels on mobile
@@ -39,6 +45,9 @@ export interface CompactSpotCardProps {
   onTap: (beachId: string) => void;
   /** Whether this is a featured/first card */
   featured?: boolean;
+  impressionRank?: number;
+  impressionSurface?: RecommendationImpressionSurface;
+  timeSlot?: RecommendationImpressionInput["timeSlot"];
 }
 
 /**
@@ -70,6 +79,9 @@ export const CompactSpotCard = React.memo(function CompactSpotCard({
   recommendation,
   onTap,
   featured = false,
+  impressionRank,
+  impressionSurface,
+  timeSlot,
 }: CompactSpotCardProps) {
   const { beach, score, window, distanceMiles, conditionBadges } = recommendation;
   const formattedScore = formatDiscoveryScore(score);
@@ -84,6 +96,16 @@ export const CompactSpotCard = React.memo(function CompactSpotCard({
   const windowMinutes = (window.end.getTime() - window.start.getTime()) / (1000 * 60);
   const peakTimeCasual = window.peakTime ? formatTimeCasual(window.peakTime, window.timezone) : null;
   const showBestAtTag = windowMinutes > 180 && peakTimeCasual;
+  const impressionRef = useRecommendationImpression<HTMLDivElement>(
+    impressionSurface && impressionRank
+      ? buildRecommendationImpressionInput({
+          recommendation,
+          rank: impressionRank,
+          surface: impressionSurface,
+          timeSlot: timeSlot ?? undefined,
+        })
+      : null
+  );
 
   // Track when favorite is shown in carousel
   useEffect(() => {
@@ -97,6 +119,7 @@ export const CompactSpotCard = React.memo(function CompactSpotCard({
 
   return (
     <Card
+      ref={impressionRef}
       className={cn(
         "w-[140px] xs:w-[160px] sm:w-[180px] h-[160px] xs:h-[180px] sm:h-[200px]",
         "shrink-0 snap-start cursor-pointer",

--- a/components/home-screen/hero-recommendation.tsx
+++ b/components/home-screen/hero-recommendation.tsx
@@ -19,6 +19,8 @@ import {
 import { HOME_HEADER_MOTION } from "@/lib/constants/animations";
 import { BoardRecommendationBadge } from "@/components/recommendations/board-recommendation-badge";
 import { useBoardRecommendation } from "@/hooks/use-board-recommendation";
+import { useRecommendationImpression } from "@/hooks/use-recommendation-impression";
+import { buildRecommendationImpressionInput } from "@/lib/recommendations/attribution";
 import type {
   SurfDiscoveryRecommendation,
   PersonalizedInsights,
@@ -188,6 +190,16 @@ export const HeroRecommendation = React.memo(function HeroRecommendation({
     beachId: recommendation?.beach?.id ?? null,
     enabled: !!recommendation?.forecast,
   });
+  const impressionRef = useRecommendationImpression<HTMLDivElement>(
+    recommendation
+      ? buildRecommendationImpressionInput({
+          recommendation,
+          rank: 1,
+          surface: "home_hero",
+          timeSlot,
+        })
+      : null
+  );
 
   // Handle loading state
   if (loading) {
@@ -246,7 +258,11 @@ export const HeroRecommendation = React.memo(function HeroRecommendation({
   }
 
   return (
-    <div className="space-y-4 px-4 sm:px-1" data-testid="hero-recommendation">
+    <div
+      ref={impressionRef}
+      className="space-y-4 px-4 sm:px-1"
+      data-testid="hero-recommendation"
+    >
       {/* Main headline */}
       <h1 className="text-2xl xs:text-3xl sm:text-4xl font-heading font-bold tracking-tight text-white leading-tight">
         {headline.prefix}

--- a/components/home-screen/index.tsx
+++ b/components/home-screen/index.tsx
@@ -30,6 +30,7 @@ import { useTimeOfDay } from "./use-time-of-day";
 import { HeroRecommendation } from "./hero-recommendation";
 import { PrimaryActions } from "./primary-actions";
 import { buildSurfCallShareData } from "@/lib/share/share-data-builder";
+import { buildRecommendationLogUrl } from "@/lib/recommendations/attribution";
 import { buildBeachUrlWithTab } from "@/lib/utils/beach-url-utils";
 import { getForecastRegionForCity } from "@/lib/data/forecast-regions";
 import { TopSpotsCarousel } from "./top-spots-carousel";
@@ -302,14 +303,17 @@ export function HomeScreen() {
 
   // Handler for "I'm at the beach" button
   const handleAtBeach = useCallback(() => {
-    // Navigate to session creation with mode=log
-    const params = new URLSearchParams({ mode: "log" });
-
-    // Pre-fill with top recommendation if available
     if (topRecommendation) {
-      params.set("beach", topRecommendation.beach.id);
-      params.set("beachName", topRecommendation.beach.name);
-      params.set("startTime", topRecommendation.window.start.toISOString());
+      router.push(
+        buildRecommendationLogUrl({
+          recommendation: topRecommendation,
+          rank: 1,
+          surface: "home_hero",
+          timeSlot,
+        })
+      );
+    } else {
+      router.push("/sessions/new?mode=log");
     }
 
     // Track for analytics
@@ -327,8 +331,7 @@ export function HomeScreen() {
       },
     });
 
-    router.push(`/sessions/new?${params.toString()}`);
-  }, [topRecommendation, router, trackEvent]);
+  }, [topRecommendation, router, trackEvent, timeSlot]);
 
   // Handler for quick-log CTA (zero-session users)
   const handleQuickLog = useCallback(() => {

--- a/components/home-screen/top-spots-carousel.tsx
+++ b/components/home-screen/top-spots-carousel.tsx
@@ -201,6 +201,9 @@ export const TopSpotsCarousel = React.memo(function TopSpotsCarousel({
               recommendation={spot}
               onTap={onViewSpot}
               featured={index === 0}
+              impressionRank={index + 1}
+              impressionSurface="home_top_spots"
+              timeSlot={timeSlot}
             />
           ))}
           {/* Spacer for right padding on scroll */}

--- a/components/oracle/oracle-home-screen.tsx
+++ b/components/oracle/oracle-home-screen.tsx
@@ -28,6 +28,7 @@ import type { ActivityItem } from "@/components/oracle/activity-feed";
 import type { TimeWindow } from "@/components/oracle/todays-windows";
 import type { NearbySpot } from "@/components/oracle/nearby-spots";
 import type { SurfDiscoveryRecommendation } from "@/types/personalization";
+import { buildRecommendationLogUrl } from "@/lib/recommendations/attribution";
 import type { LocalActivityItem } from "@/actions/oracle-actions";
 import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
 import { isFutureDayInTimezone } from "@/lib/utils/condition-tier-utils";
@@ -561,8 +562,21 @@ export function OracleHomeScreen() {
   }, [resetOnboarding, openOnboardingDialog]);
 
   const handleLogSession = useCallback(
-    () => router.push("/sessions/new?mode=log"),
-    [router]
+    () => {
+      if (!heroRec) {
+        router.push("/sessions/new?mode=log");
+        return;
+      }
+
+      router.push(
+        buildRecommendationLogUrl({
+          recommendation: heroRec,
+          rank: 1,
+          surface: "home_hero",
+        })
+      );
+    },
+    [heroRec, router]
   );
 
   const fetchHeroSurfCall = useCallback(async (): Promise<OracleSurfCallPayload | null> => {

--- a/components/session-forms/ConditionsSection.tsx
+++ b/components/session-forms/ConditionsSection.tsx
@@ -54,6 +54,7 @@ export function ConditionsSection({
   const windDirectionLabelId = useId();
   const tideHeightInputId = useId();
   const tideStatusLabelId = useId();
+  const isRecommendationLog = Boolean(formState.recommendationId);
 
   // Helper to convert number|undefined to string for input display
   const numberToString = (value: number | undefined): string =>
@@ -232,9 +233,12 @@ export function ConditionsSection({
                     : "3.5"
                 }
                 value={numberToString(formState.waveHeight)}
-                onChange={(e) =>
-                  updateField("waveHeight", stringToNumber(e.target.value))
-                }
+                onChange={(e) => {
+                  updateField("waveHeight", stringToNumber(e.target.value));
+                  if (isRecommendationLog) {
+                    updateField("waveHeightEdited", true);
+                  }
+                }}
               />
             </div>
 
@@ -316,37 +320,38 @@ export function ConditionsSection({
               </Select>
             </div>
 
-            {/* Tide Height */}
-            <div>
-              <label
-                className="mb-2 flex items-center gap-2 text-sm font-medium"
-                htmlFor={tideHeightInputId}
-              >
-                <TrendingUp className="h-4 w-4" />
-                Tide Height (ft)
-              </label>
-              <Input
-                id={tideHeightInputId}
-                type="number"
-                step="0.1"
-                min="-5"
-                max="15"
-                placeholder={
-                  !forecastData && formState.selectedBeachId
-                    ? "e.g., 2.1"
-                    : "2.5"
-                }
-                value={numberToString(formState.tideHeight)}
-                onChange={(e) =>
-                  updateField("tideHeight", stringToNumber(e.target.value))
-                }
-              />
-              {tidePreviewText && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Forecast: {tidePreviewText}
-                </p>
-              )}
-            </div>
+            {!isRecommendationLog && (
+              <div>
+                <label
+                  className="mb-2 flex items-center gap-2 text-sm font-medium"
+                  htmlFor={tideHeightInputId}
+                >
+                  <TrendingUp className="h-4 w-4" />
+                  Tide Height (ft)
+                </label>
+                <Input
+                  id={tideHeightInputId}
+                  type="number"
+                  step="0.1"
+                  min="-5"
+                  max="15"
+                  placeholder={
+                    !forecastData && formState.selectedBeachId
+                      ? "e.g., 2.1"
+                      : "2.5"
+                  }
+                  value={numberToString(formState.tideHeight)}
+                  onChange={(e) =>
+                    updateField("tideHeight", stringToNumber(e.target.value))
+                  }
+                />
+                {tidePreviewText && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Forecast: {tidePreviewText}
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* Tide Status */}
             <div>
@@ -358,9 +363,12 @@ export function ConditionsSection({
               </span>
               <Select
                 value={formState.tideStatus ?? ""}
-                onValueChange={(value) =>
-                  updateField("tideStatus", value)
-                }
+                onValueChange={(value) => {
+                  updateField("tideStatus", value);
+                  if (isRecommendationLog) {
+                    updateField("tideStatusEdited", true);
+                  }
+                }}
               >
                 <SelectTrigger aria-labelledby={tideStatusLabelId}>
                   <SelectValue placeholder="Select tide status" />

--- a/components/session-forms/QuickLogView.tsx
+++ b/components/session-forms/QuickLogView.tsx
@@ -6,7 +6,10 @@ import { SessionSlider } from "./SessionSlider";
 import { LocationStep } from "./LocationStep";
 import { BeachChip } from "./BeachChip";
 import { DetailsExpander } from "./DetailsExpander";
-import { FORECAST_ACCURACY_OPTIONS } from "./shared/constants";
+import {
+  FORECAST_ACCURACY_OPTIONS,
+  RECOMMENDATION_CALL_ACCURACY_OPTIONS,
+} from "./shared/constants";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { cn } from "@/lib/utils";
 import type { SessionFormState } from "@/hooks/use-session-form";
@@ -199,24 +202,42 @@ export function QuickLogView({
 
       <hr className="border-[#404C92]/60" />
 
-      {/* 4. Forecast check — core ML signal */}
+      {/* 4. Forecast/call check — core ML signal */}
       <motion.section className="space-y-2" variants={sectionVariants}>
         <h2 className="text-xs font-bold text-[#9AABC6] uppercase tracking-wider">
-          Was our forecast right?
+          {formState.recommendationId ? "Was this call right?" : "Was our forecast right?"}
         </h2>
-        <div className="grid grid-cols-3 gap-2">
-          {FORECAST_ACCURACY_OPTIONS.map((option) => {
-            const isSelected = formState.forecastAccuracy === option.value;
+        <div
+          className={cn(
+            "grid gap-2",
+            formState.recommendationId ? "grid-cols-2" : "grid-cols-3"
+          )}
+        >
+          {(formState.recommendationId
+            ? RECOMMENDATION_CALL_ACCURACY_OPTIONS
+            : FORECAST_ACCURACY_OPTIONS
+          ).map((option) => {
+            const isSelected = formState.recommendationId
+              ? formState.recommendationCallAccuracy === option.value
+              : formState.forecastAccuracy === option.value;
             return (
               <button
                 key={option.value}
                 type="button"
-                onClick={() =>
+                onClick={() => {
+                  if (formState.recommendationId) {
+                    updateField(
+                      "recommendationCallAccuracy",
+                      option.value as "right" | "partly" | "wrong" | "not_sure"
+                    );
+                    return;
+                  }
+
                   updateField(
                     "forecastAccuracy",
                     option.value as "accurate" | "somewhat" | "inaccurate"
-                  )
-                }
+                  );
+                }}
                 className={cn(
                   "py-3 rounded-lg border text-center transition-all duration-150",
                   "active:scale-[0.96]",

--- a/components/session-forms/SessionScrollForm.tsx
+++ b/components/session-forms/SessionScrollForm.tsx
@@ -22,7 +22,10 @@ import {
   type SessionFitSelection,
 } from "./SessionFitPicker";
 import { WaveTypeSelector } from "@/components/ui/wave-type-selector";
-import { FORECAST_ACCURACY_OPTIONS } from "./shared/constants";
+import {
+  FORECAST_ACCURACY_OPTIONS,
+  RECOMMENDATION_CALL_ACCURACY_OPTIONS,
+} from "./shared/constants";
 import { SessionCelebration } from "@/components/session/session-celebration";
 import { QuickLogView } from "./QuickLogView";
 import type { BeachSource } from "@/hooks/use-nearest-beach";
@@ -94,6 +97,7 @@ export function SessionScrollForm({
   const isLog = true;
   const useQuickMode = quickMode;
   const title = useQuickMode ? "How was it?" : "Log Session";
+  const isRecommendationLog = Boolean(formState.recommendationId);
 
   // Prefill wave/wind/tide from forecast at the form level so it runs even when
   // the conditions UI is collapsed behind QuickLog's details accordion.
@@ -505,15 +509,49 @@ export function SessionScrollForm({
 
                 <hr className="border-[#404C92]" />
                 <section className="space-y-4">
-                  <h2 className="text-sm font-bold text-[#F0F0F0] uppercase tracking-wide">Was the forecast accurate?</h2>
-                  <div className="grid grid-cols-3 gap-3">
-                    {FORECAST_ACCURACY_OPTIONS.map((option) => {
-                      const IconComponent = option.icon;
-                      const isSelected = formState.forecastAccuracy === option.value;
+                  <h2 className="text-sm font-bold text-[#F0F0F0] uppercase tracking-wide">
+                    {isRecommendationLog ? "Was this call right?" : "Was the forecast accurate?"}
+                  </h2>
+                  <div className={cn("grid gap-3", isRecommendationLog ? "grid-cols-2" : "grid-cols-3")}>
+                    {(isRecommendationLog
+                      ? RECOMMENDATION_CALL_ACCURACY_OPTIONS
+                      : FORECAST_ACCURACY_OPTIONS
+                    ).map((option) => {
+                      const IconComponent = "icon" in option ? option.icon : null;
+                      const iconColor = "color" in option ? option.color : "text-[#9AABC6]";
+                      const isSelected = isRecommendationLog
+                        ? formState.recommendationCallAccuracy === option.value
+                        : formState.forecastAccuracy === option.value;
                       return (
-                        <button key={option.value} type="button" onClick={() => updateField("forecastAccuracy", option.value as "accurate" | "somewhat" | "inaccurate")} className={cn("p-4 rounded-lg border-2 transition-all", isSelected ? "border-[#F78E42] bg-[#F78E42]/10" : "border-[#404C92] bg-[#354090] hover:bg-[#404C92]")} aria-label={`${option.label}: ${option.description}`}>
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => {
+                            if (isRecommendationLog) {
+                              updateField(
+                                "recommendationCallAccuracy",
+                                option.value as "right" | "partly" | "wrong" | "not_sure"
+                              );
+                              return;
+                            }
+
+                            updateField(
+                              "forecastAccuracy",
+                              option.value as "accurate" | "somewhat" | "inaccurate"
+                            );
+                          }}
+                          className={cn(
+                            "p-4 rounded-lg border-2 transition-all",
+                            isSelected
+                              ? "border-[#F78E42] bg-[#F78E42]/10"
+                              : "border-[#404C92] bg-[#354090] hover:bg-[#404C92]"
+                          )}
+                          aria-label={`${option.label}: ${option.description}`}
+                        >
                           <div className="flex flex-col items-center gap-2">
-                            <IconComponent className={cn("h-6 w-6", isSelected ? "text-[#F78E42]" : option.color)} />
+                            {IconComponent && (
+                              <IconComponent className={cn("h-6 w-6", isSelected ? "text-[#F78E42]" : iconColor)} />
+                            )}
                             <span className={cn("font-medium", isSelected ? "text-[#F78E42]" : "text-[#F0F0F0]")}>{option.label}</span>
                             <span className="text-xs text-[#9AABC6] text-center">{option.description}</span>
                           </div>

--- a/components/session-forms/shared/constants.ts
+++ b/components/session-forms/shared/constants.ts
@@ -49,6 +49,29 @@ export const FORECAST_ACCURACY_OPTIONS = [
   },
 ] as const;
 
+export const RECOMMENDATION_CALL_ACCURACY_OPTIONS = [
+  {
+    value: "right",
+    label: "Right",
+    description: "The call matched the waves",
+  },
+  {
+    value: "partly",
+    label: "Partly",
+    description: "Some of it was right",
+  },
+  {
+    value: "wrong",
+    label: "Wrong",
+    description: "The call missed",
+  },
+  {
+    value: "not_sure",
+    label: "Not sure",
+    description: "Hard to tell",
+  },
+] as const;
+
 export const WAVE_CHARACTERISTICS = [
   { value: "clean", label: "Clean" },
   { value: "glassy", label: "Glassy" },

--- a/e2e/session-wizard-autofill.spec.ts
+++ b/e2e/session-wizard-autofill.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable playwright/no-conditional-in-test -- session form E2E handles quick-log variants and test-specific URLs. */
 import { test, expect } from "./fixtures/auth-fixture";
 import { waitForPageLoad } from './utils/test-helpers';
 import { TIMEOUTS } from './fixtures/test-data';
@@ -14,13 +15,33 @@ import { setupErrorDetection, assertNoErrors, ErrorCapture } from './utils/error
  * @project auth
  */
 
+function buildRecommendationLogUrl(): string {
+  const params = new URLSearchParams({
+    mode: 'log',
+    beach: '123e4567-e89b-12d3-a456-426614174000',
+    beachName: 'HB Cliffs',
+    startTime: '2026-07-09T14:00:00.000Z',
+    endTime: '2026-07-09T17:00:00.000Z',
+    recommendation_id: 'beach:123e4567-e89b-12d3-a456-426614174000:2026-07-09T14:00:00.000Z',
+    recommendation_surface: 'home_hero',
+    recommendation_rank: '1',
+    recommendation_score: '88',
+    recommendation_window_start: '2026-07-09T14:00:00.000Z',
+    recommendation_window_end: '2026-07-09T17:00:00.000Z',
+  });
+
+  return `/sessions/new?${params.toString()}`;
+}
+
 test.describe('Session Form - Auto-Forecast Autofill', () => {
   let errorCapture: ErrorCapture;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
     errorCapture = setupErrorDetection(page);
-    // Navigate to new session log mode
-    await page.goto('/sessions/new?mode=log');
+    const targetUrl = testInfo.title.includes('recommendation-attributed')
+      ? buildRecommendationLogUrl()
+      : '/sessions/new?mode=log';
+    await page.goto(targetUrl);
     await waitForPageLoad(page);
   });
 
@@ -68,5 +89,13 @@ test.describe('Session Form - Auto-Forecast Autofill', () => {
     // Evening sessions should use neutral language
     expect(hasRecommendedText).toBe(false);
     expect(hasShouldText).toBe(false);
+  });
+
+  test('should show call accuracy prompt for recommendation-attributed logs', async ({ page }) => {
+    await expect(
+      page.getByRole('heading', { name: /was this call right/i })
+    ).toBeVisible({ timeout: TIMEOUTS.medium });
+    await expect(page.getByRole('button', { name: /^right$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^wrong$/i })).toBeVisible();
   });
 });

--- a/hooks/use-recommendation-impression.ts
+++ b/hooks/use-recommendation-impression.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useAuth } from "@/context/auth-context";
+import type { RecommendationImpressionInput } from "@/lib/recommendations/impressions";
+import { buildRecommendationImpressionKey } from "@/lib/recommendations/impressions";
+
+const seenImpressionKeys = new Set<string>();
+const pendingImpressions = new Map<string, RecommendationImpressionInput>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+function flushPendingImpressions(): void {
+  const entries = Array.from(pendingImpressions.entries());
+  pendingImpressions.clear();
+  flushTimer = null;
+
+  if (entries.length === 0) return;
+
+  void fetch("/api/recommendation-impressions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      impressions: entries.map(([, impression]) => impression),
+    }),
+  })
+    .then((response) => {
+      if (response.ok) return;
+      entries.forEach(([entryKey]) => seenImpressionKeys.delete(entryKey));
+    })
+    .catch(() => {
+      entries.forEach(([entryKey]) => seenImpressionKeys.delete(entryKey));
+    });
+}
+
+function queueRecommendationImpression(
+  key: string,
+  impression: RecommendationImpressionInput
+): void {
+  pendingImpressions.set(key, impression);
+  if (flushTimer) return;
+  flushTimer = setTimeout(flushPendingImpressions, 0);
+}
+
+export function useRecommendationImpression<TElement extends Element>(
+  impression: RecommendationImpressionInput | null
+) {
+  const { user } = useAuth();
+  const elementRef = useRef<TElement | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const key = useMemo(
+    () =>
+      impression && user?.id
+        ? buildRecommendationImpressionKey(user.id, impression)
+        : null,
+    [impression, user?.id]
+  );
+
+  useEffect(() => {
+    if (!impression || !user?.id || !key || seenImpressionKeys.has(key)) return;
+    const element = elementRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") return;
+
+    const clearPending = (): void => {
+      if (!timeoutRef.current) return;
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    };
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting || entry.intersectionRatio < 0.5) {
+          clearPending();
+          return;
+        }
+
+        if (timeoutRef.current) return;
+        timeoutRef.current = setTimeout(() => {
+          if (seenImpressionKeys.has(key)) return;
+          seenImpressionKeys.add(key);
+          queueRecommendationImpression(key, impression);
+        }, 500);
+      },
+      { threshold: [0, 0.5, 1] }
+    );
+
+    observer.observe(element);
+
+    return () => {
+      clearPending();
+      observer.disconnect();
+    };
+  }, [impression, key, user?.id]);
+
+  return elementRef;
+}

--- a/hooks/use-session-conditions-prefill.ts
+++ b/hooks/use-session-conditions-prefill.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useSessionForecast } from "./use-session-forecast";
+import { useSessionTideSnapshot } from "./use-session-tide-snapshot";
 import type { SessionFormState, SessionFormMode } from "./use-session-form";
 
 type FieldKey =
@@ -66,6 +67,11 @@ export function useSessionConditionsPrefill(
     formState.selectedDate ?? null,
     formState.selectedTime ?? null
   );
+  const { tideSnapshot } = useSessionTideSnapshot(
+    formState.selectedBeachId ?? null,
+    formState.selectedDate ?? null,
+    formState.selectedTime ?? null
+  );
 
   useEffect(() => {
     if (mode !== "log") return;
@@ -98,6 +104,14 @@ export function useSessionConditionsPrefill(
     };
 
     tryPrefill("waveHeight", "waveHeight", forecastData.wave_height);
+    if (
+      formState.recommendationId &&
+      formState.forecastWaveHeightFt === undefined &&
+      forecastData.wave_height !== undefined &&
+      forecastData.wave_height !== null
+    ) {
+      updateField("forecastWaveHeightFt", forecastData.wave_height);
+    }
     tryPrefill("windSpeed", "windSpeed", forecastData.wind_speed);
     tryPrefill("windDirection", "windDirection", forecastData.wind_direction);
     tryPrefill(
@@ -107,8 +121,21 @@ export function useSessionConditionsPrefill(
         ? String(forecastData.water_temp)
         : undefined
     );
+
+    if (formState.recommendationId) {
+      const tideStatus =
+        tideSnapshot?.tideStatus?.toLowerCase() ??
+        forecastData.tide_status?.toLowerCase();
+      if (!formState.forecastTideStatus && tideStatus) {
+        updateField("forecastTideStatus", tideStatus);
+      }
+      if (!formState.tideStatus && tideStatus) {
+        updateField("tideStatus", tideStatus);
+      }
+    }
   }, [
     forecastData,
+    tideSnapshot,
     loading,
     mode,
     formState.selectedBeachId,

--- a/hooks/use-session-form.ts
+++ b/hooks/use-session-form.ts
@@ -30,6 +30,18 @@ export type SessionFormState = {
   windSpeed?: number; // Wind speed in mph
   windDirection?: string; // Wind direction (N, NE, E, etc.)
   forecastAccuracy?: "accurate" | "somewhat" | "inaccurate"; // User-reported forecast accuracy
+  recommendationId?: string;
+  recommendationSurface?: string;
+  recommendationRank?: number;
+  recommendationScore?: number;
+  recommendationWindowStart?: string;
+  recommendationWindowEnd?: string;
+  recommendationTimeSlot?: string;
+  recommendationCallAccuracy?: "right" | "partly" | "wrong" | "not_sure";
+  forecastWaveHeightFt?: number;
+  forecastTideStatus?: string;
+  waveHeightEdited?: boolean;
+  tideStatusEdited?: boolean;
   // Tide fields for session conditions:
   tideHeight?: number; // User-reported tide height in feet
   tideStatus?: string; // User-reported tide status (rising, falling, high, low)
@@ -104,6 +116,18 @@ function getDefaultFormState(mode: SessionFormMode): SessionFormState {
     windSpeed: undefined,
     windDirection: undefined,
     forecastAccuracy: undefined,
+    recommendationId: undefined,
+    recommendationSurface: undefined,
+    recommendationRank: undefined,
+    recommendationScore: undefined,
+    recommendationWindowStart: undefined,
+    recommendationWindowEnd: undefined,
+    recommendationTimeSlot: undefined,
+    recommendationCallAccuracy: undefined,
+    forecastWaveHeightFt: undefined,
+    forecastTideStatus: undefined,
+    waveHeightEdited: false,
+    tideStatusEdited: false,
     // Tide fields (initialize to undefined)
     tideHeight: undefined,
     tideStatus: undefined,

--- a/lib/analytics/event-taxonomy.ts
+++ b/lib/analytics/event-taxonomy.ts
@@ -119,6 +119,7 @@ export const VALID_EVENTS = [
   'learning_progress_revealed',
   'learned_me_moment_viewed',
   // Discovery events
+  'recommendation_impression',
   'personalized_score_shown',
   'favorite_shown_in_carousel',
   'mini_log_teaser_click',

--- a/lib/analytics/session-created.ts
+++ b/lib/analytics/session-created.ts
@@ -56,7 +56,9 @@ interface QueryResult<T> {
 }
 
 interface EmitSessionCreatedEventInput {
-  session: Pick<Session, "id" | "beach_id">;
+  session: Pick<Session, "id" | "beach_id"> & {
+    recommendation_id?: string | null;
+  };
   source: SessionCreatedSource;
   surface: SessionCreatedSurface;
   userId: string;
@@ -148,6 +150,7 @@ export async function emitSessionCreatedEvent(
         spot_type: beachId ? "beach" : "custom",
         user_id: userId,
         session_id: session.id,
+        recommendation_id: session.recommendation_id ?? undefined,
       },
     })) ?? {}) as QueryResult<never>;
 

--- a/lib/recommendations/attribution.ts
+++ b/lib/recommendations/attribution.ts
@@ -1,0 +1,94 @@
+import type {
+  SurfDiscoveryRecommendation,
+  TimeSlot,
+} from "@/types/personalization";
+import type {
+  RecommendationImpressionInput,
+  RecommendationImpressionSurface,
+} from "./impressions";
+import { RecommendationImpressionTimeSlotSchema } from "./impressions";
+
+interface RecommendationAttributionInput {
+  recommendation: SurfDiscoveryRecommendation;
+  rank: number;
+  surface: RecommendationImpressionSurface;
+  timeSlot?: TimeSlot | string | null;
+}
+
+function normalizeImpressionTimeSlot(
+  timeSlot: RecommendationAttributionInput["timeSlot"]
+): RecommendationImpressionInput["timeSlot"] {
+  const parsed = RecommendationImpressionTimeSlotSchema.safeParse(
+    timeSlot ?? undefined
+  );
+
+  if (!parsed.success) {
+    return undefined;
+  }
+
+  return parsed.data ?? undefined;
+}
+
+export function getRecommendationId(
+  recommendation: SurfDiscoveryRecommendation
+): string {
+  if (recommendation.recommendationId) {
+    return recommendation.recommendationId;
+  }
+
+  const forecastAt =
+    recommendation.forecast.forecast_at ??
+    recommendation.window.start.toISOString();
+  const entityId =
+    recommendation.kind === "custom_spot" && recommendation.customSpotId
+      ? `custom:${recommendation.customSpotId}`
+      : `beach:${recommendation.beach.id}`;
+
+  return `${entityId}:${forecastAt}`;
+}
+
+export function buildRecommendationImpressionInput({
+  recommendation,
+  rank,
+  surface,
+  timeSlot,
+}: RecommendationAttributionInput): RecommendationImpressionInput {
+  return {
+    recommendationId: getRecommendationId(recommendation),
+    beachId: recommendation.beach.id,
+    rank,
+    score: recommendation.score,
+    windowStart: recommendation.window.start.toISOString(),
+    windowEnd: recommendation.window.end.toISOString(),
+    mode: "log",
+    timeSlot: normalizeImpressionTimeSlot(timeSlot),
+    surface,
+  };
+}
+
+export function buildRecommendationLogUrl({
+  recommendation,
+  rank,
+  surface,
+  timeSlot,
+}: RecommendationAttributionInput): string {
+  const params = new URLSearchParams({
+    mode: "log",
+    beach: recommendation.beach.id,
+    beachName: recommendation.beach.name,
+    startTime: recommendation.window.start.toISOString(),
+    endTime: recommendation.window.end.toISOString(),
+    recommendation_id: getRecommendationId(recommendation),
+    recommendation_surface: surface,
+    recommendation_rank: rank.toString(),
+    recommendation_score: recommendation.score.toString(),
+    recommendation_window_start: recommendation.window.start.toISOString(),
+    recommendation_window_end: recommendation.window.end.toISOString(),
+  });
+
+  if (timeSlot) {
+    params.set("recommendation_time_slot", String(timeSlot));
+  }
+
+  return `/sessions/new?${params.toString()}`;
+}

--- a/lib/recommendations/impressions.ts
+++ b/lib/recommendations/impressions.ts
@@ -1,0 +1,105 @@
+import { z } from "zod";
+
+export const RecommendationImpressionSurfaceSchema = z.enum([
+  "home_hero",
+  "home_top_spots",
+  "home_nearby_spots",
+  "discover_list",
+  "explore_for_you",
+  "session_intelligence",
+]);
+
+export const RecommendationImpressionModeSchema = z.enum(["log"]);
+
+export const RecommendationImpressionTimeSlotSchema = z
+  .enum([
+    "dawn-patrol",
+    "morning",
+    "late-morning",
+    "lunch-session",
+    "afternoon",
+    "evening",
+    "any",
+  ])
+  .nullable()
+  .optional();
+
+export const RecommendationImpressionInputSchema = z.object({
+  recommendationId: z.string().min(1).max(200),
+  beachId: z.string().uuid(),
+  rank: z.number().int().min(1).max(100),
+  score: z.number().min(0).max(100).nullable().optional(),
+  windowStart: z.string().datetime(),
+  windowEnd: z.string().datetime(),
+  mode: RecommendationImpressionModeSchema.default("log"),
+  timeSlot: RecommendationImpressionTimeSlotSchema,
+  surface: RecommendationImpressionSurfaceSchema,
+});
+
+export const RecommendationImpressionsRequestSchema = z.object({
+  impressions: z.array(RecommendationImpressionInputSchema).min(1).max(20),
+});
+
+export type RecommendationImpressionInput = z.infer<
+  typeof RecommendationImpressionInputSchema
+>;
+
+export type RecommendationImpressionSurface = z.infer<
+  typeof RecommendationImpressionSurfaceSchema
+>;
+
+export function buildRecommendationImpressionKey(
+  userId: string,
+  impression: Pick<
+    RecommendationImpressionInput,
+    "recommendationId" | "surface" | "windowStart"
+  >
+): string {
+  return [
+    userId,
+    impression.recommendationId,
+    impression.surface,
+    new Date(impression.windowStart).toISOString(),
+  ].join(":");
+}
+
+export function toRecommendationImpressionRow(
+  userId: string,
+  impression: RecommendationImpressionInput
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    recommendation_id: impression.recommendationId,
+    beach_id: impression.beachId,
+    rank: impression.rank,
+    score: impression.score ?? null,
+    window_start: impression.windowStart,
+    window_end: impression.windowEnd,
+    mode: impression.mode,
+    time_slot: impression.timeSlot ?? null,
+    surface: impression.surface,
+    impression_key: buildRecommendationImpressionKey(userId, impression),
+  };
+}
+
+export function toRecommendationImpressionEventRow(
+  userId: string,
+  impression: RecommendationImpressionInput
+): Record<string, unknown> {
+  return {
+    user_id: userId,
+    event_type: "recommendation_impression",
+    beach_id: impression.beachId,
+    metadata: {
+      recommendation_id: impression.recommendationId,
+      rank: impression.rank,
+      score: impression.score ?? null,
+      window_start: impression.windowStart,
+      window_end: impression.windowEnd,
+      mode: impression.mode,
+      time_slot: impression.timeSlot ?? null,
+      surface: impression.surface,
+      impression_key: buildRecommendationImpressionKey(userId, impression),
+    },
+  };
+}

--- a/lib/recommendations/session-context.ts
+++ b/lib/recommendations/session-context.ts
@@ -5,9 +5,13 @@ export const RecommendationSessionContextSchema = z.object({
   recommendationId: z.string().min(1).max(160),
   sourceSurface: z.enum([
     'home_hero',
+    'home_top_spots',
+    'home_nearby_spots',
     'home_also_worth_it',
+    'discover_list',
     'explore_for_you',
     'beach_detail',
+    'session_intelligence',
     'surf_window_adjacent',
   ]),
   beachId: z.string().uuid(),

--- a/lib/services/discovery/personalization-layer.ts
+++ b/lib/services/discovery/personalization-layer.ts
@@ -201,6 +201,7 @@ export function calculatePersonalizationBonus(
   let personalizationBonus = 0;
   let affinityBonus = 0;
   let avoidancePenalty = 0;
+  let suppressAffinity = false;
   const reasons: string[] = [];
 
   // ── 1–3. Learned preferences (session history) ────────────────────────────
@@ -268,6 +269,7 @@ export function calculatePersonalizationBonus(
       avoidanceMatch * MAX_AVOIDANCE_PERSONALIZATION_PENALTY,
       MAX_AVOIDANCE_PERSONALIZATION_PENALTY
     );
+    suppressAffinity = (avoidancePattern?.negative_sample_size ?? 0) >= 2;
   }
 
   personalizationBonus = Math.max(
@@ -279,7 +281,7 @@ export function calculatePersonalizationBonus(
   // Small tie-breaker for beaches the user frequents.
   // Threshold at 10 matches the same guard in personalized-scoring-service.ts.
   const affinityScore = context.affinityMap.get(beach.id) ?? 0;
-  if (affinityScore > 10) {
+  if (affinityScore > 10 && !suppressAffinity) {
     affinityBonus = Math.min(affinityScore * AFFINITY_BONUS_SCALE, MAX_AFFINITY_BONUS);
     reasons.push("One of your go-to spots");
   }

--- a/lib/services/preference-learning-service.ts
+++ b/lib/services/preference-learning-service.ts
@@ -103,6 +103,18 @@ interface SessionWithConditions {
     goals?: string[] | null;
     notes?: string | null;
     source?: string | null;
+    rating?: number | string | null;
+    wave_quality?: number | string | null;
+    wave_height_ft?: number | string | null;
+    wind_speed_mph?: number | string | null;
+    wind_direction?: string | null;
+    tide_status?: string | null;
+    recommendation_id?: string | null;
+    recommendation_call_accuracy?: string | null;
+    forecast_wave_height_ft?: number | string | null;
+    forecast_tide_status?: string | null;
+    wave_height_correct?: boolean | null;
+    tide_status_correct?: boolean | null;
   } | Array<{
     id?: string | null;
     beach_id?: string | null;
@@ -113,6 +125,18 @@ interface SessionWithConditions {
     goals?: string[] | null;
     notes?: string | null;
     source?: string | null;
+    rating?: number | string | null;
+    wave_quality?: number | string | null;
+    wave_height_ft?: number | string | null;
+    wind_speed_mph?: number | string | null;
+    wind_direction?: string | null;
+    tide_status?: string | null;
+    recommendation_id?: string | null;
+    recommendation_call_accuracy?: string | null;
+    forecast_wave_height_ft?: number | string | null;
+    forecast_tide_status?: string | null;
+    wave_height_correct?: boolean | null;
+    tide_status_correct?: boolean | null;
   }> | null;
   sessions?: {
     id?: string | null;
@@ -321,6 +345,11 @@ function getSessionNumber(
     return actual;
   }
 
+  const session = parseForecastNumber(firstPresentValue(getSessionRelation(snapshot), actualKeys));
+  if (session !== null) {
+    return session;
+  }
+
   return parseForecastNumber(firstPresentValue(getForecastSnapshot(snapshot), forecastKeys));
 }
 
@@ -330,6 +359,13 @@ function getSessionWindDirection(snapshot: SessionWithConditions): number | null
   );
   if (actual !== null) {
     return actual;
+  }
+
+  const session = parseWindDirection(
+    firstPresentValue(getSessionRelation(snapshot), ['wind_direction'])
+  );
+  if (session !== null) {
+    return session;
   }
 
   return parseWindDirection(
@@ -345,17 +381,41 @@ function getSessionTideStatus(snapshot: SessionWithConditions): string | null {
     return actual;
   }
 
+  const session = normalizeTideStatus(
+    firstPresentValue(getSessionRelation(snapshot), ['tide_status'])
+  );
+  if (session) {
+    return session;
+  }
+
   return normalizeTideStatus(
     firstPresentValue(getForecastSnapshot(snapshot), ['tide_status'])
   );
 }
 
 function getRating(snapshot: SessionWithConditions): number | null {
-  return parseForecastNumber(firstPresentValue(getActualConditions(snapshot), ['rating']));
+  const actual = parseForecastNumber(firstPresentValue(getActualConditions(snapshot), ['rating']));
+  if (actual !== null) {
+    return actual;
+  }
+
+  return parseForecastNumber(firstPresentValue(getSessionRelation(snapshot), ['rating']));
 }
 
 function getWaveQuality(snapshot: SessionWithConditions): number | null {
-  return parseForecastNumber(firstPresentValue(getActualConditions(snapshot), ['wave_quality']));
+  const actual = parseForecastNumber(firstPresentValue(getActualConditions(snapshot), ['wave_quality']));
+  if (actual !== null) {
+    return actual;
+  }
+
+  return parseForecastNumber(firstPresentValue(getSessionRelation(snapshot), ['wave_quality']));
+}
+
+function getRecommendationCallAccuracy(snapshot: SessionWithConditions): string | null {
+  const relation = getSessionRelation(snapshot);
+  return typeof relation.recommendation_call_accuracy === 'string'
+    ? relation.recommendation_call_accuracy
+    : null;
 }
 
 function isSeededOrTestSession(snapshot: SessionWithConditions): boolean {
@@ -453,6 +513,10 @@ function hasNegativeWaveQuality(snapshot: SessionWithConditions): boolean {
 function hasNegativeSignal(snapshot: SessionWithConditions): boolean {
   const rating = getRating(snapshot);
   if (rating !== null && rating <= 2) {
+    return true;
+  }
+
+  if (getRecommendationCallAccuracy(snapshot) === 'wrong') {
     return true;
   }
 
@@ -605,7 +669,19 @@ export async function computeUserPreferences(
               board_snapshot,
               goals,
               notes,
-              source
+              source,
+              rating,
+              wave_quality,
+              wave_height_ft,
+              wind_speed_mph,
+              wind_direction,
+              tide_status,
+              recommendation_id,
+              recommendation_call_accuracy,
+              forecast_wave_height_ft,
+              forecast_tide_status,
+              wave_height_correct,
+              tide_status_correct
             )
           `)
           .eq('user_id', userId)
@@ -627,16 +703,24 @@ export async function computeUserPreferences(
       .filter((session) => !isSeededOrTestCompletedSession(session))
       .length;
 
-    if (eligibleSessionCount < MIN_SIGNAL_SAMPLE_SIZE) {
+    const cleanSessions = ((snapshots ?? []) as unknown as SessionWithConditions[]).filter(
+      (snapshot) => !isSeededOrTestSession(snapshot)
+    );
+
+    const negativePreferenceSessions = cleanSessions.filter((snapshot) =>
+      hasNegativeSignal(snapshot)
+    );
+    const avoidanceByBeach = buildAvoidanceByBeach(negativePreferenceSessions);
+    const hasActionableAvoidance = Object.values(avoidanceByBeach).some(
+      (pattern) => pattern.negative_sample_size >= 2
+    );
+
+    if (eligibleSessionCount < MIN_SIGNAL_SAMPLE_SIZE && !hasActionableAvoidance) {
       console.log(
         `Not enough completed sessions for user ${userId}: ${eligibleSessionCount} eligible sessions (need 5+)`
       );
       return null;
     }
-
-    const cleanSessions = ((snapshots ?? []) as unknown as SessionWithConditions[]).filter(
-      (snapshot) => !isSeededOrTestSession(snapshot)
-    );
 
     const waveQualitySessions = cleanSessions
       .filter((snapshot) => hasPositiveWaveQuality(snapshot))
@@ -667,11 +751,6 @@ export async function computeUserPreferences(
       wavePreferenceSessions.length,
       conditionPreferenceSessions.length
     );
-    const negativePreferenceSessions = cleanSessions.filter((snapshot) =>
-      hasNegativeSignal(snapshot)
-    );
-    const avoidanceByBeach = buildAvoidanceByBeach(negativePreferenceSessions);
-
     // 3. Extract arrays of values
     const waveHeights = wavePreferenceSessions
       .map((s) => getSessionNumber(s, ['wave_height_ft'], ['wave_height', 'wave_height_ft']))
@@ -835,11 +914,23 @@ export function getAvoidancePatternForBeach(
   preferences: Pick<UserSurfPreferences, 'eligible_session_count' | 'avoidance_by_beach'> | null,
   beachId: string
 ): AvoidancePattern | null {
-  if (!preferences || (preferences.eligible_session_count ?? 0) < MIN_SIGNAL_SAMPLE_SIZE) {
+  if (!preferences) {
     return null;
   }
 
-  return preferences.avoidance_by_beach?.[beachId] ?? null;
+  const pattern = preferences.avoidance_by_beach?.[beachId] ?? null;
+  if (!pattern) {
+    return null;
+  }
+
+  if (
+    (preferences.eligible_session_count ?? 0) >= MIN_SIGNAL_SAMPLE_SIZE ||
+    pattern.negative_sample_size >= 2
+  ) {
+    return pattern;
+  }
+
+  return null;
 }
 
 function isInRangeWithTolerance(

--- a/lib/utils/session-data-builder.ts
+++ b/lib/utils/session-data-builder.ts
@@ -43,6 +43,18 @@ export interface SessionPayloadInput {
   tideHeight?: number;
   tideStatus?: string;
   forecastAccuracy?: "accurate" | "somewhat" | "inaccurate" | string;
+  recommendationId?: string;
+  recommendationSurface?: string;
+  recommendationRank?: number;
+  recommendationScore?: number;
+  recommendationWindowStart?: string;
+  recommendationWindowEnd?: string;
+  recommendationTimeSlot?: string;
+  recommendationCallAccuracy?: "right" | "partly" | "wrong" | "not_sure";
+  forecastWaveHeightFt?: number;
+  forecastTideStatus?: string;
+  waveHeightEdited?: boolean;
+  tideStatusEdited?: boolean;
   waveCharacteristics?: string[];
   waveTypes?: string[];
   ripCurrentObserved?: "none" | "light" | "strong" | string;
@@ -84,6 +96,12 @@ export interface SessionPayload {
   tide_height_ft?: number;
   tide_status?: string;
   forecast_accuracy?: string;
+  recommendation_id?: string;
+  recommendation_call_accuracy?: string;
+  forecast_wave_height_ft?: number;
+  forecast_tide_status?: string;
+  wave_height_correct?: boolean;
+  tide_status_correct?: boolean;
   wave_characteristics: string[] | null;
   rip_current_observed: string | null;
 
@@ -95,6 +113,16 @@ export interface SessionPayload {
   // Visibility and feed controls
   is_public?: boolean;
   muted?: boolean;
+  recommendation_context?: {
+    recommendationId: string;
+    surface?: string;
+    rank?: number;
+    score?: number;
+    windowStart?: string;
+    windowEnd?: string;
+    mode?: string;
+    timeSlot?: string;
+  };
 }
 
 /**
@@ -143,6 +171,18 @@ function parseWaterTemp(raw?: string): number | null {
   if (!raw || raw.trim().length === 0) return null;
   const parsed = Number.parseFloat(raw);
   return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : null;
+}
+
+function shouldMarkCorrectForRecommendation(
+  recommendationId: string | undefined,
+  forecastValue: unknown,
+  edited: boolean | undefined
+): boolean | undefined {
+  if (!recommendationId || forecastValue === undefined || forecastValue === null || forecastValue === "") {
+    return undefined;
+  }
+
+  return edited === true ? false : true;
 }
 
 /**
@@ -217,7 +257,7 @@ export function buildSessionPayload(
     ...(input.windDirection && {
       wind_direction: input.windDirection,
     }),
-    ...(input.tideHeight !== undefined && {
+    ...(!input.recommendationId && input.tideHeight !== undefined && {
       tide_height_ft: input.tideHeight,
     }),
     ...(input.tideStatus && {
@@ -226,12 +266,58 @@ export function buildSessionPayload(
     ...(input.forecastAccuracy && {
       forecast_accuracy: input.forecastAccuracy,
     }),
+    ...(input.recommendationId && {
+      recommendation_id: input.recommendationId,
+    }),
+    ...(input.recommendationCallAccuracy && {
+      recommendation_call_accuracy: input.recommendationCallAccuracy,
+    }),
+    ...(input.forecastWaveHeightFt !== undefined && {
+      forecast_wave_height_ft: input.forecastWaveHeightFt,
+    }),
+    ...(input.forecastTideStatus && {
+      forecast_tide_status: input.forecastTideStatus,
+    }),
+    ...(shouldMarkCorrectForRecommendation(
+      input.recommendationId,
+      input.forecastWaveHeightFt,
+      input.waveHeightEdited
+    ) !== undefined && {
+      wave_height_correct: shouldMarkCorrectForRecommendation(
+        input.recommendationId,
+        input.forecastWaveHeightFt,
+        input.waveHeightEdited
+      ),
+    }),
+    ...(shouldMarkCorrectForRecommendation(
+      input.recommendationId,
+      input.forecastTideStatus,
+      input.tideStatusEdited
+    ) !== undefined && {
+      tide_status_correct: shouldMarkCorrectForRecommendation(
+        input.recommendationId,
+        input.forecastTideStatus,
+        input.tideStatusEdited
+      ),
+    }),
     // Goals and skill ratings
     ...(input.selectedGoals && input.selectedGoals.length > 0 && {
       goals: input.selectedGoals,
     }),
     ...(input.skillRatings && Object.keys(input.skillRatings).length > 0 && {
       skill_ratings: input.skillRatings,
+    }),
+    ...(input.recommendationId && {
+      recommendation_context: {
+        recommendationId: input.recommendationId,
+        surface: input.recommendationSurface,
+        rank: input.recommendationRank,
+        score: input.recommendationScore,
+        windowStart: input.recommendationWindowStart,
+        windowEnd: input.recommendationWindowEnd,
+        mode: "log",
+        timeSlot: input.recommendationTimeSlot,
+      },
     }),
   };
 }

--- a/lib/utils/session-utils.ts
+++ b/lib/utils/session-utils.ts
@@ -133,7 +133,7 @@ export const getSessionMapImageUrl = (session: SessionWithDetails) => {
 export function transformSessionFormStateToDbSchema(
   formState: SessionFormState
 ): Partial<Session> {
-  const dbData: SessionWithWaveCharacteristics = {};
+  const dbData: SessionWithWaveCharacteristics & Record<string, unknown> = {};
 
   // Map camelCase form fields to snake_case database columns
   if (formState.selectedBeachId) {
@@ -239,8 +239,26 @@ export function transformSessionFormStateToDbSchema(
     dbData.forecast_accuracy = formState.forecastAccuracy;
   }
 
+  if (formState.recommendationId) {
+    dbData.recommendation_id = formState.recommendationId;
+  }
+
+  if (formState.recommendationCallAccuracy) {
+    dbData.recommendation_call_accuracy = formState.recommendationCallAccuracy;
+  }
+
+  if (formState.recommendationId && formState.forecastWaveHeightFt !== undefined) {
+    dbData.forecast_wave_height_ft = formState.forecastWaveHeightFt;
+    dbData.wave_height_correct = formState.waveHeightEdited === true ? false : true;
+  }
+
+  if (formState.recommendationId && formState.forecastTideStatus) {
+    dbData.forecast_tide_status = formState.forecastTideStatus;
+    dbData.tide_status_correct = formState.tideStatusEdited === true ? false : true;
+  }
+
   // NEW FIELDS: Handle tide data
-  if (formState.tideHeight !== undefined) {
+  if (!formState.recommendationId && formState.tideHeight !== undefined) {
     dbData.tide_height_ft = formState.tideHeight;
   }
 

--- a/lib/utils/session-wizard-params.ts
+++ b/lib/utils/session-wizard-params.ts
@@ -101,6 +101,22 @@ export function parseSessionWizardParams(
       step: getParam('step'),
       forecastFeedbackId: getParam('forecastFeedbackId'),
       forecastFeedbackValue: getParam('forecastFeedbackValue'),
+      recommendationId:
+        getParam('recommendation_id') ?? getParam('recommendationId'),
+      recommendationSurface:
+        getParam('recommendation_surface') ?? getParam('recommendationSurface'),
+      recommendationRank:
+        getParam('recommendation_rank') ?? getParam('recommendationRank'),
+      recommendationScore:
+        getParam('recommendation_score') ?? getParam('recommendationScore'),
+      recommendationTimeSlot:
+        getParam('recommendation_time_slot') ?? getParam('recommendationTimeSlot'),
+      recommendationWindowStart:
+        getParam('recommendation_window_start') ??
+        getParam('recommendationWindowStart'),
+      recommendationWindowEnd:
+        getParam('recommendation_window_end') ??
+        getParam('recommendationWindowEnd'),
     };
 
     // Validate using Zod schema
@@ -138,6 +154,17 @@ export function parseSessionWizardParams(
       targetStep: validated.step,
       forecastFeedbackId: validated.forecastFeedbackId,
       forecastFeedbackValue: validated.forecastFeedbackValue,
+      recommendationId: validated.recommendationId,
+      recommendationSurface: validated.recommendationSurface,
+      recommendationRank: validated.recommendationRank,
+      recommendationScore: validated.recommendationScore,
+      recommendationTimeSlot: validated.recommendationTimeSlot,
+      recommendationWindowStart: validated.recommendationWindowStart
+        ? new Date(validated.recommendationWindowStart)
+        : undefined,
+      recommendationWindowEnd: validated.recommendationWindowEnd
+        ? new Date(validated.recommendationWindowEnd)
+        : undefined,
     };
 
     return {
@@ -245,6 +272,40 @@ export function buildSessionWizardUrl(
     urlParams.set('forecastFeedbackValue', params.forecastFeedbackValue);
   }
 
+  if (params.recommendationId) {
+    urlParams.set('recommendation_id', params.recommendationId);
+  }
+
+  if (params.recommendationSurface) {
+    urlParams.set('recommendation_surface', params.recommendationSurface);
+  }
+
+  if (params.recommendationRank !== undefined) {
+    urlParams.set('recommendation_rank', params.recommendationRank.toString());
+  }
+
+  if (params.recommendationScore !== undefined) {
+    urlParams.set('recommendation_score', params.recommendationScore.toString());
+  }
+
+  if (params.recommendationTimeSlot) {
+    urlParams.set('recommendation_time_slot', params.recommendationTimeSlot);
+  }
+
+  if (params.recommendationWindowStart) {
+    urlParams.set(
+      'recommendation_window_start',
+      params.recommendationWindowStart.toISOString()
+    );
+  }
+
+  if (params.recommendationWindowEnd) {
+    urlParams.set(
+      'recommendation_window_end',
+      params.recommendationWindowEnd.toISOString()
+    );
+  }
+
   return `/sessions/new?${urlParams.toString()}`;
 }
 
@@ -283,7 +344,9 @@ export function hasWizardParams(
     searchParams.has('mode') ||
     searchParams.has('startTime') ||
     searchParams.has('startedAt') ||
-    searchParams.has('quick')
+    searchParams.has('quick') ||
+    searchParams.has('recommendation_id') ||
+    searchParams.has('recommendationId')
   );
 }
 
@@ -319,5 +382,16 @@ export function extractFormState(params: ValidatedSessionWizardParams) {
       ? { selectedTime: params.startTime.toTimeString().slice(0, 5) }
       : {}),
     ...(forecastAccuracy ? { forecastAccuracy } : {}),
+    ...(params.recommendationId ? { recommendationId: params.recommendationId } : {}),
+    ...(params.recommendationSurface ? { recommendationSurface: params.recommendationSurface } : {}),
+    ...(params.recommendationRank !== undefined ? { recommendationRank: params.recommendationRank } : {}),
+    ...(params.recommendationScore !== undefined ? { recommendationScore: params.recommendationScore } : {}),
+    ...(params.recommendationTimeSlot ? { recommendationTimeSlot: params.recommendationTimeSlot } : {}),
+    ...(params.recommendationWindowStart
+      ? { recommendationWindowStart: params.recommendationWindowStart.toISOString() }
+      : {}),
+    ...(params.recommendationWindowEnd
+      ? { recommendationWindowEnd: params.recommendationWindowEnd.toISOString() }
+      : {}),
   };
 }

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -361,6 +361,46 @@ export const SessionWizardPrefillSchema = z.object({
   forecastFeedbackValue: z.enum(['too_low', 'about_right', 'too_high'])
     .optional()
     .describe('One-tap forecast feedback value used to prefill session accuracy'),
+
+  recommendationId: z.string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Deterministic recommendation id used to attribute the logged session'),
+
+  recommendationSurface: z.enum([
+    'home_hero',
+    'home_top_spots',
+    'home_nearby_spots',
+    'discover_list',
+    'explore_for_you',
+    'session_intelligence',
+  ])
+    .optional()
+    .describe('Recommendation surface used for attribution'),
+
+  recommendationRank: z.string()
+    .regex(/^\d+$/, 'Recommendation rank must be a number')
+    .transform((val) => parseInt(val, 10))
+    .refine((num) => num >= 1 && num <= 100, 'Recommendation rank must be between 1 and 100')
+    .optional(),
+
+  recommendationScore: z.string()
+    .regex(/^\d+(?:\.\d+)?$/, 'Recommendation score must be numeric')
+    .transform((val) => Number.parseFloat(val))
+    .refine((num) => Number.isFinite(num) && num >= 0 && num <= 100, 'Recommendation score must be between 0 and 100')
+    .optional(),
+
+  recommendationTimeSlot: z.enum(['dawn-patrol', 'morning', 'late-morning', 'lunch-session', 'afternoon', 'evening', 'any'])
+    .optional(),
+
+  recommendationWindowStart: z.string()
+    .datetime({ message: 'Invalid recommendation window start format' })
+    .optional(),
+
+  recommendationWindowEnd: z.string()
+    .datetime({ message: 'Invalid recommendation window end format' })
+    .optional(),
 })
   // Cross-field validation: end time must be after start time
   .refine(

--- a/supabase/migrations/20260709090000_recommendation_feedback_loop.sql
+++ b/supabase/migrations/20260709090000_recommendation_feedback_loop.sql
@@ -1,0 +1,215 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.recommendation_impressions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  recommendation_id text NOT NULL CHECK (char_length(recommendation_id) BETWEEN 1 AND 200),
+  beach_id uuid NOT NULL REFERENCES public.beaches(id) ON DELETE CASCADE,
+  rank integer NOT NULL CHECK (rank > 0 AND rank <= 100),
+  score numeric(5,2) CHECK (score IS NULL OR (score >= 0 AND score <= 100)),
+  window_start timestamptz NOT NULL,
+  window_end timestamptz NOT NULL,
+  mode text NOT NULL DEFAULT 'log' CHECK (mode IN ('log')),
+  time_slot text CHECK (
+    time_slot IS NULL OR time_slot IN (
+      'dawn-patrol',
+      'morning',
+      'late-morning',
+      'lunch-session',
+      'afternoon',
+      'evening',
+      'any'
+    )
+  ),
+  surface text NOT NULL CHECK (
+    surface IN (
+      'home_hero',
+      'home_top_spots',
+      'home_nearby_spots',
+      'discover_list',
+      'explore_for_you',
+      'session_intelligence'
+    )
+  ),
+  impression_key text NOT NULL CHECK (char_length(impression_key) BETWEEN 1 AND 260),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT recommendation_impressions_window_check CHECK (window_start < window_end)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS recommendation_impressions_key_idx
+  ON public.recommendation_impressions (impression_key);
+
+CREATE INDEX IF NOT EXISTS recommendation_impressions_user_created_idx
+  ON public.recommendation_impressions (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS recommendation_impressions_recommendation_idx
+  ON public.recommendation_impressions (recommendation_id);
+
+CREATE INDEX IF NOT EXISTS recommendation_impressions_beach_created_idx
+  ON public.recommendation_impressions (beach_id, created_at DESC);
+
+ALTER TABLE public.recommendation_impressions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS recommendation_impressions_select_own
+  ON public.recommendation_impressions;
+CREATE POLICY recommendation_impressions_select_own
+  ON public.recommendation_impressions
+  FOR SELECT
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS recommendation_impressions_insert_own
+  ON public.recommendation_impressions;
+CREATE POLICY recommendation_impressions_insert_own
+  ON public.recommendation_impressions
+  FOR INSERT
+  WITH CHECK ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS recommendation_impressions_service_role_all
+  ON public.recommendation_impressions;
+CREATE POLICY recommendation_impressions_service_role_all
+  ON public.recommendation_impressions
+  FOR ALL
+  USING ((auth.jwt() ->> 'role') = 'service_role')
+  WITH CHECK ((auth.jwt() ->> 'role') = 'service_role');
+
+REVOKE ALL ON public.recommendation_impressions FROM PUBLIC;
+GRANT SELECT, INSERT ON public.recommendation_impressions TO authenticated;
+GRANT ALL ON public.recommendation_impressions TO service_role;
+
+ALTER TABLE public.sessions
+  ADD COLUMN IF NOT EXISTS recommendation_id text,
+  ADD COLUMN IF NOT EXISTS recommendation_call_accuracy text,
+  ADD COLUMN IF NOT EXISTS forecast_wave_height_ft numeric,
+  ADD COLUMN IF NOT EXISTS forecast_tide_status text,
+  ADD COLUMN IF NOT EXISTS wave_height_correct boolean,
+  ADD COLUMN IF NOT EXISTS tide_status_correct boolean;
+
+ALTER TABLE public.sessions
+  DROP CONSTRAINT IF EXISTS sessions_recommendation_call_accuracy_check;
+ALTER TABLE public.sessions
+  ADD CONSTRAINT sessions_recommendation_call_accuracy_check
+  CHECK (
+    recommendation_call_accuracy IS NULL OR
+    recommendation_call_accuracy IN ('right', 'partly', 'wrong', 'not_sure')
+  );
+
+ALTER TABLE public.sessions
+  DROP CONSTRAINT IF EXISTS sessions_forecast_tide_status_check;
+ALTER TABLE public.sessions
+  ADD CONSTRAINT sessions_forecast_tide_status_check
+  CHECK (
+    forecast_tide_status IS NULL OR
+    forecast_tide_status IN ('rising', 'falling', 'high', 'low')
+  );
+
+ALTER TABLE public.sessions
+  DROP CONSTRAINT IF EXISTS sessions_forecast_wave_height_ft_check;
+ALTER TABLE public.sessions
+  ADD CONSTRAINT sessions_forecast_wave_height_ft_check
+  CHECK (
+    forecast_wave_height_ft IS NULL OR
+    (forecast_wave_height_ft >= 0 AND forecast_wave_height_ft <= 50)
+  );
+
+CREATE INDEX IF NOT EXISTS sessions_recommendation_id_idx
+  ON public.sessions (recommendation_id)
+  WHERE recommendation_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sessions_recommendation_feedback_idx
+  ON public.sessions (user_id, beach_id, created_at DESC)
+  WHERE recommendation_id IS NOT NULL
+    AND (
+      rating <= 2 OR
+      recommendation_call_accuracy = 'wrong'
+    );
+
+ALTER TABLE public.recommendation_session_contexts
+  DROP CONSTRAINT IF EXISTS recommendation_session_contexts_source_surface_check;
+
+ALTER TABLE public.recommendation_session_contexts
+  ADD CONSTRAINT recommendation_session_contexts_source_surface_check
+  CHECK (source_surface IN (
+    'home_hero',
+    'home_top_spots',
+    'home_nearby_spots',
+    'home_also_worth_it',
+    'discover_list',
+    'explore_for_you',
+    'beach_detail',
+    'session_intelligence',
+    'surf_window_adjacent'
+  ));
+
+DO $$
+DECLARE
+  current_check text;
+  candidate_events text[] := ARRAY['recommendation_impression'];
+  missing_events text[];
+BEGIN
+  SELECT regexp_replace(pg_get_constraintdef(oid), '^CHECK \((.*)\)$', '\1')
+    INTO current_check
+  FROM pg_constraint
+  WHERE conrelid = 'public.user_events'::regclass
+    AND conname = 'user_events_event_type_check';
+
+  IF current_check IS NULL THEN
+    RAISE EXCEPTION 'user_events_event_type_check constraint not found';
+  END IF;
+
+  SELECT array_agg(event_name)
+    INTO missing_events
+  FROM unnest(candidate_events) AS event_name
+  WHERE current_check NOT LIKE '%' || event_name || '%';
+
+  IF missing_events IS NOT NULL AND array_length(missing_events, 1) IS NOT NULL THEN
+    ALTER TABLE public.user_events
+      DROP CONSTRAINT user_events_event_type_check;
+
+    EXECUTE format(
+      'ALTER TABLE public.user_events ADD CONSTRAINT user_events_event_type_check CHECK ((%s) OR event_type = ANY (%L::text[]))',
+      current_check,
+      missing_events
+    );
+  END IF;
+END $$;
+
+CREATE OR REPLACE VIEW public.recommendation_feedback_summary
+WITH (security_invoker = true)
+AS
+SELECT
+  ri.user_id,
+  ri.recommendation_id,
+  ri.beach_id,
+  ri.surface,
+  ri.rank,
+  ri.score,
+  ri.window_start,
+  ri.window_end,
+  ri.created_at AS impression_at,
+  s.id AS session_id,
+  s.created_at AS session_created_at,
+  s.rating,
+  s.recommendation_call_accuracy,
+  s.wave_height_correct,
+  s.tide_status_correct
+FROM public.recommendation_impressions ri
+LEFT JOIN public.sessions s
+  ON s.user_id = ri.user_id
+ AND s.recommendation_id = ri.recommendation_id
+ AND s.deleted_at IS NULL;
+
+GRANT SELECT ON public.recommendation_feedback_summary TO authenticated;
+GRANT SELECT ON public.recommendation_feedback_summary TO service_role;
+
+COMMENT ON TABLE public.recommendation_impressions IS
+  'Durable authenticated recommendation exposure log. No historical backfill exists before this migration.';
+COMMENT ON COLUMN public.sessions.recommendation_id IS
+  'Deterministic recommendation identifier passed when a session is logged from a recommendation surface.';
+COMMENT ON COLUMN public.sessions.recommendation_call_accuracy IS
+  'User answer to suggested-session call correctness: right, partly, wrong, not_sure.';
+COMMENT ON VIEW public.recommendation_feedback_summary IS
+  'Forward-looking attribution view linking recommendation impressions to subsequently attributed sessions.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/database.generated.ts
+++ b/types/database.generated.ts
@@ -2532,6 +2532,13 @@ export type Database = {
             foreignKeyName: "comments_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "comments_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -6026,6 +6033,111 @@ export type Database = {
           },
         ]
       }
+      recommendation_impressions: {
+        Row: {
+          beach_id: string
+          created_at: string
+          id: string
+          impression_key: string
+          mode: string
+          rank: number
+          recommendation_id: string
+          score: number | null
+          surface: string
+          time_slot: string | null
+          user_id: string
+          window_end: string
+          window_start: string
+        }
+        Insert: {
+          beach_id: string
+          created_at?: string
+          id?: string
+          impression_key: string
+          mode?: string
+          rank: number
+          recommendation_id: string
+          score?: number | null
+          surface: string
+          time_slot?: string | null
+          user_id: string
+          window_end: string
+          window_start: string
+        }
+        Update: {
+          beach_id?: string
+          created_at?: string
+          id?: string
+          impression_key?: string
+          mode?: string
+          rank?: number
+          recommendation_id?: string
+          score?: number | null
+          surface?: string
+          time_slot?: string | null
+          user_id?: string
+          window_end?: string
+          window_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beach_location_audit"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beach_ml_performance_baseline"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beaches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_enhanced_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_marine_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_sun_times_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_tide_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "auth_apple_orphan_users"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       recommendation_session_contexts: {
         Row: {
           beach_id: string | null
@@ -6136,6 +6248,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "v_tide_forecast_latest"
             referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_session_contexts_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
           },
           {
             foreignKeyName: "recommendation_session_contexts_session_id_fkey"
@@ -6628,6 +6747,13 @@ export type Database = {
             foreignKeyName: "session_forecast_snapshots_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: true
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "session_forecast_snapshots_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: true
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -6720,6 +6846,13 @@ export type Database = {
             foreignKeyName: "session_invitations_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "session_invitations_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -6745,6 +6878,13 @@ export type Database = {
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "session_likes_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
           {
             foreignKeyName: "session_likes_session_id_fkey"
             columns: ["session_id"]
@@ -6909,6 +7049,13 @@ export type Database = {
             foreignKeyName: "session_media_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "session_media_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -7030,6 +7177,13 @@ export type Database = {
             foreignKeyName: "session_share_links_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "session_share_links_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -7084,6 +7238,13 @@ export type Database = {
           variant?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "session_shares_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
           {
             foreignKeyName: "session_shares_session_id_fkey"
             columns: ["session_id"]
@@ -7210,6 +7371,13 @@ export type Database = {
             foreignKeyName: "session_wave_observation_candidates_session_id_fkey"
             columns: ["session_id"]
             isOneToOne: true
+            referencedRelation: "recommendation_feedback_summary"
+            referencedColumns: ["session_id"]
+          },
+          {
+            foreignKeyName: "session_wave_observation_candidates_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: true
             referencedRelation: "sessions"
             referencedColumns: ["id"]
           },
@@ -7230,6 +7398,8 @@ export type Database = {
           description: string | null
           duration_minutes: number
           forecast_accuracy: string | null
+          forecast_tide_status: string | null
+          forecast_wave_height_ft: number | null
           goals: string[]
           id: string
           image_url: string | null
@@ -7240,6 +7410,8 @@ export type Database = {
           notes: string | null
           parking_ease: number | null
           rating: number | null
+          recommendation_call_accuracy: string | null
+          recommendation_id: string | null
           rip_current_observed: string | null
           rip_current_risk: string | null
           session_board_fit: string | null
@@ -7253,9 +7425,11 @@ export type Database = {
           tide_height_ft: number | null
           tide_rate_ft_per_hr: number | null
           tide_status: string | null
+          tide_status_correct: boolean | null
           user_id: string
           water_temp: number | null
           wave_characteristics: string[] | null
+          wave_height_correct: boolean | null
           wave_height_ft: number | null
           wave_quality: number | null
           wind_direction: string | null
@@ -7275,6 +7449,8 @@ export type Database = {
           description?: string | null
           duration_minutes?: number
           forecast_accuracy?: string | null
+          forecast_tide_status?: string | null
+          forecast_wave_height_ft?: number | null
           goals?: string[]
           id?: string
           image_url?: string | null
@@ -7285,6 +7461,8 @@ export type Database = {
           notes?: string | null
           parking_ease?: number | null
           rating?: number | null
+          recommendation_call_accuracy?: string | null
+          recommendation_id?: string | null
           rip_current_observed?: string | null
           rip_current_risk?: string | null
           session_board_fit?: string | null
@@ -7298,9 +7476,11 @@ export type Database = {
           tide_height_ft?: number | null
           tide_rate_ft_per_hr?: number | null
           tide_status?: string | null
+          tide_status_correct?: boolean | null
           user_id: string
           water_temp?: number | null
           wave_characteristics?: string[] | null
+          wave_height_correct?: boolean | null
           wave_height_ft?: number | null
           wave_quality?: number | null
           wind_direction?: string | null
@@ -7320,6 +7500,8 @@ export type Database = {
           description?: string | null
           duration_minutes?: number
           forecast_accuracy?: string | null
+          forecast_tide_status?: string | null
+          forecast_wave_height_ft?: number | null
           goals?: string[]
           id?: string
           image_url?: string | null
@@ -7330,6 +7512,8 @@ export type Database = {
           notes?: string | null
           parking_ease?: number | null
           rating?: number | null
+          recommendation_call_accuracy?: string | null
+          recommendation_id?: string | null
           rip_current_observed?: string | null
           rip_current_risk?: string | null
           session_board_fit?: string | null
@@ -7343,9 +7527,11 @@ export type Database = {
           tide_height_ft?: number | null
           tide_rate_ft_per_hr?: number | null
           tide_status?: string | null
+          tide_status_correct?: boolean | null
           user_id?: string
           water_temp?: number | null
           wave_characteristics?: string[] | null
+          wave_height_correct?: boolean | null
           wave_height_ft?: number | null
           wave_quality?: number | null
           wind_direction?: string | null
@@ -7611,35 +7797,6 @@ export type Database = {
             isOneToOne: true
             referencedRelation: "profiles_with_home_beach"
             referencedColumns: ["id"]
-          },
-        ]
-      }
-      streak_reminder_log: {
-        Row: {
-          period_key: string
-          reminder_type: string
-          sent_at: string
-          user_id: string
-        }
-        Insert: {
-          period_key: string
-          reminder_type: string
-          sent_at?: string
-          user_id: string
-        }
-        Update: {
-          period_key?: string
-          reminder_type?: string
-          sent_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "streak_reminder_log_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "auth_apple_orphan_users"
-            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -9259,17 +9416,6 @@ export type Database = {
           },
         ]
       }
-      mv_nowcast_anchors: {
-        Row: {
-          beach_id: string | null
-          observed_at: string | null
-          station_id: string | null
-          wave_direction_deg: number | null
-          wave_height_m: number | null
-          wave_period_s: number | null
-        }
-        Relationships: []
-      }
       observable_beaches: {
         Row: {
           beach_id: string | null
@@ -9397,6 +9543,83 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "v_tide_forecast_latest"
             referencedColumns: ["beach_id"]
+          },
+        ]
+      }
+      recommendation_feedback_summary: {
+        Row: {
+          beach_id: string | null
+          impression_at: string | null
+          rank: number | null
+          rating: number | null
+          recommendation_call_accuracy: string | null
+          recommendation_id: string | null
+          score: number | null
+          session_created_at: string | null
+          session_id: string | null
+          surface: string | null
+          tide_status_correct: boolean | null
+          user_id: string | null
+          wave_height_correct: boolean | null
+          window_end: string | null
+          window_start: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beach_location_audit"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beach_ml_performance_baseline"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "beaches"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_enhanced_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_marine_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_sun_times_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_beach_id_fkey"
+            columns: ["beach_id"]
+            isOneToOne: false
+            referencedRelation: "v_tide_forecast_latest"
+            referencedColumns: ["beach_id"]
+          },
+          {
+            foreignKeyName: "recommendation_impressions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "auth_apple_orphan_users"
+            referencedColumns: ["user_id"]
           },
         ]
       }
@@ -9773,7 +9996,6 @@ export type Database = {
           sentinel_marked: number
         }[]
       }
-      bulk_update_hrrr_wind: { Args: { payload: Json }; Returns: number }
       check_database_health: {
         Args: never
         Returns: {
@@ -9993,7 +10215,6 @@ export type Database = {
         | { Args: { schema_name: string; table_name: string }; Returns: string }
         | { Args: { table_name: string }; Returns: string }
       enablelongtransactions: { Args: never; Returns: string }
-      ensure_user_xp: { Args: { p_user_id: string }; Returns: undefined }
       equals: { Args: { geom1: unknown; geom2: unknown }; Returns: boolean }
       finalize_anon_alert_capture: {
         Args: { p_email: string; p_user_id: string }

--- a/types/implicit-preferences.ts
+++ b/types/implicit-preferences.ts
@@ -136,6 +136,7 @@ export const EVENT_WEIGHTS: Record<ImplicitEventType, number> = {
   learning_progress_revealed: 0,
   learned_me_moment_viewed: 0,
   // Discovery events
+  recommendation_impression: 0,
   personalized_score_shown: 0,
   favorite_shown_in_carousel: 0,
   mini_log_teaser_click: 0,

--- a/types/personalization.ts
+++ b/types/personalization.ts
@@ -265,6 +265,8 @@ export interface SurfDiscoveryBoardPick {
  * match quality indicators, and distance information for GPS phase.
  */
 export interface SurfDiscoveryRecommendation {
+  /** Deterministic recommendation id shared by web attribution and Recommendations V2. */
+  recommendationId?: string;
   /** Recommendation source discriminator. Missing values should be treated as "beach" by older clients. */
   kind?: 'beach' | 'custom_spot';
   /** Custom spot id when kind="custom_spot"; null/undefined for curated beach recommendations. */

--- a/types/session-wizard.ts
+++ b/types/session-wizard.ts
@@ -48,6 +48,27 @@ export interface SessionWizardPrefillParams {
 
   /** One-tap forecast verification value captured before session logging */
   forecastFeedbackValue?: 'too_low' | 'about_right' | 'too_high';
+
+  /** Recommendation attribution id from surf discovery/home surfaces */
+  recommendation_id?: string;
+
+  /** Recommendation surface name used for attribution */
+  recommendation_surface?: string;
+
+  /** Recommendation rank on the source surface */
+  recommendation_rank?: string;
+
+  /** Recommendation score shown on the source surface */
+  recommendation_score?: string;
+
+  /** Recommendation source time slot */
+  recommendation_time_slot?: string;
+
+  /** Recommendation window start ISO timestamp */
+  recommendation_window_start?: string;
+
+  /** Recommendation window end ISO timestamp */
+  recommendation_window_end?: string;
 }
 
 /**
@@ -81,4 +102,12 @@ export interface ValidatedSessionWizardParams {
 
   /** One-tap forecast verification value captured before session logging */
   forecastFeedbackValue?: 'too_low' | 'about_right' | 'too_high';
+
+  recommendationId?: string;
+  recommendationSurface?: string;
+  recommendationRank?: number;
+  recommendationScore?: number;
+  recommendationTimeSlot?: string;
+  recommendationWindowStart?: Date;
+  recommendationWindowEnd?: Date;
 }


### PR DESCRIPTION
## Summary
- Add durable `recommendation_impressions` tracking with authenticated API batching and analytics event parity.
- Carry recommendation attribution into session logging and collect “Was this call right?” feedback plus wave/tide correctness signals.
- Feed bad recommendation-linked sessions into personal demotion so repeated wrong/low-rated beach-condition pairs suppress affinity.

## Migration / Release Impact
- Adds `public.recommendation_impressions`, RLS policies, indexes, grants, and `recommendation_feedback_summary` reporting view.
- Adds nullable recommendation feedback columns on `public.sessions`.
- Widens `user_events_event_type_check` for `recommendation_impression`.
- Regenerated DB types from local Supabase after applying the migration locally.
- Migration reviewed and approved in-thread by Steven before commit.

## Verification
- `psql postgresql://postgres:postgres@127.0.0.1:54322/postgres -v ON_ERROR_STOP=1 -f supabase/migrations/20260709090000_recommendation_feedback_loop.sql` passed.
- `yarn db:types` passed.
- `npx tsc --noEmit --pretty false --incremental false` passed.
- `yarn test:unit --runTestsByPath __tests__/lib/utils/session-wizard-params.test.ts __tests__/lib/utils/session-data-builder.test.ts __tests__/lib/utils/session-utils.test.ts __tests__/actions/session-actions-create-logged.test.ts __tests__/api/recommendation-impressions.test.ts __tests__/hooks/use-session-conditions-prefill.test.tsx __tests__/hooks/use-recommendation-impression.test.tsx __tests__/components/session-forms/ConditionsSection.recommendation.test.tsx __tests__/migrations/recommendation-feedback-loop.test.ts __tests__/lib/services/discovery/personalization-layer.test.ts __tests__/lib/recommendations/attribution.test.ts __tests__/app/vs-surfline-metadata.test.ts` passed: 12 suites, 148 tests.
- `npx eslint --max-warnings=0 <touched recommendation feedback files>` passed.
- `BASE_URL=http://localhost:3000 npx playwright test e2e/session-wizard-autofill.spec.ts --project=auth` passed: 2 tests.
- `git diff --cached --check` passed before commit.

## Notes
- GitHub Actions are unavailable for this repo; local checks above are the release evidence.
- Existing unrelated dirty files were left unstaged and are not part of this PR.
