### PR TITLE
release: promote main to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Map search and forecast playback regressions** (`components/map-view.tsx`, `components/map/*`). Beach search suggestions now keep surfers on the map, the condition legend clears the forecast scrubber at every viewport size, and playback skips missing swell frames without blanking pins or the active field.
+
 ### Added
 - **AI-scored wave punchiness grounding layer** (`lib/domains/spot-profile/wave-punchiness.ts`, `lib/services/discovery/surf-discovery-orchestrator.ts`, `supabase/migrations/20260704180000_add_wave_punchiness_ai.sql`, `..._180001_seed_wave_punchiness_ai.sql`). Adds nullable `beaches.wave_punchiness_ai` / `_confidence` / `_meta` columns and a `resolveWavePunchiness` precedence — manual override > confident AI score (≥0.55) > structural derivation. AI scores are distilled from each spot's own freetext (no external scrape); the confidence gate keeps the board-fit mismatch penalty off low-signal spots. Seeds 258 scored beaches.
 - **Board/style to spot-character discovery fit** (`lib/services/discovery/board-style-fit.ts`, `lib/services/discovery/surf-discovery-orchestrator.ts`, `supabase/migrations/20260704160000_add_beach_wave_punchiness.sql`). Adds an unapplied nullable `beaches.wave_punchiness` migration seed for iconic CA contrasts and folds the user's once-resolved dominant board class into discovery score reasons/warnings without changing the `/api/surf/discover` response contract.

--- a/__tests__/app/api/forecasts/bulk/route.test.ts
+++ b/__tests__/app/api/forecasts/bulk/route.test.ts
@@ -752,7 +752,7 @@ describe("/api/forecasts/bulk", () => {
       hourlyTimelineRow("beach-1", "2", "2026-07-10T20:00:00.000Z"),
       hourlyTimelineRow("beach-2", "3", "2026-07-10T21:00:00.000Z"),
     ];
-    const nextRow = hourlyTimelineRow("beach-1", "4", "2026-07-13T04:00:00.000Z");
+    const nextRow = hourlyTimelineRow("beach-1", "4", "2026-07-25T04:00:00.000Z");
     const { hourlyTimelineChain, nextHourlyTimelineChain } = mockBulkQueries({
       hourlyTimelineRows: windowRows,
       nextHourlyTimelineRows: [nextRow],
@@ -761,7 +761,7 @@ describe("/api/forecasts/bulk", () => {
 
     const hourlyResponse = await GET(
       createHourlyTimelineRequest(
-        "http://localhost:3000/api/forecasts/bulk?beachIds=beach-1,beach-2&timeline=hourly&timelineStart=2026-07-10T20:00:00.000Z&timelineHours=99",
+        "http://localhost:3000/api/forecasts/bulk?beachIds=beach-1,beach-2&timeline=hourly&timelineStart=2026-07-10T20:00:00.000Z&timelineHours=999",
       ),
     );
     const hourlyData = await expectSuccessResponse<BulkForecastResponse>(hourlyResponse, 200);
@@ -772,11 +772,11 @@ describe("/api/forecasts/bulk", () => {
     );
     expect(hourlyTimelineChain.lt).toHaveBeenCalledWith(
       "forecast_at",
-      "2026-07-12T20:00:00.000Z",
+      "2026-07-24T20:00:00.000Z",
     );
     expect(nextHourlyTimelineChain.gte).toHaveBeenCalledWith(
       "forecast_at",
-      "2026-07-12T20:00:00.000Z",
+      "2026-07-24T20:00:00.000Z",
     );
     expect(nextHourlyTimelineChain.order).toHaveBeenCalledWith(
       "forecast_at",
@@ -790,7 +790,7 @@ describe("/api/forecasts/bulk", () => {
         "beach-2": [null, expect.objectContaining({ s1HeightFt: 3 })],
       },
       hasMore: true,
-      nextStart: "2026-07-13T04:00:00.000Z",
+      nextStart: "2026-07-25T04:00:00.000Z",
     });
   });
 

--- a/__tests__/components/map-view.test.tsx
+++ b/__tests__/components/map-view.test.tsx
@@ -5,7 +5,9 @@ import type { Beach } from "@/types/database";
 
 const mockLoadNearbyBeaches = jest.fn();
 const mockRouterReplace = jest.fn();
+const mockRouterPush = jest.fn();
 const mockSetSearchQuery = jest.fn();
+const mockSetSelectedBeach = jest.fn();
 const mockGetUserLocation = jest.fn();
 let mockIsMobile = false;
 let mockSearchParams = new URLSearchParams();
@@ -33,7 +35,7 @@ const mockCustomSpots = [
 
 jest.mock("next/navigation", () => ({
   usePathname: () => "/map",
-  useRouter: () => ({ replace: mockRouterReplace }),
+  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
   useSearchParams: () => mockSearchParams,
 }));
 
@@ -75,7 +77,7 @@ jest.mock("@/hooks/use-beach-search", () => ({
     loadNearbyBeaches: mockLoadNearbyBeaches,
     setSearchQuery: mockSetSearchQuery,
     clearSearch: jest.fn(),
-    setSelectedBeach: jest.fn(),
+    setSelectedBeach: mockSetSelectedBeach,
     toggleBeginnerFriendly: jest.fn(),
     toggleBreakType: jest.fn(),
     clearAllFilters: jest.fn(),
@@ -193,19 +195,11 @@ describe("MapView", () => {
       lon: -117.25,
       timezone: "America/Los_Angeles",
     } as Beach;
-    const hawaii = {
-      id: "hawaii",
-      label: "Hawaii",
-      center: { lat: 21.66, lon: -158.06 },
-      timezone: "Pacific/Honolulu",
-    };
-
     expect(
       resolveViewedMapTimezone({
         selectedBeach: sanDiego,
         loadedBeaches: [honolulu, sanDiego],
         exploredCenter: { lat: 21.29, lon: -157.86 },
-        activeRegion: hawaii,
       }),
     ).toBe("America/Los_Angeles");
     expect(
@@ -213,15 +207,6 @@ describe("MapView", () => {
         selectedBeach: null,
         loadedBeaches: [honolulu, sanDiego],
         exploredCenter: { lat: 21.29, lon: -157.86 },
-        activeRegion: null,
-      }),
-    ).toBe("Pacific/Honolulu");
-    expect(
-      resolveViewedMapTimezone({
-        selectedBeach: null,
-        loadedBeaches: [],
-        exploredCenter: null,
-        activeRegion: hawaii,
       }),
     ).toBe("Pacific/Honolulu");
   });
@@ -280,6 +265,33 @@ describe("MapView", () => {
     });
     expect((lastMapContentProps.cameraCommand as { source: string }).source)
       .toBe("pin");
+  });
+
+  it("keeps search suggestion selection on the map and centers the selected beach", async () => {
+    const waikiki = {
+      id: "waikiki",
+      name: "Waikiki",
+      slug: "waikiki",
+      city: "Honolulu",
+      state: "HI",
+      lat: 21.2767,
+      lon: -157.8263,
+    } as Beach;
+    mockSearchQuery = "waikiki";
+    mockFilteredBeaches = [waikiki];
+    const user = userEvent.setup();
+
+    render(<MapView />);
+    await user.click(screen.getByRole("option", { name: /Waikiki/i }));
+
+    expect(mockSetSelectedBeach).toHaveBeenCalledWith(waikiki);
+    expect(lastMapContentProps.cameraCommand).toMatchObject({
+      source: "pin",
+      center: { lat: 21.2767, lon: -157.8263 },
+    });
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("map-search-suggestions")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toHaveValue("waikiki");
   });
 
   it("uses the final user move center for timezone without issuing camera or beach loads", () => {
@@ -392,6 +404,9 @@ describe("MapView", () => {
     expect(parsed.searchParams.get("qr_id")).toBe("map_literacy_field_guide");
     expect(parsed.searchParams.get("target")).toBe("download");
     expect(parsed.searchParams.get("utm_source")).toBe("qr");
+    expect(screen.queryByText("Smart QR")).not.toBeInTheDocument();
+    expect(screen.getByText(/take the map with you/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Get the app" })).toBeInTheDocument();
     expect(mockTrackQrRendered).toHaveBeenCalledWith(
       expect.objectContaining({
         source: "map_literacy_panel",
@@ -434,21 +449,6 @@ describe("MapView", () => {
     expect(mockSetSearchQuery).not.toHaveBeenCalledWith("");
   });
 
-  it("strips stale search URL params when a region is selected", async () => {
-    const user = userEvent.setup();
-    mockSearchParams = new URLSearchParams("search=Blacks");
-
-    render(<MapView />);
-
-    await user.click(
-      screen.getByRole("button", { name: "Regions and filters" }),
-    );
-    await user.click(screen.getByRole("button", { name: "OC" }));
-
-    expect(mockRouterReplace).toHaveBeenCalledWith("/map", { scroll: false });
-    expect(mockLoadNearbyBeaches).toHaveBeenCalledWith(33.63, -117.95);
-  });
-
   it("centers on the signed-in home beach without prompting for GPS", async () => {
     mockHomeBeach = { lat: 36.9512, lon: -122.0258 }; // Steamer Lane, Santa Cruz
 
@@ -474,7 +474,7 @@ describe("MapView", () => {
     expect(mockGetUserLocation).toHaveBeenCalled();
   });
 
-  it("does not restore GPS ownership after region, pin, or map interaction", async () => {
+  it("does not restore GPS ownership after pin or map interaction", async () => {
     const alaMoana = {
       id: "ala-moana",
       lat: 21.28,
@@ -482,11 +482,12 @@ describe("MapView", () => {
     } as Beach;
     const { rerender } = render(<MapView />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Regions and filters" }));
-    fireEvent.click(screen.getByRole("button", { name: "Hawaii" }));
+    act(() => {
+      (lastMapContentProps.onBeachSelect as (beach: Beach) => void)(alaMoana);
+    });
     expect(
       (lastMapContentProps.cameraCommand as { source: string }).source,
-    ).toBe("region");
+    ).toBe("pin");
 
     mockLoadNearbyBeaches.mockClear();
     mockUserLocation = { lat: 32.7702, lon: -117.2525 };
@@ -495,13 +496,6 @@ describe("MapView", () => {
       32.7702,
       -117.2525,
     );
-
-    act(() => {
-      (lastMapContentProps.onBeachSelect as (beach: Beach) => void)(alaMoana);
-    });
-    expect(
-      (lastMapContentProps.cameraCommand as { source: string }).source,
-    ).toBe("pin");
 
     act(() => {
       (lastMapContentProps.onUserCameraInteraction as (interaction: {

--- a/__tests__/components/map/interactive-map.test.tsx
+++ b/__tests__/components/map/interactive-map.test.tsx
@@ -34,6 +34,7 @@ jest.mock("mapbox-gl", () => ({
     flyTo: jest.fn(),
     easeTo: jest.fn(),
     fitBounds: jest.fn(),
+    resize: jest.fn(),
     getBounds: jest.fn(() => ({
       getWest: () => -117.3,
       getSouth: () => 32.7,
@@ -135,6 +136,7 @@ describe("InteractiveMap", () => {
     flyTo: jest.Mock;
     getCenter: jest.Mock;
     setMaxBounds: jest.Mock;
+    resize: jest.Mock;
   } {
     const Map = require("mapbox-gl").Map;
     return Map.mock.results[Map.mock.results.length - 1].value;
@@ -204,6 +206,49 @@ describe("InteractiveMap", () => {
       center: { lat: 32.7493, lon: -117.2511 },
       phase: "start",
     });
+  });
+
+  it("restores the swell overlay after the map style loads", async () => {
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    render(
+      <InteractiveMap
+        beaches={[]}
+        showSwellField
+        swellLayerId="s1"
+      />,
+    );
+
+    await waitFor(() => expect(mockMapHandlers["style.load"]).toHaveLength(1));
+    const map = getMapInstance() as ReturnType<typeof getMapInstance> & {
+      addLayer: jest.Mock;
+    };
+    await waitFor(() => expect(map.addLayer).toHaveBeenCalled());
+    const initialAdds = map.addLayer.mock.calls.length;
+
+    act(() => mockMapHandlers["style.load"][0]());
+
+    await waitFor(() => {
+      expect(map.addLayer.mock.calls.length).toBeGreaterThan(initialAdds);
+    });
+  });
+
+  it("resizes Mapbox when its container changes size", async () => {
+    let resizeCallback: ResizeObserverCallback | null = null;
+    global.ResizeObserver = jest.fn((callback: ResizeObserverCallback) => {
+      resizeCallback = callback;
+      return {
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      } as ResizeObserver;
+    }) as unknown as typeof ResizeObserver;
+    const { InteractiveMap } = await import("@/components/map/interactive-map");
+    render(<InteractiveMap beaches={[]} />);
+
+    await waitFor(() => expect(resizeCallback).not.toBeNull());
+    act(() => resizeCallback?.([], {} as ResizeObserver));
+
+    await waitFor(() => expect(getMapInstance().resize).toHaveBeenCalled());
   });
 
   it("reports only a user gesture's final moveend center", async () => {
@@ -356,6 +401,38 @@ describe("InteractiveMap", () => {
       )
       : firstFrame;
     expect(mismatchedPartition).toBeUndefined();
+  });
+
+  it("interpolates absolute hourly partitions at a fractional playback position", async () => {
+    const interactiveMapModule = await import("@/components/map/interactive-map");
+    const resolve = interactiveMapModule.partitionAtAbsoluteTimelinePosition;
+    const timeline = {
+      timestamps: [
+        "2026-07-10T20:00:00.000Z",
+        "2026-07-10T21:00:00.000Z",
+      ],
+      partitionsByBeach: {
+        "beach-1": [
+          {
+            s1Dir: 350, s1PeriodS: 10, s1HeightFt: 2,
+            s2Dir: null, s2PeriodS: null, s2HeightFt: null,
+            windDir: null, windMph: null,
+          },
+          {
+            s1Dir: 10, s1PeriodS: 14, s1HeightFt: 4,
+            s2Dir: null, s2PeriodS: null, s2HeightFt: null,
+            windDir: null, windMph: null,
+          },
+        ],
+      },
+      hasMore: false,
+      nextStart: null,
+    };
+
+    expect(resolve(timeline, "beach-1", 0.5)).toEqual(expect.objectContaining({
+      s1HeightFt: 3,
+      s1PeriodS: 12,
+    }));
   });
 
   it("clears the debug center during map setup and cleanup", async () => {

--- a/__tests__/components/map/map-toolbar.test.tsx
+++ b/__tests__/components/map/map-toolbar.test.tsx
@@ -1,13 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MapToolbar } from "@/components/map/map-toolbar";
-import type { MapRegionPill } from "@/components/map/map-regions";
 import type { Beach } from "@/types/database";
-
-const regions: MapRegionPill[] = [
-  { id: "san-diego", label: "San Diego", center: { lat: 32.79, lon: -117.25 } },
-  { id: "orange-county", label: "OC", center: { lat: 33.63, lon: -117.95 } },
-];
 
 const suggestions = [
   {
@@ -26,8 +20,6 @@ const defaultProps = {
   onClearSearch: jest.fn(),
   suggestions,
   onSuggestionSelect: jest.fn(),
-  regions,
-  onRegionSelect: jest.fn(),
   onUseMyLocation: jest.fn(),
   filters: { beginnerFriendly: false, breakTypes: new Set<string>() },
   onToggleBeginner: jest.fn(),
@@ -46,11 +38,15 @@ describe("MapToolbar", () => {
   it("renders an always-visible beach search input", () => {
     render(<MapToolbar {...defaultProps} />);
 
+    expect(screen.getByTestId("map-controls")).toHaveStyle({
+      background: "#F4EBD8",
+      color: "#11100D",
+    });
     expect(
       screen.getByRole("combobox", {
         name: "Search beaches, spots, or cities",
       }),
-    ).toBeInTheDocument();
+    ).toHaveClass("border-2", "border-[#11100D]", "bg-[#F5EEDC]");
   });
 
   it("calls onSearchChange when typing in the search input", async () => {
@@ -74,6 +70,7 @@ describe("MapToolbar", () => {
     await user.click(screen.getByRole("option", { name: /Blacks San Diego, CA/i }));
 
     expect(defaultProps.onSuggestionSelect).toHaveBeenCalledWith(suggestions[0]);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
   it("supports keyboard selection from the suggestions combobox", async () => {
@@ -90,18 +87,18 @@ describe("MapToolbar", () => {
     await user.keyboard("{ArrowDown}{Enter}");
 
     expect(defaultProps.onSuggestionSelect).toHaveBeenCalledWith(suggestions[0]);
+    expect(search).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
-  it("calls onRegionSelect with the selected region pill", async () => {
+  it("only shows filters in the filters popover", async () => {
     const user = userEvent.setup();
     render(<MapToolbar {...defaultProps} />);
 
-    await user.click(
-      screen.getByRole("button", { name: "Regions and filters" }),
-    );
-    await user.click(screen.getByRole("button", { name: "OC" }));
+    await user.click(screen.getByRole("button", { name: "Filters" }));
 
-    expect(defaultProps.onRegionSelect).toHaveBeenCalledWith(regions[1]);
+    expect(screen.queryByText("Regions")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Beginner-friendly" })).toBeInTheDocument();
   });
 
   it("does not render the removed Map/List segmented control", () => {
@@ -155,7 +152,7 @@ describe("MapToolbar", () => {
     const { rerender } = render(<MapToolbar {...defaultProps} />);
 
     await user.click(
-      screen.getByRole("button", { name: "Regions and filters" }),
+      screen.getByRole("button", { name: "Filters" }),
     );
 
     expect(screen.queryByTestId("map-clear-all")).not.toBeInTheDocument();
@@ -165,25 +162,21 @@ describe("MapToolbar", () => {
     expect(screen.getByTestId("map-clear-all")).toBeInTheDocument();
   });
 
-  it("moves regions and filters into a dropdown", async () => {
+  it("moves filters into a dropdown", async () => {
     const user = userEvent.setup();
     render(<MapToolbar {...defaultProps} hasActiveFilters />);
 
     expect(
-      screen.getByRole("button", { name: "Regions and filters" }),
+      screen.getByRole("button", { name: "Filters" }),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("map-region-pill-san-diego"),
-    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Beginner-friendly" }),
     ).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: "Regions and filters" }),
+      screen.getByRole("button", { name: "Filters" }),
     );
 
-    expect(screen.getByTestId("map-region-pill-san-diego")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Beginner-friendly" }),
     ).toBeInTheDocument();

--- a/__tests__/components/map/swell-day-timeline.test.tsx
+++ b/__tests__/components/map/swell-day-timeline.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { TimelineDaySegment } from "@/components/map/hourly-swell-timeline";
 import {
+  advancePlaybackPosition,
   findAdjacentLocalDayIndex,
   SwellDayTimeline,
   type SwellDayTimelineProps,
@@ -42,6 +43,12 @@ function createProps(
 }
 
 describe("SwellDayTimeline", () => {
+  it("advances the visual playhead continuously between forecast frames", () => {
+    expect(advancePlaybackPosition(2, 125, 10)).toBe(2.25);
+    expect(advancePlaybackPosition(2.25, 125, 10)).toBe(2.5);
+    expect(advancePlaybackPosition(9.9, 100, 10)).toBe(10);
+  });
+
   it("exposes the active local forecast time through the native slider", () => {
     render(<SwellDayTimeline {...createProps()} />);
 
@@ -64,6 +71,14 @@ describe("SwellDayTimeline", () => {
     rerender(<SwellDayTimeline {...createProps({ isPlaying: true, onPlayingChange })} />);
     fireEvent.click(screen.getByRole("button", { name: "Pause forecast timeline" }));
     expect(onPlayingChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("keeps playback progress above the day labels", () => {
+    render(<SwellDayTimeline {...createProps({ index: 12, isPlaying: true })} />);
+
+    expect(screen.getByTestId("timeline-progress")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-visual-track")).toHaveClass("bottom-8");
+    expect(screen.getByRole("slider", { name: "Forecast time" })).toHaveClass("opacity-0");
   });
 
   it("moves the controlled index with keyboard steps and clamps endpoints", () => {

--- a/__tests__/hooks/use-expandable-swell-timeline.test.ts
+++ b/__tests__/hooks/use-expandable-swell-timeline.test.ts
@@ -354,6 +354,42 @@ describe("useExpandableSwellTimeline", () => {
     );
   });
 
+  it("skips playback frames that cannot render the active swell layer", () => {
+    const initial = makeTimeline(0, 4, { hasMore: false, nextStart: null });
+    const isFramePlayable = jest.fn((_timeline: HourlySwellTimeline, index: number) =>
+      index !== 1,
+    );
+    const { result } = renderHook(() => useExpandableSwellTimeline({
+      scopeKey: "a",
+      initial,
+      timezone: "Pacific/Honolulu",
+      loadChunk: jest.fn(),
+      reducedMotion: false,
+      isFramePlayable,
+    }));
+
+    act(() => {
+      result.current.setPlaying(true);
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.index).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.index).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(result.current.index).toBe(2);
+    expect(isFramePlayable).toHaveBeenCalledWith(initial, 1);
+    expect(isFramePlayable).toHaveBeenCalledWith(initial, 2);
+  });
+
   it("does not rebuild reset identity or day segments for index-only renders", () => {
     const stringifySpy = jest.spyOn(JSON, "stringify");
     const timelineUtils = jest.requireMock(

--- a/__tests__/migrations/match-candidates-postgis-search-path.test.ts
+++ b/__tests__/migrations/match-candidates-postgis-search-path.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('match candidates PostGIS search path migration', () => {
+  it('makes PostGIS geography types available to the security-definer RPC', () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        'supabase/migrations/20260712160000_fix_match_candidates_postgis_search_path.sql',
+      ),
+      'utf8',
+    );
+
+    expect(migration).toContain('ALTER FUNCTION public.get_user_match_candidates');
+    expect(migration).toContain('SET search_path = public, extensions, pg_temp');
+    expect(migration).not.toContain('DROP FUNCTION');
+  });
+});

--- a/app/api/forecasts/bulk/route.ts
+++ b/app/api/forecasts/bulk/route.ts
@@ -61,7 +61,7 @@ const HOURLY_SWELL_TIMELINE_HOUR_OFFSETS = Array.from(
   (_, hourOffset) => hourOffset,
 );
 const DEFAULT_TIMELINE_HOURS = 48;
-const MAX_TIMELINE_HOURS = 48;
+const MAX_TIMELINE_HOURS = 14 * 24;
 const HOUR_MS = 60 * 60 * 1000;
 const ISO_TIMESTAMP_WITH_TIMEZONE =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -234,7 +234,7 @@
   color: var(--ink);
 }
 
-.theme-retro-dark .zine-tab input[data-zine-input="true"] {
+.theme-retro-dark input[data-zine-input="true"] {
   background-color: #F4EBD8 !important;
   border-color: #11100D !important;
   color: #11100D !important;

--- a/components/map-view.tsx
+++ b/components/map-view.tsx
@@ -7,10 +7,6 @@ import { useGeolocation } from "@/hooks/use-geolocation";
 import { useBeachSearch } from "@/hooks/use-beach-search";
 import { MapToolbar } from "@/components/map/map-toolbar";
 import { useCustomSpots } from "@/hooks/use-custom-spots";
-import {
-  MAP_REGION_PILLS,
-  type MapRegionPill,
-} from "@/components/map/map-regions";
 import { MapContent } from "@/components/map/map-content";
 import { MapLearningPanel } from "@/components/map/map-learning-panel";
 import {
@@ -21,7 +17,6 @@ import {
 import { type SwellLayerId } from "@/components/map/swell-map-theme";
 import { useProfileContext } from "@/context/profile-context";
 import type { Beach } from "@/types/database";
-import { getBeachUrlSafe } from "@/lib/utils/beach-url-utils";
 
 const MISSION_BEACH_COORDS = { lat: 32.7702, lon: -117.2525 } as const;
 
@@ -52,12 +47,10 @@ export function resolveViewedMapTimezone({
   selectedBeach,
   loadedBeaches,
   exploredCenter,
-  activeRegion,
 }: {
   selectedBeach: Beach | null;
   loadedBeaches: Beach[];
   exploredCenter: { lat: number; lon: number } | null;
-  activeRegion: MapRegionPill | null;
 }): string {
   const selectedTimezone = selectedBeach?.timezone;
   if (isTimeZone(selectedTimezone)) return selectedTimezone;
@@ -75,7 +68,6 @@ export function resolveViewedMapTimezone({
     if (isTimeZone(nearestBeach?.timezone)) return nearestBeach.timezone;
   }
 
-  if (isTimeZone(activeRegion?.timezone)) return activeRegion.timezone;
   return deviceTimezone();
 }
 
@@ -135,7 +127,6 @@ export function MapView() {
     lat: number;
     lon: number;
   } | null>(null);
-  const [activeRegion, setActiveRegion] = useState<MapRegionPill | null>(null);
 
   const issueCameraCommand = useCallback(
     (input: Omit<MapCameraCommand, "id">, owner: MapCameraOwner) => {
@@ -201,9 +192,8 @@ export function MapView() {
         selectedBeach,
         loadedBeaches: filteredBeaches,
         exploredCenter,
-        activeRegion,
       }),
-    [activeRegion, exploredCenter, filteredBeaches, selectedBeach],
+    [exploredCenter, filteredBeaches, selectedBeach],
   );
 
   // Load nearby beaches when user location is available - prevent duplicate calls
@@ -427,7 +417,6 @@ export function MapView() {
   const handleBeachSelect = useCallback(
     (beach: Beach) => {
       setSelectedBeach(beach);
-      setActiveRegion(null);
       if (isFiniteCoord(beach.lat) && isFiniteCoord(beach.lon)) {
         issueCameraCommand(
           { source: "pin", center: { lat: beach.lat, lon: beach.lon } },
@@ -443,12 +432,8 @@ export function MapView() {
   const handleSuggestionSelect = useCallback(
     (beach: Beach) => {
       handleBeachSelect(beach);
-      const href = getBeachUrlSafe(beach);
-      if (href) {
-        router.push(href);
-      }
     },
-    [handleBeachSelect, router]
+    [handleBeachSelect]
   );
 
   const stripMapUrlParams = useCallback(
@@ -523,30 +508,6 @@ export function MapView() {
     applyDefaultLocation();
   }, [applyDefaultLocation, issueCameraCommand]);
 
-  const handleRegionSelect = useCallback(
-    (region: MapRegionPill) => {
-      setSelectedBeach(null);
-      setActiveRegion(region);
-      clearSearch();
-      issueCameraCommand(
-        region.bounds
-          ? { source: "region", bounds: region.bounds }
-          : { source: "region", center: region.center },
-        "explicit-command",
-      );
-      stripMapUrlParams(["search"]);
-      lastLocationRef.current = null;
-      void loadNearbyBeaches(region.center.lat, region.center.lon);
-    },
-    [
-      clearSearch,
-      issueCameraCommand,
-      loadNearbyBeaches,
-      setSelectedBeach,
-      stripMapUrlParams,
-    ]
-  );
-
   const handleMapClick = useCallback(() => {
     setSelectedBeach(null);
   }, [setSelectedBeach]);
@@ -593,8 +554,6 @@ export function MapView() {
         onClearSearch={handleClearSearch}
         suggestions={filteredBeaches.slice(0, 6)}
         onSuggestionSelect={handleSuggestionSelect}
-        regions={MAP_REGION_PILLS}
-        onRegionSelect={handleRegionSelect}
         onUseMyLocation={handleUseMyLocation}
         filters={filters}
         onToggleBeginner={toggleBeginnerFriendly}

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -228,6 +228,30 @@ export function partitionAtAbsoluteTimelineIndex(
   return partitions[frameIndex] ?? undefined;
 }
 
+export function partitionAtAbsoluteTimelinePosition(
+  timeline: HourlySwellTimeline | null,
+  beachId: string,
+  position: number,
+): SwellPartition | undefined {
+  if (!timeline || !Number.isFinite(position) || timeline.timestamps.length === 0) {
+    return undefined;
+  }
+  const clampedPosition = Math.min(
+    Math.max(position, 0),
+    timeline.timestamps.length - 1,
+  );
+  const leftIndex = Math.floor(clampedPosition);
+  const rightIndex = Math.ceil(clampedPosition);
+  const progress = clampedPosition - leftIndex;
+  const left = partitionAtAbsoluteTimelineIndex(timeline, beachId, leftIndex);
+  const right = partitionAtAbsoluteTimelineIndex(timeline, beachId, rightIndex);
+
+  if (left && right && progress > 0) {
+    return interpolateSwellPartition(left, right, progress);
+  }
+  return left ?? right;
+}
+
 /** Sub-layer component ids whose flow fields a given active layer needs built. */
 function componentsForLayer(
   layerId: SwellLayerId
@@ -293,6 +317,7 @@ interface InteractiveMapProps {
 
 const SAN_DIEGO: [number, number] = [32.7157, -117.1611];
 const EMPTY_CUSTOM_SPOTS: CustomSpot[] = [];
+const FULL_FORECAST_TIMELINE_HOURS = 14 * 24;
 
 const CONDITION_LEGEND_ITEMS: Array<{
   label: ConditionSummary;
@@ -307,11 +332,13 @@ const CONDITION_LEGEND_ITEMS: Array<{
 interface MapConditionLegendProps {
   controls?: ReactNode;
   timeline?: ReactNode;
+  bottomOffset?: number;
 }
 
 function MapConditionLegend({
   controls,
   timeline,
+  bottomOffset = 0,
 }: MapConditionLegendProps): ReactElement {
   const [isMinimized, setIsMinimized] = useState(false);
   const embeddedControls = Children.toArray(controls);
@@ -346,6 +373,7 @@ function MapConditionLegend({
           : ""
       }`}
       style={{
+        bottom: bottomOffset > 0 ? `calc(${bottomOffset}px + 0.75rem)` : undefined,
         background: SWELL_MAP_LEGEND_SURFACE.paper,
         border: `2px solid ${SWELL_MAP_LEGEND_SURFACE.border}`,
         borderRadius: SWELL_MAP_STICKER_RADIUS,
@@ -463,6 +491,7 @@ export function InteractiveMap({
     zoom: number;
   } | null>(null);
   const [isMapReady, setIsMapReady] = useState(false);
+  const [mapStyleRevision, setMapStyleRevision] = useState(0);
   const [leashSuspendedCommandId, setLeashSuspendedCommandId] = useState<
     number | null
   >(null);
@@ -496,6 +525,8 @@ export function InteractiveMap({
   // so we surface a small "no swell data" sticker. Defaults true to avoid a
   // flash before the first build.
   const [hasSwellData, setHasSwellData] = useState(true);
+  const [expandableTimelineHeight, setExpandableTimelineHeight] = useState(0);
+  const [expandablePlaybackPosition, setExpandablePlaybackPosition] = useState(0);
   const [showAuth, setShowAuth] = useState(false);
   // One-time coastal-leash hint: the camera silently loses zoom-out when the
   // field's leash applies, so we flash a one-shot note the FIRST time it locks
@@ -684,12 +715,33 @@ export function InteractiveMap({
     },
     [],
   );
+  const isExpandableFramePlayable = useCallback(
+    (timeline: HourlySwellTimeline, index: number): boolean => {
+      const beachList = swellFieldBeaches.length > 0
+        ? swellFieldBeaches
+        : (beaches ?? []);
+      const components = componentsForLayer(swellLayerId);
+
+      return beachList.some((beach) => {
+        if (beach.lat == null || beach.lon == null) return false;
+        const lat = beach.lat;
+        const lon = beach.lon;
+        const partition = timeline.partitionsByBeach[beach.id]?.[index];
+        if (!partition) return false;
+        return components.some((component) =>
+          partitionToPoint(lon, lat, partition, component) != null,
+        );
+      });
+    },
+    [beaches, swellFieldBeaches, swellLayerId],
+  );
   const expandableTimeline = useExpandableSwellTimeline({
     scopeKey: hourlyTimelineScopeKey,
     initial: hourlyTimelineSeed,
     timezone: timelineTimezone,
     loadChunk: loadHourlyChunk,
     reducedMotion,
+    isFramePlayable: isExpandableFramePlayable,
   });
   const isExpandableTimeline = swellTimelineMode === "expandable-hourly";
   const isEmbedHourlyTimeline = swellTimelineMode === "hourly";
@@ -1307,7 +1359,10 @@ export function InteractiveMap({
           { fetchNearbyBeaches: fetchNearbyBeaches.current },
           swellTimelineMode === "legacy"
             ? {}
-            : { timeline: "hourly", timelineHours: 48 },
+            : {
+                timeline: "hourly",
+                timelineHours: FULL_FORECAST_TIMELINE_HOURS,
+              },
         );
         if (requestId !== populateRequestIdRef.current) return;
 
@@ -1434,7 +1489,16 @@ export function InteractiveMap({
       const points: BeachPartitionPoint[] = [];
       for (const beach of beachList) {
         const partition = isExpandableTimeline
-          ? expandableTimeline.partitionsByBeach[beach.id]?.[expandableTimeline.index] ?? null
+          ? partitionAtAbsoluteTimelinePosition(
+              {
+                timestamps: expandableTimeline.timestamps,
+                partitionsByBeach: expandableTimeline.partitionsByBeach,
+                hasMore: false,
+                nextStart: null,
+              },
+              beach.id,
+              expandablePlaybackPosition,
+            )
           : isEmbedHourlyTimeline
             ? partitionAtAbsoluteTimelineIndex(hourlyTimelineSeed, beach.id, swellTimelineIndex)
           : partitionAtTimelinePosition(
@@ -1465,6 +1529,10 @@ export function InteractiveMap({
       }
       nextFields[component] = buildFlowField(points, bounds, 12);
     }
+    if (!anyPoints && expandableTimeline.isPlaying) {
+      setHasSwellData(true);
+      return;
+    }
     flowFieldsRef.current = nextFields;
     setHasSwellData(anyPoints);
     // Best-effort mask now; the idle/moveend listener re-masks once tiles render.
@@ -1475,7 +1543,10 @@ export function InteractiveMap({
     applyWaterMask,
     beaches,
     expandableTimeline.index,
+    expandableTimeline.isPlaying,
     expandableTimeline.partitionsByBeach,
+    expandableTimeline.timestamps,
+    expandablePlaybackPosition,
     hourlyTimelineSeed,
     isEmbedHourlyTimeline,
     isExpandableTimeline,
@@ -1665,7 +1736,7 @@ export function InteractiveMap({
     swellLayerKeyRef.current = shapeKey;
     // No cleanup teardown: the layer persists across same-shape switches and is
     // removed on the next shape change (or with the map on unmount).
-  }, [showSwellField, isMapReady, reducedMotion, swellLayerId]);
+  }, [showSwellField, isMapReady, reducedMotion, swellLayerId, mapStyleRevision]);
 
   // Leash the camera to the coastal data corridor while the swell field is ON.
   // Locks zoom (so users can't pull back to open-ocean/continent scale) and pins
@@ -1953,6 +2024,9 @@ export function InteractiveMap({
     map.on("load", markMapReady);
     map.on("styledata", markMapReady);
     map.on("idle", markMapReady);
+    map.on("style.load", () => {
+      setMapStyleRevision((current) => current + 1);
+    });
 
     map.on("error", (e) => {
       console.error("Map error:", e);
@@ -2120,6 +2194,26 @@ export function InteractiveMap({
       cleanupMap();
     };
   }, [initialZoom, cleanupMap]);
+
+  useEffect(() => {
+    const container = mapContainerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+
+    let resizeFrame: number | null = null;
+    const observer = new ResizeObserver(() => {
+      if (resizeFrame != null) window.cancelAnimationFrame(resizeFrame);
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        mapRef.current?.resize();
+      });
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      if (resizeFrame != null) window.cancelAnimationFrame(resizeFrame);
+    };
+  }, []);
 
   // Initial population when map becomes ready
   useEffect(() => {
@@ -2555,6 +2649,8 @@ export function InteractiveMap({
         onIndexChange={handleExpandableTimelineIndexChange}
         onPlayingChange={handleExpandableTimelinePlayingChange}
         onRetry={expandableTimeline.retry}
+        onHeightChange={setExpandableTimelineHeight}
+        onPlaybackPositionChange={setExpandablePlaybackPosition}
       />
     ) : null;
 
@@ -2577,6 +2673,7 @@ export function InteractiveMap({
         <MapConditionLegend
           controls={swellLayerSelector}
           timeline={swellTimeline}
+          bottomOffset={expandableSwellTimeline ? expandableTimelineHeight : 0}
         />
       )}
       {showMapChrome && displayMode !== "wave-height" && swellLayerSelector}

--- a/components/map/map-learning-panel.tsx
+++ b/components/map/map-learning-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { QRCodeSVG } from "qrcode.react";
-import { Activity, Clock3, Gauge, Smartphone, Waves, Wind } from "lucide-react";
+import { Activity, Clock3, Gauge, Waves, Wind } from "lucide-react";
 
 import { trackAppHandoffQrRendered } from "@/lib/analytics/app-handoff-tracking";
 import { buildSmartQrHandoffUrl } from "@/lib/constants/app-handoff";
@@ -322,19 +322,15 @@ export function MapLearningPanel(): ReactElement {
             />
           </div>
           <div className="min-w-0">
-            <div className="mb-2 flex items-center gap-2 font-mono text-[11px] font-black uppercase tracking-[0.16em] text-[#FDB84B]">
-              <Smartphone className="h-4 w-4" aria-hidden="true" />
-              Smart QR
-            </div>
             <p className="font-mono text-sm leading-6 text-[#F5EEDC]/78">
-              Scan once. iPhone goes to the App Store, Android goes to the
-              Android access path, desktop lands back on the phone handoff.
+              Take the map with you. Scan the code to get Quiver on your phone
+              and check conditions wherever you surf.
             </p>
             <a
               href={QR_VALUE}
               className="mt-3 inline-flex min-h-10 items-center justify-center bg-[#F78E42] px-4 font-mono text-xs font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_3px_0_rgba(245,238,220,0.2)] transition hover:-translate-y-0.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FDB84B]"
             >
-              Open smart link
+              Get the app
             </a>
           </div>
         </section>

--- a/components/map/map-toolbar.tsx
+++ b/components/map/map-toolbar.tsx
@@ -9,7 +9,9 @@ import {
 } from "@/components/ui/popover";
 import {
   SWELL_LAYER_COLOR,
-  SWELL_MAP_CTA_CLASS,
+  SWELL_MAP_LEGEND_SURFACE,
+  SWELL_MAP_STICKER_RADIUS,
+  SWELL_MAP_STICKER_SHADOW,
 } from "@/components/map/swell-map-theme";
 import {
   BookOpen,
@@ -20,7 +22,6 @@ import {
   X,
 } from "lucide-react";
 import type { Beach } from "@/types/database";
-import type { MapRegionPill } from "@/components/map/map-regions";
 
 interface MapToolbarProps {
   searchQuery: string;
@@ -29,8 +30,6 @@ interface MapToolbarProps {
   onClearSearch: () => void;
   suggestions: Beach[];
   onSuggestionSelect: (beach: Beach) => void;
-  regions: MapRegionPill[];
-  onRegionSelect: (region: MapRegionPill) => void;
   onUseMyLocation: () => void;
   filters: { beginnerFriendly: boolean; breakTypes: Set<string> };
   onToggleBeginner: () => void;
@@ -53,15 +52,15 @@ const BREAK_TYPE_FILTERS = [
 
 const filterChipClass = (active: boolean): string =>
   [
-    "rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+    "rounded-full border-2 border-[#11100D] px-3 py-1.5 text-xs font-bold uppercase tracking-[0.04em] transition-colors",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]",
     active
-      ? "border-primary bg-primary text-primary-foreground"
-      : "border-white/15 bg-white/5 text-white hover:bg-white/10",
+      ? "bg-[#F78E42] text-[#11100D]"
+      : "bg-[#F5EEDC] text-[#11100D] hover:bg-[#E9DEC7]",
   ].join(" ");
 
 const toolbarActionClass =
-  "h-10 w-full min-w-0 justify-center whitespace-nowrap px-2 text-xs sm:px-3 sm:text-sm lg:w-auto";
+  "h-10 w-full min-w-0 justify-center whitespace-nowrap rounded-[8px_3px_9px_4px] border-2 border-[#11100D] bg-[#F5EEDC] px-2 text-xs font-bold text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.22)] hover:bg-[#E9DEC7] sm:px-3 sm:text-sm lg:w-auto";
 
 export function MapToolbar({
   searchQuery,
@@ -70,8 +69,6 @@ export function MapToolbar({
   onClearSearch,
   suggestions,
   onSuggestionSelect,
-  regions,
-  onRegionSelect,
   onUseMyLocation,
   filters,
   onToggleBeginner,
@@ -83,9 +80,13 @@ export function MapToolbar({
   fieldGuideVisible = false,
   onOpenFieldGuide,
 }: MapToolbarProps) {
-  const showSuggestions = searchQuery.trim().length > 0 && suggestions.length > 0;
   const suggestionsListId = useId();
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
+  const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
+  const showSuggestions =
+    !suggestionsDismissed &&
+    searchQuery.trim().length > 0 &&
+    suggestions.length > 0;
   const activeSuggestion =
     activeSuggestionIndex >= 0 ? suggestions[activeSuggestionIndex] : undefined;
 
@@ -93,27 +94,39 @@ export function MapToolbar({
     setActiveSuggestionIndex(-1);
   }, [searchQuery, suggestions.length]);
 
+  useEffect(() => {
+    setSuggestionsDismissed(false);
+  }, [searchQuery]);
+
   const selectSuggestion = (index: number): void => {
     const suggestion = suggestions[index];
     if (!suggestion) return;
 
+    setSuggestionsDismissed(true);
+    setActiveSuggestionIndex(-1);
     onSuggestionSelect(suggestion);
   };
 
   return (
     <div
       data-testid="map-controls"
-      className="sticky top-0 z-20 border-b bg-background px-3 py-3 sm:px-4"
+      className="sticky top-0 z-20 border-b-2 border-[#11100D] px-3 py-3 sm:px-4"
+      style={{
+        background: SWELL_MAP_LEGEND_SURFACE.paper,
+        boxShadow: SWELL_MAP_STICKER_SHADOW,
+        color: SWELL_MAP_LEGEND_SURFACE.ink,
+      }}
     >
       <div className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
           <div className="relative w-full lg:max-w-md">
             <Search
-              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#11100D]/65"
               aria-hidden="true"
             />
             <input
               ref={searchInputRef}
+              data-zine-input="true"
               data-testid="map-toolbar-search"
               role="combobox"
               aria-label="Search beaches, spots, or cities"
@@ -157,14 +170,20 @@ export function MapToolbar({
                 }
               }}
               placeholder="Search beaches, spots, or cities"
-              className="h-10 w-full rounded-md border border-input bg-background py-2 pl-9 pr-10 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
+              className="h-10 w-full rounded-[9px_4px_10px_5px] border-2 !border-[#11100D] border-[#11100D] !bg-[#F5EEDC] bg-[#F5EEDC] py-2 pl-9 pr-10 text-sm font-medium !text-[#11100D] text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.2)] outline-none transition-colors placeholder:!text-[#11100D]/55 focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
+              style={{
+                background: SWELL_MAP_LEGEND_SURFACE.paperRaised,
+                borderColor: SWELL_MAP_LEGEND_SURFACE.border,
+                boxShadow: "2px 2px 0 rgba(17,16,13,0.2)",
+                color: SWELL_MAP_LEGEND_SURFACE.ink,
+              }}
             />
             {searchQuery && (
               <button
                 type="button"
                 aria-label="Clear map search"
                 onClick={onClearSearch}
-                className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
+                className="absolute right-2 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md text-[#11100D]/65 hover:bg-[#E9DEC7] hover:text-[#11100D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
               >
                 <X className="h-4 w-4" aria-hidden="true" />
               </button>
@@ -174,7 +193,7 @@ export function MapToolbar({
                 id={suggestionsListId}
                 role="listbox"
                 data-testid="map-search-suggestions"
-                className="absolute left-0 right-0 top-11 z-30 overflow-hidden rounded-md border bg-background shadow-lg"
+                className="absolute left-0 right-0 top-11 z-30 overflow-hidden rounded-[9px_4px_10px_5px] border-2 border-[#11100D] bg-[#F5EEDC] text-[#11100D] shadow-[3px_4px_0_rgba(17,16,13,0.28)]"
               >
                 {suggestions.map((beach, index) => {
                   const location = [beach.city, beach.state]
@@ -189,11 +208,11 @@ export function MapToolbar({
                       type="button"
                       onMouseEnter={() => setActiveSuggestionIndex(index)}
                       onClick={() => selectSuggestion(index)}
-                      className="flex w-full flex-col px-3 py-2 text-left text-sm hover:bg-muted focus-visible:bg-muted focus-visible:outline-none aria-selected:bg-muted"
+                      className="flex w-full flex-col px-3 py-2 text-left text-sm hover:bg-[#E9DEC7] focus-visible:bg-[#E9DEC7] focus-visible:outline-none aria-selected:bg-[#E9DEC7]"
                     >
                       <span className="font-medium">{beach.name}</span>
                       {location && (
-                        <span className="text-xs text-muted-foreground">
+                        <span className="text-xs text-[#11100D]/65">
                           {location}
                         </span>
                       )}
@@ -214,7 +233,7 @@ export function MapToolbar({
               <PopoverTrigger asChild>
                 <Button
                   type="button"
-                  aria-label="Regions and filters"
+                  aria-label="Filters"
                   variant="secondary"
                   size="sm"
                   className={toolbarActionClass}
@@ -223,8 +242,7 @@ export function MapToolbar({
                     className="h-4 w-4 shrink-0"
                     aria-hidden="true"
                   />
-                  <span className="sm:hidden">Filters</span>
-                  <span className="hidden sm:inline">Regions and filters</span>
+                  <span>Filters</span>
                   {hasActiveFilters && (
                     <span
                       className="ml-1 h-2 w-2 rounded-full bg-[#F78E42]"
@@ -235,42 +253,16 @@ export function MapToolbar({
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                className="w-[calc(100vw-2rem)] max-w-md space-y-4 border-white/15 bg-[#252D70] p-4 text-white shadow-2xl sm:w-[28rem]"
+                className="w-[calc(100vw-2rem)] max-w-md space-y-4 border-2 border-[#11100D] bg-[#F4EBD8] p-4 text-[#11100D] shadow-[4px_5px_0_rgba(17,16,13,0.32)] sm:w-[28rem]"
+                style={{ borderRadius: SWELL_MAP_STICKER_RADIUS }}
               >
-                <section
-                  className="space-y-2"
-                  aria-labelledby="map-regions-label"
-                >
-                  <div
-                    id="map-regions-label"
-                    className="text-xs font-semibold uppercase tracking-[0.08em] text-[#C8D0FF]"
-                  >
-                    Regions
-                  </div>
-                  <nav aria-label="Map regions">
-                    <div className="flex flex-wrap gap-2">
-                      {regions.map((region) => (
-                        <button
-                          key={region.id}
-                          type="button"
-                          data-testid={`map-region-pill-${region.id}`}
-                          onClick={() => onRegionSelect(region)}
-                          className="rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
-                        >
-                          {region.label}
-                        </button>
-                      ))}
-                    </div>
-                  </nav>
-                </section>
-
                 <section
                   className="space-y-2"
                   aria-labelledby="map-filters-label"
                 >
                   <div
                     id="map-filters-label"
-                    className="text-xs font-semibold uppercase tracking-[0.08em] text-[#C8D0FF]"
+                    className="text-xs font-bold uppercase tracking-[0.08em] text-[#11100D]/70"
                   >
                     Filters
                   </div>
@@ -297,7 +289,7 @@ export function MapToolbar({
                         type="button"
                         onClick={onClearAll}
                         data-testid="map-clear-all"
-                        className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
+                        className="rounded-full border-2 border-[#11100D] bg-[#E9DEC7] px-3 py-1.5 text-xs font-bold text-[#11100D] transition-colors hover:bg-[#D9C49C] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B]"
                       >
                         Clear all
                       </button>
@@ -325,10 +317,8 @@ export function MapToolbar({
               aria-pressed={showSwellField}
               data-testid="swell-field-toggle"
               onClick={onToggleSwellField}
-              className={`${toolbarActionClass} inline-flex items-center gap-2 rounded-md py-1.5 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B] ${
-                showSwellField
-                  ? "text-[#161A40] shadow-inner ring-1 ring-black/20"
-                  : SWELL_MAP_CTA_CLASS
+              className={`${toolbarActionClass} inline-flex items-center gap-2 py-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B] ${
+                showSwellField ? "bg-[#F78E42]" : ""
               }`}
               style={
                 showSwellField

--- a/components/map/swell-field/swell-day-timeline.tsx
+++ b/components/map/swell-field/swell-day-timeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Pause, Play } from "lucide-react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, ReactElement, ReactNode } from "react";
 import type { TimelineDaySegment } from "@/components/map/hourly-swell-timeline";
 import { formatTimelineBubble } from "@/components/map/hourly-swell-timeline";
@@ -26,6 +27,8 @@ export interface SwellDayTimelineProps {
   onIndexChange: (index: number) => void;
   onPlayingChange: (playing: boolean) => void;
   onRetry: () => void;
+  onHeightChange?: (height: number) => void;
+  onPlaybackPositionChange?: (position: number) => void;
 }
 
 const deltaByKey: Record<string, number> = {
@@ -34,6 +37,16 @@ const deltaByKey: Record<string, number> = {
   ArrowRight: 1,
   ArrowUp: 1,
 };
+const PLAYBACK_VISUAL_FRAME_MS = 500;
+const FIELD_UPDATE_INTERVAL_MS = 100;
+
+export function advancePlaybackPosition(
+  current: number,
+  elapsedMs: number,
+  maxIndex: number,
+): number {
+  return Math.min(maxIndex, current + elapsedMs / PLAYBACK_VISUAL_FRAME_MS);
+}
 
 interface LocalTimestampParts {
   dateOrdinal: number;
@@ -167,12 +180,32 @@ function TimelineStatus({
 function TimelineShell({
   children,
   timezone,
+  onHeightChange,
 }: {
   children: ReactNode;
   timezone: string;
+  onHeightChange?: (height: number) => void;
 }): ReactElement {
+  const shellRef = useRef<HTMLElement>(null);
+
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell || !onHeightChange) return;
+
+    const reportHeight = (): void => {
+      onHeightChange(shell.getBoundingClientRect().height);
+    };
+    reportHeight();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(reportHeight);
+    observer.observe(shell);
+    return () => observer.disconnect();
+  }, [onHeightChange]);
+
   return (
     <aside
+      ref={shellRef}
       data-testid="swell-day-timeline"
       data-timezone={timezone}
       className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 sm:px-5"
@@ -208,16 +241,76 @@ export function SwellDayTimeline({
   onIndexChange,
   onPlayingChange,
   onRetry,
+  onHeightChange,
+  onPlaybackPositionChange,
 }: SwellDayTimelineProps): ReactElement | null {
   const finalTimestamp = timestamps.at(-1);
   const exhaustionLabel = finalTimestamp
     ? `Forecast ends ${formatTimelineBubble(finalTimestamp, timezone)}`
     : "No forecast hours available";
+  const safeIndex = clampIndex(index, timestamps.length);
+  const canPlay = timestamps.length > 1;
+  const maxIndex = Math.max(0, timestamps.length - 1);
+  const [visualIndex, setVisualIndex] = useState(safeIndex);
+  const visualIndexRef = useRef(safeIndex);
+  const controlledIndexRef = useRef(safeIndex);
+  const maxIndexRef = useRef(maxIndex);
+  const onPlaybackPositionChangeRef = useRef(onPlaybackPositionChange);
+
+  useEffect(() => {
+    onPlaybackPositionChangeRef.current = onPlaybackPositionChange;
+  }, [onPlaybackPositionChange]);
+
+  useEffect(() => {
+    controlledIndexRef.current = safeIndex;
+    if (isPlaying) return;
+    visualIndexRef.current = safeIndex;
+    setVisualIndex(safeIndex);
+    onPlaybackPositionChangeRef.current?.(safeIndex);
+  }, [isPlaying, safeIndex]);
+
+  useEffect(() => {
+    maxIndexRef.current = maxIndex;
+  }, [maxIndex]);
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    visualIndexRef.current = controlledIndexRef.current;
+    setVisualIndex(controlledIndexRef.current);
+    onPlaybackPositionChangeRef.current?.(controlledIndexRef.current);
+    let animationFrame = 0;
+    let lastFrameTime: number | null = null;
+    let lastFieldUpdateTime: number | null = null;
+
+    const animate = (frameTime: number): void => {
+      if (lastFrameTime != null) {
+        const next = advancePlaybackPosition(
+          visualIndexRef.current,
+          frameTime - lastFrameTime,
+          maxIndexRef.current,
+        );
+        visualIndexRef.current = next;
+        setVisualIndex(next);
+        if (
+          lastFieldUpdateTime == null
+          || frameTime - lastFieldUpdateTime >= FIELD_UPDATE_INTERVAL_MS
+        ) {
+          lastFieldUpdateTime = frameTime;
+          onPlaybackPositionChangeRef.current?.(next);
+        }
+      }
+      lastFrameTime = frameTime;
+      animationFrame = window.requestAnimationFrame(animate);
+    };
+    animationFrame = window.requestAnimationFrame(animate);
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [isPlaying]);
+
   if (timestamps.length === 0) {
     if (!error && !isLoadingMore && !isExhausted) return null;
 
     return (
-      <TimelineShell timezone={timezone}>
+      <TimelineShell timezone={timezone} onHeightChange={onHeightChange}>
         <TimelineStatus
           error={error}
           isLoadingMore={isLoadingMore}
@@ -229,9 +322,7 @@ export function SwellDayTimeline({
     );
   }
 
-  const safeIndex = clampIndex(index, timestamps.length);
-  const canPlay = timestamps.length > 1;
-  const progress = timestamps.length <= 1 ? 0 : safeIndex / (timestamps.length - 1);
+  const progress = timestamps.length <= 1 ? 0 : visualIndex / maxIndex;
   const bubbleLeft = `${Math.min(96, Math.max(4, progress * 100))}%`;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
@@ -255,7 +346,7 @@ export function SwellDayTimeline({
   };
 
   return (
-    <TimelineShell timezone={timezone}>
+    <TimelineShell timezone={timezone} onHeightChange={onHeightChange}>
       <div className="flex items-end gap-3">
         <Button
           type="button"
@@ -288,6 +379,34 @@ export function SwellDayTimeline({
           </div>
 
           <div className="relative h-11">
+            <input
+              type="range"
+              min={0}
+              max={timestamps.length - 1}
+              step={1}
+              value={safeIndex}
+              disabled={!canPlay}
+              aria-label="Forecast time"
+              aria-valuetext={bubbleLabel}
+              onChange={(event) => onIndexChange(clampIndex(Number(event.target.value), timestamps.length))}
+              onKeyDown={handleKeyDown}
+              className="peer absolute inset-x-0 bottom-0 z-20 h-11 w-full cursor-pointer opacity-0 accent-[var(--swell-timeline-active)] focus-visible:outline-none focus-visible:ring-[var(--swell-timeline-focus)] disabled:cursor-not-allowed disabled:opacity-0"
+            />
+            <div
+              data-testid="timeline-visual-track"
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-8 h-1 overflow-visible rounded-full bg-[var(--swell-timeline-ink)]/35 peer-focus-visible:ring-2 peer-focus-visible:ring-[var(--swell-timeline-focus)] peer-focus-visible:ring-offset-2"
+            >
+              <div
+                data-testid="timeline-progress"
+                className="h-full rounded-full bg-[var(--swell-timeline-active)]"
+                style={{ width: `${progress * 100}%` }}
+              />
+              <span
+                className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-[var(--swell-timeline-ink)] bg-[var(--swell-timeline-active)] shadow-sm"
+                style={{ left: `${progress * 100}%` }}
+              />
+            </div>
             <div
               data-testid="timeline-day-layer"
               aria-hidden="true"
@@ -321,19 +440,6 @@ export function SwellDayTimeline({
                 );
               })}
             </div>
-            <input
-              type="range"
-              min={0}
-              max={timestamps.length - 1}
-              step={1}
-              value={safeIndex}
-              disabled={!canPlay}
-              aria-label="Forecast time"
-              aria-valuetext={bubbleLabel}
-              onChange={(event) => onIndexChange(clampIndex(Number(event.target.value), timestamps.length))}
-              onKeyDown={handleKeyDown}
-              className="absolute inset-x-0 bottom-0 z-10 h-11 w-full cursor-pointer accent-[var(--swell-timeline-active)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--swell-timeline-focus)] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-            />
           </div>
         </div>
       </div>

--- a/e2e/map-region-nav.spec.ts
+++ b/e2e/map-region-nav.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { TIMEOUTS, VIEWPORTS } from "./fixtures/test-data";
 import {
   assertNoErrors,
@@ -7,76 +7,9 @@ import {
 } from "./utils/error-detection";
 import { dismissMapEntryOverlay } from "./utils/map-helpers";
 
-type MapCenter = {
-  lat: number;
-  lon: number;
-};
-
-async function waitForMapInstance(page: Page): Promise<void> {
-  await page.waitForFunction(
-    () =>
-      Boolean(
-        (window as unknown as { __quiverMapInstance?: unknown })
-          .__quiverMapInstance,
-      ),
-    { timeout: TIMEOUTS.long },
-  );
-}
-
-async function getMapCenter(page: Page): Promise<MapCenter> {
-  return page.evaluate(() => {
-    const map = (
-      window as unknown as {
-        __quiverMapInstance?: {
-          getCenter: () => { lat: number; lng: number };
-        };
-      }
-    ).__quiverMapInstance;
-
-    if (!map) {
-      throw new Error("Map instance unavailable");
-    }
-
-    const center = map.getCenter();
-    return { lat: center.lat, lon: center.lng };
-  });
-}
-
-async function waitForMapCenterNear(
-  page: Page,
-  expected: MapCenter,
-  toleranceDegrees: number,
-): Promise<void> {
-  await page.waitForFunction(
-    ({ lat, lon, tolerance }) => {
-      const map = (
-        window as unknown as {
-          __quiverMapInstance?: {
-            getCenter: () => { lat: number; lng: number };
-          };
-        }
-      ).__quiverMapInstance;
-
-      if (!map) return false;
-
-      const center = map.getCenter();
-      return (
-        Math.abs(center.lat - lat) <= tolerance &&
-        Math.abs(center.lng - lon) <= tolerance
-      );
-    },
-    { lat: expected.lat, lon: expected.lon, tolerance: toleranceDegrees },
-    { timeout: TIMEOUTS.long },
-  );
-}
-
-async function openRegionsAndFilters(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Regions and filters" }).click();
-}
-
 test.use({ storageState: { cookies: [], origins: [] } });
 
-test.describe("Map toolbar region navigation", () => {
+test.describe("Map toolbar filters", () => {
   let errorCapture: ErrorCapture;
 
   test.beforeEach(async ({ page }) => {
@@ -84,115 +17,32 @@ test.describe("Map toolbar region navigation", () => {
   });
 
   test.afterEach(async ({ page }) => {
-    await assertNoErrors(page, errorCapture, { context: "Map region nav" });
+    await assertNoErrors(page, errorCapture, { context: "Map toolbar filters" });
   });
 
-  test("anonymous desktop has one toolbar, search, region dropdown, and no desktop sidebar", async ({
-    page,
-  }) => {
-    await page.setViewportSize(VIEWPORTS.desktop);
+  for (const viewport of [VIEWPORTS.desktop, { width: 390, height: 844 }]) {
+    test(`shows filter controls without region shortcuts at ${viewport.width}px`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await page.goto("/map");
+      await page.waitForLoadState("load");
+      await dismissMapEntryOverlay(page);
 
-    await page.goto("/map");
-    await page.waitForLoadState("load");
-    await dismissMapEntryOverlay(page);
+      await expect(page.getByTestId("map-controls")).toHaveCount(1);
+      await expect(
+        page.getByRole("combobox", {
+          name: "Search beaches, spots, or cities",
+        }),
+      ).toBeVisible({ timeout: TIMEOUTS.medium });
 
-    await expect(page.getByTestId("map-controls")).toHaveCount(1);
-    await expect(
-      page.getByRole("combobox", {
-        name: "Search beaches, spots, or cities",
-      }),
-    ).toBeVisible({ timeout: TIMEOUTS.medium });
-    await expect(
-      page.getByRole("button", { name: "Regions and filters" }),
-    ).toBeVisible();
-    await expect(page.getByTestId("map-region-pill-san-diego")).toHaveCount(0);
+      await page.getByRole("button", { name: "Filters" }).click();
 
-    await openRegionsAndFilters(page);
-
-    await expect(page.getByTestId("map-region-pill-san-diego")).toBeVisible();
-    await expect(page.getByTestId("map-region-pill-hawaii")).toBeVisible();
-    await expect(page.getByText(/spots in view/i)).toHaveCount(0);
-  });
-
-  test("region pills remount and recenter the map while the swell field is on", async ({
-    page,
-  }) => {
-    await page.setViewportSize(VIEWPORTS.desktop);
-
-    await page.goto("/map");
-    await page.waitForLoadState("load");
-    await dismissMapEntryOverlay(page);
-    await waitForMapInstance(page);
-
-    const initialCenter = await getMapCenter(page);
-
-    await expect(page.getByTestId("swell-layer-selector")).toBeVisible({
-      timeout: TIMEOUTS.medium,
+      await expect(
+        page.getByRole("button", { name: "Beginner-friendly" }),
+      ).toBeVisible();
+      await expect(page.getByRole("navigation", { name: "Map regions" })).toHaveCount(0);
+      await expect(page.getByTestId("map-region-pill-hawaii")).toHaveCount(0);
     });
-
-    await openRegionsAndFilters(page);
-    await page.getByTestId("map-region-pill-hawaii").click();
-    await waitForMapCenterNear(
-      page,
-      { lat: 21.66, lon: -158.06 },
-      1.25,
-    );
-
-    const hawaiiCenter = await getMapCenter(page);
-    expect(Math.abs(hawaiiCenter.lon - initialCenter.lon)).toBeGreaterThan(10);
-  });
-
-  test("toolbar search recenters from one region to an out-of-region beach", async ({ page }) => {
-    await page.setViewportSize(VIEWPORTS.desktop);
-
-    await page.goto("/map");
-    await page.waitForLoadState("load");
-    await dismissMapEntryOverlay(page);
-    await waitForMapInstance(page);
-
-    await openRegionsAndFilters(page);
-    await page.getByTestId("map-region-pill-hawaii").click();
-    await waitForMapCenterNear(
-      page,
-      { lat: 21.66, lon: -158.06 },
-      1.25,
-    );
-    await page.keyboard.press("Escape");
-
-    const hawaiiCenter = await getMapCenter(page);
-    const search = page.getByRole("combobox", {
-      name: "Search beaches, spots, or cities",
-    });
-    await search.fill("Blacks");
-
-    await waitForMapCenterNear(
-      page,
-      { lat: 32.89, lon: -117.25 },
-      1,
-    );
-
-    const sanDiegoCenter = await getMapCenter(page);
-    expect(Math.abs(sanDiegoCenter.lon - hawaiiCenter.lon)).toBeGreaterThan(10);
-  });
-
-  test("mobile keeps search and region dropdown visible", async ({ page }) => {
-    await page.setViewportSize({ width: 390, height: 844 });
-
-    await page.goto("/map");
-    await page.waitForLoadState("load");
-    await dismissMapEntryOverlay(page);
-
-    await expect(
-      page.getByRole("combobox", {
-        name: "Search beaches, spots, or cities",
-      }),
-    ).toBeVisible({ timeout: TIMEOUTS.medium });
-    await expect(
-      page.getByRole("button", { name: "Regions and filters" }),
-    ).toBeVisible();
-
-    await openRegionsAndFilters(page);
-
-    await expect(page.getByTestId("map-region-pill-san-diego")).toBeVisible();
-  });
+  }
 });

--- a/e2e/map-swell-field.spec.ts
+++ b/e2e/map-swell-field.spec.ts
@@ -228,11 +228,8 @@ test.describe("expandable local forecast timeline", () => {
 
   test("uses absolute Hawaii time, keyboard hours, and a second forecast chunk", async ({ page }) => {
     const timeline = await routeExpandableTimeline(page);
-    await page.goto("/map");
+    await page.goto("/map?search=Waikiki");
     await page.waitForLoadState("load");
-
-    await page.getByRole("button", { name: "Regions and filters" }).click();
-    await page.getByRole("button", { name: "Hawaii" }).click();
 
     const dayTimeline = page.getByTestId("swell-day-timeline");
     await expect(dayTimeline).toBeVisible({ timeout: 30000 });
@@ -288,6 +285,30 @@ test.describe("expandable local forecast timeline", () => {
     const calloutBox = await callout.boundingBox();
     expect(calloutBox).not.toBeNull();
     expect(calloutBox!.y + calloutBox!.height).toBeLessThanOrEqual(panelBox!.y);
+  });
+
+  test("keeps Hawaii pins and the swell field visible while playback skips a missing frame", async ({ page }) => {
+    await routeExpandableTimeline(page);
+    await page.goto("/map?search=Waikiki");
+    await page.waitForLoadState("load");
+    await waitForMapInstance(page);
+    await requireRenderedSwellLayer(page);
+
+    const markers = page.getByTestId("beach-marker");
+    await expect(markers.first()).toBeVisible({ timeout: 30000 });
+    const initialMarkerCount = await markers.count();
+    expect(initialMarkerCount).toBeGreaterThan(0);
+
+    await page.getByRole("button", { name: "Play forecast timeline" }).click();
+    await expect.poll(
+      async () => Number(await page.getByRole("slider", { name: "Forecast time" }).inputValue()),
+      { timeout: 10000 },
+    ).toBeGreaterThan(7);
+
+    expect(await markers.count()).toBe(initialMarkerCount);
+    await expect(markers.first()).toBeVisible();
+    await expect(page.getByTestId("swell-field-empty-note")).toHaveCount(0);
+    expect(await layerExists(page)).toBe(true);
   });
 });
 
@@ -353,6 +374,7 @@ for (const viewport of [
       await waitForMapIdle(page);
 
       await expect(page.getByTestId("swell-layer-selector")).toBeVisible();
+      expect(await layerExists(page)).toBe(true);
 
       await page.getByTestId("swell-field-toggle").click();
       await expect(page.getByTestId("swell-layer-selector")).toHaveCount(0);
@@ -429,6 +451,13 @@ for (const viewport of [
         || timelineBox!.y >= fieldGuideBox!.y + fieldGuideBox!.height
       );
       expect(timelineOverlapsFieldGuide).toBe(false);
+      const timelineOverlapsLegend = !(
+        timelineBox!.x + timelineBox!.width <= legendBox!.x
+        || timelineBox!.x >= legendBox!.x + legendBox!.width
+        || timelineBox!.y + timelineBox!.height <= legendBox!.y
+        || timelineBox!.y >= legendBox!.y + legendBox!.height
+      );
+      expect(timelineOverlapsLegend).toBe(false);
 
       const visibleLegendBox = legendBox!;
       const visibleSelectorBox = selectorBox!;

--- a/e2e/map.spec.ts
+++ b/e2e/map.spec.ts
@@ -6,8 +6,8 @@ import { isVisibleSafe } from './utils/strict-helpers';
 import { setupErrorDetection, assertNoErrors, ErrorCapture } from './utils/error-detection';
 import { dismissMapEntryOverlay } from './utils/map-helpers';
 
-async function openRegionsAndFilters(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Regions and filters' }).click();
+async function openFilters(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Filters' }).click();
 }
 
 type MapRegion = 'hawaii' | 'san-diego' | 'unknown';
@@ -379,7 +379,7 @@ test.describe('Map Page - Toolbar Controls', () => {
       page.getByRole('combobox', { name: 'Search beaches, spots, or cities' })
     ).toBeVisible({ timeout: TIMEOUTS.medium });
     await expect(
-      page.getByRole('button', { name: 'Regions and filters' })
+      page.getByRole('button', { name: 'Filters' })
     ).toBeVisible();
 
     const toolbarActions = page.getByTestId('map-toolbar-actions');
@@ -410,7 +410,7 @@ test.describe('Map Page - Filter Functionality', () => {
   });
 
   test('should display filter badges', async ({ page }) => {
-    await openRegionsAndFilters(page);
+    await openFilters(page);
 
     const beginnerBadge = page.getByRole('button', { name: 'Beginner-friendly' });
     const beachBadge = page.getByRole('button', { name: 'beach', exact: true });
@@ -424,7 +424,7 @@ test.describe('Map Page - Filter Functionality', () => {
   });
 
   test('should toggle beginner-friendly filter', async ({ page }) => {
-    await openRegionsAndFilters(page);
+    await openFilters(page);
 
     const beginnerBadge = page.getByRole('button', { name: 'Beginner-friendly' });
 
@@ -448,7 +448,7 @@ test.describe('Map Page - Filter Functionality', () => {
   });
 
   test('should toggle break type filters', async ({ page }) => {
-    await openRegionsAndFilters(page);
+    await openFilters(page);
 
     const beachBadge = page.getByRole('button', { name: 'beach', exact: true });
 
@@ -514,6 +514,38 @@ test.describe('Map Page - Search Integration', () => {
     const count = await beachLinks.count();
 
     expect(count).toBeGreaterThanOrEqual(0);
+  });
+
+  test('should select a beach suggestion without leaving the map', async ({ page }) => {
+    await page.goto('/map');
+    await waitForPageLoad(page);
+    await dismissMapEntryOverlay(page);
+
+    const search = page.getByRole('combobox', {
+      name: 'Search beaches, spots, or cities',
+    });
+    await search.fill('Waikiki');
+    await expect(page.getByRole('option', { name: /Waikiki/i }).first()).toBeVisible({
+      timeout: TIMEOUTS.long,
+    });
+    await search.press('ArrowDown');
+    await search.press('Enter');
+
+    await expect(page).toHaveURL(/\/map(?:\?.*)?$/);
+    await expect(page.getByTestId('map-search-suggestions')).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'View Waikiki conditions' }),
+    ).toBeVisible({ timeout: TIMEOUTS.long });
+    await expect
+      .poll(async () => {
+        const center = await readMapCenter(page);
+        if (!center) return false;
+        return (
+          Math.abs(center.lat - 21.2767) < 0.05 &&
+          Math.abs(center.lon - -157.8263) < 0.05
+        );
+      }, { timeout: TIMEOUTS.long })
+      .toBe(true);
   });
 });
 
@@ -677,8 +709,11 @@ test.describe('Map Page - Camera Ownership', () => {
       .poll(() => readMapRegion(page), { timeout: TIMEOUTS.long })
       .toBe('san-diego');
 
-    await page.getByRole('button', { name: 'Regions and filters' }).click();
-    await page.getByRole('button', { name: 'Hawaii' }).click();
+    const search = page.getByRole('combobox', {
+      name: 'Search beaches, spots, or cities',
+    });
+    await search.fill('Waikiki');
+    await page.getByRole('option').first().click();
     await expect
       .poll(() => readMapRegion(page), { timeout: TIMEOUTS.long })
       .toBe('hawaii');
@@ -877,7 +912,7 @@ test.describe('Map Page - Stability and Performance', () => {
 
     const initialCount = mapInitCount;
 
-    await openRegionsAndFilters(page);
+    await openFilters(page);
     await page.keyboard.press('Escape');
 
     // The map should not reinitialize during normal interactions

--- a/e2e/prod-readonly/auth-api.spec.ts
+++ b/e2e/prod-readonly/auth-api.spec.ts
@@ -1,27 +1,48 @@
-import { expect, test } from '@playwright/test';
-import { checkServerSession } from '../utils/auth-helpers';
+import { expect, test, type BrowserContext } from '@playwright/test';
 import { getProdReadonlyAuthBlockReason } from '../utils/prod-readonly-auth';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
+async function getAccessToken(context: BrowserContext): Promise<string> {
+  const chunks = (await context.cookies())
+    .filter(
+      (cookie) =>
+        cookie.name.startsWith('sb-') && cookie.name.includes('auth-token'),
+    )
+    .sort((left, right) =>
+      left.name.localeCompare(right.name, undefined, { numeric: true }),
+    );
+  const encoded = chunks.map((cookie) => cookie.value).join('');
+  const raw = encoded.startsWith('base64-')
+    ? Buffer.from(encoded.slice('base64-'.length), 'base64').toString('utf8')
+    : decodeURIComponent(encoded);
+  const session = JSON.parse(raw) as { access_token?: unknown };
+  if (typeof session.access_token !== 'string' || !session.access_token) {
+    throw new Error('Approved prod-readonly session has no access token');
+  }
+  return session.access_token;
+}
+
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Prod Read-Only Auth API', () => {
-  test.beforeEach(async ({ page }) => {
+  let accessToken: string | null = null;
+
+  test.beforeEach(async ({ context }) => {
     const blockReason = getProdReadonlyAuthBlockReason();
     // eslint-disable-next-line playwright/no-skipped-test -- auth specs are explicitly marked blocked when prod-readonly auth bootstrap fails.
     test.skip(Boolean(blockReason), blockReason ?? undefined);
-
-    const session = await checkServerSession(page, { baseUrl: BASE_URL });
-    expect(session.hasSession, 'Approved prod-readonly session must be active').toBe(true);
+    accessToken = await getAccessToken(context);
   });
 
   for (const [label, query] of [
     ['friends', 'page=1&limit=10&feed_type=friends'],
     ['nearby', 'page=1&limit=10&lat=32.75&lon=-117.25&radius_miles=30'],
   ] as const) {
-    test(`@smoke authenticated public sessions ${label} feed remains healthy`, async ({ page }) => {
-      const response = await page.request.get(`${BASE_URL}/api/sessions/public?${query}`);
+    test(`@smoke authenticated public sessions ${label} feed remains healthy`, async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/sessions/public?${query}`, {
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
       const body = await response.text();
 
       expect(response.status(), body).toBe(200);

--- a/e2e/prod-readonly/auth-api.spec.ts
+++ b/e2e/prod-readonly/auth-api.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { checkServerSession } from '../utils/auth-helpers';
+import { getProdReadonlyAuthBlockReason } from '../utils/prod-readonly-auth';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Prod Read-Only Auth API', () => {
+  test.beforeEach(async ({ page }) => {
+    const blockReason = getProdReadonlyAuthBlockReason();
+    // eslint-disable-next-line playwright/no-skipped-test -- auth specs are explicitly marked blocked when prod-readonly auth bootstrap fails.
+    test.skip(Boolean(blockReason), blockReason ?? undefined);
+
+    const session = await checkServerSession(page, { baseUrl: BASE_URL });
+    expect(session.hasSession, 'Approved prod-readonly session must be active').toBe(true);
+  });
+
+  for (const [label, query] of [
+    ['friends', 'page=1&limit=10&feed_type=friends'],
+    ['nearby', 'page=1&limit=10&lat=32.75&lon=-117.25&radius_miles=30'],
+  ] as const) {
+    test(`@smoke authenticated public sessions ${label} feed remains healthy`, async ({ page }) => {
+      const response = await page.request.get(`${BASE_URL}/api/sessions/public?${query}`);
+      const body = await response.text();
+
+      expect(response.status(), body).toBe(200);
+      expect(response.headers()['cache-control']).toContain('private');
+      const json = JSON.parse(body);
+      expect(json.success).toBe(true);
+      expect(Array.isArray(json.data)).toBe(true);
+    });
+  }
+});

--- a/e2e/prod-readonly/guest-api.spec.ts
+++ b/e2e/prod-readonly/guest-api.spec.ts
@@ -47,4 +47,20 @@ test.describe('Prod Read-Only Guest API', () => {
     expect(firstBeach).toHaveProperty('name');
     expect(firstBeach).toHaveProperty('slug');
   });
+
+  for (const [label, query] of [
+    ['global', 'page=1&limit=10'],
+    ['friends', 'page=1&limit=10&feed_type=friends'],
+    ['nearby', 'page=1&limit=10&lat=32.75&lon=-117.25&radius_miles=30'],
+  ] as const) {
+    test(`@smoke public sessions ${label} feed does not return a server error`, async ({ request }) => {
+      const response = await request.get(`${BASE_URL}/api/sessions/public?${query}`);
+      const body = await response.text();
+
+      expect(response.status(), body).toBe(200);
+      const json = JSON.parse(body);
+      expect(json.success).toBe(true);
+      expect(Array.isArray(json.data)).toBe(true);
+    });
+  }
 });

--- a/hooks/use-expandable-swell-timeline.ts
+++ b/hooks/use-expandable-swell-timeline.ts
@@ -31,6 +31,7 @@ export interface UseExpandableSwellTimelineArgs {
   timezone: string;
   loadChunk: (start: string, hours: number, signal: AbortSignal) => Promise<HourlySwellTimeline>;
   reducedMotion: boolean;
+  isFramePlayable?: (timeline: HourlySwellTimeline, index: number) => boolean;
 }
 
 export interface UseExpandableSwellTimelineResult extends ExpandableTimelineState {
@@ -95,6 +96,7 @@ export function useExpandableSwellTimeline({
   timezone,
   loadChunk,
   reducedMotion,
+  isFramePlayable = frameHasPartitions,
 }: UseExpandableSwellTimelineArgs): UseExpandableSwellTimelineResult {
   const [timeline, setTimeline] = useState<HourlySwellTimeline | null>(initial);
   const [index, setIndexState] = useState(0);
@@ -108,6 +110,7 @@ export function useExpandableSwellTimeline({
   const indexRef = useRef(0);
   const scopeKeyRef = useRef(scopeKey);
   const loadChunkRef = useRef(loadChunk);
+  const isFramePlayableRef = useRef(isFramePlayable);
   const abortControllerRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
   const isLoadingRef = useRef(false);
@@ -121,7 +124,8 @@ export function useExpandableSwellTimeline({
     initialRef.current = initial;
     scopeKeyRef.current = scopeKey;
     loadChunkRef.current = loadChunk;
-  }, [initial, loadChunk, scopeKey]);
+    isFramePlayableRef.current = isFramePlayable;
+  }, [initial, isFramePlayable, loadChunk, scopeKey]);
 
   const setIndex = useCallback((nextIndex: number) => {
     const timestamps = timelineRef.current?.timestamps ?? [];
@@ -275,7 +279,7 @@ export function useExpandableSwellTimeline({
       for (let candidateIndex = indexRef.current + 1; candidateIndex < current.timestamps.length; candidateIndex += 1) {
         const candidateTime = parseTimestamp(current.timestamps[candidateIndex]);
         if (candidateTime == null || candidateTime > nextForecastTime) break;
-        if (frameHasPartitions(current, candidateIndex)) {
+        if (isFramePlayableRef.current(current, candidateIndex)) {
           selectedIndex = candidateIndex;
         }
       }

--- a/supabase/migrations/20260712160000_fix_match_candidates_postgis_search_path.sql
+++ b/supabase/migrations/20260712160000_fix_match_candidates_postgis_search_path.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER FUNCTION public.get_user_match_candidates(
+  uuid,
+  uuid,
+  double precision,
+  double precision,
+  double precision,
+  integer
+)
+SET search_path = public, extensions, pg_temp;
+
+COMMIT;


### PR DESCRIPTION
## User-visible changes

- Stabilizes `/map` forecast playback so the scrubber moves smoothly and the swell field stays synchronized across available forecast frames.
- Keeps map pins and the last valid swell field visible while playback skips unusable forecast frames.
- Keeps beach-search selections on the map and centers the selected beach.
- Prevents the legend and forecast timeline from overlapping across desktop and mobile layouts.
- Simplifies the map toolbar to beach filters, improves map-guide copy, and fixes map resizing after the guide closes.
- Restores Community global, friends, and nearby feeds and adds release-blocking guest/native-authenticated smoke coverage.
- Hardens match-candidate RPC PostGIS resolution while preserving its existing contract.

## Surfaces touched

- Quiver web `/map`
- Bulk hourly forecast API
- Community production smoke checks
- Match-candidate database function hardening

## Local verification

- `yarn typecheck` — passed in a clean detached worktree
- `yarn test:unit --bail=0` — passed: 1,135 suites / 15,351 tests
- Scoped ESLint for touched map/API/test files — passed
- `VERCEL_ENV=preview yarn build` — passed
- `npx playwright test --list e2e/map.spec.ts e2e/map-region-nav.spec.ts e2e/map-swell-field.spec.ts` — passed: 40 tests registered
- Production public-session Playwright smoke — passed: 5/5 global, friends, nearby, authenticated friends, and authenticated nearby
- Authenticated Pro `get_user_match_candidates` verification — passed: five candidates returned
- Vercel Preview deployment — Ready and aliased to `dev.quiversurf.app`

## Release notes

- Includes migration `20260712160000_fix_match_candidates_postgis_search_path.sql`.
- Production migrations `20260709123000` and `20260712160000` are applied and tracked.
- No environment-variable changes.
