### PR TITLE
feat(analytics): ship session logging activation backend

### DIFF
--- a/__tests__/api/events-taxonomy-characterization.test.ts
+++ b/__tests__/api/events-taxonomy-characterization.test.ts
@@ -21,7 +21,7 @@ import {
 import { EVENT_WEIGHTS } from "@/types/implicit-preferences";
 
 const CURRENT_EVENT_SET_HASHES = {
-  valid: "982fd37dd5142c051d89fcc1fa411e339f7aa87de963ddbd74ce9778b9d5632e",
+  valid: "eaf6c2a8c7333a9306e0e0b7334fc0c74e86bdbbdc64d04476c2c5f1af02e06b",
   anonymousAllowed:
     "f251e55a9cf646afcaf8ec59e1e872531fb08d6b15f9ae7efeb233c084fe9b05",
   preAuthOnly:

--- a/__tests__/api/invites/consume.test.ts
+++ b/__tests__/api/invites/consume.test.ts
@@ -13,11 +13,12 @@ import {
   mockUnauthenticatedUser,
 } from "@/test-utils/api-test-helpers";
 import { NextRequest } from "next/server";
+import { expectConsoleErrors } from "@/__tests__/setup/test-utils";
 
 const mockSupabaseClient = createMockSupabaseClient();
 const mockCapturePostHogEvent = jest.fn();
 const mockUserEventInsert = jest.fn();
-const mockTrackingPreferenceMaybeSingle = jest.fn();
+const mockAnalyticsConsentRpc = jest.fn();
 
 jest.mock("@/lib/middleware/api-wrappers", () => {
   const { NextResponse } = require("next/server");
@@ -94,18 +95,25 @@ function mockAcceptInviteResult(result?: {
     referral_created: true,
     referral_existing: false,
   };
-  mockSupabaseClient.rpc.mockResolvedValue({
-    data,
-    error: result?.error ?? null,
+  mockSupabaseClient.rpc.mockImplementation((functionName: string) => {
+    if (functionName === "accept_invite_for_user") {
+      return Promise.resolve({
+        data,
+        error: result?.error ?? null,
+      });
+    }
+
+    if (functionName === "get_my_analytics_tracking_allowed") {
+      return mockAnalyticsConsentRpc();
+    }
+
+    throw new Error(`Unexpected RPC: ${functionName}`);
   });
 }
 
-function mockTrackingPreference(allowImplicitTracking: boolean | null = true) {
-  mockTrackingPreferenceMaybeSingle.mockResolvedValue({
-    data:
-      allowImplicitTracking === null
-        ? null
-        : { allow_implicit_tracking: allowImplicitTracking },
+function mockTrackingPreference(allowImplicitTracking = true) {
+  mockAnalyticsConsentRpc.mockResolvedValue({
+    data: allowImplicitTracking,
     error: null,
   });
 }
@@ -120,18 +128,9 @@ describe("POST /api/invites/consume", () => {
     jest.clearAllMocks();
     mockUserEventInsert.mockResolvedValue({ error: null });
     mockTrackingPreference();
-    mockSupabaseClient.from.mockImplementation((table: string) => {
-      if (table === "profiles") {
-        return {
-          select: jest.fn(() => ({
-            eq: jest.fn(() => ({
-              maybeSingle: mockTrackingPreferenceMaybeSingle,
-            })),
-          })),
-        } as any;
-      }
-      return { insert: mockUserEventInsert } as any;
-    });
+    mockSupabaseClient.from.mockReturnValue({
+      insert: mockUserEventInsert,
+    } as any);
     mockAcceptInviteResult();
   });
 
@@ -220,6 +219,10 @@ describe("POST /api/invites/consume", () => {
         invitee: "follower-uuid",
       },
     );
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "follower-uuid" },
+    );
     expect(mockUserEventInsert).toHaveBeenCalledWith({
       user_id: "follower-uuid",
       event_type: "invite_consumed",
@@ -273,7 +276,32 @@ describe("POST /api/invites/consume", () => {
         invitee: "follower-uuid",
       },
     );
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "follower-uuid" },
+    );
     expect(mockUserEventInsert).not.toHaveBeenCalled();
+    expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips PostHog when the consent-gated event insert is rejected", async () => {
+    const follower = createMockUser({ id: "follower-uuid" });
+    mockAuthenticatedUser(mockSupabaseClient, follower);
+    mockUserEventInsert.mockResolvedValueOnce({
+      error: { code: "42501", message: "row-level security violation" },
+    });
+
+    const token = await signEmailToken(
+      { user_id: "inviter-uuid", purpose: "invite" },
+      TEST_SECRET,
+    );
+
+    const { POST } = require("@/app/api/invites/consume/route");
+    const response = await POST(buildRequest({ token }), { params: {} });
+
+    expectConsoleErrors([/failed to record invite_consumed/]);
+    expect(response.status).toBe(200);
+    expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
   });
 
   it("treats duplicate follow acceptance as success", async () => {
@@ -349,7 +377,7 @@ describe("POST /api/invites/consume", () => {
     );
   });
 
-  it("skips RPC and flags self_invite when follower === inviter", async () => {
+  it("skips invite acceptance and flags self_invite when follower === inviter", async () => {
     const sameUser = createMockUser({ id: "same-id" });
     mockAuthenticatedUser(mockSupabaseClient, sameUser);
 
@@ -367,7 +395,14 @@ describe("POST /api/invites/consume", () => {
     }>(response, 200);
 
     expect(data.data.self_invite).toBe(true);
-    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled();
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalledWith(
+      "accept_invite_for_user",
+      expect.anything(),
+    );
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "same-id" },
+    );
     expect(mockUserEventInsert).toHaveBeenCalledWith({
       user_id: "same-id",
       event_type: "invite_consumed",

--- a/__tests__/api/invites/generate.test.ts
+++ b/__tests__/api/invites/generate.test.ts
@@ -15,6 +15,11 @@ import {
 } from "@/test-utils/api-test-helpers";
 
 const mockSupabaseClient = createMockSupabaseClient();
+const mockCapturePostHogEvent = jest.fn();
+
+jest.mock("@/lib/posthog-server", () => ({
+  capturePostHogEvent: (...args: any[]) => mockCapturePostHogEvent(...args),
+}));
 
 // Phase 4.5 test-mock template: mock the api-wrappers module directly and
 // wire the auth check through the shared mock Supabase client.
@@ -78,6 +83,7 @@ describe("POST /api/invites/generate", () => {
     process.env.EMAIL_TOKEN_SECRET = TEST_SECRET;
     process.env.NEXT_PUBLIC_SITE_URL = "https://dev.quiversurf.app";
     jest.clearAllMocks();
+    mockSupabaseClient.rpc.mockResolvedValue({ data: true, error: null });
   });
 
   afterEach(() => {
@@ -123,7 +129,44 @@ describe("POST /api/invites/generate", () => {
     );
     expect(data.data.token_hash).toBe(hashInviteToken(data.data.token));
     expect(data.data.token_hash).toHaveLength(64);
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "inviter-uuid-123" },
+    );
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith({
+      distinctId: "inviter-uuid-123",
+      event: "invite_link_generated",
+    });
   });
+
+  it.each([
+    ["is disabled", { data: false, error: null }],
+    ["cannot be read", { data: null, error: { message: "rpc unavailable" } }],
+  ])(
+    "returns the invite without PostHog capture when analytics consent %s",
+    async (_label, consentResult) => {
+      const user = createMockUser({ id: "private-inviter" });
+      mockAuthenticatedUser(mockSupabaseClient, user);
+      mockSupabaseClient.rpc.mockResolvedValue(consentResult);
+
+      const { POST } = require("@/app/api/invites/generate/route");
+      const request = createMockRequest(
+        "POST",
+        "http://localhost:3000/api/invites/generate",
+      );
+      const response = await POST(request, { params: {} });
+      const data = await expectSuccessResponse<{
+        token: string;
+        url: string;
+        token_hash: string;
+      }>(response, 200);
+
+      expect(data.data.token).toEqual(expect.any(String));
+      expect(data.data.url).toContain(`/invite/${data.data.token}`);
+      expect(data.data.token_hash).toBe(hashInviteToken(data.data.token));
+      expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
+    },
+  );
 
   it("generated token verifies back to the inviter user_id + invite purpose", async () => {
     const user = createMockUser({ id: "verifiable-inviter" });

--- a/__tests__/api/roadmap-submissions.test.ts
+++ b/__tests__/api/roadmap-submissions.test.ts
@@ -24,7 +24,14 @@ const mockSupabaseClient = {
     getUser: jest.fn(),
   },
   from: jest.fn(),
+  rpc: jest.fn(),
 };
+
+const mockCapturePostHogEvent = jest.fn();
+
+jest.mock("@/lib/posthog-server", () => ({
+  capturePostHogEvent: (...args: any[]) => mockCapturePostHogEvent(...args),
+}));
 
 const mockServiceRoleClient = {
   from: jest.fn(),
@@ -57,6 +64,7 @@ describe("POST /api/roadmap/submissions", () => {
       data: { user: { id: "u1" } },
       error: null,
     });
+    mockSupabaseClient.rpc.mockResolvedValue({ data: true, error: null });
   });
 
   const makeReq = (body: unknown) =>
@@ -201,7 +209,57 @@ describe("POST /api/roadmap/submissions", () => {
         is_custom_spot_request: false,
       },
     });
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "u1" },
+    );
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "u1",
+        event: "feedback_roadmap_request_created",
+      }),
+    );
   });
+
+  it.each([
+    ["is disabled", { data: false, error: null }],
+    ["cannot be read", { data: null, error: { message: "rpc unavailable" } }],
+  ])(
+    "saves the submission but skips PostHog when analytics consent %s",
+    async (_label, consentResult) => {
+      const mockSingle = jest.fn().mockResolvedValue({
+        data: { id: "sub-private" },
+        error: null,
+      });
+      const mockSelect = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockInsert = jest.fn().mockReturnValue({ select: mockSelect });
+      const mockEventInsert = jest.fn().mockResolvedValue({ error: null });
+      mockSupabaseClient.rpc.mockResolvedValue(consentResult);
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === "roadmap_item_submissions") {
+          return { insert: mockInsert };
+        }
+        if (table === "user_events") {
+          return { insert: mockEventInsert };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await POST(makeReq(validBody));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({ id: "sub-private", decision: "pending" });
+      expect(mockInsert).toHaveBeenCalledWith({
+        title: "Add tide charts",
+        description: "Would love to see tide charts on the beach page",
+        category: "forecasts",
+        submitter_user_id: "u1",
+      });
+      expect(mockEventInsert).toHaveBeenCalledTimes(1);
+      expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
+    },
+  );
 
   it("10. DB insert error → 500 with generic message", async () => {
     const mockSingle = jest.fn().mockResolvedValue({

--- a/__tests__/api/roadmap-vote-toggle.test.ts
+++ b/__tests__/api/roadmap-vote-toggle.test.ts
@@ -14,7 +14,14 @@ const mockSupabaseClient = {
     getUser: jest.fn(),
   },
   from: jest.fn(),
+  rpc: jest.fn(),
 };
+
+const mockCapturePostHogEvent = jest.fn();
+
+jest.mock("@/lib/posthog-server", () => ({
+  capturePostHogEvent: (...args: any[]) => mockCapturePostHogEvent(...args),
+}));
 
 const mockServiceRoleClient = {
   from: jest.fn(),
@@ -49,6 +56,7 @@ describe("POST /api/roadmap/items/[id]/vote", () => {
       data: { user: { id: "u1" } },
       error: null,
     });
+    mockSupabaseClient.rpc.mockResolvedValue({ data: true, error: null });
   });
 
   const makeReq = () =>
@@ -133,7 +141,84 @@ describe("POST /api/roadmap/items/[id]/vote", () => {
         roadmap_item_title: "Custom spots",
       },
     });
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "u1" },
+    );
+    expect(mockCapturePostHogEvent).toHaveBeenCalledTimes(2);
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "u1",
+        event: "feedback_roadmap_vote_submitted",
+      }),
+    );
+    expect(mockCapturePostHogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        distinctId: "u1",
+        event: "custom_spots_feedback_voted",
+      }),
+    );
   });
+
+  it.each([
+    ["is disabled", { data: false, error: null }],
+    ["cannot be read", { data: null, error: { message: "rpc unavailable" } }],
+  ])(
+    "keeps the vote but skips PostHog when analytics consent %s",
+    async (_label, consentResult) => {
+      const mockInsert = jest.fn().mockResolvedValue({ error: null });
+      const mockEventInsert = jest.fn().mockResolvedValue({ error: null });
+      mockSupabaseClient.rpc.mockResolvedValue(consentResult);
+      mockSupabaseClient.from.mockImplementation((table: string) => {
+        if (table === "roadmap_votes") {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  maybeSingle: jest.fn().mockResolvedValue({
+                    data: null,
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+            insert: mockInsert,
+          };
+        }
+        if (table === "roadmap_items_with_vote_count") {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                maybeSingle: jest.fn().mockResolvedValue({
+                  data: {
+                    title: "Custom spots",
+                    description: "Create private custom spots",
+                  },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        if (table === "user_events") {
+          return { insert: mockEventInsert };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await POST(makeReq(), { params: { id: "abc" } });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.voted).toBe(true);
+      expect(mockInsert).toHaveBeenCalledWith({
+        item_id: "abc",
+        user_id: "u1",
+      });
+      expect(mockEventInsert).toHaveBeenCalledTimes(2);
+      expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
+    },
+  );
 
   it("3. toggle off (existing vote) → deletes, returns { voted: false }, insert NOT called", async () => {
     const mockDelete = jest.fn().mockReturnValue({

--- a/__tests__/app/api/events/route.test.ts
+++ b/__tests__/app/api/events/route.test.ts
@@ -52,10 +52,16 @@ jest.mock('@/lib/middleware/api-wrappers', () => {
   };
 });
 
+const mockAnalyticsConsentRpc = jest.fn().mockResolvedValue({
+  data: true,
+  error: null,
+});
+
 const mockSupabase = {
   auth: {
     getUser: jest.fn(),
   },
+  rpc: mockAnalyticsConsentRpc,
   from: jest.fn((_table: string) => ({
     select: jest.fn(() => ({
       eq: jest.fn(() => ({
@@ -82,6 +88,7 @@ const BROWSER_HEADERS = {
 describe('POST /api/events', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAnalyticsConsentRpc.mockResolvedValue({ data: true, error: null });
     __clearTrackingCache(); // Clear the in-memory cache between tests
   });
 
@@ -147,6 +154,10 @@ describe('POST /api/events', () => {
     });
 
     const mockInsert = jest.fn();
+    mockAnalyticsConsentRpc.mockResolvedValueOnce({
+      data: false,
+      error: null,
+    });
 
     // User has opted out
     mockSupabase.from.mockImplementation((table: string) => {
@@ -625,7 +636,7 @@ describe('POST /api/events', () => {
   });
 
   describe('tracking cache integration', () => {
-    it('caches tracking preference after first check', async () => {
+    it('rechecks an allowed preference so revocation takes effect immediately', async () => {
       mockSupabase.auth.getUser.mockResolvedValue({
         data: { user: { id: 'user-cache-test' } },
         error: null,
@@ -651,24 +662,56 @@ describe('POST /api/events', () => {
         return { insert: mockInsert, select: jest.fn() };
       });
 
-      // First request - should query database
+      mockAnalyticsConsentRpc
+        .mockResolvedValueOnce({ data: true, error: null })
+        .mockResolvedValueOnce({ data: false, error: null });
+
       const request1 = new Request('http://localhost/api/events', {
         method: 'POST',
         headers: BROWSER_HEADERS,
         body: JSON.stringify({ eventType: 'beach_view' }),
       });
-      await POST(request1);
-      expect(mockProfileSelect).toHaveBeenCalledTimes(1);
+      const response1 = await POST(request1);
+      expect(response1.status).toBe(200);
+      expect(mockAnalyticsConsentRpc).toHaveBeenCalledTimes(1);
+      expect(mockInsert).toHaveBeenCalledTimes(1);
 
-      // Second request - should use cache
       const request2 = new Request('http://localhost/api/events', {
         method: 'POST',
         headers: BROWSER_HEADERS,
         body: JSON.stringify({ eventType: 'beach_view' }),
       });
+      const response2 = await POST(request2);
+      const data2 = await response2.json();
+
+      expect(response2.status).toBe(200);
+      expect(data2.data.status).toBe('tracking_disabled');
+      expect(mockAnalyticsConsentRpc).toHaveBeenCalledTimes(2);
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches a disabled preference without retaining positive consent', async () => {
+      mockSupabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: 'user-disabled-cache-test' } },
+        error: null,
+      });
+      mockAnalyticsConsentRpc.mockResolvedValue({ data: false, error: null });
+
+      const request1 = new Request('http://localhost/api/events', {
+        method: 'POST',
+        headers: BROWSER_HEADERS,
+        body: JSON.stringify({ eventType: 'beach_view' }),
+      });
+      const request2 = new Request('http://localhost/api/events', {
+        method: 'POST',
+        headers: BROWSER_HEADERS,
+        body: JSON.stringify({ eventType: 'beach_view' }),
+      });
+
+      await POST(request1);
       await POST(request2);
-      // Should still be 1 (cache hit)
-      expect(mockProfileSelect).toHaveBeenCalledTimes(1);
+
+      expect(mockAnalyticsConsentRpc).toHaveBeenCalledTimes(1);
     });
 
     it('defaults to tracking allowed when no profile preference', async () => {
@@ -811,6 +854,7 @@ describe('POST /api/events', () => {
         'home_plan_weekend_no_recommendation',
         // Session logging events
         'session_log_start',
+        'session_log_form_view',
         'session_log_submit',
         'session_created',
         'session_log_validation_failed',

--- a/__tests__/app/api/forecast-feedback-route.test.ts
+++ b/__tests__/app/api/forecast-feedback-route.test.ts
@@ -7,7 +7,19 @@ import { POST } from "@/app/api/forecast-feedback/route";
 
 const mockUser = { id: "user-1" };
 const mockSupabase = { from: jest.fn() };
+const mockFeedbackMaybeSingle = jest.fn();
+const mockServiceFrom = jest.fn(() => ({
+  select: jest.fn(() => ({
+    eq: jest.fn(() => ({
+      eq: jest.fn(() => ({ maybeSingle: mockFeedbackMaybeSingle })),
+    })),
+  })),
+}));
 const MOCK_FORECAST_ID = "22222222-2222-4222-8222-222222222222";
+
+jest.mock("@/lib/supabase", () => ({
+  createServiceRoleClient: () => ({ from: mockServiceFrom }),
+}));
 
 jest.mock("@/lib/middleware/api-wrappers", () => {
   const actual = jest.requireActual("@/lib/api-utils");
@@ -106,6 +118,7 @@ describe("POST /api/forecast-feedback", () => {
     jest.clearAllMocks();
     mockSupabase.from.mockReset();
     mockForecastAccuracyVotePersistence();
+    mockFeedbackMaybeSingle.mockResolvedValue({ data: null, error: null });
     process.env = {
       ...originalEnv,
       ML_INTERNAL_SECRET: "test-secret",
@@ -195,6 +208,53 @@ describe("POST /api/forecast-feedback", () => {
       },
       { onConflict: "user_id,forecast_id" },
     );
+  });
+
+  it("acknowledges an already-stored stable request without calling Seaside", async () => {
+    mockFeedbackMaybeSingle.mockResolvedValueOnce({
+      data: {
+        id: "feedback-existing",
+        contract_version: "forecast-feedback-context.v1",
+        correlation_id: "corr-original",
+      },
+      error: null,
+    });
+
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toEqual({
+      id: "feedback-existing",
+      contractVersion: "forecast-feedback-context.v1",
+      correlationId: "corr-original",
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSupabase.from).not.toHaveBeenCalledWith("forecast_accuracy_votes");
+  });
+
+  it("recovers a lost Seaside response when the stable request was stored", async () => {
+    mockFeedbackMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({
+        data: {
+          id: "feedback-stored-before-error",
+          contract_version: "forecast-feedback-context.v1",
+          correlation_id: "corr-client",
+        },
+        error: null,
+      });
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error("connection closed after write"),
+    );
+
+    const response = await POST(requestWithBody(basePayload()));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.id).toBe("feedback-stored-before-error");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockFeedbackMaybeSingle).toHaveBeenCalledTimes(2);
   });
 
   it("adds explicit missing flags for empty context groups before calling Seaside", async () => {

--- a/__tests__/app/invite/consume-route.test.ts
+++ b/__tests__/app/invite/consume-route.test.ts
@@ -11,7 +11,11 @@ import {
 
 const mockSupabaseClient = createMockSupabaseClient();
 const mockUserEventInsert = jest.fn();
-const mockTrackingPreferenceMaybeSingle = jest.fn();
+let mockTrackingAllowed = true;
+let mockAcceptInviteResponse: {
+  data: Record<string, boolean>;
+  error: { code?: string; message?: string } | null;
+};
 
 jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: jest.fn(() => mockSupabaseClient),
@@ -56,7 +60,7 @@ function mockAcceptInviteResult(result?: {
   data?: Record<string, boolean>;
   error?: { code?: string; message?: string } | null;
 }) {
-  mockSupabaseClient.rpc.mockResolvedValue({
+  mockAcceptInviteResponse = {
     data: result?.data ?? {
       follow_created: true,
       follow_existing: false,
@@ -64,16 +68,24 @@ function mockAcceptInviteResult(result?: {
       referral_existing: false,
     },
     error: result?.error ?? null,
-  });
+  };
 }
 
-function mockTrackingPreference(allowImplicitTracking: boolean | null = true) {
-  mockTrackingPreferenceMaybeSingle.mockResolvedValue({
-    data:
-      allowImplicitTracking === null
-        ? null
-        : { allow_implicit_tracking: allowImplicitTracking },
-    error: null,
+function mockTrackingPreference(allowImplicitTracking = true) {
+  mockTrackingAllowed = allowImplicitTracking;
+}
+
+function installRpcMock() {
+  mockSupabaseClient.rpc.mockImplementation((functionName: string) => {
+    if (functionName === "get_my_analytics_tracking_allowed") {
+      return Promise.resolve({ data: mockTrackingAllowed, error: null });
+    }
+
+    if (functionName === "accept_invite_for_user") {
+      return Promise.resolve(mockAcceptInviteResponse);
+    }
+
+    return Promise.resolve({ data: null, error: null });
   });
 }
 
@@ -91,19 +103,11 @@ describe("GET /invite/consume", () => {
     process.env.EMAIL_TOKEN_SECRET = TEST_SECRET;
     mockUserEventInsert.mockResolvedValue({ error: null });
     mockTrackingPreference();
-    mockSupabaseClient.from.mockImplementation((table: string) => {
-      if (table === "profiles") {
-        return {
-          select: jest.fn(() => ({
-            eq: jest.fn(() => ({
-              maybeSingle: mockTrackingPreferenceMaybeSingle,
-            })),
-          })),
-        } as any;
-      }
-      return { insert: mockUserEventInsert } as any;
-    });
+    mockSupabaseClient.from.mockImplementation(
+      () => ({ insert: mockUserEventInsert }) as any,
+    );
     mockAcceptInviteResult();
+    installRpcMock();
   });
 
   afterEach(() => {
@@ -256,7 +260,14 @@ describe("GET /invite/consume", () => {
     const location = getRedirectLocation(response);
     expect(location.pathname).toBe("/community");
     expect(location.searchParams.get("tab")).toBe("friends");
-    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled();
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalledWith(
+      "accept_invite_for_user",
+      expect.anything(),
+    );
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "same-id" },
+    );
     expect(mockUserEventInsert).toHaveBeenCalledWith({
       user_id: "same-id",
       event_type: "invite_consumed",

--- a/__tests__/app/invite/token-page.test.ts
+++ b/__tests__/app/invite/token-page.test.ts
@@ -61,14 +61,24 @@ function mockAuthUser(userId: string | null) {
 }
 
 function mockAcceptInviteRpc(error: { code: string } | null = null) {
-  mockSupabaseClient.rpc.mockResolvedValue({
-    data: {
-      follow_created: error ? false : true,
-      follow_existing: error?.code === "23505",
-      referral_created: error ? false : true,
-      referral_existing: false,
-    },
-    error: null,
+  mockSupabaseClient.rpc.mockImplementation((functionName: string) => {
+    if (functionName === "get_my_analytics_tracking_allowed") {
+      return Promise.resolve({ data: true, error: null });
+    }
+
+    if (functionName === "accept_invite_for_user") {
+      return Promise.resolve({
+        data: {
+          follow_created: !error,
+          follow_existing: error?.code === "23505",
+          referral_created: !error,
+          referral_existing: false,
+        },
+        error: null,
+      });
+    }
+
+    return Promise.resolve({ data: null, error: null });
   });
 
   return mockSupabaseClient.rpc;
@@ -95,6 +105,13 @@ function mockInviterProfile() {
 describe("/invite/[token]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSupabaseClient.rpc.mockReset();
+    mockSupabaseClient.rpc.mockImplementation((functionName: string) => {
+      if (functionName === "get_my_analytics_tracking_allowed") {
+        return Promise.resolve({ data: true, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
     process.env.EMAIL_TOKEN_SECRET = TEST_SECRET;
   });
 
@@ -179,7 +196,14 @@ describe("/invite/[token]", () => {
 
     await expectRedirect(renderInvitePage(token), "/community?tab=friends");
 
-    expect(mockSupabaseClient.rpc).not.toHaveBeenCalled();
+    expect(mockSupabaseClient.rpc).not.toHaveBeenCalledWith(
+      "accept_invite_for_user",
+      expect.anything(),
+    );
+    expect(mockSupabaseClient.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "same-id" },
+    );
     expect(mockCookies).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/analytics/posthog-provider.test.tsx
+++ b/__tests__/components/analytics/posthog-provider.test.tsx
@@ -1,57 +1,266 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { PostHogProvider } from "@/components/analytics/posthog-provider";
 import { useAuth } from "@/context/auth-context";
 import {
+  applyClientPostHogTrackingStorageEvent,
   buildPostHogUserProperties,
+  captureQueuedClientPostHogSignup,
   identifyPostHogUser,
-  initPostHog,
+  isClientPostHogTrackingRevisionCurrent,
   resetPostHog,
+  setAnonymousClientPostHogTracking,
+  setClientPostHogTrackingAllowed,
 } from "@/lib/posthog-client";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 
 jest.mock("@/context/auth-context", () => ({
   useAuth: jest.fn(),
 }));
 
+const mockSupabaseClient = { rpc: jest.fn() };
+jest.mock("@/lib/supabase/client", () => ({
+  createClient: () => mockSupabaseClient,
+}));
+
+jest.mock("@/lib/analytics/consent", () => ({
+  getOwnAnalyticsTrackingAllowed: jest.fn(),
+}));
+
 jest.mock("@/lib/posthog-client", () => ({
+  applyClientPostHogTrackingStorageEvent: jest.fn(),
   buildPostHogUserProperties: jest.fn((user) => ({
     email_domain: user.email?.split("@")[1],
     provider: user.app_metadata?.provider ?? "email",
   })),
+  captureQueuedClientPostHogSignup: jest.fn(),
   identifyPostHogUser: jest.fn(),
-  initPostHog: jest.fn(),
+  isClientPostHogTrackingRevisionCurrent: jest.fn(() => true),
   resetPostHog: jest.fn(),
+  setAnonymousClientPostHogTracking: jest.fn(),
+  setClientPostHogTrackingAllowed: jest.fn(() => 1),
 }));
 
 describe("PostHogProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (useAuth as jest.Mock).mockReturnValue({ user: null });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockReset();
+    (isClientPostHogTrackingRevisionCurrent as jest.Mock).mockReset();
+    (setClientPostHogTrackingAllowed as jest.Mock).mockReset();
+    (isClientPostHogTrackingRevisionCurrent as jest.Mock).mockReturnValue(true);
+    (setClientPostHogTrackingAllowed as jest.Mock).mockReturnValue(1);
+    (useAuth as jest.Mock).mockReturnValue({ user: null, isLoading: false });
   });
 
-  it("initializes PostHog on mount", () => {
+  it("enables anonymous tracking only after auth resolves unauthenticated", () => {
     render(<PostHogProvider />);
 
-    expect(initPostHog).toHaveBeenCalledTimes(1);
+    expect(setClientPostHogTrackingAllowed).toHaveBeenCalledWith(null);
+    expect(setAnonymousClientPostHogTracking).toHaveBeenCalledTimes(1);
+    expect(identifyPostHogUser).not.toHaveBeenCalled();
   });
 
-  it("identifies authenticated users with privacy-safe properties", async () => {
+  it("listens for consent revocation from another browser tab", () => {
+    const { unmount } = render(<PostHogProvider />);
+    const event = new StorageEvent("storage", {
+      key: "quiver_posthog_tracking_denied_v1",
+      newValue: "true",
+    });
+
+    window.dispatchEvent(event);
+    expect(applyClientPostHogTrackingStorageEvent).toHaveBeenCalledWith(event);
+
+    unmount();
+    (applyClientPostHogTrackingStorageEvent as jest.Mock).mockClear();
+    window.dispatchEvent(event);
+    expect(applyClientPostHogTrackingStorageEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps PostHog pending while authentication is unresolved", () => {
+    (useAuth as jest.Mock).mockReturnValue({ user: null, isLoading: true });
+
+    render(<PostHogProvider />);
+
+    expect(setClientPostHogTrackingAllowed).toHaveBeenCalledWith(null);
+    expect(setAnonymousClientPostHogTracking).not.toHaveBeenCalled();
+    expect(getOwnAnalyticsTrackingAllowed).not.toHaveBeenCalled();
+  });
+
+  it("identifies authenticated users only after owner consent resolves true", async () => {
     const user = {
       id: "user-123",
       email: "steven@example.com",
       app_metadata: { provider: "google" },
     };
-    (useAuth as jest.Mock).mockReturnValue({ user });
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockResolvedValueOnce(true);
 
     render(<PostHogProvider />);
 
     await waitFor(() => {
+      expect(getOwnAnalyticsTrackingAllowed).toHaveBeenCalledWith(
+        mockSupabaseClient,
+        "user-123",
+      );
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(true);
       expect(buildPostHogUserProperties).toHaveBeenCalledWith(user);
       expect(identifyPostHogUser).toHaveBeenCalledWith("user-123", {
         email_domain: "example.com",
         provider: "google",
       });
+      expect(captureQueuedClientPostHogSignup).toHaveBeenCalledWith(
+        "user-123",
+      );
     });
+  });
+
+  it("fails closed and revalidates authenticated consent when the tab becomes visible", async () => {
+    const user = {
+      id: "user-123",
+      email: "steven@example.com",
+      app_metadata: { provider: "google" },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+
+    render(<PostHogProvider />);
+    await waitFor(() => {
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(true);
+    });
+
+    (setClientPostHogTrackingAllowed as jest.Mock).mockClear();
+    (resetPostHog as jest.Mock).mockClear();
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(setClientPostHogTrackingAllowed).toHaveBeenCalledWith(null);
+    await waitFor(() => {
+      expect(getOwnAnalyticsTrackingAllowed).toHaveBeenCalledTimes(2);
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(false);
+      expect(resetPostHog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("ignores an older foreground consent response after a newer recheck", async () => {
+    let currentRevision = 0;
+    let resolveOlderConsent: (allowed: boolean) => void = () => undefined;
+    let resolveNewerConsent: (allowed: boolean) => void = () => undefined;
+    const olderConsent = new Promise<boolean>((resolve) => {
+      resolveOlderConsent = resolve;
+    });
+    const newerConsent = new Promise<boolean>((resolve) => {
+      resolveNewerConsent = resolve;
+    });
+    const user = {
+      id: "user-123",
+      email: "steven@example.com",
+      app_metadata: { provider: "google" },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (setClientPostHogTrackingAllowed as jest.Mock).mockImplementation(
+      () => ++currentRevision,
+    );
+    (isClientPostHogTrackingRevisionCurrent as jest.Mock).mockImplementation(
+      (revision: number) => revision === currentRevision,
+    );
+    (getOwnAnalyticsTrackingAllowed as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockReturnValueOnce(olderConsent)
+      .mockReturnValueOnce(newerConsent);
+
+    render(<PostHogProvider />);
+    await waitFor(() => {
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(true);
+    });
+
+    (setClientPostHogTrackingAllowed as jest.Mock).mockClear();
+    (identifyPostHogUser as jest.Mock).mockClear();
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(getOwnAnalyticsTrackingAllowed).toHaveBeenCalledTimes(3);
+
+    resolveNewerConsent(false);
+    await waitFor(() => {
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(false);
+    });
+
+    resolveOlderConsent(true);
+    await act(async () => {
+      await olderConsent;
+    });
+    expect(setClientPostHogTrackingAllowed).not.toHaveBeenCalledWith(true);
+    expect(identifyPostHogUser).not.toHaveBeenCalled();
+  });
+
+  it("opts out and never identifies when owner consent resolves false", async () => {
+    const user = {
+      id: "user-123",
+      email: "steven@example.com",
+      app_metadata: { provider: "google" },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockResolvedValueOnce(false);
+
+    render(<PostHogProvider />);
+
+    await waitFor(() => {
+      expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(false);
+    });
+    expect(identifyPostHogUser).not.toHaveBeenCalled();
+    expect(resetPostHog).toHaveBeenCalledTimes(1);
+  });
+
+  it("remains fail-closed when owner consent cannot be loaded", async () => {
+    const user = {
+      id: "user-123",
+      email: "steven@example.com",
+      app_metadata: { provider: "google" },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockRejectedValueOnce(
+      new Error("consent unavailable"),
+    );
+
+    render(<PostHogProvider />);
+
+    await waitFor(() => {
+      expect(getOwnAnalyticsTrackingAllowed).toHaveBeenCalled();
+    });
+    expect(setClientPostHogTrackingAllowed).toHaveBeenLastCalledWith(null);
+    expect(identifyPostHogUser).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale consent lookup overwrite a newer gate decision", async () => {
+    let resolveConsent: (allowed: boolean) => void = () => undefined;
+    const consentResult = new Promise<boolean>((resolve) => {
+      resolveConsent = resolve;
+    });
+    const user = {
+      id: "user-123",
+      email: "steven@example.com",
+      app_metadata: { provider: "google" },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockReturnValueOnce(
+      consentResult,
+    );
+    (isClientPostHogTrackingRevisionCurrent as jest.Mock).mockReturnValue(false);
+
+    render(<PostHogProvider />);
+    resolveConsent(true);
+
+    await waitFor(() => expect(getOwnAnalyticsTrackingAllowed).toHaveBeenCalled());
+    expect(setClientPostHogTrackingAllowed).not.toHaveBeenCalledWith(true);
+    expect(identifyPostHogUser).not.toHaveBeenCalled();
   });
 
   it("resets identity after a previously identified user logs out", async () => {
@@ -60,7 +269,8 @@ describe("PostHogProvider", () => {
       email: "steven@example.com",
       app_metadata: { provider: "google" },
     };
-    (useAuth as jest.Mock).mockReturnValue({ user });
+    (useAuth as jest.Mock).mockReturnValue({ user, isLoading: false });
+    (getOwnAnalyticsTrackingAllowed as jest.Mock).mockResolvedValueOnce(true);
 
     const { rerender } = render(<PostHogProvider />);
 
@@ -71,7 +281,7 @@ describe("PostHogProvider", () => {
       );
     });
 
-    (useAuth as jest.Mock).mockReturnValue({ user: null });
+    (useAuth as jest.Mock).mockReturnValue({ user: null, isLoading: false });
     rerender(<PostHogProvider />);
 
     await waitFor(() => {

--- a/__tests__/components/profile/profile-preferences-consent.test.tsx
+++ b/__tests__/components/profile/profile-preferences-consent.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockGetOwnAnalyticsTrackingAllowed = jest.fn();
+const mockSetClientPostHogTrackingAllowed = jest.fn();
+const mockIdentifyPostHogUser = jest.fn();
+const mockResetPostHog = jest.fn();
+const mockCaptureQueuedClientPostHogSignup = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock("@/lib/server-action-utils", () => ({
+  withAuthenticatedAction: jest.fn().mockResolvedValue({
+    success: true,
+    data: {},
+  }),
+}));
+
+jest.mock("@/lib/analytics/consent", () => {
+  const actual = jest.requireActual("@/lib/analytics/consent");
+  return {
+    ...actual,
+    getOwnAnalyticsTrackingAllowed: (...args: unknown[]) =>
+      mockGetOwnAnalyticsTrackingAllowed(...args),
+  };
+});
+
+jest.mock("@/lib/posthog-client", () => ({
+  captureQueuedClientPostHogSignup: (...args: unknown[]) =>
+    mockCaptureQueuedClientPostHogSignup(...args),
+  identifyPostHogUser: (...args: unknown[]) => mockIdentifyPostHogUser(...args),
+  resetPostHog: (...args: unknown[]) => mockResetPostHog(...args),
+  setClientPostHogTrackingAllowed: (...args: unknown[]) =>
+    mockSetClientPostHogTrackingAllowed(...args),
+}));
+
+jest.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ rpc: jest.fn() }),
+}));
+
+jest.mock("@/components/BeachSelector", () => ({
+  BeachSelector: () => null,
+}));
+
+jest.mock("@/components/profile/shared/preference-fields", () => ({
+  ExperienceLevelField: () => null,
+  SurfStylesField: () => null,
+}));
+
+jest.mock("@/components/ui/use-toast", () => ({
+  toast: jest.fn(),
+}));
+
+const { ProfilePreferences } = require("@/components/profile/profile-preferences");
+
+describe("ProfilePreferences analytics consent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOwnAnalyticsTrackingAllowed.mockResolvedValue(true);
+  });
+
+  it("updates the client PostHog gate immediately after saving an opt-out", async () => {
+    render(
+      <ProfilePreferences
+        userId="user-123"
+        profile={null}
+        beaches={[]}
+        onSaveComplete={jest.fn()}
+      />,
+    );
+
+    const trackingSwitch = await screen.findByRole("switch", {
+      name: "Improve recommendations with my activity",
+    });
+    await waitFor(() => expect(trackingSwitch).toBeEnabled());
+
+    fireEvent.click(trackingSwitch);
+    fireEvent.click(screen.getByRole("button", { name: "Save Preferences" }));
+
+    await waitFor(() =>
+      expect(mockSetClientPostHogTrackingAllowed).toHaveBeenCalledWith(false),
+    );
+    expect(mockResetPostHog).toHaveBeenCalledTimes(1);
+    expect(mockIdentifyPostHogUser).not.toHaveBeenCalled();
+  });
+
+  it("re-identifies the current user after saving an opt-in", async () => {
+    mockGetOwnAnalyticsTrackingAllowed.mockResolvedValue(false);
+
+    render(
+      <ProfilePreferences
+        userId="user-123"
+        profile={null}
+        beaches={[]}
+        onSaveComplete={jest.fn()}
+      />,
+    );
+
+    const trackingSwitch = await screen.findByRole("switch", {
+      name: "Improve recommendations with my activity",
+    });
+    await waitFor(() => expect(trackingSwitch).toBeEnabled());
+
+    fireEvent.click(trackingSwitch);
+    fireEvent.click(screen.getByRole("button", { name: "Save Preferences" }));
+
+    await waitFor(() =>
+      expect(mockSetClientPostHogTrackingAllowed).toHaveBeenCalledWith(true),
+    );
+    expect(mockIdentifyPostHogUser).toHaveBeenCalledWith("user-123");
+    expect(mockCaptureQueuedClientPostHogSignup).toHaveBeenCalledWith(
+      "user-123",
+    );
+    expect(mockResetPostHog).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/context/auth-context.error-paths.test.tsx
+++ b/__tests__/context/auth-context.error-paths.test.tsx
@@ -1,5 +1,19 @@
 import * as React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+const mockSetClientPostHogTrackingAllowed = jest.fn();
+const mockQueueClientPostHogSignup = jest.fn();
+const originalPostHogToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+jest.mock("@/lib/posthog-client", () => ({
+  buildPostHogUserProperties: jest.fn(() => ({})),
+  captureClientPostHogEvent: jest.fn(),
+  identifyPostHogUser: jest.fn(),
+  resetPostHog: jest.fn(),
+  queueClientPostHogSignup: (...args: unknown[]) =>
+    mockQueueClientPostHogSignup(...args),
+  setClientPostHogTrackingAllowed: (...args: unknown[]) =>
+    mockSetClientPostHogTrackingAllowed(...args),
+}));
 
 // Mock Supabase client setup
 const mockGetSession = jest.fn(() =>
@@ -8,9 +22,27 @@ const mockGetSession = jest.fn(() =>
 const mockGetUser = jest.fn(() =>
   Promise.resolve({ data: { user: null }, error: null })
 );
-const mockOnAuthStateChange = jest.fn(() => ({
-  data: { subscription: { unsubscribe: jest.fn() } },
-}));
+type AuthStateChangeHandler = (
+  event: string,
+  session: {
+    user: {
+      id: string;
+      created_at: string;
+      app_metadata: Record<string, unknown>;
+    };
+  } | null,
+) => void;
+const mockOnAuthStateChange = jest.fn(
+  (_handler: AuthStateChangeHandler) => ({
+    data: { subscription: { unsubscribe: jest.fn() } },
+  }),
+);
+
+function getAuthStateChangeHandler(): AuthStateChangeHandler {
+  const handler = mockOnAuthStateChange.mock.calls[0]?.[0];
+  if (!handler) throw new Error("Auth state change handler was not registered");
+  return handler;
+}
 
 jest.mock("@/lib/supabase/client", () => ({
   __esModule: true,
@@ -51,6 +83,15 @@ describe("AuthContext error paths", () => {
     });
   });
 
+  afterEach(() => {
+    sessionStorage.removeItem("welcome_email_sent_new-user");
+    if (originalPostHogToken === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = originalPostHogToken;
+    }
+  });
+
   it("handles getSession error and sets unauthenticated", async () => {
     mockGetSession.mockResolvedValueOnce({
       data: { session: null },
@@ -65,6 +106,59 @@ describe("AuthContext error paths", () => {
 
     await waitFor(() =>
       expect(screen.getByTestId("authed").textContent).toBe("false")
+    );
+  });
+
+  it("closes the PostHog gate synchronously when a session signs in", async () => {
+    render(
+      <AuthProvider>
+        <div>child</div>
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(mockOnAuthStateChange).toHaveBeenCalled());
+    mockSetClientPostHogTrackingAllowed.mockClear();
+    const onAuthStateChange = getAuthStateChangeHandler();
+
+    act(() => {
+      onAuthStateChange("SIGNED_IN", {
+        user: {
+          id: "user-123",
+          created_at: "2020-01-01T00:00:00.000Z",
+          app_metadata: {},
+        },
+      });
+    });
+
+    expect(mockSetClientPostHogTrackingAllowed).toHaveBeenCalledWith(null);
+  });
+
+  it("queues a fresh signup conversion for the consent-aware provider", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = "phc_test";
+    sessionStorage.setItem("welcome_email_sent_new-user", "true");
+
+    render(
+      <AuthProvider>
+        <div>child</div>
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(mockOnAuthStateChange).toHaveBeenCalled());
+    const onAuthStateChange = getAuthStateChangeHandler();
+
+    act(() => {
+      onAuthStateChange("SIGNED_IN", {
+        user: {
+          id: "new-user",
+          created_at: new Date().toISOString(),
+          app_metadata: { provider: "google" },
+        },
+      });
+    });
+
+    expect(mockQueueClientPostHogSignup).toHaveBeenCalledWith(
+      "new-user",
+      "google",
     );
   });
 });

--- a/__tests__/hooks/use-track-event.test.ts
+++ b/__tests__/hooks/use-track-event.test.ts
@@ -142,6 +142,57 @@ describe("useTrackEvent", () => {
     });
   });
 
+  describe("PostHog handoff", () => {
+    it("waits for the consent-aware API before capturing", async () => {
+      (useOptionalAuth as jest.Mock).mockReturnValue({ user: { id: "user-123" } });
+      let resolveFetch: (response: unknown) => void = () => undefined;
+      const fetchPromise = new Promise((resolve) => {
+        resolveFetch = resolve;
+      });
+      (global.fetch as jest.Mock).mockReturnValueOnce(fetchPromise);
+      const { result } = renderHook(() => useTrackEvent());
+
+      let trackPromise: Promise<void>;
+      act(() => {
+        trackPromise = result.current.track("beach_view");
+      });
+
+      expect(mockCaptureClientPostHogEvent).not.toHaveBeenCalled();
+
+      resolveFetch({
+        ok: true,
+        json: async () => ({ success: true, data: { ok: true } }),
+      });
+      await act(async () => {
+        await trackPromise!;
+      });
+
+      expect(mockCaptureClientPostHogEvent).toHaveBeenCalledWith(
+        "beach_view",
+        {},
+      );
+    });
+
+    it.each([
+      ["tracking_disabled", { ok: true, status: "tracking_disabled" }],
+      ["bot_filtered", { ok: true, status: "bot_filtered" }],
+      ["skipped", { ok: true, skipped: true }],
+    ])("does not capture when the API reports %s", async (_name, data) => {
+      (useOptionalAuth as jest.Mock).mockReturnValue({ user: { id: "user-123" } });
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, data }),
+      });
+      const { result } = renderHook(() => useTrackEvent());
+
+      await act(async () => {
+        await result.current.track("beach_view");
+      });
+
+      expect(mockCaptureClientPostHogEvent).not.toHaveBeenCalled();
+    });
+  });
+
   describe("guest users", () => {
     it("tracks anonymously for guests with sessionId", async () => {
       (useOptionalAuth as jest.Mock).mockReturnValue({ user: null });

--- a/__tests__/lib/analytics/consent.test.ts
+++ b/__tests__/lib/analytics/consent.test.ts
@@ -1,0 +1,43 @@
+import {
+  buildAnalyticsConsentProfileUpdate,
+  getOwnAnalyticsTrackingAllowed,
+} from "@/lib/analytics/consent";
+
+describe("getOwnAnalyticsTrackingAllowed", () => {
+  it("reads consent only through the owner-scoped RPC", async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: true, error: null });
+
+    await expect(
+      getOwnAnalyticsTrackingAllowed({ rpc } as any, "user-123"),
+    ).resolves.toBe(true);
+    expect(rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "user-123" },
+    );
+  });
+
+  it("fails closed when the RPC does not affirm consent", async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: null, error: null });
+
+    await expect(
+      getOwnAnalyticsTrackingAllowed({ rpc } as any, "user-123"),
+    ).resolves.toBe(false);
+  });
+
+  it("surfaces RPC failures to callers", async () => {
+    const error = { message: "unavailable" };
+    const rpc = jest.fn().mockResolvedValue({ data: null, error });
+
+    await expect(
+      getOwnAnalyticsTrackingAllowed({ rpc } as any, "user-123"),
+    ).rejects.toBe(error);
+  });
+
+  it("does not overwrite consent when the owner preference failed to load", () => {
+    expect(buildAnalyticsConsentProfileUpdate(false, false)).toEqual({});
+    expect(buildAnalyticsConsentProfileUpdate(false, true)).toEqual({});
+    expect(buildAnalyticsConsentProfileUpdate(true, false)).toEqual({
+      allow_implicit_tracking: false,
+    });
+  });
+});

--- a/__tests__/lib/invites/events.test.ts
+++ b/__tests__/lib/invites/events.test.ts
@@ -3,28 +3,23 @@
  */
 
 import { recordInviteConsumedEvent } from "@/lib/invites/events";
+import { expectConsoleErrors } from "@/__tests__/setup/test-utils";
 
 function createSupabaseMock(allowImplicitTracking: boolean | null = true) {
   const insert = jest.fn().mockResolvedValue({ error: null });
-  const maybeSingle = jest.fn().mockResolvedValue({
-    data:
-      allowImplicitTracking === null
-        ? null
-        : { allow_implicit_tracking: allowImplicitTracking },
+  const rpc = jest.fn().mockResolvedValue({
+    data: allowImplicitTracking === true,
     error: null,
   });
-  const eq = jest.fn(() => ({ maybeSingle }));
-  const select = jest.fn(() => ({ eq }));
   const from = jest.fn((table: string) => {
-    if (table === "profiles") return { select };
     if (table === "user_events") return { insert };
     throw new Error(`Unexpected table: ${table}`);
   });
 
   return {
-    supabase: { from },
+    supabase: { from, rpc },
     insert,
-    maybeSingle,
+    rpc,
   };
 }
 
@@ -32,17 +27,24 @@ describe("recordInviteConsumedEvent", () => {
   it("records invite_consumed when product telemetry is allowed", async () => {
     const { supabase, insert } = createSupabaseMock(true);
 
-    await recordInviteConsumedEvent(supabase as any, {
-      followerId: "follower-id",
-      inviterId: "inviter-id",
-      tokenHash: "hash-token",
-      surface: "native",
-      selfInvite: false,
-      flags: {
-        followCreated: true,
-        referralCreated: true,
-      },
-    });
+    await expect(
+      recordInviteConsumedEvent(supabase as any, {
+        followerId: "follower-id",
+        inviterId: "inviter-id",
+        tokenHash: "hash-token",
+        surface: "native",
+        selfInvite: false,
+        flags: {
+          followCreated: true,
+          referralCreated: true,
+        },
+      }),
+    ).resolves.toBe(true);
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      "get_my_analytics_tracking_allowed",
+      { p_expected_user_id: "follower-id" },
+    );
 
     expect(insert).toHaveBeenCalledWith({
       user_id: "follower-id",
@@ -62,14 +64,34 @@ describe("recordInviteConsumedEvent", () => {
   it("skips invite_consumed when product telemetry is disabled", async () => {
     const { supabase, insert } = createSupabaseMock(false);
 
-    await recordInviteConsumedEvent(supabase as any, {
-      followerId: "follower-id",
-      inviterId: "inviter-id",
-      tokenHash: "hash-token",
-      surface: "web",
-      selfInvite: false,
-    });
+    await expect(
+      recordInviteConsumedEvent(supabase as any, {
+        followerId: "follower-id",
+        inviterId: "inviter-id",
+        tokenHash: "hash-token",
+        surface: "web",
+        selfInvite: false,
+      }),
+    ).resolves.toBe(false);
 
     expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("does not authorize downstream telemetry when the event insert fails", async () => {
+    const { supabase, insert } = createSupabaseMock(true);
+    insert.mockResolvedValueOnce({
+      error: { code: "42501", message: "row-level security violation" },
+    });
+
+    await expect(
+      recordInviteConsumedEvent(supabase as any, {
+        followerId: "follower-id",
+        inviterId: "inviter-id",
+        tokenHash: "hash-token",
+        surface: "native",
+        selfInvite: false,
+      }),
+    ).resolves.toBe(false);
+    expectConsoleErrors([/failed to record invite_consumed/]);
   });
 });

--- a/__tests__/lib/posthog-client.test.ts
+++ b/__tests__/lib/posthog-client.test.ts
@@ -2,12 +2,23 @@ jest.mock("posthog-js", () => ({
   init: jest.fn(),
   capture: jest.fn(),
   identify: jest.fn(),
+  opt_in_capturing: jest.fn(),
+  opt_out_capturing: jest.fn(),
   reset: jest.fn(),
   __quiverInitialized: false,
 }));
 
 import posthog from "posthog-js";
-import { _resetPostHogClientForTesting, initPostHog } from "@/lib/posthog-client";
+import {
+  _resetPostHogClientForTesting,
+  applyClientPostHogTrackingStorageEvent,
+  captureClientPostHogEvent,
+  captureQueuedClientPostHogSignup,
+  identifyPostHogUser,
+  initPostHog,
+  queueClientPostHogSignup,
+  setClientPostHogTrackingAllowed,
+} from "@/lib/posthog-client";
 
 describe("posthog-client", () => {
   const originalToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
@@ -16,14 +27,45 @@ describe("posthog-client", () => {
     jest.clearAllMocks();
     _resetPostHogClientForTesting();
     process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = "phc_test";
+    window.sessionStorage.removeItem("posthog_signup_pending_new-user");
+    window.sessionStorage.removeItem("posthog_signup_captured_new-user");
   });
 
   afterAll(() => {
-    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = originalToken;
+    if (originalToken === undefined) {
+      delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+    } else {
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN = originalToken;
+    }
   });
 
-  it("disables PostHog autocaptured pageviews so PageTracker owns page_view taxonomy", () => {
+  it("fails closed before analytics consent is known", () => {
+    expect(initPostHog()).toBe(false);
+
+    captureClientPostHogEvent("beach_view");
+    identifyPostHogUser("user-123");
+
+    expect(posthog.init).not.toHaveBeenCalled();
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it("keeps capture and identity disabled after an explicit opt-out", () => {
+    setClientPostHogTrackingAllowed(false);
+
+    captureClientPostHogEvent("beach_view");
+    identifyPostHogUser("user-123");
+
+    expect(posthog.init).not.toHaveBeenCalled();
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.identify).not.toHaveBeenCalled();
+  });
+
+  it("enables capture only after explicit consent and disables autocapture", () => {
+    setClientPostHogTrackingAllowed(true);
     expect(initPostHog()).toBe(true);
+    captureClientPostHogEvent("beach_view", { beach_id: "beach-1" });
+    identifyPostHogUser("user-123", { provider: "email" });
 
     expect(posthog.init).toHaveBeenCalledWith(
       "phc_test",
@@ -32,5 +74,95 @@ describe("posthog-client", () => {
         autocapture: false,
       }),
     );
+    expect(posthog.opt_in_capturing).toHaveBeenCalled();
+    expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith(
+      "beach_view",
+      expect.objectContaining({ beach_id: "beach-1" }),
+    );
+    expect(posthog.identify).toHaveBeenCalledWith(
+      "user-123",
+      expect.objectContaining({ provider: "email" }),
+    );
+  });
+
+  it("actively opts out while authenticated consent is unresolved", () => {
+    setClientPostHogTrackingAllowed(true);
+    jest.clearAllMocks();
+
+    setClientPostHogTrackingAllowed(null);
+    captureClientPostHogEvent("beach_view");
+
+    expect(posthog.opt_out_capturing).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("keeps the in-memory gate denied when the PostHog opt-out throws", () => {
+    setClientPostHogTrackingAllowed(true);
+    jest.clearAllMocks();
+    (posthog.opt_out_capturing as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("SDK unavailable");
+    });
+
+    expect(() => setClientPostHogTrackingAllowed(false)).not.toThrow();
+    captureClientPostHogEvent("beach_view");
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("opts in once when initialization succeeds on a later retry", () => {
+    (posthog.init as jest.Mock).mockImplementationOnce(() => {
+      throw new Error("SDK unavailable");
+    });
+
+    expect(() => setClientPostHogTrackingAllowed(true)).not.toThrow();
+    expect(posthog.opt_in_capturing).not.toHaveBeenCalled();
+
+    captureClientPostHogEvent("beach_view");
+
+    expect(posthog.opt_in_capturing).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies an opt-out saved in another browser tab", () => {
+    setClientPostHogTrackingAllowed(true);
+    identifyPostHogUser("user-123");
+    jest.clearAllMocks();
+
+    applyClientPostHogTrackingStorageEvent({
+      key: "quiver_posthog_tracking_denied_v1",
+      newValue: "true",
+    } as StorageEvent);
+    captureClientPostHogEvent("beach_view");
+
+    expect(posthog.reset).toHaveBeenCalledTimes(1);
+    expect(posthog.opt_out_capturing).toHaveBeenCalled();
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("delays and deduplicates the signup conversion until consent is allowed", () => {
+    queueClientPostHogSignup("new-user", "google");
+
+    captureQueuedClientPostHogSignup("new-user");
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(
+      window.sessionStorage.getItem("posthog_signup_captured_new-user"),
+    ).toBeNull();
+
+    setClientPostHogTrackingAllowed(true);
+    captureQueuedClientPostHogSignup("new-user");
+    captureQueuedClientPostHogSignup("new-user");
+
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith(
+      "user_signed_up",
+      expect.objectContaining({ provider: "google" }),
+    );
+    expect(
+      window.sessionStorage.getItem("posthog_signup_captured_new-user"),
+    ).toBe("true");
+    expect(
+      window.sessionStorage.getItem("posthog_signup_pending_new-user"),
+    ).toBeNull();
   });
 });

--- a/__tests__/migrations/forecast-feedback-request-dedupe.test.ts
+++ b/__tests__/migrations/forecast-feedback-request-dedupe.test.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSQL = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260718120000_dedupe_forecast_feedback_requests.sql",
+  ),
+  "utf8",
+);
+
+describe("forecast feedback request dedupe migration", () => {
+  it("matches the immutable shared-schema contract mirror", () => {
+    expect(createHash("sha256").update(migrationSQL).digest("hex")).toBe(
+      "09c40c9ce9b019b4cae5544bdc11ef346b26d292aa598739d41fb7a7e2cd09df",
+    );
+  });
+
+  it("repairs historical duplicate keys before enforcing uniqueness", () => {
+    const lockPosition = migrationSQL.indexOf(
+      "LOCK TABLE public.forecast_feedback_contexts IN SHARE ROW EXCLUSIVE MODE",
+    );
+    const repairPosition = migrationSQL.indexOf(
+      "UPDATE public.forecast_feedback_contexts",
+    );
+    const indexPosition = migrationSQL.indexOf("CREATE UNIQUE INDEX");
+
+    expect(lockPosition).toBeGreaterThanOrEqual(0);
+    expect(repairPosition).toBeGreaterThan(lockPosition);
+    expect(indexPosition).toBeGreaterThan(repairPosition);
+    expect(migrationSQL).toContain("PARTITION BY user_id, request_id");
+    expect(migrationSQL).toContain("delivery_rank > 1");
+    expect(migrationSQL).toContain(":legacy-duplicate:");
+  });
+
+  it("enforces one authenticated delivery per stable request ID", () => {
+    expect(migrationSQL).toMatch(
+      /ON public\.forecast_feedback_contexts \(user_id, request_id\)/,
+    );
+    expect(migrationSQL).toContain(
+      "WHERE user_id IS NOT NULL AND request_id IS NOT NULL",
+    );
+  });
+});

--- a/__tests__/migrations/native-session-funnel-event-idempotency.test.ts
+++ b/__tests__/migrations/native-session-funnel-event-idempotency.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const migrationsDirectory = path.join(process.cwd(), 'supabase', 'migrations');
+
+describe('native canonical session funnel event idempotency migration', () => {
+  it('repairs legacy duplicate event ids before adding owner-scoped uniqueness', () => {
+    const migrationName = fs
+      .readdirSync(migrationsDirectory)
+      .find((name) => name.endsWith('_dedupe_native_session_funnel_events.sql'));
+
+    expect(migrationName ?? '').toMatch(
+      /^\d+_dedupe_native_session_funnel_events\.sql$/,
+    );
+    if (!migrationName) return;
+
+    const sql = fs
+      .readFileSync(path.join(migrationsDirectory, migrationName), 'utf8')
+      .toLowerCase();
+    const beginPosition = sql.indexOf('begin;');
+    const lockPosition = sql.indexOf(
+      'lock table public.user_events in share row exclusive mode;',
+    );
+    const repairPosition = sql.indexOf('update public.user_events');
+    const indexPosition = sql.indexOf('create unique index');
+
+    expect(sql).toContain('begin;');
+    expect(sql).toContain('commit;');
+    expect(sql).not.toContain('delete from public.user_events');
+    expect(lockPosition).toBeGreaterThan(beginPosition);
+    expect(repairPosition).toBeGreaterThan(lockPosition);
+    expect(repairPosition).toBeGreaterThanOrEqual(0);
+    expect(indexPosition).toBeGreaterThan(repairPosition);
+    expect(sql).toMatch(
+      /partition by[\s\S]+user_id,\s*metadata\s*->>\s*'event_id'/,
+    );
+    expect(sql).toMatch(
+      /on public\.user_events[\s\S]*\(\s*user_id,\s*\(\(metadata\s*->>\s*'event_id'\)\)\s*\)/,
+    );
+    expect(sql).toContain("'session_log_start'");
+    expect(sql).toContain("'session_log_form_view'");
+    expect(sql).toContain("'session_log_validation_failed'");
+    expect(sql).toContain("'session_log_submit'");
+    expect(sql).toContain("metadata ->> 'event_id' is not null");
+  });
+});

--- a/__tests__/migrations/own-analytics-preferences-rpc.test.ts
+++ b/__tests__/migrations/own-analytics-preferences-rpc.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260718141000_get_my_analytics_tracking_allowed.sql",
+);
+
+describe("owner-scoped analytics consent RPC", () => {
+  it("returns only the authenticated user's tracking preference", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("get_my_analytics_tracking_allowed");
+    expect(sql).toContain("p_expected_user_id uuid");
+    expect(sql).toMatch(/p\.id\s*=\s*\(select auth\.uid\(\)\)/i);
+    expect(sql).toMatch(/p\.id\s*=\s*p_expected_user_id/i);
+    expect(sql).toMatch(/SECURITY DEFINER/i);
+    expect(sql).toMatch(/auth\.uid\(\)\)\s*<>\s*p_expected_user_id/i);
+    expect(sql).toMatch(/REVOKE ALL ON FUNCTION[\s\S]*FROM PUBLIC/i);
+    expect(sql).toMatch(/GRANT EXECUTE ON FUNCTION[\s\S]*TO authenticated/i);
+    expect(sql).not.toMatch(/GRANT EXECUTE ON FUNCTION[\s\S]*TO anon/i);
+  });
+});

--- a/__tests__/migrations/profile-analytics-consent-privacy.test.ts
+++ b/__tests__/migrations/profile-analytics-consent-privacy.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { PROFILE_PUBLIC_FIELDS } from "@/lib/profile/constants";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260718142000_restrict_profile_analytics_consent.sql",
+);
+
+describe("profile analytics consent privacy", () => {
+  it("keeps analytics consent out of reusable public profile projections", () => {
+    expect(PROFILE_PUBLIC_FIELDS).not.toContain("allow_implicit_tracking");
+  });
+
+  it("removes public column access while preserving the public profile surface", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toMatch(
+      /REVOKE SELECT ON TABLE public\.profiles FROM anon, authenticated/i,
+    );
+    expect(sql).toMatch(
+      /REVOKE SELECT ON TABLE public\.profiles FROM PUBLIC/i,
+    );
+    expect(sql).toMatch(/attname\s*<>\s*'allow_implicit_tracking'/i);
+    expect(sql).toMatch(
+      /GRANT SELECT \(%s\) ON TABLE public\.profiles TO anon, authenticated/i,
+    );
+    expect(sql).not.toMatch(
+      /GRANT SELECT ON TABLE public\.profiles TO (?:anon|authenticated)/i,
+    );
+  });
+
+  it("keeps direct user-event inserts owner scoped without reading the private column", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toMatch(/DROP POLICY IF EXISTS "Users can insert their own events"/i);
+    expect(sql).toMatch(
+      /public\.get_my_analytics_tracking_allowed\(\(select auth\.uid\(\)\)\)/i,
+    );
+    expect(sql).not.toMatch(/allow_implicit_tracking\s*=\s*false/i);
+  });
+});

--- a/__tests__/migrations/session-log-form-view-event.test.ts
+++ b/__tests__/migrations/session-log-form-view-event.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260718130000_allow_session_log_form_view_event.sql",
+);
+
+describe("session_log_form_view user_events migration", () => {
+  it("preserves the live CHECK expression and appends the durable funnel stage", () => {
+    const sql = fs.readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("COMMIT;");
+    expect(sql).toContain("pg_get_constraintdef");
+    expect(sql).toContain("user_events_event_type_check");
+    expect(sql).toContain("'session_log_form_view'");
+    expect(sql).toContain("current_check");
+    expect(sql).toContain("missing_events");
+    expect(sql).not.toMatch(/DELETE\s+FROM|TRUNCATE\s+|DROP\s+TABLE/i);
+  });
+});

--- a/__tests__/migrations/sessions-source-auto-title.test.ts
+++ b/__tests__/migrations/sessions-source-auto-title.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const migrationPath = join(
+  __dirname,
+  "../../supabase/migrations/20260717162000_allow_auto_title_session_source.sql"
+);
+
+describe("sessions source auto-title migration", () => {
+  const migrationSQL = readFileSync(migrationPath, "utf8");
+
+  it("preserves existing source values and allows auto_title", () => {
+    expect(migrationSQL).toContain("'manual'");
+    expect(migrationSQL).toContain("'conditions_report'");
+    expect(migrationSQL).toContain("'email_one_tap'");
+    expect(migrationSQL).toContain("'maestro_smoke'");
+    expect(migrationSQL).toContain("'auto_title'");
+  });
+
+  it("recreates and validates the constraint inside a transaction", () => {
+    expect(migrationSQL).toMatch(/^BEGIN;/m);
+    expect(migrationSQL).toMatch(/DROP CONSTRAINT IF EXISTS sessions_source_check/i);
+    expect(migrationSQL).toMatch(/ADD CONSTRAINT sessions_source_check/i);
+    expect(migrationSQL).toMatch(/VALIDATE CONSTRAINT sessions_source_check/i);
+    expect(migrationSQL).toMatch(/^COMMIT;/m);
+  });
+});

--- a/__tests__/migrations/sessions-source-preservation-repair.test.ts
+++ b/__tests__/migrations/sessions-source-preservation-repair.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const migrationPath = path.join(
+  process.cwd(),
+  "supabase/migrations/20260718140000_preserve_session_source_check.sql",
+);
+
+describe("sessions source CHECK preservation repair", () => {
+  it("appends auto_title to the live constraint instead of hardcoding its values", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("BEGIN;");
+    expect(sql).toContain("COMMIT;");
+    expect(sql).toContain("pg_get_constraintdef");
+    expect(sql).toContain("sessions_source_check");
+    expect(sql).toContain("'auto_title'");
+    expect(sql).toContain("current_check");
+    expect(sql).toContain("missing_sources");
+    expect(sql).toContain("NOT VALID");
+    expect(sql).toContain("VALIDATE CONSTRAINT sessions_source_check");
+    expect(sql).not.toMatch(/DELETE\s+FROM|TRUNCATE\s+|DROP\s+TABLE/i);
+  });
+
+  it("rejects future hardcoded rebuilds regardless of migration timestamp", () => {
+    const migrationsDirectory = path.join(process.cwd(), "supabase/migrations");
+    const appliedLegacyRebuilders = new Set([
+      "20260312120000_add_conditions_report_fields.sql",
+      "20260505171909_allow_maestro_smoke_session_source.sql",
+      "20260717162000_allow_auto_title_session_source.sql",
+    ]);
+    const unsafeRebuilders = readdirSync(migrationsDirectory)
+      .filter((filename) => filename.endsWith(".sql"))
+      .filter((filename) => !appliedLegacyRebuilders.has(filename))
+      .filter((filename) => {
+        const sql = readFileSync(path.join(migrationsDirectory, filename), "utf8");
+        const rebuildsSourceConstraint = /DROP\s+CONSTRAINT(?:\s+IF\s+EXISTS)?\s+sessions_source_check/i.test(
+          sql,
+        );
+        return rebuildsSourceConstraint && !sql.includes("pg_get_constraintdef");
+      });
+
+    expect(unsafeRebuilders).toEqual([]);
+  });
+});

--- a/__tests__/notifications/worker.test.ts
+++ b/__tests__/notifications/worker.test.ts
@@ -48,6 +48,7 @@ interface MockProfile {
   id: string;
   display_name: string | null;
   timezone: string | null;
+  allow_implicit_tracking: boolean;
   notif_push_enabled: boolean;
   notif_email_enabled: boolean;
   notif_inapp_enabled: boolean;
@@ -102,6 +103,7 @@ function buildProfile(over: Partial<MockProfile> = {}): MockProfile {
     id: "user-recipient",
     display_name: "Recipient User",
     timezone: "America/Los_Angeles",
+    allow_implicit_tracking: true,
     notif_push_enabled: true,
     notif_email_enabled: true,
     notif_inapp_enabled: true,
@@ -573,6 +575,44 @@ describe("processPendingEvents — happy path", () => {
         notification_status: "sent",
       }),
     });
+  });
+
+  it("delivers and records attempts without PostHog when the recipient opted out", async () => {
+    const state = emptyState();
+    state.events.push(buildEvent());
+    state.profiles.set(
+      "user-recipient",
+      buildProfile({ allow_implicit_tracking: false }),
+    );
+    state.profiles.set(
+      "user-actor",
+      buildProfile({ id: "user-actor", display_name: "Actor User" }),
+    );
+    state.devices.set("user-recipient", ["device-token-A"]);
+
+    const fakeFcm = {
+      sendEach: jest.fn(async () => ({
+        successCount: 1,
+        failureCount: 0,
+        responses: [{ success: true }],
+      })),
+    };
+
+    const summary = await processPendingEvents(
+      buildMockSupabase(state) as never,
+      { now: NOON_PT, fcm: fakeFcm as never },
+    );
+
+    expect(summary.processed).toBe(1);
+    expect(fakeFcm.sendEach).toHaveBeenCalledTimes(1);
+    expect(state.attempts).toEqual([
+      expect.objectContaining({ channel: "push", status: "sent" }),
+      expect.objectContaining({ channel: "in_app", status: "sent" }),
+    ]);
+    expect(state.eventUpdates).toEqual([
+      { id: "evt-1", status: "processed", skip_reason: null },
+    ]);
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
   });
 
   it("push payload includes notification_event_id", async () => {

--- a/actions/onboarding-actions.ts
+++ b/actions/onboarding-actions.ts
@@ -1,7 +1,14 @@
 "use server";
 
 import { withAuthenticatedAction } from "@/lib/server-action-utils";
+import { PROFILE_PUBLIC_SELECT } from "@/lib/profile/constants";
+import type { Database } from "@/types/database.generated";
 import type { SupabaseServerClient } from "@/types/supabase";
+
+type PublicProfile = Omit<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "allow_implicit_tracking"
+>;
 
 function normalizeIanaTimezone(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -256,8 +263,8 @@ export async function saveOnboardingData(data: OnboardingData) {
         .from("profiles")
         .update(profileUpdate)
         .eq("id", user.id)
-        .select()
-        .single();
+        .select(PROFILE_PUBLIC_SELECT)
+        .single<PublicProfile>();
 
       if (profileError) {
         console.error("Profile update error:", profileError);

--- a/actions/profile-actions.ts
+++ b/actions/profile-actions.ts
@@ -7,6 +7,10 @@ import type { Profile } from "@/types/database";
 import type { Database } from "@/types/supabase";
 import { z } from "zod";
 import { getProfileWithHomeBeachById } from "@/lib/profile/fetchers";
+import {
+  PROFILE_PUBLIC_SELECT,
+  PROFILE_PUBLIC_WITH_HOME_BEACH_SELECT,
+} from "@/lib/profile/constants";
 
 // Unified profile update schema with permissive validation
 const profileUpdateSchema = z.object({
@@ -47,8 +51,13 @@ const profileUpdateSchema = z.object({
   allow_implicit_tracking: z.boolean().optional(),
 }).passthrough(); // Allow extra fields that aren't in schema
 
+type PublicProfile = Omit<Profile, "allow_implicit_tracking">;
+type PublicProfileWithHomeBeach = PublicProfile & {
+  home_beach: Record<string, unknown> | null;
+};
+
 // Return types for profile functions
-type ProfileSuccessResult = { success: true; data: Profile };
+type ProfileSuccessResult = { success: true; data: PublicProfile };
 type ProfileErrorResult = { success: false; error: string; isConnectionError?: boolean };
 type ProfileResult = ProfileSuccessResult | ProfileErrorResult;
 
@@ -62,9 +71,9 @@ export async function getProfile(userId: string): Promise<ProfileResult> {
 
     const { data, error } = await supabase
       .from("profiles")
-      .select("*")
+      .select(PROFILE_PUBLIC_SELECT)
       .eq("id", userId)
-      .maybeSingle();
+      .maybeSingle<PublicProfile>();
 
     if (error) {
       throw new Error(error.message || "Failed to fetch profile");
@@ -106,9 +115,9 @@ export async function getProfileWithHomeBeach(userId: string): Promise<{
 
     const { data, error } = await supabase
       .from("profiles")
-      .select("*, home_beach:beaches!profiles_home_beach_id_fkey(*)")
+      .select(PROFILE_PUBLIC_WITH_HOME_BEACH_SELECT)
       .eq("id", userId)
-      .maybeSingle();
+      .maybeSingle<PublicProfileWithHomeBeach>();
 
     if (error) {
       throw new Error(error.message || "Failed to fetch profile");
@@ -147,9 +156,9 @@ async function _fetchProfile(userId: string) {
     
     const { data, error } = await supabase
       .from("profiles")
-      .select("*")
+      .select(PROFILE_PUBLIC_SELECT)
       .eq("id", userId)
-      .maybeSingle();
+      .maybeSingle<PublicProfile>();
 
     if (error) {
       console.error("Error in _fetchProfile:", error);
@@ -245,8 +254,8 @@ async function createProfile(userId: string): Promise<ProfileResult> {
     const { data, error } = await supabase
       .from("profiles")
       .insert(insertPayload)
-      .select()
-      .single();
+      .select(PROFILE_PUBLIC_SELECT)
+      .single<PublicProfile>();
 
     if (error) {
       throw new Error(error.message || "Failed to create profile");
@@ -344,8 +353,8 @@ export async function updateProfile(
       .from("profiles")
       .update(dbPayload)
       .eq("id", user.id)
-      .select()
-      .single();
+      .select(PROFILE_PUBLIC_SELECT)
+      .single<PublicProfile>();
 
     if (error) {
       throw new Error(error.message || "Failed to update profile");

--- a/actions/session-actions.ts
+++ b/actions/session-actions.ts
@@ -17,6 +17,7 @@ import type {
   SessionInsert,
   Database,
 } from "@/types/database";
+import { PROFILE_PUBLIC_SESSION_RELATION_SELECT } from "@/lib/profile/constants";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { SessionFormState } from "@/hooks/use-session-form";
 import { 
@@ -196,7 +197,7 @@ export async function getUserSessions(userId: string, limit?: number) {
           session_date:arrival_time,
           beach:beaches(*),
           board:boards(*),
-          user:profiles(*)
+          ${PROFILE_PUBLIC_SESSION_RELATION_SELECT}
         `
         )
         .eq("user_id", userId)
@@ -577,7 +578,7 @@ async function getAllSessions(limit = 20) {
       *,
       beach:beaches(*),
       board:boards(*),
-      user:profiles(*)
+      ${PROFILE_PUBLIC_SESSION_RELATION_SELECT}
     `
     )
     .order("created_at", { ascending: false })

--- a/app/api/ARCHITECTURE.md
+++ b/app/api/ARCHITECTURE.md
@@ -480,9 +480,9 @@ export const GET = withAuth(handler);
 - **Authentication**: Required (user session)
 - **Function**: Records user behavioral events for implicit preference learning and analytics
 - **Features**:
-  - Privacy-aware: Respects `allow_implicit_tracking` profile setting
+  - Privacy-aware: Reads `allow_implicit_tracking` through the owner-only `get_my_analytics_tracking_allowed` RPC
   - Per-user rate limiting (60 requests/minute)
-  - LRU cache (5000 entries) for tracking permission lookups
+  - LRU cache (5000 entries) for denials only; allowed consent is rechecked so revocation is immediate
   - Debounced event processing on client side
 
 **Event Types:**
@@ -532,7 +532,7 @@ export const GET = withAuth(handler);
 
 | Table | Operation | Description |
 |-------|-----------|-------------|
-| `profiles` | SELECT | Check `allow_implicit_tracking` setting |
+| `get_my_analytics_tracking_allowed` | RPC | Check the authenticated owner's private analytics-consent setting |
 | `user_events` | INSERT | Store event with user_id, event_type, beach_id, metadata |
 
 **Integration:**

--- a/app/api/beaches/[id]/sessions/route.ts
+++ b/app/api/beaches/[id]/sessions/route.ts
@@ -5,6 +5,7 @@ import {
   handleApiError,
 } from "@/lib/middleware/api-wrappers";
 import { addFeaturedPhotoToSessions } from "@/actions/session-actions";
+import { PROFILE_PUBLIC_SESSION_RELATION_SELECT } from "@/lib/profile/constants";
 
 // GET /api/beaches/[id]/sessions?limit=5 - fetch recent completed sessions for beach
 export async function GET(request: NextRequest, props: { params: Promise<{ id: string }> }) {
@@ -22,7 +23,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ id: s
         *,
         beach:beaches(*),
         board:boards(*),
-        user:profiles(*)
+        ${PROFILE_PUBLIC_SESSION_RELATION_SELECT}
       `
       )
       .eq("beach_id", params.id)

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -30,6 +30,7 @@ import { getTrackingCache, setTrackingCache } from '@/lib/services/tracking-cach
 import { parseUserAgent } from '@/lib/utils/user-agent-parser';
 import { isBot, isSuspiciousFingerprint } from '@/lib/utils/bot-detector';
 import { createServiceRoleClient } from '@/lib/supabase';
+import { getOwnAnalyticsTrackingAllowed } from '@/lib/analytics/consent';
 
 export const dynamic = 'force-dynamic';
 
@@ -112,36 +113,33 @@ const ANON_RATE_LIMIT = 30; // Lower rate limit for anonymous users
 import { isValidUUID } from '@/lib/utils/validation';
 
 /**
- * Check if implicit tracking is allowed for a user
- * Uses 5-minute in-memory cache to reduce database queries
+ * Check if implicit tracking is allowed for a user.
+ *
+ * Only denials are cached. Retaining an allowed result would let tracking
+ * continue after a user revokes consent until the cache expires.
  */
 async function isTrackingAllowed(
   supabase: OptionalAuthContext['supabase'],
   userId: string
 ): Promise<boolean> {
-  // Check cache first (using LRU-aware getter)
   const cached = getTrackingCache(userId);
-  if (cached && cached.expires > Date.now()) {
-    return cached.allowed;
+  if (cached && !cached.allowed && cached.expires > Date.now()) {
+    return false;
   }
 
-  // Query database
-  const { data } = await supabase
-    .from('profiles')
-    .select('allow_implicit_tracking')
-    .eq('id', userId)
-    .single();
-
-  // Default to true if no preference set
-  const allowed = data?.allow_implicit_tracking !== false;
-
-  // Cache for 5 minutes (using LRU-aware setter)
-  setTrackingCache(userId, {
-    allowed,
-    expires: Date.now() + 5 * 60 * 1000,
-  });
-
-  return allowed;
+  try {
+    const allowed = await getOwnAnalyticsTrackingAllowed(supabase, userId);
+    if (!allowed) {
+      setTrackingCache(userId, {
+        allowed: false,
+        expires: Date.now() + 5 * 60 * 1000,
+      });
+    }
+    return allowed;
+  } catch (error) {
+    console.error('Error checking analytics consent:', error);
+    return false;
+  }
 }
 
 /**

--- a/app/api/forecast-feedback/route.ts
+++ b/app/api/forecast-feedback/route.ts
@@ -13,6 +13,7 @@ import {
   type ForecastFeedbackClientPayload,
 } from "@/lib/services/forecast/forecast-feedback";
 import type { Json } from "@/types/database.generated";
+import { createServiceRoleClient } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +22,12 @@ type SeasideFeedbackResponse = {
   id?: string | null;
   contract_version?: string;
   correlation_id?: string | null;
+};
+
+type ExistingFeedbackContext = {
+  id: string;
+  contract_version: string;
+  correlation_id: string | null;
 };
 
 const FORECAST_ACCURACY_VOTE_VALUES: Record<string, boolean> = {
@@ -54,6 +61,36 @@ async function parseJsonResponse(
   } catch {
     return null;
   }
+}
+
+async function findExistingFeedbackContext(
+  userId: string,
+  requestId: string,
+): Promise<ExistingFeedbackContext | null> {
+  try {
+    const serviceClient = createServiceRoleClient();
+    const { data, error } = await serviceClient
+      .from("forecast_feedback_contexts")
+      .select("id,contract_version,correlation_id")
+      .eq("user_id", userId)
+      .eq("request_id", requestId)
+      .maybeSingle();
+    if (error) return null;
+    return (data as ExistingFeedbackContext | null) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function existingFeedbackResponse(
+  existing: ExistingFeedbackContext,
+  fallbackCorrelationId: string,
+): NextResponse {
+  return createSuccessResponse({
+    id: existing.id,
+    contractVersion: existing.contract_version,
+    correlationId: existing.correlation_id ?? fallbackCorrelationId,
+  });
 }
 
 function forecastAccuracyVoteValue(
@@ -142,6 +179,11 @@ async function forecastFeedbackHandler(
 
   const correlationId = validation.data.correlationId ?? randomUUID();
   const requestId = validation.data.requestId ?? randomUUID();
+  const existing = await findExistingFeedbackContext(
+    context.user.id,
+    requestId,
+  );
+  if (existing) return existingFeedbackResponse(existing, correlationId);
 
   try {
     await persistForecastAccuracyVote(context, validation.data);
@@ -176,6 +218,11 @@ async function forecastFeedbackHandler(
       cache: "no-store",
     });
   } catch {
+    const recovered = await findExistingFeedbackContext(
+      context.user.id,
+      requestId,
+    );
+    if (recovered) return existingFeedbackResponse(recovered, correlationId);
     return createErrorResponse(
       "Feedback storage failed",
       { correlationId, service: "seaside", status: "network_error" },
@@ -185,6 +232,11 @@ async function forecastFeedbackHandler(
 
   const responseBody = await parseJsonResponse(response);
   if (!response.ok || responseBody?.ok !== true) {
+    const recovered = await findExistingFeedbackContext(
+      context.user.id,
+      requestId,
+    );
+    if (recovered) return existingFeedbackResponse(recovered, correlationId);
     return createErrorResponse(
       "Feedback storage failed",
       { correlationId, service: "seaside", status: response.status },

--- a/app/api/invites/consume/route.ts
+++ b/app/api/invites/consume/route.ts
@@ -65,7 +65,7 @@ export const POST = withAuth(
       throw result.error;
     }
 
-    await recordInviteConsumedEvent(supabase, {
+    const telemetryAllowed = await recordInviteConsumedEvent(supabase, {
       followerId: user.id,
       inviterId: result.inviterId,
       tokenHash,
@@ -74,17 +74,19 @@ export const POST = withAuth(
       flags: result,
     });
 
-    await capturePostHogEvent({
-      distinctId: user.id,
-      event: "invite_consumed",
-      properties: {
-        inviter_id: result.inviterId,
-        duplicate: result.followExisting,
-        follow_created: result.followCreated,
-        referral_created: result.referralCreated,
-        referral_existing: result.referralExisting,
-      },
-    });
+    if (telemetryAllowed) {
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: "invite_consumed",
+        properties: {
+          inviter_id: result.inviterId,
+          duplicate: result.followExisting,
+          follow_created: result.followCreated,
+          referral_created: result.referralCreated,
+          referral_existing: result.referralExisting,
+        },
+      });
+    }
 
     return createSuccessResponse({
       success: true,

--- a/app/api/invites/generate/route.ts
+++ b/app/api/invites/generate/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/utils/email-token";
 import { capturePostHogEvent } from "@/lib/posthog-server";
 import { hashInviteToken } from "@/lib/invites/token-hash";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 
 /**
  * POST /api/invites/generate
@@ -24,7 +25,7 @@ import { hashInviteToken } from "@/lib/invites/token-hash";
  * `withRateLimit` so a compromised account can't mint unlimited invite tokens.
  */
 const generateHandler = withAuth(
-  async (_request: NextRequest, { user }: AuthenticatedContext) => {
+  async (_request: NextRequest, { user, supabase }: AuthenticatedContext) => {
     const token = await signEmailToken(
       { user_id: user.id, purpose: "invite" },
       getEmailTokenSecret(),
@@ -35,10 +36,16 @@ const generateHandler = withAuth(
     const url = `${siteUrl.replace(/\/$/, "")}/invite/${token}`;
     const token_hash = hashInviteToken(token);
 
-    await capturePostHogEvent({
-      distinctId: user.id,
-      event: "invite_link_generated",
-    });
+    const telemetryAllowed = await getOwnAnalyticsTrackingAllowed(
+      supabase,
+      user.id,
+    ).catch(() => false);
+    if (telemetryAllowed) {
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: "invite_link_generated",
+      });
+    }
 
     return createSuccessResponse({ token, url, token_hash });
   },

--- a/app/api/journal/export/route.ts
+++ b/app/api/journal/export/route.ts
@@ -7,6 +7,7 @@ import { addFeaturedPhotoToSessions } from "@/actions/session-actions";
 import { getSessionAnalytics } from "@/actions/analytics-actions";
 import type { ExportOptions, ExportResult } from "@/types/database";
 import { format } from "date-fns";
+import { PROFILE_PUBLIC_SESSION_RELATION_SELECT } from "@/lib/profile/constants";
 
 /**
  * Generate and export PDF documents for surf journal data
@@ -31,7 +32,7 @@ export const POST = withAuth(async (request, { user, supabase }) => {
       session_date:arrival_time,
       beach:beaches(*),
       board:boards(*),
-      user:profiles(*)
+      ${PROFILE_PUBLIC_SESSION_RELATION_SELECT}
     `,
     )
     .eq("user_id", user.id)

--- a/app/api/me/profile-page/route.ts
+++ b/app/api/me/profile-page/route.ts
@@ -12,6 +12,7 @@ import type {
   ProfilePagePreferences,
   ProfilePageProfile,
 } from "@/types/profile-page";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 import type { Board, SessionWithDetails } from "@/types/database";
 
 const PROFILE_PAGE_LEARNED_PREFERENCES_SELECT = `
@@ -105,6 +106,7 @@ export const GET = withAuth(async (_request, { user, supabase }) => {
     learnedPrefsResult,
     recentSessionsResult,
     boardsResult,
+    analyticsConsent,
   ] = await Promise.all([
     // 1. Full profile with home beach join (all fields needed for profile page UI)
     supabase
@@ -122,7 +124,6 @@ export const GET = withAuth(async (_request, { user, supabase }) => {
         surf_styles,
         notif_reminders,
         notif_forecast_alerts,
-        allow_implicit_tracking,
         home_beach:beaches!profiles_home_beach_id_fkey ( id, name )
       `
       )
@@ -178,6 +179,12 @@ export const GET = withAuth(async (_request, { user, supabase }) => {
       .select(PROFILE_PAGE_BOARD_SELECT)
       .eq("user_id", userId)
       .order("created_at", { ascending: false }),
+
+    // 9. Owner-only analytics consent. Never expose this through public profile reads.
+    getOwnAnalyticsTrackingAllowed(supabase, userId).catch((error) => {
+      console.warn("Analytics consent fetch failed:", error);
+      return null;
+    }),
   ]);
 
   if (profileResult.error || !profileResult.data) {
@@ -266,7 +273,7 @@ export const GET = withAuth(async (_request, { user, supabase }) => {
     // Notification settings for ProfilePreferences
     notif_reminders: profileData.notif_reminders ?? null,
     notif_forecast_alerts: profileData.notif_forecast_alerts ?? null,
-    allow_implicit_tracking: profileData.allow_implicit_tracking ?? null,
+    allow_implicit_tracking: analyticsConsent,
   };
 
   // Enrich sessions with featured photos.

--- a/app/api/roadmap/items/[id]/vote/route.ts
+++ b/app/api/roadmap/items/[id]/vote/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { withAuth, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
 import { capturePostHogEvent } from "@/lib/posthog-server";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 
 export const dynamic = "force-dynamic";
 
@@ -63,17 +64,23 @@ export const POST = withAuth(
     if (eventError) {
       console.warn("[roadmap] vote analytics insert error:", eventError);
     }
-    await capturePostHogEvent({
-      distinctId: user.id,
-      event: "feedback_roadmap_vote_submitted",
-      properties: {
-        source: "web_roadmap",
-        roadmap_item_id: id,
-        roadmap_item_title: item?.title ?? null,
-        vote_state: "cast",
-        is_custom_spot_request: isCustomSpotRequest,
-      },
-    });
+    const telemetryAllowed = await getOwnAnalyticsTrackingAllowed(
+      supabase,
+      user.id,
+    ).catch(() => false);
+    if (telemetryAllowed) {
+      await capturePostHogEvent({
+        distinctId: user.id,
+        event: "feedback_roadmap_vote_submitted",
+        properties: {
+          source: "web_roadmap",
+          roadmap_item_id: id,
+          roadmap_item_title: item?.title ?? null,
+          vote_state: "cast",
+          is_custom_spot_request: isCustomSpotRequest,
+        },
+      });
+    }
 
     if (isCustomSpotRequest) {
       const { error: customSpotEventError } = await supabase.from("user_events").insert({
@@ -88,15 +95,17 @@ export const POST = withAuth(
       if (customSpotEventError) {
         console.warn("[roadmap] custom spot vote analytics insert error:", customSpotEventError);
       }
-      await capturePostHogEvent({
-        distinctId: user.id,
-        event: "custom_spots_feedback_voted",
-        properties: {
-          source: "web_roadmap",
-          roadmap_item_id: id,
-          roadmap_item_title: item?.title ?? null,
-        },
-      });
+      if (telemetryAllowed) {
+        await capturePostHogEvent({
+          distinctId: user.id,
+          event: "custom_spots_feedback_voted",
+          properties: {
+            source: "web_roadmap",
+            roadmap_item_id: id,
+            roadmap_item_title: item?.title ?? null,
+          },
+        });
+      }
     }
 
     return NextResponse.json({ voted: true });

--- a/app/api/roadmap/submissions/route.ts
+++ b/app/api/roadmap/submissions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { withAuth, withRateLimit, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
 import { capturePostHogEvent } from "@/lib/posthog-server";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 import type { RoadmapCategory } from "@/lib/roadmap/types";
 
 export const dynamic = "force-dynamic";
@@ -68,16 +69,22 @@ export const POST = withRateLimit(
       if (eventError) {
         console.warn("[roadmap] submission analytics insert error:", eventError);
       }
-      await capturePostHogEvent({
-        distinctId: user.id,
-        event: "feedback_roadmap_request_created",
-        properties: {
-          source: "web_roadmap",
-          roadmap_submission_id: data.id,
-          category,
-          is_custom_spot_request: isCustomSpotRequest,
-        },
-      });
+      const telemetryAllowed = await getOwnAnalyticsTrackingAllowed(
+        supabase,
+        user.id,
+      ).catch(() => false);
+      if (telemetryAllowed) {
+        await capturePostHogEvent({
+          distinctId: user.id,
+          event: "feedback_roadmap_request_created",
+          properties: {
+            source: "web_roadmap",
+            roadmap_submission_id: data.id,
+            category,
+            is_custom_spot_request: isCustomSpotRequest,
+          },
+        });
+      }
 
       return NextResponse.json({ id: data.id, decision: "pending" });
     },

--- a/components/ARCHITECTURE.md
+++ b/components/ARCHITECTURE.md
@@ -218,7 +218,8 @@ function Providers({ children }) {
 **Privacy Considerations:**
 - Respects `allow_implicit_tracking` profile setting
 - Rate limited: 60 requests/minute per user
-- Uses LRU cache (5000 entries) for permission lookups
+- Caches denials only; allowed consent is rechecked before each recorded event
+- Authenticated PostHog consent is revalidated when the tab becomes visible or focused, with capture disabled while the owner-only lookup is pending
 
 ---
 

--- a/components/analytics/posthog-provider.tsx
+++ b/components/analytics/posthog-provider.tsx
@@ -1,34 +1,112 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useAuth } from "@/context/auth-context";
 import {
+  applyClientPostHogTrackingStorageEvent,
   buildPostHogUserProperties,
+  captureQueuedClientPostHogSignup,
   identifyPostHogUser,
-  initPostHog,
+  isClientPostHogTrackingRevisionCurrent,
   resetPostHog,
+  setAnonymousClientPostHogTracking,
+  setClientPostHogTrackingAllowed,
 } from "@/lib/posthog-client";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
+import { createClient } from "@/lib/supabase/client";
 
 export function PostHogProvider(): null {
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const identifiedUserId = useRef<string | null>(null);
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
-    initPostHog();
+    window.addEventListener("storage", applyClientPostHogTrackingStorageEvent);
+    return () => {
+      window.removeEventListener(
+        "storage",
+        applyClientPostHogTrackingStorageEvent,
+      );
+    };
   }, []);
 
   useEffect(() => {
-    if (user?.id) {
-      identifyPostHogUser(user.id, buildPostHogUserProperties(user));
-      identifiedUserId.current = user.id;
-      return;
+    let active = true;
+
+    if (isLoading) {
+      setClientPostHogTrackingAllowed(null);
+      return () => {
+        active = false;
+      };
     }
 
-    if (identifiedUserId.current) {
+    if (!user) {
+      setClientPostHogTrackingAllowed(null);
+      resetPostHog();
+      identifiedUserId.current = null;
+      setAnonymousClientPostHogTracking();
+      return () => {
+        active = false;
+      };
+    }
+
+    if (
+      identifiedUserId.current &&
+      identifiedUserId.current !== user.id
+    ) {
       resetPostHog();
       identifiedUserId.current = null;
     }
-  }, [user]);
+
+    const revalidateTrackingConsent = (): void => {
+      const trackingRevision = setClientPostHogTrackingAllowed(null);
+
+      void getOwnAnalyticsTrackingAllowed(supabase, user.id)
+        .then((allowed) => {
+          if (
+            !active ||
+            !isClientPostHogTrackingRevisionCurrent(trackingRevision)
+          ) {
+            return;
+          }
+          setClientPostHogTrackingAllowed(allowed);
+          if (!allowed) {
+            resetPostHog();
+            identifiedUserId.current = null;
+            return;
+          }
+
+          identifyPostHogUser(user.id, buildPostHogUserProperties(user));
+          identifiedUserId.current = user.id;
+          captureQueuedClientPostHogSignup(user.id);
+        })
+        .catch(() => {
+          if (
+            !active ||
+            !isClientPostHogTrackingRevisionCurrent(trackingRevision)
+          ) {
+            return;
+          }
+          resetPostHog();
+          identifiedUserId.current = null;
+        });
+    };
+
+    const handleForeground = (): void => {
+      if (document.visibilityState !== "visible") return;
+      revalidateTrackingConsent();
+    };
+
+    document.addEventListener("visibilitychange", handleForeground);
+    window.addEventListener("focus", handleForeground);
+    revalidateTrackingConsent();
+
+    return () => {
+      active = false;
+      document.removeEventListener("visibilitychange", handleForeground);
+      window.removeEventListener("focus", handleForeground);
+    };
+  }, [isLoading, supabase, user]);
 
   return null;
 }

--- a/components/profile/profile-preferences.tsx
+++ b/components/profile/profile-preferences.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, useWatch } from "react-hook-form";
@@ -34,6 +34,16 @@ import {
 } from "@/components/profile/shared/preference-fields";
 import { createClient } from "@/lib/supabase/client";
 import type { Beach, Profile } from "@/types/database";
+import {
+  buildAnalyticsConsentProfileUpdate,
+  getOwnAnalyticsTrackingAllowed,
+} from "@/lib/analytics/consent";
+import {
+  captureQueuedClientPostHogSignup,
+  identifyPostHogUser,
+  resetPostHog,
+  setClientPostHogTrackingAllowed,
+} from "@/lib/posthog-client";
 
 const preferencesFormSchema = z.object({
   home_beach_id: z.string().uuid().nullable().optional(),
@@ -72,6 +82,9 @@ export function ProfilePreferences({
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
+  const [consentStatus, setConsentStatus] = useState<
+    "loading" | "ready" | "error"
+  >("loading");
 
   const form = useForm<PreferencesFormValues>({
     resolver: zodResolver(preferencesFormSchema) as any,
@@ -91,9 +104,34 @@ export function ProfilePreferences({
       notif_reminders: profile?.notif_reminders || false,
       notif_forecast_alerts: profile?.notif_forecast_alerts ?? true,
       // Privacy preferences
-      allow_implicit_tracking: (profile as any)?.allow_implicit_tracking ?? true,
+      allow_implicit_tracking: false,
     },
   });
+
+  useEffect(() => {
+    let active = true;
+    setConsentStatus("loading");
+
+    void getOwnAnalyticsTrackingAllowed(createClient(), userId)
+      .then((allowed) => {
+        if (!active) return;
+        form.setValue("allow_implicit_tracking", allowed, {
+          shouldDirty: false,
+          shouldTouch: false,
+          shouldValidate: false,
+        });
+        setConsentStatus("ready");
+      })
+      .catch((error) => {
+        if (!active) return;
+        console.error("Error loading analytics consent:", error);
+        setConsentStatus("error");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [form, userId]);
 
   // Watch the allow_implicit_tracking value for conditional rendering
   const allowImplicitTracking = useWatch({
@@ -131,6 +169,10 @@ export function ProfilePreferences({
 
     setIsSubmitting(true);
     try {
+      const consentUpdate = buildAnalyticsConsentProfileUpdate(
+        consentStatus === "ready",
+        data.allow_implicit_tracking,
+      );
       const result = await updateProfile({
         home_beach_id: data.home_beach_id ?? null,
         // Surf preferences
@@ -140,12 +182,21 @@ export function ProfilePreferences({
         // Notification preferences
         notif_reminders: data.notif_reminders,
         notif_forecast_alerts: data.notif_forecast_alerts,
-        // Privacy preferences (new column from implicit-preference-learning migration)
-        allow_implicit_tracking: data.allow_implicit_tracking,
+        ...consentUpdate,
       } as any);
 
       if (!result.success) {
         throw new Error(result.error || "Failed to update preferences");
+      }
+
+      if (consentStatus === "ready") {
+        setClientPostHogTrackingAllowed(data.allow_implicit_tracking);
+        if (data.allow_implicit_tracking) {
+          identifyPostHogUser(userId);
+          captureQueuedClientPostHogSignup(userId);
+        } else {
+          resetPostHog();
+        }
       }
 
       toast({
@@ -303,10 +354,17 @@ export function ProfilePreferences({
                 name="allow_implicit_tracking"
                 label="Improve recommendations with my activity"
                 description="Uses your browsing behavior to personalize surf spot recommendations. Disabling this stops new tracking but does not delete pre-signup data."
-                disabled={isSubmitting}
+                disabled={isSubmitting || consentStatus !== "ready"}
               />
 
-              {!allowImplicitTracking && (
+              {consentStatus === "error" && (
+                <p className="text-sm text-destructive">
+                  Privacy preference could not be loaded. Your current setting
+                  will not be changed when you save.
+                </p>
+              )}
+
+              {consentStatus === "ready" && !allowImplicitTracking && (
                 <div className="pl-4 border-l-2 border-muted">
                   <p className="text-sm text-muted-foreground mb-3">
                     Tracking is disabled. You can also clear your existing browsing history.

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -47,10 +47,10 @@ import {
 import { getExistingVisitorId, clearVisitorId } from "@/lib/utils/visitor-id";
 import { AUTH_INIT_TIMEOUT_MS } from "@/lib/constants/ui";
 import {
-  buildPostHogUserProperties,
   captureClientPostHogEvent,
-  identifyPostHogUser,
+  queueClientPostHogSignup,
   resetPostHog,
+  setClientPostHogTrackingAllowed,
 } from "@/lib/posthog-client";
 
 /**
@@ -303,6 +303,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
             // Handle post-auth redirect when user signs in
             if (event === "SIGNED_IN" && session) {
+              setClientPostHogTrackingAllowed(null);
+
               // Clear stored redirect path - components will re-render with new auth state
               // This prevents redirect loops caused by hard page reloads
               const storedPath = safeGetItem("auth_redirect_path");
@@ -453,20 +455,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               }
 
               if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
-                const postHogUserProperties = buildPostHogUserProperties(session.user);
-                const provider = postHogUserProperties.provider ?? "email";
-                identifyPostHogUser(session.user.id, postHogUserProperties);
-
                 const isNewUserForPostHog = session.user.created_at
                   ? Date.now() - new Date(session.user.created_at).getTime() < 60_000
                   : false;
-                const signupCaptureKey = `posthog_signup_captured_${session.user.id}`;
-                const alreadyCapturedSignup =
-                  sessionStorage.getItem(signupCaptureKey);
 
-                if (isNewUserForPostHog && !alreadyCapturedSignup) {
-                  sessionStorage.setItem(signupCaptureKey, "true");
-                  captureClientPostHogEvent("user_signed_up", { provider });
+                if (isNewUserForPostHog) {
+                  const rawProvider = session.user.app_metadata?.provider;
+                  const provider =
+                    typeof rawProvider === "string" ? rawProvider : "email";
+                  queueClientPostHogSignup(session.user.id, provider);
                 }
               }
 

--- a/hooks/use-track-event.ts
+++ b/hooks/use-track-event.ts
@@ -39,11 +39,28 @@ interface TrackEventOptions {
   debounceMs?: number;
 }
 
+function wasEventRecorded(responseBody: unknown): boolean {
+  if (!responseBody || typeof responseBody !== "object") return false;
+
+  const envelope = responseBody as Record<string, unknown>;
+  const result =
+    envelope.data && typeof envelope.data === "object"
+      ? (envelope.data as Record<string, unknown>)
+      : envelope;
+
+  if (result.ok !== true) return false;
+  if (result.skipped === true) return false;
+  return (
+    result.status !== "tracking_disabled" &&
+    result.status !== "bot_filtered"
+  );
+}
+
 /**
  * Hook for tracking implicit user events
  *
  * Features:
- * - Automatic user authentication check (no tracking for guests)
+ * - User or anonymous-session attribution
  * - Client-side debouncing to prevent duplicate events
  * - Fire-and-forget approach (doesn't block UI)
  * - Uses fetch keepalive to survive page navigation
@@ -69,11 +86,6 @@ export function useTrackEvent() {
       if (now - lastTime < debounceMs) return;
       lastFired.current.set(key, now);
 
-      captureClientPostHogEvent(eventType, {
-        ...(beachId ? { beach_id: beachId } : {}),
-        ...metadata,
-      });
-
       // Fire and forget - don't block UI
       try {
         const response = await fetch("/api/events", {
@@ -89,16 +101,26 @@ export function useTrackEvent() {
           keepalive: true, // Survives page navigation
         });
 
-        // Log non-OK responses in development for debugging
-        if (!response.ok && process.env.NODE_ENV === "development") {
-          console.warn(
-            `[useTrackEvent] Failed to track ${eventType}: HTTP ${response.status}`
-          );
+        if (!response.ok) {
+          if (process.env.NODE_ENV === "development") {
+            console.warn(
+              `[useTrackEvent] Failed to track ${eventType}: HTTP ${response.status}`
+            );
+          }
+          return;
         }
+
+        const responseBody: unknown = await response.json();
+        if (!wasEventRecorded(responseBody)) return;
+
+        captureClientPostHogEvent(eventType, {
+          ...(beachId ? { beach_id: beachId } : {}),
+          ...metadata,
+        });
       } catch (error) {
         // Log errors in development for debugging, but never break the app
         if (process.env.NODE_ENV === "development") {
-          console.warn("[useTrackEvent] Network error:", error);
+          console.warn("[useTrackEvent] Tracking error:", error);
         }
       }
     },

--- a/lib/analytics/consent.ts
+++ b/lib/analytics/consent.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+type AnalyticsConsentClient = Pick<SupabaseClient<Database>, "rpc">;
+type AnalyticsConsentUpdate = Pick<
+  Database["public"]["Tables"]["profiles"]["Update"],
+  "allow_implicit_tracking"
+>;
+
+export function buildAnalyticsConsentProfileUpdate(
+  consentLoaded: boolean,
+  allowed: boolean,
+): AnalyticsConsentUpdate | Record<string, never> {
+  return consentLoaded ? { allow_implicit_tracking: allowed } : {};
+}
+
+/** Reads analytics consent through the owner-only database boundary. */
+export async function getOwnAnalyticsTrackingAllowed(
+  supabase: AnalyticsConsentClient,
+  expectedUserId: string,
+): Promise<boolean> {
+  const { data, error } = await (supabase.rpc as any)(
+    "get_my_analytics_tracking_allowed",
+    { p_expected_user_id: expectedUserId },
+  );
+
+  if (error) throw error;
+  return data === true;
+}

--- a/lib/analytics/event-taxonomy.ts
+++ b/lib/analytics/event-taxonomy.ts
@@ -165,6 +165,7 @@ export const VALID_EVENTS = [
   // Session log funnel
   'session_log_beach_selected',
   'session_log_conditions_set',
+  'session_log_form_view',
   'session_log_rating_set',
   'session_log_photo_added',
   'session_photo_upload_started',

--- a/lib/invites/events.ts
+++ b/lib/invites/events.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import type { InviteAcceptanceFlags } from "@/lib/invites/consume";
+import { getOwnAnalyticsTrackingAllowed } from "@/lib/analytics/consent";
 
 type InviteConsumeSurface = "web" | "native";
 
@@ -18,22 +19,7 @@ async function isInviteProductTelemetryAllowed(
   userId: string,
 ): Promise<boolean> {
   try {
-    const query = (supabase as any)
-      .from("profiles")
-      .select("allow_implicit_tracking")
-      .eq("id", userId);
-
-    const { data, error } =
-      typeof query.maybeSingle === "function"
-        ? await query.maybeSingle()
-        : await query.single();
-
-    if (error) {
-      console.error("[invite] failed to check invite telemetry preference:", error);
-      return false;
-    }
-
-    return data?.allow_implicit_tracking !== false;
+    return await getOwnAnalyticsTrackingAllowed(supabase, userId);
   } catch (error) {
     console.error("[invite] failed to check invite telemetry preference:", error);
     return false;
@@ -50,7 +36,7 @@ export async function recordInviteConsumedEvent(
     selfInvite,
     flags,
   }: RecordInviteConsumedEventInput,
-): Promise<void> {
+): Promise<boolean> {
   const metadata = {
     token_hash: tokenHash,
     inviter_id: inviterId,
@@ -64,7 +50,7 @@ export async function recordInviteConsumedEvent(
 
   try {
     const allowed = await isInviteProductTelemetryAllowed(supabase, followerId);
-    if (!allowed) return;
+    if (!allowed) return false;
 
     const { error } = await (supabase as any).from("user_events").insert({
       user_id: followerId,
@@ -75,8 +61,11 @@ export async function recordInviteConsumedEvent(
 
     if (error) {
       console.error("[invite] failed to record invite_consumed:", error);
+      return false;
     }
+    return true;
   } catch (error) {
     console.error("[invite] failed to record invite_consumed:", error);
+    return false;
   }
 }

--- a/lib/notifications/worker.ts
+++ b/lib/notifications/worker.ts
@@ -151,6 +151,7 @@ interface ProfileRow {
   id: string;
   display_name: string | null;
   timezone: string | null;
+  allow_implicit_tracking: boolean;
   notif_push_enabled: boolean;
   notif_email_enabled: boolean;
   notif_inapp_enabled: boolean;
@@ -633,7 +634,7 @@ async function processOne(
 
   if (newAttempts.length > 0) {
     const attemptsInserted = await insertDeliveryAttempts(supabase, newAttempts);
-    if (attemptsInserted) {
+    if (attemptsInserted && profile.allow_implicit_tracking === true) {
       await captureDeliveryAttemptEvents(event, newAttempts);
     }
   }
@@ -1242,7 +1243,7 @@ async function loadProfile(
   const { data, error } = await supabase
     .from("profiles")
     .select(
-      "id, display_name, timezone, notif_push_enabled, notif_email_enabled, notif_inapp_enabled, notif_likes, notif_follows, notif_reminders, notif_xp_updates, notif_forecast_alerts, notif_water_quality, notif_similarity_alerts"
+      "id, display_name, timezone, allow_implicit_tracking, notif_push_enabled, notif_email_enabled, notif_inapp_enabled, notif_likes, notif_follows, notif_reminders, notif_xp_updates, notif_forecast_alerts, notif_water_quality, notif_similarity_alerts"
     )
     .eq("id", userId)
     .maybeSingle();

--- a/lib/posthog-client.ts
+++ b/lib/posthog-client.ts
@@ -3,9 +3,16 @@ import { getAttributionForAnalytics } from "@/lib/attribution";
 
 type PostHogProperties = Record<string, unknown>;
 type PostHogClient = typeof posthog & { __quiverInitialized?: boolean };
+type PostHogTrackingState = "unknown" | "allowed" | "denied";
 
 const POSTHOG_HOST = "/ingest";
 const POSTHOG_UI_HOST = "https://us.posthog.com";
+const POSTHOG_TRACKING_DENIED_KEY = "quiver_posthog_tracking_denied_v1";
+const POSTHOG_SIGNUP_PENDING_PREFIX = "posthog_signup_pending_";
+const POSTHOG_SIGNUP_CAPTURED_PREFIX = "posthog_signup_captured_";
+
+let postHogTrackingState: PostHogTrackingState = "unknown";
+let postHogTrackingRevision = 0;
 
 function getPostHogToken(): string {
   return process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN ?? "";
@@ -66,9 +73,52 @@ export function isPostHogEnabled(): boolean {
   return Boolean(getPostHogToken());
 }
 
+function isPostHogInitialized(): boolean {
+  return (posthog as PostHogClient).__quiverInitialized === true;
+}
+
+function safelySetPostHogCapturing(enabled: boolean): void {
+  try {
+    if (enabled) {
+      posthog.opt_in_capturing();
+      return;
+    }
+    posthog.opt_out_capturing();
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn("[PostHog] Failed to update capture state:", error);
+    }
+  }
+}
+
+function persistPostHogTrackingDenial(denied: boolean): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    if (denied) {
+      window.localStorage.setItem(POSTHOG_TRACKING_DENIED_KEY, "true");
+      return;
+    }
+    window.localStorage.removeItem(POSTHOG_TRACKING_DENIED_KEY);
+  } catch {
+    // The in-memory gate still prevents capture for the current page.
+  }
+}
+
+function hasPersistedPostHogTrackingDenial(): boolean {
+  if (typeof window === "undefined") return true;
+
+  try {
+    return window.localStorage.getItem(POSTHOG_TRACKING_DENIED_KEY) === "true";
+  } catch {
+    return true;
+  }
+}
+
 export function initPostHog(): boolean {
   if (typeof window === "undefined") return false;
   if (!isPostHogEnabled()) return false;
+  if (postHogTrackingState !== "allowed") return false;
 
   const posthogClient = posthog as PostHogClient;
   if (posthogClient.__quiverInitialized) return true;
@@ -86,6 +136,7 @@ export function initPostHog(): boolean {
       },
     });
     posthogClient.__quiverInitialized = true;
+    safelySetPostHogCapturing(true);
     return true;
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
@@ -95,21 +146,124 @@ export function initPostHog(): boolean {
   }
 }
 
+export function setClientPostHogTrackingAllowed(
+  allowed: boolean | null,
+): number {
+  postHogTrackingRevision += 1;
+  const previousState = postHogTrackingState;
+
+  if (allowed === null) {
+    postHogTrackingState = "unknown";
+    if (isPostHogInitialized()) {
+      safelySetPostHogCapturing(false);
+    }
+    return postHogTrackingRevision;
+  }
+
+  postHogTrackingState = allowed ? "allowed" : "denied";
+  persistPostHogTrackingDenial(!allowed);
+
+  if (!allowed) {
+    if (isPostHogInitialized()) {
+      safelySetPostHogCapturing(false);
+    }
+    return postHogTrackingRevision;
+  }
+
+  const wasInitialized = isPostHogInitialized();
+  if (
+    initPostHog() &&
+    wasInitialized &&
+    previousState !== "allowed"
+  ) {
+    safelySetPostHogCapturing(true);
+  }
+  return postHogTrackingRevision;
+}
+
+export function setAnonymousClientPostHogTracking(): void {
+  setClientPostHogTrackingAllowed(!hasPersistedPostHogTrackingDenial());
+}
+
+export function isClientPostHogTrackingRevisionCurrent(
+  revision: number,
+): boolean {
+  return postHogTrackingRevision === revision;
+}
+
+export function applyClientPostHogTrackingStorageEvent(
+  event: StorageEvent,
+): void {
+  if (event.key !== POSTHOG_TRACKING_DENIED_KEY) return;
+  if (event.newValue !== "true") return;
+
+  setClientPostHogTrackingAllowed(false);
+  resetPostHog();
+}
+
 export function captureClientPostHogEvent(
   event: string,
   properties: PostHogProperties = {}
-): void {
-  if (!initPostHog()) return;
+): boolean {
+  if (postHogTrackingState !== "allowed") return false;
+  if (!initPostHog()) return false;
 
   try {
     posthog.capture(event, {
       ...getBaseProperties(),
       ...properties,
     });
+    return true;
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       console.warn("[PostHog] Failed to capture event:", error);
     }
+    return false;
+  }
+}
+
+export function queueClientPostHogSignup(
+  userId: string,
+  provider: string,
+): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    const capturedKey = `${POSTHOG_SIGNUP_CAPTURED_PREFIX}${userId}`;
+    if (window.sessionStorage.getItem(capturedKey) === "true") return;
+
+    window.sessionStorage.setItem(
+      `${POSTHOG_SIGNUP_PENDING_PREFIX}${userId}`,
+      provider,
+    );
+  } catch {
+    // Signup analytics must never interfere with authentication.
+  }
+}
+
+export function captureQueuedClientPostHogSignup(userId: string): void {
+  if (postHogTrackingState !== "allowed") return;
+  if (typeof window === "undefined") return;
+
+  try {
+    const pendingKey = `${POSTHOG_SIGNUP_PENDING_PREFIX}${userId}`;
+    const capturedKey = `${POSTHOG_SIGNUP_CAPTURED_PREFIX}${userId}`;
+
+    if (window.sessionStorage.getItem(capturedKey) === "true") {
+      window.sessionStorage.removeItem(pendingKey);
+      return;
+    }
+
+    const provider = window.sessionStorage.getItem(pendingKey);
+    if (!provider) return;
+
+    const captured = captureClientPostHogEvent("user_signed_up", { provider });
+    if (!captured) return;
+
+    window.sessionStorage.setItem(capturedKey, "true");
+    window.sessionStorage.removeItem(pendingKey);
+  } catch {
+    // Keep the event pending when storage or capture is unavailable.
   }
 }
 
@@ -117,6 +271,7 @@ export function identifyPostHogUser(
   userId: string,
   properties: PostHogProperties = {}
 ): void {
+  if (postHogTrackingState !== "allowed") return;
   if (!initPostHog()) return;
 
   try {
@@ -132,10 +287,13 @@ export function identifyPostHogUser(
 }
 
 export function resetPostHog(): void {
-  if (!initPostHog()) return;
+  if (!isPostHogInitialized()) return;
 
   try {
     posthog.reset();
+    if (postHogTrackingState !== "allowed") {
+      safelySetPostHogCapturing(false);
+    }
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       console.warn("[PostHog] Failed to reset user:", error);
@@ -162,4 +320,9 @@ export function buildPostHogUserProperties(user: {
 
 export function _resetPostHogClientForTesting(): void {
   (posthog as PostHogClient).__quiverInitialized = false;
+  postHogTrackingState = "unknown";
+  postHogTrackingRevision = 0;
+  if (typeof window !== "undefined") {
+    window.localStorage.removeItem(POSTHOG_TRACKING_DENIED_KEY);
+  }
 }

--- a/lib/profile/constants.ts
+++ b/lib/profile/constants.ts
@@ -48,6 +48,84 @@ export const PROFILE_ANDROID_WAITLIST_FIELDS = [
   'android_waitlist_placement',
 ] as const;
 
+/**
+ * Every profile column currently readable through the public profile surface.
+ * Analytics consent is intentionally absent and is available only through the
+ * owner-scoped get_my_analytics_tracking_allowed RPC.
+ */
+export const PROFILE_PUBLIC_FIELDS = [
+  'activity_level',
+  'analytics_exclusion_reason',
+  'analytics_is_real_user',
+  'android_waitlist_joined_at',
+  'android_waitlist_placement',
+  'android_waitlist_source',
+  'android_waitlist_surface',
+  'avatar_url',
+  'bio',
+  'created_at',
+  'crowd_tolerance',
+  'deleted_at',
+  'digest_session_invites',
+  'display_name',
+  'email',
+  'email_session_invites',
+  'experience_level',
+  'followers_count',
+  'following_count',
+  'full_name',
+  'home_beach_id',
+  'home_region',
+  'id',
+  'inapp_session_invites',
+  'instagram',
+  'is_admin',
+  'is_mock',
+  'is_system_account',
+  'location',
+  'max_drive_minutes',
+  'notif_email_enabled',
+  'notif_follows',
+  'notif_forecast_alerts',
+  'notif_inapp_enabled',
+  'notif_likes',
+  'notif_push_enabled',
+  'notif_reminders',
+  'notif_session_invites',
+  'notif_similarity_alerts',
+  'notif_water_quality',
+  'notif_xp_updates',
+  'onboarding_completed_at',
+  'paywall_soft_prompt_shown',
+  'personality_type',
+  'phone_number',
+  'posting_window',
+  'preferences_v2_shown_at',
+  'preferred_session_time',
+  'preferred_wave_size',
+  'referral_code',
+  'signup_context',
+  'signup_location',
+  'sound_effects_enabled',
+  'surf_styles',
+  'tide_comfort',
+  'timezone',
+  'trust_score',
+  'updated_at',
+  'wants_android_access',
+  'wind_comfort',
+] as const;
+
+export const PROFILE_PUBLIC_SELECT = PROFILE_PUBLIC_FIELDS.join(',');
+
+export const PROFILE_PUBLIC_WITH_HOME_BEACH_SELECT = [
+  PROFILE_PUBLIC_SELECT,
+  'home_beach:beaches!profiles_home_beach_id_fkey(*)',
+].join(',');
+
+export const PROFILE_PUBLIC_SESSION_RELATION_SELECT =
+  'user:profiles(id,full_name,avatar_url)' as const;
+
 /** Complete SELECT string for profile queries with home beach join */
 export const PROFILE_FULL_SELECT = [
   ...PROFILE_CORE_FIELDS,

--- a/lib/server-action-utils.ts
+++ b/lib/server-action-utils.ts
@@ -8,6 +8,12 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { User } from "@supabase/supabase-js";
 import { z } from "zod";
 import type { Database } from "@/types/database.generated";
+import { PROFILE_PUBLIC_SELECT } from "@/lib/profile/constants";
+
+type PublicProfile = Omit<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "allow_implicit_tracking"
+>;
 
 // Standard server action response type
 export interface ServerActionResponse<T = any> {
@@ -268,13 +274,21 @@ export async function withPublicDatabaseOperation<T>(
 // Common database queries
 export async function getUserById(userId: string) {
   return withDatabaseOperation(async (supabase) => {
-    return supabase.from("profiles").select("*").eq("id", userId).single();
+    return supabase
+      .from("profiles")
+      .select(PROFILE_PUBLIC_SELECT)
+      .eq("id", userId)
+      .single<PublicProfile>();
   });
 }
 
 export async function getUserByEmail(email: string) {
   return withDatabaseOperation(async (supabase) => {
-    return supabase.from("profiles").select("*").eq("email", email).single();
+    return supabase
+      .from("profiles")
+      .select(PROFILE_PUBLIC_SELECT)
+      .eq("email", email)
+      .single<PublicProfile>();
   });
 }
 

--- a/supabase/migrations/20260717162000_allow_auto_title_session_source.sql
+++ b/supabase/migrations/20260717162000_allow_auto_title_session_source.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+-- Native distinguishes generated titles from user-authored titles for feed
+-- eligibility. Preserve every existing source while accepting that marker.
+ALTER TABLE public.sessions
+  DROP CONSTRAINT IF EXISTS sessions_source_check,
+  ADD CONSTRAINT sessions_source_check
+  CHECK (
+    source IS NULL
+    OR source IN (
+      'manual',
+      'auto_title',
+      'conditions_report',
+      'email_one_tap',
+      'maestro_smoke'
+    )
+  ) NOT VALID;
+
+ALTER TABLE public.sessions
+  VALIDATE CONSTRAINT sessions_source_check;
+
+COMMENT ON CONSTRAINT sessions_source_check ON public.sessions IS
+  'Allowed session source values. auto_title identifies generated native titles; maestro_smoke identifies test cleanup rows.';
+
+COMMIT;

--- a/supabase/migrations/20260718120000_dedupe_forecast_feedback_requests.sql
+++ b/supabase/migrations/20260718120000_dedupe_forecast_feedback_requests.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+LOCK TABLE public.forecast_feedback_contexts IN SHARE ROW EXCLUSIVE MODE;
+
+-- Preserve every historical feedback row while making any pre-existing
+-- duplicate key unique. The oldest row keeps the original request ID so a
+-- retry still resolves to the first accepted delivery.
+WITH ranked_requests AS (
+  SELECT
+    id,
+    request_id,
+    row_number() OVER (
+      PARTITION BY user_id, request_id
+      ORDER BY created_at ASC, id ASC
+    ) AS delivery_rank
+  FROM public.forecast_feedback_contexts
+  WHERE user_id IS NOT NULL AND request_id IS NOT NULL
+)
+UPDATE public.forecast_feedback_contexts AS feedback
+SET
+  request_id = feedback.request_id || ':legacy-duplicate:' || feedback.id::text,
+  updated_at = now()
+FROM ranked_requests AS ranked
+WHERE feedback.id = ranked.id
+  AND ranked.delivery_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forecast_feedback_contexts_user_request
+  ON public.forecast_feedback_contexts (user_id, request_id)
+  WHERE user_id IS NOT NULL AND request_id IS NOT NULL;
+
+COMMENT ON INDEX public.uq_forecast_feedback_contexts_user_request IS
+  'Makes authenticated forecast-feedback retries idempotent by stable client request ID.';
+
+COMMIT;

--- a/supabase/migrations/20260718130000_allow_session_log_form_view_event.sql
+++ b/supabase/migrations/20260718130000_allow_session_log_form_view_event.sql
@@ -1,0 +1,45 @@
+-- Make the form-view stage durable so start-to-form conversion is measurable
+-- even when the PostHog client is still resolving consent or initialization.
+-- Preserve the live CHECK expression so earlier event additions remain valid.
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_check text;
+  candidate_events text[] := ARRAY['session_log_form_view'];
+  missing_events text[];
+BEGIN
+  SELECT regexp_replace(pg_get_constraintdef(oid), '^CHECK \((.*)\)$', '\1')
+    INTO current_check
+  FROM pg_constraint
+  WHERE conrelid = 'public.user_events'::regclass
+    AND conname = 'user_events_event_type_check';
+
+  IF current_check IS NULL THEN
+    RAISE EXCEPTION 'user_events_event_type_check constraint not found';
+  END IF;
+
+  SELECT array_agg(event_name)
+    INTO missing_events
+  FROM unnest(candidate_events) AS event_name
+  WHERE current_check NOT LIKE '%' || event_name || '%';
+
+  IF missing_events IS NULL OR array_length(missing_events, 1) IS NULL THEN
+    RAISE NOTICE 'session_log_form_view is already allowed; no change.';
+    RETURN;
+  END IF;
+
+  ALTER TABLE public.user_events
+    DROP CONSTRAINT user_events_event_type_check;
+
+  EXECUTE format(
+    'ALTER TABLE public.user_events ADD CONSTRAINT user_events_event_type_check CHECK ((%s) OR event_type = ANY (%L::text[]))',
+    current_check,
+    missing_events
+  );
+END $$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260718140000_preserve_session_source_check.sql
+++ b/supabase/migrations/20260718140000_preserve_session_source_check.sql
@@ -1,0 +1,47 @@
+-- Forward repair for the already-applied auto_title migration. Rebuild from
+-- the live expression so later source additions are never removed.
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_check text;
+  candidate_sources text[] := ARRAY['auto_title'];
+  missing_sources text[];
+BEGIN
+  SELECT regexp_replace(pg_get_constraintdef(oid), '^CHECK \((.*)\)$', '\1')
+    INTO current_check
+  FROM pg_constraint
+  WHERE conrelid = 'public.sessions'::regclass
+    AND conname = 'sessions_source_check';
+
+  IF current_check IS NULL THEN
+    RAISE EXCEPTION 'sessions_source_check constraint not found';
+  END IF;
+
+  SELECT array_agg(source_name)
+    INTO missing_sources
+  FROM unnest(candidate_sources) AS source_name
+  WHERE current_check NOT LIKE '%' || source_name || '%';
+
+  IF missing_sources IS NULL OR array_length(missing_sources, 1) IS NULL THEN
+    RAISE NOTICE 'auto_title is already allowed; no change.';
+    RETURN;
+  END IF;
+
+  ALTER TABLE public.sessions
+    DROP CONSTRAINT sessions_source_check;
+
+  EXECUTE format(
+    'ALTER TABLE public.sessions ADD CONSTRAINT sessions_source_check CHECK ((%s) OR source = ANY (%L::text[])) NOT VALID',
+    current_check,
+    missing_sources
+  );
+
+  ALTER TABLE public.sessions
+    VALIDATE CONSTRAINT sessions_source_check;
+END $$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260718141000_get_my_analytics_tracking_allowed.sql
+++ b/supabase/migrations/20260718141000_get_my_analytics_tracking_allowed.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_my_analytics_tracking_allowed(
+  p_expected_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT CASE
+    WHEN (SELECT auth.uid()) IS NULL
+      OR (SELECT auth.uid()) <> p_expected_user_id
+      THEN false
+    ELSE COALESCE(
+      (
+        SELECT p.allow_implicit_tracking
+        FROM public.profiles AS p
+        WHERE p.id = (SELECT auth.uid())
+          AND p.id = p_expected_user_id
+      ),
+      true
+    )
+  END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_my_analytics_tracking_allowed(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_my_analytics_tracking_allowed(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_my_analytics_tracking_allowed(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_my_analytics_tracking_allowed(uuid) IS
+  'Returns analytics consent only for the authenticated profile selected by auth.uid(); defaults to the schema default when the profile is still bootstrapping.';
+
+COMMIT;

--- a/supabase/migrations/20260718142000_restrict_profile_analytics_consent.sql
+++ b/supabase/migrations/20260718142000_restrict_profile_analytics_consent.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+-- Row-level security cannot hide an individual profile column. Remove the
+-- table-wide SELECT grant, then restore column-level access for every current
+-- public profile column except analytics consent. Future columns remain private
+-- until a migration explicitly grants them.
+REVOKE SELECT ON TABLE public.profiles FROM PUBLIC;
+REVOKE SELECT ON TABLE public.profiles FROM anon, authenticated;
+REVOKE SELECT (allow_implicit_tracking) ON TABLE public.profiles FROM PUBLIC;
+REVOKE SELECT (allow_implicit_tracking) ON TABLE public.profiles FROM anon, authenticated;
+
+DO $$
+DECLARE
+  public_profile_columns text;
+BEGIN
+  SELECT string_agg(format('%I', attribute.attname), ', ' ORDER BY attribute.attnum)
+    INTO public_profile_columns
+  FROM pg_attribute AS attribute
+  WHERE attribute.attrelid = 'public.profiles'::regclass
+    AND attribute.attnum > 0
+    AND NOT attribute.attisdropped
+    AND attribute.attname <> 'allow_implicit_tracking';
+
+  IF public_profile_columns IS NULL THEN
+    RAISE EXCEPTION 'profiles has no selectable public columns';
+  END IF;
+
+  EXECUTE format(
+    'GRANT SELECT (%s) ON TABLE public.profiles TO anon, authenticated',
+    public_profile_columns
+  );
+END
+$$;
+
+-- The direct native insert policy previously read the now-private consent
+-- column as the caller. Route the check through the owner-scoped definer RPC.
+DROP POLICY IF EXISTS "Users can insert their own events" ON public.user_events;
+CREATE POLICY "Users can insert their own events"
+  ON public.user_events
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND public.get_my_analytics_tracking_allowed((SELECT auth.uid()))
+  );
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260718143000_dedupe_native_session_funnel_events.sql
+++ b/supabase/migrations/20260718143000_dedupe_native_session_funnel_events.sql
@@ -1,0 +1,55 @@
+BEGIN;
+
+LOCK TABLE public.user_events IN SHARE ROW EXCLUSIVE MODE;
+
+-- Preserve every historical row while assigning a distinct key to later
+-- duplicates. Canonical native callers already send stable event_id values;
+-- the repair only makes a forward unique index safe on existing data.
+WITH ranked_duplicates AS (
+  SELECT
+    id,
+    metadata ->> 'event_id' AS event_id,
+    row_number() OVER (
+      PARTITION BY user_id, metadata ->> 'event_id'
+      ORDER BY created_at, id
+    ) AS duplicate_rank
+  FROM public.user_events
+  WHERE event_type IN (
+    'session_log_start',
+    'session_log_form_view',
+    'session_log_validation_failed',
+    'session_log_submit'
+  )
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> ''
+)
+UPDATE public.user_events AS user_event
+SET metadata = jsonb_set(
+  user_event.metadata,
+  '{event_id}',
+  to_jsonb(
+    ranked_duplicates.event_id
+      || ':legacy-duplicate:'
+      || user_event.id::text
+  ),
+  false
+)
+FROM ranked_duplicates
+WHERE user_event.id = ranked_duplicates.id
+  AND ranked_duplicates.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_events_native_session_funnel_event_id_uidx
+  ON public.user_events (user_id, ((metadata ->> 'event_id')))
+  WHERE event_type IN (
+    'session_log_start',
+    'session_log_form_view',
+    'session_log_validation_failed',
+    'session_log_submit'
+  )
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> '';
+
+COMMENT ON INDEX public.user_events_native_session_funnel_event_id_uidx IS
+  'Idempotency guard for owner-scoped canonical native session funnel events.';
+
+COMMIT;

--- a/types/implicit-preferences.ts
+++ b/types/implicit-preferences.ts
@@ -93,6 +93,7 @@ export const EVENT_WEIGHTS: Record<ImplicitEventType, number> = {
   home_timeline_tap: 0,
   // Session logging events
   session_log_start: 0,
+  session_log_form_view: 0,
   session_log_draft_opened: 0,
   session_log_time_selected: 0,
   session_log_draft_progress: 0,


### PR DESCRIPTION
## User-visible change
- Makes forecast feedback retries idempotent.
- Preserves native auto-title session sources during persistence.
- Accepts and deduplicates the native session funnel telemetry needed to measure start-to-submit conversion.
- Enforces owner-only analytics consent reads across profile and event surfaces.

## Surface
Quiver web API, analytics consent, session persistence contracts, and Supabase migrations supporting the production native OTA.

## Local verification
- `npm run typecheck` — passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn lint` — passed with zero warnings
- `yarn test:unit --bail=0 --silent --runInBand` — 1,150 suites passed; 15,440 tests passed; 0 failures
- `VERCEL_ENV=preview NODE_OPTIONS=--max-old-space-size=8192 yarn build` — passed (known nonfatal `beaches.location` static-generation warning)

## Production impact / release order
Deploy this web code and wait for Vercel READY before applying the six included 20260718 migrations. Migration `20260718142000` tightens profile SELECT privileges, so the old web artifact must not be restored after the database step without restoring grants first. The unrelated `20260717170000_create_regional_recommendation_holds.sql` migration is intentionally excluded.

## UI evidence
No layout change in this web release; screenshots not applicable. Native UI shipped separately via the production OTA.