### PR TITLE
fix(build): align beach list query with production schema

### DIFF
--- a/__tests__/lib/services/beach-query-service.test.ts
+++ b/__tests__/lib/services/beach-query-service.test.ts
@@ -43,6 +43,10 @@ describe("beach-query-service", () => {
     mockFrom.mockClear();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("getBeachesFromDb", () => {
     it("filters beaches without finite lat/lon coordinates", async () => {
       const validBeach = beach({ id: "valid" });
@@ -64,6 +68,26 @@ describe("beach-query-service", () => {
       });
       expect(mockFrom).toHaveBeenCalledWith("beaches");
       expect(mockSelect).toHaveBeenCalledWith(expect.stringContaining("lat, lon"));
+      const selectedFields = (mockSelect.mock.calls[0] as unknown as [string])[0];
+      expect(selectedFields).toContain("city");
+      expect(selectedFields).toContain("state");
+      expect(selectedFields).not.toMatch(/\b(?:location|updated_at)\b/);
+    });
+
+    it("does not retry schema errors with removed legacy columns", async () => {
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+      mockOrder.mockResolvedValue({
+        data: null,
+        error: { code: "42703", message: "column beaches.unknown does not exist" },
+      });
+
+      await expect(getBeachesFromDb()).resolves.toEqual({
+        success: false,
+        error: "column beaches.unknown does not exist",
+      });
+
+      expect(mockSelect).toHaveBeenCalledTimes(1);
+      expect(mockSelect).not.toHaveBeenCalledWith(expect.stringContaining("location"));
     });
   });
 });

--- a/lib/services/beach-query-service.ts
+++ b/lib/services/beach-query-service.ts
@@ -22,11 +22,8 @@ import type { Beach } from "@/types/database";
 
 // Selective field query for beach list - only fetch commonly needed fields
 // Updated after 20251025 migrations: location->city, latitude->lat, longitude->lon, region->state
-// WARNING: Some environments may still use legacy columns (location/region) and may not have updated_at.
 const BEACH_LIST_FIELDS =
-  "id, name, slug, city, lat, lon, state, country, created_at, updated_at, is_private, break_type, skill_level, average_rating, review_count, description, crowd_tips, wave_tips, best_conditions_prose, seo_indexable, editorial_reviewed_at, editorial_sources";
-const BEACH_LIST_FIELDS_LEGACY =
-  "id, name, location, region, lat, lon, country, created_at, is_private, break_type, skill_level, average_rating, review_count";
+  "id, name, slug, city, lat, lon, state, country, created_at, is_private, break_type, skill_level, average_rating, review_count, description, crowd_tips, wave_tips, best_conditions_prose, seo_indexable, editorial_reviewed_at, editorial_sources";
 
 // Full beach detail fields for single beach queries
 const BEACH_DETAIL_FIELDS = "*";
@@ -48,33 +45,12 @@ export async function getBeachesFromDb(): Promise<ServerActionResponse<Beach[]>>
       // Use selective fields instead of * to reduce data transfer.
       // Exclude private beaches (is_private = true) and soft-deleted beaches
       // so they don't appear in the sitemap or other public-facing lists.
-      let result: any = await supabase
+      const result = await supabase
         .from("beaches")
         .select(BEACH_LIST_FIELDS)
         .or("is_private.is.null,is_private.eq.false")
         .is("deleted_at", null)
         .order("name");
-
-      // If schema mismatch (unknown column), retry with legacy field set.
-      if (result.error && (result.error as any)?.code === "42703") {
-        result = (await supabase
-          .from("beaches")
-          .select(BEACH_LIST_FIELDS_LEGACY)
-          .or("is_private.is.null,is_private.eq.false")
-          .is("deleted_at", null)
-          .order("name")) as any;
-
-        // Normalize legacy location/region into city/state for downstream match strategies
-        if (Array.isArray((result as any).data)) {
-          (result as any).data = (result as any).data.map((b: any) => ({
-            ...b,
-            city: b.city ?? b.location ?? null,
-            state: b.state ?? b.region ?? null,
-            slug: b.slug ?? null,
-            updated_at: b.updated_at ?? null,
-          }));
-        }
-      }
 
       if (result.error) {
         throw new Error(result.error.message || "Database operation failed");


### PR DESCRIPTION
Closes #423

## What changed

- Removed the nonexistent `updated_at` field from the public beach-list query.
- Removed the obsolete `location`/`region` schema fallback so database shape errors are surfaced instead of retried against removed columns.
- Added regression coverage proving the query requests canonical `city`/`state` fields and never retries with `location`.

## Root cause

The production `public.beaches` schema and generated TypeScript types contain `city` and `state`, but neither `updated_at` nor `location`. The canonical list query requested `updated_at`, received PostgreSQL error `42703`, and then retried with a legacy select containing `location`. During static generation, the second failure produced the repeated `column beaches.location does not exist` warnings and left the business/surf-school pages without beach options.

## User impact

Static-generation consumers now receive the canonical beach list with city/state data. Preview builds complete without the `beaches.location` warning; sitemap and canonical beach URL generation remain covered.

## Verification

- `npx eslint --max-warnings=0 lib/services/beach-query-service.ts __tests__/lib/services/beach-query-service.test.ts` — passed
- `yarn typecheck` — passed
- Focused Jest routing/static-generation suite — 6 suites, 220 tests passed
- `yarn test:unit --bail=0` — 1,177 suites, 16,050 tests passed
- `VERCEL_ENV=preview yarn build` — passed; 153/153 static pages generated with no `beaches.location` warning
- `SKIP_E2E_CLEANUP=true npx playwright test e2e/guest-smoke.spec.ts --grep "Sitemap returns valid XML response" --project=guest` — 1 passed

## Release notes

- Database migrations: none
- Environment changes: none
- UI screenshots: not applicable