### PR TITLE
fix(migrations): restore profile drive preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Clean migration replays restore the profile drive-radius preference** (`supabase/migrations/20260715050000_restore_profile_max_drive_minutes.sql`). Reconciles the nullable `profiles.max_drive_minutes` column and production comment before the local match-candidate RPC first reads it, without rewriting applied history or dropping preference data.
 - **Clean migration replays exclude the Board Rec seed from analytics** (`supabase/migrations/20260709122000_exclude_board_rec_seed_from_analytics.sql`). Classifies the auth-orphaned synthetic profile as mock data before the historical `session_created` backfill, preserving the `user_events.user_id` foreign key without rewriting applied migration history.
 - **SEO canonical discovery and crawl continuity** (`app/sitemap.ts`, `lib/seo/funnel-pages.ts`, `next.config.mjs`). Keeps international country/region hubs discoverable before city editorial is approved, points Cocoa Beach Pier cards and retired URLs at the live database-backed canonical page, redirects the legacy El Morro URL, and lets technical audits report individual page-fetch failures without abandoning the full crawl.
 - **CDIP fallback deadlines stop expired work** (`lib/services/forecast/data-source-manager.ts`). Fast CDIP responses now clear their fallback timer, and station lookups or buoy fetches that finish after the 10-second deadline can no longer continue work or emit late test/runtime activity after the IOOS fallback has started.

--- a/__tests__/migrations/profile-max-drive-minutes.test.ts
+++ b/__tests__/migrations/profile-max-drive-minutes.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const RECONCILIATION_VERSION = "20260715050000";
+const CONSUMER_VERSION = "20260715051000";
+const RECONCILIATION_FILE = join(
+  process.cwd(),
+  `supabase/migrations/${RECONCILIATION_VERSION}_restore_profile_max_drive_minutes.sql`,
+);
+const reconciliationSQL = existsSync(RECONCILIATION_FILE)
+  ? readFileSync(RECONCILIATION_FILE, "utf8")
+  : "";
+const normalizedSQL = reconciliationSQL.replace(/\s+/g, " ").toLowerCase();
+
+describe("profiles.max_drive_minutes schema reconciliation", () => {
+  it("runs before the first migration that reads the column", () => {
+    expect(existsSync(RECONCILIATION_FILE)).toBe(true);
+    expect(Number(RECONCILIATION_VERSION)).toBeLessThan(Number(CONSUMER_VERSION));
+  });
+
+  it("replays the nullable integer column and its production comment idempotently", () => {
+    expect(normalizedSQL).toContain("begin;");
+    expect(normalizedSQL).toContain(
+      "alter table public.profiles add column if not exists max_drive_minutes integer",
+    );
+    expect(normalizedSQL).toContain(
+      "comment on column public.profiles.max_drive_minutes is 'optional maximum drive time preference in minutes for discovery candidate radius. null means no cap/current behavior.'",
+    );
+    expect(normalizedSQL).toContain("commit;");
+  });
+
+  it("does not remove profile data or relax the column shape", () => {
+    expect(normalizedSQL).not.toMatch(/delete from|truncate|drop table|drop column/);
+    expect(normalizedSQL).not.toContain("not null");
+    expect(normalizedSQL).not.toContain("default");
+  });
+});

--- a/supabase/migrations/20260715050000_restore_profile_max_drive_minutes.sql
+++ b/supabase/migrations/20260715050000_restore_profile_max_drive_minutes.sql
@@ -1,0 +1,18 @@
+-- Reconcile migration history with the nullable discovery-radius preference
+-- already present in production. This timestamp intentionally precedes
+-- 20260715051000_local_match_candidates.sql, the first migration that reads it.
+-- Production tracks the consumer already, so apply and track this migration
+-- with the approved out-of-order ledger procedure after it is merged.
+--
+-- Rollback is forward-only: do not drop this user preference or its data. If
+-- its schema ever needs correction, add another idempotent migration.
+
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS max_drive_minutes integer;
+
+COMMENT ON COLUMN public.profiles.max_drive_minutes IS
+  'Optional maximum drive time preference in minutes for discovery candidate radius. NULL means no cap/current behavior.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add an idempotent pre-consumer migration for `profiles.max_drive_minutes integer NULL`
- preserve the exact production column comment
- document the required out-of-order production-ledger handling and forward-only rollback policy
- add a regression test that fails if replay history loses the column definition or moves it after its first consumer

Refs #425

## Root cause
Production acquired `profiles.max_drive_minutes` outside tracked migration history. A later remote type regeneration imported the column into `types/database.generated.ts`, and `20260715051000_local_match_candidates.sql` then began reading it. Fresh replay history therefore diverged from production and failed when creating that RPC.

## Verification
- `RUN_SUPABASE_INTEGRATION=1 MATCH_CANDIDATES_DATABASE_URL=<local-loopback-db> yarn test:unit --runInBand __tests__/migrations/local-match-candidates.integration.test.ts __tests__/migrations/profile-max-drive-minutes.test.ts __tests__/migrations/local-match-candidates.test.ts` — passed, 9/9
- `npx eslint --max-warnings=0 __tests__/migrations/profile-max-drive-minutes.test.ts` — passed
- `yarn typecheck` — passed
- `yarn test:unit --runInBand __tests__/migrations/profile-max-drive-minutes.test.ts __tests__/migrations/local-match-candidates.test.ts` — passed, 8/8
- `yarn test:unit --bail=0` — passed, 1,179 suites / 16,056 tests
- Migration applied twice locally; second application skipped the existing column and preserved the canonical comment.
- Starting from a newly recreated database, migrations were replayed in order through `20260715051000`; the column was nullable integer with the production comment, the RPC existed, and its integration test passed.

## Clean reset note
A literal `supabase db reset --local` reaches the unrelated explicit approval guard in `20260618160000_phase0_forecast_accuracy_metrics.sql` and stops before this migration. Three local-only token propagation approaches were rejected by the reset lifecycle/role permissions, so no bypass is included. The approved Phase 0 file was instead applied in one psql session and the remaining migrations replayed in filename order. This blocker is independent of #425.

## Migration / release impact
- New migration: `20260715050000_restore_profile_max_drive_minutes.sql`
- Timestamp intentionally precedes the production-tracked `20260715051000_local_match_candidates.sql`.
- Production already has the exact nullable integer and comment, so its DDL is idempotent; only out-of-order ledger alignment remains approval-gated after merge.
- No UI, environment, or generated-type changes.
