### PR TITLE
fix(beach): remove Doheny surf report snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Doheny beach pages no longer repeat the oversized surf-report snapshot** (`app/[intent]/[city]/[beachSlug]/page.tsx`). Keeps the dedicated tide, water-temperature, and best-time guide links while removing the redundant conditions summary from both known Doheny route variants.
 - **Clean migration replays restore the profile drive-radius preference** (`supabase/migrations/20260715050000_restore_profile_max_drive_minutes.sql`). Reconciles the nullable `profiles.max_drive_minutes` column and production comment before the local match-candidate RPC first reads it, without rewriting applied history or dropping preference data.
 - **Clean migration replays exclude the Board Rec seed from analytics** (`supabase/migrations/20260709122000_exclude_board_rec_seed_from_analytics.sql`). Classifies the auth-orphaned synthetic profile as mock data before the historical `session_created` backfill, preserving the `user_events.user_id` foreign key without rewriting applied migration history.
 - **SEO canonical discovery and crawl continuity** (`app/sitemap.ts`, `lib/seo/funnel-pages.ts`, `next.config.mjs`). Keeps international country/region hubs discoverable before city editorial is approved, points Cocoa Beach Pier cards and retired URLs at the live database-backed canonical page, redirects the legacy El Morro URL, and lets technical audits report individual page-fetch failures without abandoning the full crawl.

--- a/__tests__/app/generic-beach-detail-resolution.test.ts
+++ b/__tests__/app/generic-beach-detail-resolution.test.ts
@@ -10,6 +10,7 @@ import { getNearbyBeaches } from "@/actions/beach/beach-location-actions";
 import { expectConsoleWarnings } from "@/__tests__/setup/test-utils";
 import type { Beach } from "@/types/database";
 import { notFound, redirect } from "next/navigation";
+import { renderToStaticMarkup } from "react-dom/server";
 
 // Mock React's cache function for server components
 jest.mock("react", () => ({
@@ -92,7 +93,12 @@ jest.mock("@/components/beach-detail/related-guides-section", () => ({
 }));
 
 jest.mock("@/components/beach-detail/beach-prose-summary", () => ({
-  BeachProseSummary: () => null,
+  BeachProseSummary: () =>
+    jest.requireActual("react").createElement(
+      "section",
+      { "data-testid": "beach-prose-summary" },
+      "Surf report snapshot",
+    ),
 }));
 
 jest.mock("@/components/beach-detail/optimal-conditions-section", () => ({
@@ -236,6 +242,57 @@ describe("GenericBeachDetailPage slug resolution", () => {
 
     expect(notFound).not.toHaveBeenCalled();
     expect(getNearbyBeaches).not.toHaveBeenCalled();
+  });
+
+  it("removes the Doheny snapshot while preserving its supporting guide links", async () => {
+    (getBeachesBySlug as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [
+        makeBeach({
+          id: "doheny",
+          name: "Doheny Beach",
+          slug: "doheny",
+          city: "Dana Point",
+        }),
+      ],
+    });
+
+    const page = await GenericBeachDetailPage({
+      params: Promise.resolve({
+        intent: "ca",
+        city: "dana-point",
+        beachSlug: "doheny",
+      }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(html).not.toContain("Surf report snapshot");
+    expect(html).toContain("Doheny Beach tide chart");
+    expect(html).toContain("Doheny Beach water temperature");
+  });
+
+  it("keeps the snapshot on other beach pages", async () => {
+    (getBeachesBySlug as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [
+        makeBeach({
+          id: "lower-trestles",
+          name: "Lower Trestles",
+          slug: "lower-trestles",
+          city: "San Clemente",
+        }),
+      ],
+    });
+
+    const page = await GenericBeachDetailPage({
+      params: Promise.resolve({
+        intent: "ca",
+        city: "san-clemente",
+        beachSlug: "lower-trestles",
+      }),
+    });
+
+    expect(renderToStaticMarkup(page)).toContain("Surf report snapshot");
   });
 
   it("redirects stale city slugs to the canonical beach URL", async () => {

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -57,6 +57,10 @@ const getCachedBeachCandidates = cache(async (slug: string) => {
 
 const baseUrl =
   process.env.NEXT_PUBLIC_SITE_URL || "https://www.quiversurf.app";
+const BEACH_PROSE_SUMMARY_HIDDEN_SLUGS = new Set([
+  "doheny",
+  "doheny-state-beach",
+]);
 
 type BeachWithEditorialReview = Beach & {
   seo_indexable?: boolean | null;
@@ -327,11 +331,14 @@ export default async function GenericBeachDetailPage(props: PageProps) {
         )}
 
         {/* SSR prose summary for AI crawlers and search engines (GEO) */}
-        <BeachProseSummary
-          beach={beach}
-          surfCallReport={surfCallReport}
-          editorialSources={getBeachEditorialSources(beach as BeachWithEditorialReview)}
-        />
+        {!BEACH_PROSE_SUMMARY_HIDDEN_SLUGS.has(beachSlug) &&
+          !BEACH_PROSE_SUMMARY_HIDDEN_SLUGS.has(beach.slug ?? "") && (
+            <BeachProseSummary
+              beach={beach}
+              surfCallReport={surfCallReport}
+              editorialSources={getBeachEditorialSources(beach as BeachWithEditorialReview)}
+            />
+          )}
 
         <nav
           className="mx-auto flex max-w-5xl flex-wrap gap-x-4 gap-y-2 px-4 py-4 text-sm sm:px-6 lg:px-8"

--- a/e2e/guest-route-html-contracts.spec.ts
+++ b/e2e/guest-route-html-contracts.spec.ts
@@ -276,7 +276,7 @@ test.describe('Route HTML Contracts', () => {
       expect(getHeadingTexts(html, 1).join(' ')).toMatch(/alfonsos/i);
     });
 
-    test('canonical beach URL loads directly', async ({ request }) => {
+    test('Doheny loads without the snapshot and keeps supporting guide links', async ({ request }) => {
       const response = await getResponse(request, '/ca/dana-point/doheny-state-beach', {
         maxRedirects: 0,
       });
@@ -285,6 +285,9 @@ test.describe('Route HTML Contracts', () => {
       expect(response.status()).toBe(200);
       expect(response.headers().location).toBeUndefined();
       expect(html.toLowerCase()).toContain('doheny');
+      expect(html).not.toContain('Surf report snapshot');
+      expect(html).toContain('href="/ca/dana-point/doheny-state-beach/tides"');
+      expect(html).toContain('href="/ca/dana-point/doheny-state-beach/water-temp"');
     });
 
     const seoCanonicalRedirects = [


### PR DESCRIPTION
## User-visible change

Removes the oversized SSR surf-report snapshot from both known Doheny beach route variants while keeping the dedicated tide chart, water-temperature, and best-time guide links.

Other beach pages continue to render the snapshot.

Closes #427.

## Surface

- `app/[intent]/[city]/[beachSlug]/page.tsx`
- Route-level Jest coverage
- Guest route HTML E2E contract
- Changelog

## Local verification

- `yarn test:unit __tests__/app/generic-beach-detail-resolution.test.ts --runInBand` — **passed** (7/7)
- `npx eslint --max-warnings=0 'app/[intent]/[city]/[beachSlug]/page.tsx' __tests__/app/generic-beach-detail-resolution.test.ts e2e/guest-route-html-contracts.spec.ts` — **passed**
- `yarn typecheck` — **passed**
- `yarn test:unit --bail=0` — **passed** (1,179 suites; 16,058 tests; 16 suites/195 tests skipped; 1 todo)
- `VERCEL_ENV=preview yarn build` — **passed** (153 static pages generated)
- `SKIP_AUTH_SETUP=true SKIP_E2E_CLEANUP=true BASE_URL=http://0.0.0.0:3100 npx playwright test e2e/guest-route-html-contracts.spec.ts --project=guest --grep 'Doheny loads without the snapshot' --reporter=line` — **passed** (1/1)
- Hydrated browser check at `http://localhost:3100/ca/dana-point/doheny-state-beach` — **passed**: HTTP 200, Doheny heading present, snapshot count 0, tide link count 1, water link count 1.

## Visual evidence

A local full-page screenshot was reviewed after hydration. It shows the supporting guide links immediately below the header and no duplicated surf-report snapshot; the main Doheny field-guide content remains intact. The “before” state is captured in #427.

## Release impact

- No database migration
- No environment-variable change
- No production-only release step