### PR TITLE
fix(db): repair Coach Picks score source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Coach Picks no longer depends on the retired hourly-score view** (`supabase/migrations/20260722193000_repair_get_coach_picks_daily_intel.sql`). Preserves the existing RPC response while ranking public, non-deleted beaches inside the requested radius by their latest precomputed daily conditions score.
 - **Doheny beach pages no longer repeat the oversized surf-report snapshot** (`app/[intent]/[city]/[beachSlug]/page.tsx`). Keeps the dedicated tide, water-temperature, and best-time guide links while removing the redundant conditions summary from both known Doheny route variants.
 - **Clean migration replays restore the profile drive-radius preference** (`supabase/migrations/20260715050000_restore_profile_max_drive_minutes.sql`). Reconciles the nullable `profiles.max_drive_minutes` column and production comment before the local match-candidate RPC first reads it, without rewriting applied history or dropping preference data.
 - **Clean migration replays exclude the Board Rec seed from analytics** (`supabase/migrations/20260709122000_exclude_board_rec_seed_from_analytics.sql`). Classifies the auth-orphaned synthetic profile as mock data before the historical `session_created` backfill, preserving the `user_events.user_id` foreign key without rewriting applied migration history.

--- a/__tests__/migrations/coach-picks-daily-intel.test.ts
+++ b/__tests__/migrations/coach-picks-daily-intel.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSql = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260722193000_repair_get_coach_picks_daily_intel.sql",
+  ),
+  "utf8",
+);
+const fixtureSql = readFileSync(
+  join(process.cwd(), "scripts/db/coach-picks-daily-intel-smoke.sql"),
+  "utf8",
+);
+
+describe("Coach Picks daily-intel repair migration", () => {
+  it("preserves the RPC contract without depending on retired score views", () => {
+    expect(migrationSql).toContain(
+      "CREATE OR REPLACE FUNCTION public.get_coach_picks",
+    );
+    expect(migrationSql).toContain("RETURNS TABLE (");
+    expect(migrationSql).toContain("pick_rank int");
+    expect(migrationSql).toContain("distance_km numeric");
+    expect(migrationSql).toContain("score int");
+    expect(migrationSql).not.toContain("v_beach_hourly_scores");
+    expect(migrationSql).not.toContain("mv_beach_hourly_scores");
+  });
+
+  it("uses the latest daily score and enforces public strict-radius candidates", () => {
+    expect(migrationSql).toContain("FROM public.beach_daily_intel intel");
+    expect(migrationSql).toContain(
+      "ORDER BY intel.forecast_date DESC, intel.generated_at DESC",
+    );
+    expect(migrationSql).toContain(
+      "WHERE candidate.distance_km <= _radius_km",
+    );
+    expect(migrationSql.match(/b\.deleted_at IS NULL/g)).toHaveLength(2);
+    expect(migrationSql.match(/NOT b\.is_private/g)).toHaveLength(2);
+    expect(migrationSql).not.toContain("region_id");
+  });
+
+  it("is transactional and preserves least-privilege execution", () => {
+    expect(migrationSql).toMatch(/^--[\s\S]*\nBEGIN;/);
+    expect(migrationSql.trimEnd()).toMatch(/COMMIT;$/);
+    expect(migrationSql).toContain(
+      "SET search_path = public, pg_catalog",
+    );
+    expect(migrationSql).toContain(
+      "REVOKE ALL ON FUNCTION public.get_coach_picks(uuid, numeric) FROM PUBLIC",
+    );
+    expect(migrationSql).toContain("TO anon, authenticated, service_role");
+  });
+
+  it("ships a rollback-only smoke fixture covering ranking and exclusions", () => {
+    expect(fixtureSql).toContain("\\set ON_ERROR_STOP on");
+    expect(fixtureSql).toContain("CREATE TEMP TABLE coach_picks_fixture_ids");
+    expect(fixtureSql).toContain("gen_random_uuid()");
+    expect(fixtureSql).toContain("SET LOCAL ROLE anon");
+    expect(fixtureSql).toContain("coach_picks_fixture_anon_contract_failed");
+    expect(fixtureSql).toContain("coach_picks_fixture_latest_score_not_used");
+    expect(fixtureSql).toContain("coach_picks_fixture_radius_not_strict");
+    expect(fixtureSql.trimEnd()).toMatch(/ROLLBACK;$/);
+  });
+});

--- a/scripts/db/coach-picks-daily-intel-smoke.sql
+++ b/scripts/db/coach-picks-daily-intel-smoke.sql
@@ -1,0 +1,118 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+CREATE TEMP TABLE coach_picks_fixture_ids (
+  fixture text PRIMARY KEY,
+  id uuid NOT NULL UNIQUE
+) ON COMMIT DROP;
+
+INSERT INTO coach_picks_fixture_ids (fixture, id)
+VALUES
+  ('origin', gen_random_uuid()),
+  ('near_high', gen_random_uuid()),
+  ('near_low', gen_random_uuid()),
+  ('far_high', gen_random_uuid()),
+  ('private_high', gen_random_uuid()),
+  ('deleted_high', gen_random_uuid());
+
+INSERT INTO public.beaches (id, name, lat, lon, is_private, deleted_at)
+SELECT id, 'Coach Picks Origin', 0.0000, 0.0000, false, NULL::timestamptz
+FROM coach_picks_fixture_ids WHERE fixture = 'origin'
+UNION ALL
+SELECT id, 'Coach Picks Near High', 0.0100, 0.0000, false, NULL::timestamptz
+FROM coach_picks_fixture_ids WHERE fixture = 'near_high'
+UNION ALL
+SELECT id, 'Coach Picks Near Low', 0.0200, 0.0000, false, NULL::timestamptz
+FROM coach_picks_fixture_ids WHERE fixture = 'near_low'
+UNION ALL
+SELECT id, 'Coach Picks Far High', 2.0000, 0.0000, false, NULL::timestamptz
+FROM coach_picks_fixture_ids WHERE fixture = 'far_high'
+UNION ALL
+SELECT id, 'Coach Picks Private High', 0.0050, 0.0000, true, NULL::timestamptz
+FROM coach_picks_fixture_ids WHERE fixture = 'private_high'
+UNION ALL
+SELECT id, 'Coach Picks Deleted High', 0.0070, 0.0000, false, now()
+FROM coach_picks_fixture_ids WHERE fixture = 'deleted_high';
+
+INSERT INTO public.beach_daily_intel (
+  beach_id,
+  generated_at,
+  generation_time,
+  forecast_date,
+  confidence,
+  conditions_score
+)
+SELECT id, now() - interval '2 hours', '06:00', current_date, 'High', 90
+FROM coach_picks_fixture_ids WHERE fixture = 'near_high'
+UNION ALL
+SELECT id, now() - interval '3 hours', '06:00', current_date, 'High', 95
+FROM coach_picks_fixture_ids WHERE fixture = 'near_low'
+UNION ALL
+SELECT id, now() - interval '1 hour', '14:00', current_date, 'High', 30
+FROM coach_picks_fixture_ids WHERE fixture = 'near_low'
+UNION ALL
+SELECT id, now(), '06:00', current_date, 'High', 100
+FROM coach_picks_fixture_ids WHERE fixture = 'far_high'
+UNION ALL
+SELECT id, now(), '06:00', current_date, 'High', 100
+FROM coach_picks_fixture_ids WHERE fixture = 'private_high'
+UNION ALL
+SELECT id, now(), '06:00', current_date, 'High', 100
+FROM coach_picks_fixture_ids WHERE fixture = 'deleted_high';
+
+CREATE TEMP TABLE coach_picks_actual ON COMMIT DROP AS
+SELECT *
+FROM public.get_coach_picks(
+  (SELECT id FROM coach_picks_fixture_ids WHERE fixture = 'origin'),
+  80
+);
+
+GRANT SELECT ON coach_picks_fixture_ids TO anon;
+SET LOCAL ROLE anon;
+CREATE TEMP TABLE coach_picks_anon_actual ON COMMIT DROP AS
+SELECT *
+FROM public.get_coach_picks(
+  (SELECT id FROM coach_picks_fixture_ids WHERE fixture = 'origin'),
+  80
+);
+RESET ROLE;
+
+DO $fixture$
+DECLARE
+  v_near_high uuid := (
+    SELECT id FROM coach_picks_fixture_ids WHERE fixture = 'near_high'
+  );
+  v_near_low uuid := (
+    SELECT id FROM coach_picks_fixture_ids WHERE fixture = 'near_low'
+  );
+BEGIN
+  IF (SELECT count(*) FROM coach_picks_actual) <> 2 THEN
+    RAISE EXCEPTION 'coach_picks_fixture_unexpected_row_count';
+  END IF;
+
+  IF (SELECT count(*) FROM coach_picks_anon_actual) <> 2 THEN
+    RAISE EXCEPTION 'coach_picks_fixture_anon_contract_failed';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM coach_picks_actual
+    WHERE pick_rank = 1 AND beach_id = v_near_high AND score = 90
+  ) THEN
+    RAISE EXCEPTION 'coach_picks_fixture_high_score_not_ranked_first';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM coach_picks_actual
+    WHERE pick_rank = 2 AND beach_id = v_near_low AND score = 30
+  ) THEN
+    RAISE EXCEPTION 'coach_picks_fixture_latest_score_not_used';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM coach_picks_actual WHERE distance_km > 80) THEN
+    RAISE EXCEPTION 'coach_picks_fixture_radius_not_strict';
+  END IF;
+END
+$fixture$;
+
+ROLLBACK;

--- a/supabase/ARCHITECTURE.md
+++ b/supabase/ARCHITECTURE.md
@@ -1167,24 +1167,24 @@ Before any new migration:
 ## Utility Views
 
 - `public.v_beach_hourly_scores`
-  - Computes per-hour surf suitability scores (0-100) for each beach using wind direction vs. offshore bearing, tide preference band, and swell window inclusion with fade.
-  - Inputs: `marine_forecasts(beach_id, ts, wind_direction_deg, wind_speed_ms, wave_direction_deg)` and `tide_forecasts(beach_id, ts, tide_height_m)`; preferences from `beaches` (`wind_offshore_deg`, `wind_cross_shore_ok_kt`, `preferred_tide_ft_min/max`, `swell_window_min/max`).
-  - Current weights: wind 0.4, swell 0.4, tide 0.2. Period/height scoring reserved for later when calibrated fields exist.
-  - Introduced by migration `20250812160500_create_v_beach_hourly_scores.sql` with rollback `20250812160501_rollback_v_beach_hourly_scores.sql`.
-  - Security: `WITH (security_invoker = true)` so underlying table RLS is enforced for the querying role. `GRANT SELECT` provided to `anon` and `authenticated` only.
+  - Retired by migration `20260113120100_remove_unused_hourly_scores_mv.sql` together with `mv_beach_hourly_scores`.
+  - Current recommendation code must not depend on this view.
 
 ## Utility RPCs
 
+- `public.get_coach_picks(_beach_id uuid, _radius_km numeric default 80)`
+  - Returns the top three public, non-deleted beaches inside the strict requested radius.
+  - Ranks candidates by the latest `beach_daily_intel.conditions_score`, with distance as the deterministic tiebreaker.
+  - Repaired by migration `20260722193000_repair_get_coach_picks_daily_intel.sql` after the hourly-score views were retired.
+
 - `public.get_best_times(p_beach uuid, p_start timestamptz, p_end timestamptz, p_limit int default 6)`
-  - Returns top-scoring 2-hour windows within the range using `v_beach_hourly_scores` rolling averages, labelled `epic/good/fair/poor`.
-  - Read-only (`stable`), executable by `anon`, `authenticated`, and `service_role`.
-  - Introduced by migration `20250812161000_create_get_best_times.sql` with rollback `20250812161001_rollback_get_best_times.sql`.
+  - Retired when `v_beach_hourly_scores` was dropped; current session-window recommendations use the application-layer forecast scorer.
 
 ## Scoring Weights (per beach)
 
 ## Best Times Performance
 
-**Status: Infrastructure Present, No Active Consumers (Planned Feature)**
+**Status: Retired**
 
 - `public.mv_best_times` (materialized view)
 
@@ -1192,14 +1192,14 @@ Before any new migration:
   - Refreshed hourly via `pg_cron` job `refresh_mv_best_times_hourly` calling `public.refresh_mv_best_times()`.
   - Unique index on `(beach_id, start_ts)` enables concurrent refresh and fast lookup.
   - Introduced by `20250812170000_create_mv_best_times.sql` with rollback `20250812170001_rollback_mv_best_times.sql`.
-  - **Current Usage**: None - feature not yet launched. Helper function exists in `lib/bestTimes.ts` but no API routes or components consume it.
+  - **Current Usage**: None. Removed after the underlying hourly-score view was retired.
 
 - `public.mv_beach_hourly_scores` (materialized view)
 
   - Precomputes hourly marine+tide joins with surf suitability scores.
   - Refreshed via `refresh_mv_beach_hourly_scores()` function (pg_cron schedule TBD).
   - Introduced by `20250820134000_create_mv_beach_hourly_scores.sql`.
-  - **Current Usage**: None - supports `mv_best_times` which is also not yet consumed.
+  - **Current Usage**: None. Removed by `20260113120100_remove_unused_hourly_scores_mv.sql`.
 
 - **Data Engineering Review**: See `docs/data-engineering/BEACH_RECOMMENDATION_CLEANUP_REVIEW.md` for recommendations on:
 

--- a/supabase/migrations/20260722193000_repair_get_coach_picks_daily_intel.sql
+++ b/supabase/migrations/20260722193000_repair_get_coach_picks_daily_intel.sql
@@ -1,0 +1,87 @@
+-- Repair Coach Picks after the hourly scoring views were retired.
+-- Keep the existing RPC contract while ranking nearby public beaches by the
+-- latest precomputed daily conditions score.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_coach_picks(
+  _beach_id uuid,
+  _radius_km numeric DEFAULT 80
+)
+RETURNS TABLE (
+  pick_rank int,
+  beach_id uuid,
+  name text,
+  distance_km numeric,
+  score int
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_catalog
+AS $function$
+  WITH origin AS (
+    SELECT b.lat, b.lon
+    FROM public.beaches b
+    WHERE b.id = _beach_id
+      AND b.deleted_at IS NULL
+      AND NOT b.is_private
+  ),
+  candidate_distances AS (
+    SELECT
+      b.id,
+      b.name,
+      (
+        6371.0088 * 2 * asin(
+          least(
+            1.0,
+            sqrt(
+              power(sin(radians((b.lat - o.lat) / 2.0)), 2) +
+              cos(radians(o.lat)) * cos(radians(b.lat)) *
+              power(sin(radians((b.lon - o.lon) / 2.0)), 2)
+            )
+          )
+        )
+      )::numeric AS distance_km
+    FROM public.beaches b
+    CROSS JOIN origin o
+    WHERE b.id <> _beach_id
+      AND b.deleted_at IS NULL
+      AND NOT b.is_private
+  ),
+  scored_candidates AS (
+    SELECT
+      candidate.id,
+      candidate.name,
+      candidate.distance_km,
+      coalesce(latest_intel.conditions_score, 0)::int AS score
+    FROM candidate_distances candidate
+    LEFT JOIN LATERAL (
+      SELECT intel.conditions_score
+      FROM public.beach_daily_intel intel
+      WHERE intel.beach_id = candidate.id
+      ORDER BY intel.forecast_date DESC, intel.generated_at DESC
+      LIMIT 1
+    ) latest_intel ON true
+    WHERE candidate.distance_km <= _radius_km
+  )
+  SELECT
+    row_number() OVER (
+      ORDER BY candidate.score DESC, candidate.distance_km ASC, candidate.id
+    )::int AS pick_rank,
+    candidate.id AS beach_id,
+    candidate.name,
+    candidate.distance_km,
+    candidate.score
+  FROM scored_candidates candidate
+  ORDER BY pick_rank
+  LIMIT 3;
+$function$;
+
+COMMENT ON FUNCTION public.get_coach_picks(uuid, numeric) IS
+  'Returns the top three public beaches within a strict radius, ranked by each beach''s latest daily conditions score.';
+
+REVOKE ALL ON FUNCTION public.get_coach_picks(uuid, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_coach_picks(uuid, numeric)
+  TO anon, authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
## User-visible change
- restores Coach Picks by replacing its retired hourly-view dependency with the latest daily conditions score
- keeps the existing API response contract and strict requested radius
- excludes private and deleted candidate beaches

## Touched surface
- Supabase migration ledger and migration architecture docs
- deterministic local database smoke fixture
- migration contract test and changelog

## Local verification
- PASS: `psql ... -f supabase/migrations/20260722193000_repair_get_coach_picks_daily_intel.sql` against local Supabase
- PASS: `psql ... -f scripts/db/coach-picks-daily-intel-smoke.sql` (owner + anon, latest ranking, strict radius, private/deleted exclusion, rollback)
- PASS: focused Jest — 4 suites, 14 tests
- PASS: scoped ESLint, 0 warnings
- PASS: `yarn typecheck`

## Release notes
- Production database migration is approval-gated and has not been applied.
- No application response type changes and no generated database type changes.