### PR TITLE
chore(db): reconcile production migration ledger

### DIFF
--- a/supabase/migrations/20260720120000_add_android_beta_lead_session_id.sql
+++ b/supabase/migrations/20260720120000_add_android_beta_lead_session_id.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE public.android_beta_leads
+  ADD COLUMN IF NOT EXISTS session_id uuid;
+
+CREATE INDEX IF NOT EXISTS android_beta_leads_session_id_idx
+  ON public.android_beta_leads (session_id);
+
+COMMENT ON COLUMN public.android_beta_leads.session_id IS
+  'Persistent anonymous visitor session used to connect the captured Google account email to Android handoff events.';
+
+COMMIT;


### PR DESCRIPTION
## Change
- backfills the canonical `20260720120000_add_android_beta_lead_session_id.sql` file into `prod`
- restores byte-identical parity with the migration already tracked and applied in production

## Verification
- canonical file SHA-256 matches the source ledger: `e5b6603bed36eb0f5f7491fc5be955211a7d808af590276c7e0c67fc37c4aa3e`
- fresh production schema dump confirms the UUID column, index, and exact column comment
- linked migration audit leaves only `20260722193000` pending
- no SQL was executed and no production data was changed by this PR