### PR TITLE
feat(devices): deploy Expo Updates identity contract

### DIFF
--- a/__tests__/api/devices/device-upsert.test.ts
+++ b/__tests__/api/devices/device-upsert.test.ts
@@ -692,6 +692,11 @@ describe("Device Token API - POST /api/devices/upsert", () => {
       expect(upsertArg).not.toHaveProperty("build_number");
       expect(upsertArg).not.toHaveProperty("os_version");
       expect(upsertArg).not.toHaveProperty("expo_sdk");
+      expect(upsertArg).not.toHaveProperty("expo_update_id");
+      expect(upsertArg).not.toHaveProperty("expo_channel");
+      expect(upsertArg).not.toHaveProperty("expo_runtime_version");
+      expect(upsertArg).not.toHaveProperty("expo_is_embedded_launch");
+      expect(upsertArg).not.toHaveProperty("expo_is_emergency_launch");
     });
 
     it("does NOT include null or blank metadata fields in upsert so existing values are preserved", async () => {
@@ -722,6 +727,147 @@ describe("Device Token API - POST /api/devices/upsert", () => {
       expect(upsertArg).not.toHaveProperty("build_number");
       expect(upsertArg).not.toHaveProperty("os_version");
       expect(upsertArg).toHaveProperty("expo_sdk", "55.0.0");
+    });
+  });
+
+  describe("Expo Updates identity", () => {
+    it("passes valid identity fields through the conflict upsert", async () => {
+      const mockUser = createMockUser();
+      mockAuthenticatedUser(mockSupabase, mockUser);
+
+      const { mockUpsert } = mockSuccessfulDeviceRegistration();
+      const updateId = "u".repeat(64);
+      const channel = "c".repeat(64);
+      const runtimeVersion = "r".repeat(64);
+
+      const request = createMockRequest(
+        "POST",
+        "http://localhost:3000/api/devices/upsert",
+        {
+          body: {
+            platform: "ios",
+            device_token: "tok",
+            expo_update_id: updateId,
+            expo_channel: channel,
+            expo_runtime_version: runtimeVersion,
+            expo_is_embedded_launch: false,
+            expo_is_emergency_launch: true,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expo_update_id: updateId,
+          expo_channel: channel,
+          expo_runtime_version: runtimeVersion,
+          expo_is_embedded_launch: false,
+          expo_is_emergency_launch: true,
+        }),
+        { onConflict: "user_id,device_token" },
+      );
+    });
+
+    it("persists explicit null identity fields so stale values can be cleared", async () => {
+      const mockUser = createMockUser();
+      mockAuthenticatedUser(mockSupabase, mockUser);
+
+      const { mockUpsert } = mockSuccessfulDeviceRegistration();
+
+      const request = createMockRequest(
+        "POST",
+        "http://localhost:3000/api/devices/upsert",
+        {
+          body: {
+            platform: "android",
+            device_token: "tok",
+            expo_update_id: null,
+            expo_channel: null,
+            expo_runtime_version: null,
+            expo_is_embedded_launch: null,
+            expo_is_emergency_launch: null,
+          },
+        },
+      );
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expo_update_id: null,
+          expo_channel: null,
+          expo_runtime_version: null,
+          expo_is_embedded_launch: null,
+          expo_is_emergency_launch: null,
+        }),
+        { onConflict: "user_id,device_token" },
+      );
+    });
+
+    it.each([
+      ["expo_update_id", 123],
+      ["expo_channel", false],
+      ["expo_runtime_version", { version: "1.0.0" }],
+      ["expo_is_embedded_launch", "false"],
+      ["expo_is_emergency_launch", 0],
+    ])("rejects invalid %s types", async (field, invalidValue) => {
+      const mockUser = createMockUser();
+      mockAuthenticatedUser(mockSupabase, mockUser);
+
+      const request = createMockRequest(
+        "POST",
+        "http://localhost:3000/api/devices/upsert",
+        {
+          body: {
+            platform: "ios",
+            device_token: "tok",
+            [field]: invalidValue,
+          },
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain(field);
+      expect(data.error).toContain(
+        field.startsWith("expo_is_") ? "boolean" : "string",
+      );
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      "expo_update_id",
+      "expo_channel",
+      "expo_runtime_version",
+    ])("rejects %s values longer than 64 characters", async (field) => {
+      const mockUser = createMockUser();
+      mockAuthenticatedUser(mockSupabase, mockUser);
+
+      const request = createMockRequest(
+        "POST",
+        "http://localhost:3000/api/devices/upsert",
+        {
+          body: {
+            platform: "ios",
+            device_token: "tok",
+            [field]: "x".repeat(65),
+          },
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain(field);
+      expect(data.error).toContain("64 characters");
+      expect(mockSupabase.from).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/migrations/user-devices-expo-update-identity.test.ts
+++ b/__tests__/migrations/user-devices-expo-update-identity.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+describe("user_devices Expo Updates identity migration", () => {
+  const migrationsDir = join(process.cwd(), "supabase", "migrations");
+  const migrationFiles = readdirSync(migrationsDir).filter((name) =>
+    /^\d{14}_add_user_devices_expo_update_identity\.sql$/.test(name),
+  );
+  const migrationSQL = migrationFiles[0]
+    ? readFileSync(join(migrationsDir, migrationFiles[0]), "utf8")
+    : "";
+  const normalizedSQL = migrationSQL.replace(/\s+/g, " ").toLowerCase();
+
+  it("ships one timestamped transactional migration", () => {
+    expect(migrationFiles).toHaveLength(1);
+    expect(migrationSQL.trim().startsWith("BEGIN;")).toBe(true);
+    expect(migrationSQL.trim().endsWith("COMMIT;")).toBe(true);
+  });
+
+  it("adds nullable 64-character Expo Updates text identity columns", () => {
+    expect(normalizedSQL).toContain(
+      "add column if not exists expo_update_id varchar(64)",
+    );
+    expect(normalizedSQL).toContain(
+      "add column if not exists expo_channel varchar(64)",
+    );
+    expect(normalizedSQL).toContain(
+      "add column if not exists expo_runtime_version varchar(64)",
+    );
+    expect(normalizedSQL).not.toMatch(
+      /expo_(update_id|channel|runtime_version) varchar\(64\) not null/,
+    );
+  });
+
+  it("adds nullable Expo Updates launch-state boolean columns", () => {
+    expect(normalizedSQL).toContain(
+      "add column if not exists expo_is_embedded_launch boolean",
+    );
+    expect(normalizedSQL).toContain(
+      "add column if not exists expo_is_emergency_launch boolean",
+    );
+    expect(normalizedSQL).not.toMatch(
+      /expo_is_(embedded|emergency)_launch boolean not null/,
+    );
+  });
+
+  it("includes the Expo Updates fields in generated database types", () => {
+    const generatedTypes = readFileSync(
+      join(process.cwd(), "types", "database.generated.ts"),
+      "utf8",
+    );
+    const userDevicesTypes = generatedTypes.match(
+      /user_devices:\s*\{([\s\S]*?)\n\s*user_email_prefs:/,
+    )?.[1] ?? "";
+
+    expect(userDevicesTypes.match(/expo_update_id/g) ?? []).toHaveLength(3);
+    expect(userDevicesTypes.match(/expo_channel/g) ?? []).toHaveLength(3);
+    expect(userDevicesTypes.match(/expo_runtime_version/g) ?? []).toHaveLength(3);
+    expect(userDevicesTypes.match(/expo_is_embedded_launch/g) ?? []).toHaveLength(3);
+    expect(userDevicesTypes.match(/expo_is_emergency_launch/g) ?? []).toHaveLength(3);
+    expect(userDevicesTypes).toContain("expo_update_id: string | null");
+    expect(userDevicesTypes).toContain("expo_channel: string | null");
+    expect(userDevicesTypes).toContain("expo_runtime_version: string | null");
+    expect(userDevicesTypes).toContain(
+      "expo_is_embedded_launch: boolean | null",
+    );
+    expect(userDevicesTypes).toContain(
+      "expo_is_emergency_launch: boolean | null",
+    );
+  });
+});

--- a/app/api/devices/upsert/route.ts
+++ b/app/api/devices/upsert/route.ts
@@ -34,7 +34,20 @@ function normalizeIanaTimezone(value: unknown): string | null {
  */
 export const POST = withAuth(async (request: NextRequest, { user, supabase }) => {
   const body = await request.json();
-  const { platform, device_token, app_version, build_number, os_version, expo_sdk, timezone } = body;
+  const {
+    platform,
+    device_token,
+    app_version,
+    build_number,
+    os_version,
+    expo_sdk,
+    timezone,
+    expo_update_id,
+    expo_channel,
+    expo_runtime_version,
+    expo_is_embedded_launch,
+    expo_is_emergency_launch,
+  } = body;
 
   if (!platform || !device_token) {
     return NextResponse.json(
@@ -80,14 +93,16 @@ export const POST = withAuth(async (request: NextRequest, { user, supabase }) =>
     );
   }
 
-  // Phase 5l: optional device metadata. Each capped at 32 chars to keep
-  // dashboard/log payloads small. Bad values fail loudly rather than silently
-  // truncating.
-  for (const [field, value] of [
-    ["app_version", app_version],
-    ["build_number", build_number],
-    ["os_version", os_version],
-    ["expo_sdk", expo_sdk],
+  // Optional device metadata is bounded to keep dashboard/log payloads small.
+  // Bad values fail loudly rather than silently truncating.
+  for (const [field, value, maxLength] of [
+    ["app_version", app_version, 32],
+    ["build_number", build_number, 32],
+    ["os_version", os_version, 32],
+    ["expo_sdk", expo_sdk, 32],
+    ["expo_update_id", expo_update_id, 64],
+    ["expo_channel", expo_channel, 64],
+    ["expo_runtime_version", expo_runtime_version, 64],
   ] as const) {
     if (value !== undefined && value !== null) {
       if (typeof value !== "string") {
@@ -102,16 +117,32 @@ export const POST = withAuth(async (request: NextRequest, { user, supabase }) =>
       }
       const normalizedValue = value.trim();
       if (normalizedValue.length === 0) continue;
-      if (normalizedValue.length > 32) {
+      if (normalizedValue.length > maxLength) {
         return NextResponse.json(
           {
             success: false,
-            error: `${field} exceeds maximum length of 32 characters`,
+            error: `${field} exceeds maximum length of ${maxLength} characters`,
             timestamp: new Date().toISOString(),
           },
           { status: 400 }
         );
       }
+    }
+  }
+
+  for (const [field, value] of [
+    ["expo_is_embedded_launch", expo_is_embedded_launch],
+    ["expo_is_emergency_launch", expo_is_emergency_launch],
+  ] as const) {
+    if (value !== undefined && value !== null && typeof value !== "boolean") {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `${field} must be a boolean`,
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 }
+      );
     }
   }
 
@@ -145,6 +176,27 @@ export const POST = withAuth(async (request: NextRequest, { user, supabase }) =>
   if (normalizedOsVersion) upsertRow.os_version = normalizedOsVersion;
   if (normalizedExpoSdk) upsertRow.expo_sdk = normalizedExpoSdk;
   if (normalizedTimezone) upsertRow.timezone = normalizedTimezone;
+
+  for (const [field, value] of [
+    ["expo_update_id", expo_update_id],
+    ["expo_channel", expo_channel],
+    ["expo_runtime_version", expo_runtime_version],
+  ] as const) {
+    if (value === null) {
+      upsertRow[field] = null;
+      continue;
+    }
+
+    const normalizedValue = normalizeOptionalMetadata(value);
+    if (normalizedValue) upsertRow[field] = normalizedValue;
+  }
+
+  for (const [field, value] of [
+    ["expo_is_embedded_launch", expo_is_embedded_launch],
+    ["expo_is_emergency_launch", expo_is_emergency_launch],
+  ] as const) {
+    if (value !== undefined) upsertRow[field] = value;
+  }
 
   const { error: upsertError } = await supabase
     .from("user_devices")

--- a/supabase/migrations/20260715175514_add_user_devices_expo_update_identity.sql
+++ b/supabase/migrations/20260715175514_add_user_devices_expo_update_identity.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+ALTER TABLE public.user_devices
+  ADD COLUMN IF NOT EXISTS expo_update_id varchar(64),
+  ADD COLUMN IF NOT EXISTS expo_channel varchar(64),
+  ADD COLUMN IF NOT EXISTS expo_runtime_version varchar(64),
+  ADD COLUMN IF NOT EXISTS expo_is_embedded_launch boolean,
+  ADD COLUMN IF NOT EXISTS expo_is_emergency_launch boolean;
+
+COMMENT ON COLUMN public.user_devices.expo_update_id IS
+  'Optional non-secret Expo Updates update ID reported by the native client.';
+COMMENT ON COLUMN public.user_devices.expo_channel IS
+  'Optional Expo Updates channel reported by the native client.';
+COMMENT ON COLUMN public.user_devices.expo_runtime_version IS
+  'Optional Expo Updates runtime version reported by the native client.';
+COMMENT ON COLUMN public.user_devices.expo_is_embedded_launch IS
+  'Whether the native client launched the update embedded in the binary.';
+COMMENT ON COLUMN public.user_devices.expo_is_emergency_launch IS
+  'Whether Expo Updates reported an emergency launch.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/types/database.generated.ts
+++ b/types/database.generated.ts
@@ -9247,7 +9247,12 @@ export type Database = {
           build_number: string | null
           created_at: string
           device_token: string
+          expo_channel: string | null
+          expo_is_embedded_launch: boolean | null
+          expo_is_emergency_launch: boolean | null
+          expo_runtime_version: string | null
           expo_sdk: string | null
+          expo_update_id: string | null
           id: string
           os_version: string | null
           platform: string
@@ -9260,7 +9265,12 @@ export type Database = {
           build_number?: string | null
           created_at?: string
           device_token: string
+          expo_channel?: string | null
+          expo_is_embedded_launch?: boolean | null
+          expo_is_emergency_launch?: boolean | null
+          expo_runtime_version?: string | null
           expo_sdk?: string | null
+          expo_update_id?: string | null
           id?: string
           os_version?: string | null
           platform: string
@@ -9273,7 +9283,12 @@ export type Database = {
           build_number?: string | null
           created_at?: string
           device_token?: string
+          expo_channel?: string | null
+          expo_is_embedded_launch?: boolean | null
+          expo_is_emergency_launch?: boolean | null
+          expo_runtime_version?: string | null
           expo_sdk?: string | null
+          expo_update_id?: string | null
           id?: string
           os_version?: string | null
           platform?: string


### PR DESCRIPTION
## Summary

Deploy the already-reviewed Expo Updates identity contract to the production backend so native device registrations can persist the five non-secret update identity fields required by Quiver #420 and quiver-native #29.

## Surface

- `app/api/devices/upsert/route.ts`
- `public.user_devices` migration ledger/types
- device upsert and migration regression tests

The production database migration `20260715175514_add_user_devices_expo_update_identity` was already applied through the approved production migration protocol and verified. This PR deploys the matching API contract and commits the canonical migration file into the `prod` branch history.

## Behavior

- Accepts bounded optional `expo_update_id`, `expo_channel`, and `expo_runtime_version` strings.
- Accepts optional embedded/emergency launch booleans.
- Preserves omitted values and permits explicit-null clearing.
- Keeps older native payloads backward-compatible.
- Rejects invalid types and over-limit strings with HTTP 400.

## Local verification

- `yarn typecheck` — passed.
- Focused Jest: 4 suites / 58 tests — passed.
- Full Jest: 1,181 suites / 16,004 tests passed; 16 suites and 195 tests skipped; 1 todo.
- Scoped ESLint with `--max-warnings=0` — passed.
- `VERCEL_ENV=preview yarn build` — passed.
- `git diff --check origin/prod...HEAD` — passed.
- E2E: reviewed but not run; this is an authenticated API/schema-only release slice with no browser UI change.

## Production impact

Merging this PR deploys the production web backend. It performs no new database migration, environment-variable change, TestFlight submission, Expo OTA, or feature-flag change. After deployment, a real native registration must verify all five values are stored before #420 is closed.

Refs #420
Native: SteveChandler/quiver-native#29