### PR TITLE
fix(release): complete sitemap coverage and landing media budget

### DIFF
--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -216,7 +216,7 @@ describe("Sitemap Generation", () => {
       expect(route).not.toBeUndefined();
     });
 
-    it("includes acquisition hubs and keeps utility or campaign routes out", async () => {
+    it("includes indexable public routes and keeps campaign routes out", async () => {
       const result = await sitemap();
       const routesByUrl = new Map(
         result.map((route) => [route.url, route] as const),
@@ -235,8 +235,12 @@ describe("Sitemap Generation", () => {
         routesByUrl.get(`${baseUrl}/us-open-of-surfing-forecast`)
           ?.lastModified,
       ).toBe("2026-07-23");
-      expect(routesByUrl.has(`${baseUrl}/support`)).toBe(false);
-      expect(routesByUrl.has(`${baseUrl}/data-deletion`)).toBe(false);
+      expect(routesByUrl.get(`${baseUrl}/support`)?.lastModified).toBe(
+        "2026-06-25",
+      );
+      expect(
+        routesByUrl.get(`${baseUrl}/data-deletion`)?.lastModified,
+      ).toBe("2026-06-25");
       expect(routesByUrl.has(`${baseUrl}/pbsc`)).toBe(false);
     });
 

--- a/__tests__/components/field-guide/quiver-field-guide-landing.test.tsx
+++ b/__tests__/components/field-guide/quiver-field-guide-landing.test.tsx
@@ -182,9 +182,10 @@ describe("QuiverFieldGuideLanding", () => {
         "src",
         "/videos/quiver-landing-hero-720.mp4",
       );
-      expect(video).toHaveAttribute(
-        "poster",
-        "/images/hero/quiver-landing-hero-poster.jpg",
+      expect(video).not.toHaveAttribute("poster");
+      expect(media.querySelector("img")).toHaveAttribute(
+        "src",
+        expect.stringContaining("/images/hero/quiver-landing-hero-poster.jpg"),
       );
     } finally {
       window.matchMedia = originalMatchMedia;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,12 +68,6 @@ export default async function Home(): Promise<ReactElement> {
 
   return (
     <>
-      <link
-        rel="preload"
-        as="image"
-        href="/images/hero/quiver-landing-hero-poster.jpg"
-        type="image/jpeg"
-      />
       <Suspense>
         <AuthAwareLandingWrapper
           initialPlatform={initialPlatform}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -59,6 +59,8 @@ const SITEMAP_ACQUISITION_ROUTES = [
   { path: "/download", lastModified: "2026-07-15" },
   { path: "/android-beta", lastModified: "2026-07-22" },
   { path: "/guides", lastModified: "2026-06-25" },
+  { path: "/support", lastModified: "2026-06-25" },
+  { path: "/data-deletion", lastModified: "2026-06-25" },
   { path: "/us-open-of-surfing-forecast", lastModified: "2026-07-23" },
 ] as const;
 

--- a/components/landing-page/field-guide/field-guide-hero-video.tsx
+++ b/components/landing-page/field-guide/field-guide-hero-video.tsx
@@ -40,6 +40,14 @@ export function FieldGuideHeroVideo(): ReactElement {
       className="halftone-photo relative aspect-video w-full overflow-hidden bg-[#C8C2B0]"
       data-testid="field-guide-hero-video"
     >
+      <Image
+        src={HERO_POSTER_SRC}
+        alt={showVideo ? "" : "Quiver app launch video preview"}
+        fill
+        priority
+        sizes="(min-width: 1024px) 470px, (min-width: 768px) 430px, 100vw"
+        className="object-cover"
+      />
       {showVideo ? (
         <video
           src={HERO_VIDEO_SRC}
@@ -49,28 +57,17 @@ export function FieldGuideHeroVideo(): ReactElement {
           controls={userRequestedVideo}
           playsInline
           preload={canAutoplay ? "metadata" : "none"}
-          poster={HERO_POSTER_SRC}
           aria-label="Quiver app launch video preview"
           className="absolute inset-0 h-full w-full object-cover"
         />
       ) : (
-        <>
-          <Image
-            src={HERO_POSTER_SRC}
-            alt="Quiver app launch video preview"
-            fill
-            priority
-            sizes="(min-width: 1024px) 470px, (min-width: 768px) 430px, 100vw"
-            className="object-cover"
-          />
-          <button
-            type="button"
-            onClick={() => setUserRequestedVideo(true)}
-            className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 border-2 border-[#11100D] bg-[#F4EBD8] px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_3px_0_rgba(17,16,13,0.2)] transition-transform hover:scale-[1.02] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0B3A75]"
-          >
-            Play demo
-          </button>
-        </>
+        <button
+          type="button"
+          onClick={() => setUserRequestedVideo(true)}
+          className="absolute left-1/2 top-1/2 z-10 -translate-x-1/2 -translate-y-1/2 border-2 border-[#11100D] bg-[#F4EBD8] px-4 py-2 font-mono text-xs font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_3px_0_rgba(17,16,13,0.2)] transition-transform hover:scale-[1.02] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0B3A75]"
+        >
+          Play demo
+        </button>
       )}
       <div className="absolute bottom-1.5 right-1.5 z-10 border border-[#11100D] bg-[#F4EBD8]/85 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-[#11100D]">
         Live now

--- a/e2e/ARCHITECTURE.md
+++ b/e2e/ARCHITECTURE.md
@@ -572,10 +572,12 @@ Files with `@infra` tests: `push-notifications.spec.ts`, `rate-limiting.spec.ts`
 `guest-landing-media-budget.spec.ts` protects the unauthenticated landing
 page's first-load media contract at desktop (1440×900) and mobile (390×844)
 viewports. Each viewport may make at most five landing media requests: the
-optimized hero poster, the poster used by the video element, the
-`local-intel-720.webp` screenshot, and up to two byte-range requests for the
-720p hero video. The same spec proves reduced-motion and Save-Data sessions
-render the poster/play control without requesting the autoplay video.
+optimized hero poster preload/image pair, the `local-intel-720.webp`
+screenshot, and up to two byte-range requests for the 720p hero video. The
+poster remains behind the video as its loading fallback, so the video element
+does not request a second unoptimized poster asset. The same spec proves
+reduced-motion and Save-Data sessions render the poster/play control without
+requesting the autoplay video.
 
 Update this budget only when a measured landing change intentionally adds or
 replaces first-load media. Legacy screenshot PNGs and the 1280p hero video are


### PR DESCRIPTION
## User-visible change

- Adds canonical, indexable `/support` and `/data-deletion` pages to the XML sitemap, completing #400's include-or-noindex contract.
- Removes the redundant raw hero-poster preload from `/`.
- Keeps the optimized Next/Image poster behind the autoplay video as its loading fallback, so the video does not request the same poster again as an unoptimized asset.

## Touched surfaces

- `app/sitemap.ts`
- `app/page.tsx`
- `components/landing-page/field-guide/field-guide-hero-video.tsx`
- related Jest expectations and E2E architecture documentation

No database migrations, environment changes, feature-flag changes, onboarding changes, native/OTA changes, or notification sends.

## Verification

Exact head `e7b54d41d7542eb7386d5188568bceef6f03c317`:

- Focused sitemap and field-guide Jest suites — passed (78/78 initially; final field-guide rerun 11/11).
- Scoped ESLint for all changed TypeScript and the media-budget E2E — passed with zero warnings/errors.
- `yarn typecheck` — passed after the final implementation.
- `VERCEL_ENV=preview yarn build` — passed after the final implementation; only the known Waimea dynamic-server-usage warnings were emitted.
- `BASE_URL=http://localhost:3000 npx playwright test e2e/guest-landing-media-budget.spec.ts --project=guest --workers=1 --retries=0 --repeat-each=5` — 20/20 passed, including five consecutive desktop media-budget checks.
- `yarn test:unit --bail=0` — passed after the final implementation: 1,218 suites / 16,292 tests passed; 16 suites / 195 tests skipped; 1 todo; 3 snapshots passed.
- `git diff --check` and all three commit secret scans — passed.

## Production evidence that prompted the patch

On production release `76beb458360adc1f7767f4824a8cca0d6adf01ed`:
- sitemap had 365 unique URLs, 365 `lastmod`, zero `changefreq`, zero `priority`;
- `/support` and `/data-deletion` returned canonical 200 pages with `robots: index, follow` but were absent from the sitemap;
- desktop smoke observed six first-load media request events against the budget of five.

The first patch removed duplicate explicit preloads. Exact-preview repetition then exposed a second intermittent request: the hydrated video fetched the raw poster after the optimized poster preload/image pair. The final implementation removes that second asset request while preserving the poster visually behind the video.

## Post-merge acceptance

Wait for the production deployment, then verify:
- `/support` and `/data-deletion` are present in `sitemap.xml`;
- `/pbsc` remains noindex and absent;
- `/pricing` remains a redirect and absent;
- `changefreq`/`priority` remain absent;
- production guest smoke is 24/24.

Closes #400 only after live verification. #402 was closed after the prior production sitemap audit passed its metadata contract.