### PR TITLE
fix(recommendations): restore Week Scout ranking parity

### DIFF
--- a/__tests__/api/surf/discover.test.ts
+++ b/__tests__/api/surf/discover.test.ts
@@ -99,6 +99,7 @@ function makeDiscoveryResponse() {
   return {
     recommendations: [
       {
+        recommendationId: "primary-recommendation",
         kind: "custom_spot",
         customSpotId: "custom-spot-contract-id",
         visibility: "public",
@@ -174,6 +175,7 @@ function makeDiscoveryResponse() {
     ],
     includedRecommendations: [
       {
+        recommendationId: "included-recommendation",
         kind: "beach",
         customSpotId: null,
         visibility: null,
@@ -733,9 +735,65 @@ describe("/api/surf/discover entitlement resolution", () => {
           state: "available",
           holdEpoch: "route-epoch",
         },
-        recommendations: [expect.any(Object)],
+        recommendations: [expect.any(Object), expect.any(Object)],
       }),
     );
+  });
+
+  it("builds the Home decision from the deduped returned primary and included ranking pool", async () => {
+    const discovery = makeDiscoveryResponse();
+    discovery.includedRecommendations = [
+      {
+        ...discovery.includedRecommendations[0],
+        recommendationId: "shared-recommendation",
+      },
+      {
+        ...discovery.includedRecommendations[0],
+        recommendationId: "included-recommendation",
+      },
+    ];
+    discovery.recommendations = [
+      {
+        ...discovery.recommendations[0],
+        recommendationId: "shared-recommendation",
+      },
+    ];
+    mockDiscoverSurfSpots.mockResolvedValue(discovery);
+    mockBuildCanonicalDecisionFromSurfDiscovery.mockImplementationOnce(
+      ({ recommendations }) => ({
+        schemaVersion: "canonical-session-decision.v1",
+        engineVersion: "rules.v1",
+        decisionId: "b".repeat(64),
+        verdict: recommendations.length > 0 ? "go" : "no",
+        decisionBasis: "physical_conditions",
+        reasonCode: recommendations.length > 0 ? "recommended" : "no_candidates",
+        selection: recommendations.length > 0
+          ? { candidateId: recommendations[0].recommendationId }
+          : null,
+      }),
+    );
+
+    const response = await callDiscoverRoute({
+      is_pro: true,
+      is_trialing: false,
+      billing_issue: false,
+      expires_at: null,
+    });
+    const body = await response.json();
+
+    expect(mockBuildCanonicalDecisionFromSurfDiscovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recommendations: [
+          expect.objectContaining({ recommendationId: "shared-recommendation" }),
+          expect.objectContaining({ recommendationId: "included-recommendation" }),
+        ],
+      }),
+    );
+    expect(body.data.sessionDecision).toMatchObject({
+      verdict: "go",
+      reasonCode: "recommended",
+    });
+    expect(body.data.sessionDecision.reasonCode).not.toBe("no_candidates");
   });
 
   it("preserves recommendation discriminator metadata in the route response", async () => {

--- a/__tests__/app/api/surf-week-scout-route.test.ts
+++ b/__tests__/app/api/surf-week-scout-route.test.ts
@@ -23,7 +23,7 @@ jest.mock(
 );
 
 import { NextRequest } from 'next/server';
-import { POST } from '@/app/api/surf/week-scout/route';
+import { maxDuration, POST } from '@/app/api/surf/week-scout/route';
 
 const BEACH_A = '11111111-1111-4111-8111-111111111111';
 const BEACH_B = '22222222-2222-4222-8222-222222222222';
@@ -56,6 +56,10 @@ describe('POST /api/surf/week-scout', () => {
     });
   });
 
+  it('allows enough runtime for the full no-limit candidate pool', () => {
+    expect(maxDuration).toBe(60);
+  });
+
   it('deduplicates candidate IDs and returns the exact private no-store response', async () => {
     const response = await callRoute({
       candidateBeachIds: [BEACH_B, BEACH_A, BEACH_B],
@@ -79,7 +83,7 @@ describe('POST /api/surf/week-scout', () => {
     );
   });
 
-  it('accepts legacy requests but evaluates only the first eight unique candidates in order', async () => {
+  it('evaluates the full bounded candidate pool in caller order', async () => {
     const candidateBeachIds = Array.from({ length: 12 }, (_, index) => (
       `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
     ));
@@ -95,7 +99,7 @@ describe('POST /api/surf/week-scout', () => {
     expect(mockGenerateWeekScoutForecast).toHaveBeenCalledWith(
       'user-week-scout',
       expect.objectContaining({
-        candidateBeachIds: candidateBeachIds.slice(0, 8),
+        candidateBeachIds,
       }),
     );
   });
@@ -126,8 +130,8 @@ describe('POST /api/surf/week-scout', () => {
     expect(mockGenerateWeekScoutForecast).not.toHaveBeenCalled();
   });
 
-  it('rejects more than 30 unique candidate IDs', async () => {
-    const candidateBeachIds = Array.from({ length: 31 }, (_, index) => (
+  it('rejects more than 100 unique candidate IDs', async () => {
+    const candidateBeachIds = Array.from({ length: 101 }, (_, index) => (
       `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
     ));
 
@@ -179,6 +183,7 @@ describe('POST /api/surf/week-scout', () => {
             },
           ],
           bestWindowId: null,
+          exclusionReasons: [],
         },
       ],
       recommendationAvailability: {

--- a/__tests__/lib/domains/user-preferences/skill-level.test.ts
+++ b/__tests__/lib/domains/user-preferences/skill-level.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  parseBeachSkillRequirement,
   parseSkillLevel,
   getSkillLevelOrDefault,
   DEFAULT_SKILL_LEVEL,
@@ -67,6 +68,32 @@ describe('Skill Level Utilities', () => {
       expect(parseSkillLevel('  intermediate  ')).toBe('intermediate');
       expect(parseSkillLevel('\tadvanced\t')).toBe('advanced');
       expect(parseSkillLevel('\n expert \n')).toBe('expert');
+    });
+  });
+
+  describe('parseBeachSkillRequirement', () => {
+    it.each([
+      ['all', 'beginner'],
+      ['beginner-intermediate', 'intermediate'],
+      ['lower-intermediate', 'intermediate'],
+      ['intermediate-advanced', 'advanced'],
+      ['upper-intermediate', 'intermediate'],
+      ['beginner', 'beginner'],
+      ['expert', 'expert'],
+    ] as const)('normalizes %s to %s', (value, expected) => {
+      expect(parseBeachSkillRequirement(value)).toBe(expected);
+    });
+
+    it.each(['all-levels', 'advanced-expert', 'novice', '', '   '])(
+      'keeps unknown beach requirement %p unresolved',
+      (value) => {
+        expect(parseBeachSkillRequirement(value)).toBeNull();
+      },
+    );
+
+    it('does not broaden profile skill parsing', () => {
+      expect(parseSkillLevel('beginner-intermediate')).toBeNull();
+      expect(parseSkillLevel('intermediate-advanced')).toBeNull();
     });
   });
 

--- a/__tests__/lib/recommendations/canonical-decision/engine.test.ts
+++ b/__tests__/lib/recommendations/canonical-decision/engine.test.ts
@@ -591,6 +591,37 @@ describe("canonical session decision engine", () => {
     });
   });
 
+  it.each([
+    ["all", "beginner"],
+    ["beginner-intermediate", "intermediate"],
+    ["lower-intermediate", "intermediate"],
+    ["intermediate-advanced", "advanced"],
+    ["upper-intermediate", "intermediate"],
+  ])(
+    "accepts the canonical %s beach requirement for a %s surfer",
+    (beachSkillLevel, profileExperience) => {
+      const { buildCanonicalSessionDecision } = loadEngine();
+      const decision = buildCanonicalSessionDecision(
+        input(
+          [candidate({ beachSkillLevel })],
+          { profileExperience },
+        ),
+      ) as {
+        verdict: string;
+        reasonCode: string;
+        selection: { beachId: string } | null;
+        skillEligibility: { reasonCodes: string[] };
+      };
+
+      expect(decision.verdict).toBe("go");
+      expect(decision.reasonCode).toBe("selected_go");
+      expect(decision.selection?.beachId).toBe("blackies");
+      expect(decision.skillEligibility.reasonCodes).not.toContain(
+        "missing_beach_skill",
+      );
+    },
+  );
+
   it("preserves a P0-A explicit-none hold over every positive candidate", () => {
     const { buildCanonicalSessionDecision } = loadEngine();
     const decision = buildCanonicalSessionDecision(

--- a/__tests__/lib/recommendations/major-event-hold/adapters.test.ts
+++ b/__tests__/lib/recommendations/major-event-hold/adapters.test.ts
@@ -353,6 +353,7 @@ const weekScoutFixture: WeekScoutResponse = {
     {
       localDate: "2026-07-19",
       bestWindowId: "window-primary",
+      exclusionReasons: [],
       windows: [
         {
           id: "window-primary",
@@ -2078,6 +2079,7 @@ describe("major-event hold adapters", () => {
       reasonCode: "major_event_hold",
     });
     expect(result.days[0].bestWindowId).toBeNull();
+    expect(result.days[0].exclusionReasons).toEqual([]);
     expect(result.days[0].windows).toHaveLength(2);
     for (const window of result.days[0].windows) {
       expect(window.conditionScore).toBeNull();
@@ -2141,6 +2143,53 @@ describe("major-event hold adapters", () => {
     expect(result.days[0].windows[1]).toEqual({
       ...input.days[0].windows[1],
       rankedSpots: [input.days[0].windows[1].rankedSpots[1]],
+    });
+  });
+
+  it("marks only the fully held day when another day keeps the response available", () => {
+    const firstDay = structuredClone(weekScoutFixture.days[0]);
+    const secondDay = structuredClone(weekScoutFixture.days[0]);
+    secondDay.localDate = "2026-07-20";
+    secondDay.bestWindowId = "window-primary-day-two";
+    secondDay.windows = secondDay.windows.map((window) => ({
+      ...window,
+      id: `${window.id}-day-two`,
+      start: window.start.replace("2026-07-19", "2026-07-20"),
+      end: window.end.replace("2026-07-19", "2026-07-20"),
+      peakTime: window.peakTime.replace("2026-07-19", "2026-07-20"),
+    }));
+    const input: WeekScoutResponse = {
+      ...structuredClone(weekScoutFixture),
+      days: [firstDay, secondDay],
+    };
+    const candidates = input.days.flatMap((day) =>
+      day.windows.map((window) =>
+        candidate(window.id, window.beachId, window.start, window.end),
+      ),
+    );
+
+    const result = sanitizeWeekScoutForMajorEventHold(
+      deepFreeze(input),
+      candidates,
+      [
+        decision("window-primary", "blocked"),
+        decision("window-included", "blocked"),
+        decision("window-primary-day-two", "allow"),
+        decision("window-included-day-two", "allow"),
+      ],
+    );
+
+    expect(result.recommendationAvailability).toEqual({
+      state: "available",
+      holdEpoch: EPOCH,
+    });
+    expect(result.days[0]).toMatchObject({
+      bestWindowId: null,
+      exclusionReasons: ["major_event_hold"],
+    });
+    expect(result.days[1]).toMatchObject({
+      bestWindowId: "window-primary-day-two",
+      exclusionReasons: [],
     });
   });
 

--- a/__tests__/lib/services/discovery/surf-discovery-orchestrator.test.ts
+++ b/__tests__/lib/services/discovery/surf-discovery-orchestrator.test.ts
@@ -587,6 +587,69 @@ describe('discoverSurfSpots - Hotfix Candidate Boundaries', () => {
     );
   });
 
+  it.each(['best-window', 'now'] as const)(
+    'keeps the bounded %s pool distance-ordered without starving nearby candidates',
+    async (discoveryMode) => {
+      const nearbyCandidates = Array.from({ length: 12 }, (_, index) => ({
+        ...mockBeach1,
+        id: `nearby-${index + 1}`,
+        name: `Nearby ${index + 1}`,
+        lat: userLocation.lat + (index + 1) * 0.001,
+        lon: userLocation.lon,
+      })) as Beach[];
+      const includedCandidates = Array.from({ length: 8 }, (_, index) => ({
+        ...mockBeach4,
+        id: `included-${index + 1}`,
+        name: `Included ${index + 1}`,
+        lat: userLocation.lat + (index + 1) * 0.0001,
+        lon: userLocation.lon,
+      })) as Beach[];
+      const customNearestBeach = {
+        ...mockBeach4,
+        id: 'custom-nearest',
+        name: 'Custom Nearest',
+        lat: userLocation.lat + 0.00005,
+        lon: userLocation.lon,
+      } as Beach;
+
+      mockState.candidatePoolResponse.candidates = nearbyCandidates;
+      mockState.includedBeachRows = [...includedCandidates, customNearestBeach];
+      mockState.customSpots = Array.from({ length: 4 }, (_, index) =>
+        customSpotRow({
+          id: `custom-${index + 1}`,
+          userId: 'candidate-limit-user',
+          name: `Custom ${index + 1}`,
+          visibility: 'private',
+          nearestBeachId: customNearestBeach.id,
+        }),
+      );
+
+      await discoverSurfSpots('candidate-limit-user', {
+        userLocation,
+        candidatePoolLimit: 8,
+        maxResults: 10,
+        discoveryMode,
+        includeBeachIds: includedCandidates.map((beach) => beach.id),
+      });
+
+      const { batchFetchForecasts } = require(
+        '@/lib/services/discovery/forecast-batch-fetcher',
+      );
+      const fetchedCandidates = batchFetchForecasts.mock.calls[0][0] as Beach[];
+      expect(fetchedCandidates).toHaveLength(8);
+      expect(fetchedCandidates.map((beach) => beach.id)).toEqual(
+        nearbyCandidates.slice(0, 8).map((beach) => beach.id),
+      );
+      expect(new Set(fetchedCandidates.map((beach) => beach.id)).size).toBe(8);
+      const fetchedLatitudes = fetchedCandidates.map((beach) => beach.lat);
+      expect(fetchedLatitudes).toEqual(
+        [...fetchedLatitudes].sort(
+          (left, right) => (left ?? 0) - (right ?? 0),
+        ),
+      );
+    },
+  );
+
   it('marks a successful empty candidate lookup as no_candidates', async () => {
     mockState.candidatePoolResponse.candidates = [];
 

--- a/__tests__/lib/services/discovery/week-scout.test.ts
+++ b/__tests__/lib/services/discovery/week-scout.test.ts
@@ -208,7 +208,7 @@ describe('generateWeekScoutForecast', () => {
     ).rejects.toThrow(/dayCount/i);
   });
 
-  it('returns one canonical weekly session while preserving every physical forecast window', async () => {
+  it('retains every daily ranking while adding one supplemental canonical weekly session', async () => {
     const deps = dependencies();
     const response = await generateWeekScoutForecast(
       'user-week-scout',
@@ -249,11 +249,17 @@ describe('generateWeekScoutForecast', () => {
       },
     });
     const selectedId = response.sessionDecision.selection?.candidateId;
-    const visibleDecisions = response.days.flatMap((day) =>
-      day.windows.filter((window) => window.verdict !== null),
-    );
-    expect(visibleDecisions).toHaveLength(1);
-    expect(visibleDecisions[0]?.id).toBe(selectedId);
+    const visibleDecisions = response.days.flatMap((day) => day.windows);
+    expect(visibleDecisions).toHaveLength(6);
+    expect(visibleDecisions.every((window) => (
+      window.verdict !== null
+      && window.conditionScore !== null
+      && window.rankingScore !== null
+      && window.rideable !== null
+      && window.safe !== null
+      && window.takeaway !== null
+      && window.rankedSpots.length > 0
+    ))).toBe(true);
     expect(
       response.days.flatMap((day) => day.windows).every((window) => (
         window.forecast.waveHeight === '3.5'
@@ -269,23 +275,80 @@ describe('generateWeekScoutForecast', () => {
       beachId: BEACH_B,
       bucket: 'morning',
       verdict: 'worth_it',
-      conditionScore: null,
-      rankingScore: null,
-      rideable: null,
-      safe: null,
+      conditionScore: 84,
+      rankingScore: 88,
+      rideable: true,
+      safe: true,
       forecast: {
         tideHeightFt: 1.4,
         tidePhase: 'Rising',
         freshnessAt: '2026-07-31T13:30:00.000Z',
       },
-      takeaway: null,
-      rankedSpots: [],
+      takeaway: 'Clean wind and solid period',
+      rankedSpots: expect.arrayContaining([
+        expect.objectContaining({ beachId: BEACH_A }),
+        expect.objectContaining({ beachId: BEACH_B }),
+      ]),
     });
     expect(firstDay.bestWindowId).toBe(selectedId);
     expect(response.days.slice(1).every((day) => day.bestWindowId === null)).toBe(true);
+    expect(firstDay.exclusionReasons).toEqual([]);
+    expect(response.days.slice(1).every((day) => (
+      day.exclusionReasons.length === 1
+      && day.exclusionReasons[0] === 'no_forecasts'
+    ))).toBe(true);
 
     expect(deps.selectBestWindow).toHaveBeenCalledTimes(6);
     expect(deps.rankWindows).toHaveBeenCalledTimes(3);
+  });
+
+  it('scores a broad drive-range pool but returns only eight ranked windows per bucket', async () => {
+    const candidates = Array.from({ length: 10 }, (_, index) => beach(
+      `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+      `Beach ${index + 1}`,
+    ));
+    const deps = dependencies();
+    deps.fetchBeaches = jest.fn(async () => candidates);
+    deps.fetchForecasts = jest.fn(async () => new Map(
+      candidates.map((candidate) => [
+        candidate.id,
+        [
+          forecast(candidate.id, '2026-07-31T16:00:00.000Z'),
+          forecast(candidate.id, '2026-07-31T20:00:00.000Z'),
+          forecast(candidate.id, '2026-08-01T00:00:00.000Z'),
+        ],
+      ]),
+    ));
+
+    const response = await generateWeekScoutForecast(
+      'user-week-scout',
+      {
+        candidateBeachIds: candidates.map((candidate) => candidate.id),
+        localTimezone: 'Pacific/Honolulu',
+        startLocalDate: '2026-07-31',
+        dayCount: 7,
+      },
+      deps,
+    );
+
+    expect(mockEvaluateMajorEventHoldCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidates: expect.any(Array),
+      }),
+    );
+    const evaluatedCandidates = mockEvaluateMajorEventHoldCandidates.mock.calls.at(-1)?.[0]
+      .candidates as unknown[];
+    expect(deps.fetchBeaches).toHaveBeenCalledWith(
+      candidates.map((candidate) => candidate.id),
+    );
+    expect(evaluatedCandidates).toHaveLength(30);
+    expect(response.days[0].windows).toHaveLength(24);
+    expect(response.days[0].windows.every((window) => (
+      window.rankedSpots.length <= 8
+    ))).toBe(true);
+    expect(response.days[0].windows.some((window) => (
+      window.id === response.days[0].bestWindowId
+    ))).toBe(true);
   });
 
   it('generates the same candidate fingerprint regardless of input order', async () => {
@@ -334,7 +397,7 @@ describe('generateWeekScoutForecast', () => {
         distancePenalty: 0,
       },
       reasons: ['Powerful swell'],
-      warnings: ['Waves are above your usual range'],
+      warnings: [],
     }));
 
     const response = await generateWeekScoutForecast(
@@ -354,14 +417,74 @@ describe('generateWeekScoutForecast', () => {
       selection: null,
     });
     expect(response.days[0].windows[0]).toMatchObject({
-      verdict: null,
-      rideable: null,
-      safe: null,
+      verdict: 'worth_it',
+      rideable: false,
+      safe: true,
       forecast: {
         waveHeight: '20',
       },
     });
     expect(response.days[0].bestWindowId).toBeNull();
+    expect(response.days[0].exclusionReasons).toEqual(['no_rideable_windows']);
+  });
+
+  it('explains when every generated window is unsafe', async () => {
+    const deps = dependencies();
+    deps.scoreBeach = jest.fn(() => ({
+      total: 82,
+      matchQuality: 'excellent',
+      subscores: {
+        waveHeightFit: 22,
+        periodEnergyScore: 18,
+        windAlignment: 19,
+        tideFit: 14,
+        affinityBonus: 0,
+        personalizationBonus: 0,
+        distancePenalty: 0,
+      },
+      reasons: ['Strong conditions'],
+      warnings: ['Unsafe hazard at this beach'],
+    }));
+
+    const response = await generateWeekScoutForecast(
+      'user-week-scout',
+      {
+        candidateBeachIds: [BEACH_A],
+        localTimezone: 'Pacific/Honolulu',
+        startLocalDate: '2026-07-31',
+        dayCount: 7,
+      },
+      deps,
+    );
+
+    expect(response.days[0].bestWindowId).toBeNull();
+    expect(response.days[0].exclusionReasons).toEqual(['no_safe_windows']);
+  });
+
+  it('explains when safe rideable windows all have skip verdicts', async () => {
+    const deps = dependencies();
+    deps.scoreWindowCondition = jest.fn(() => 30);
+
+    const response = await generateWeekScoutForecast(
+      'user-week-scout',
+      {
+        candidateBeachIds: [BEACH_A],
+        localTimezone: 'Pacific/Honolulu',
+        startLocalDate: '2026-07-31',
+        dayCount: 7,
+      },
+      deps,
+    );
+
+    expect(response.days[0].windows[0]).toMatchObject({
+      safe: true,
+      rideable: true,
+      verdict: 'skip',
+    });
+    expect(response.days[0].bestWindowId).toBeNull();
+    expect(response.days[0].exclusionReasons).toEqual([
+      'no_recommendable_windows',
+    ]);
   });
 
   it('evaluates exact generated windows with the verified profile skill', async () => {
@@ -429,6 +552,7 @@ describe('generateWeekScoutForecast', () => {
     const firstWindow = response.days[0].windows[0];
 
     expect(response.days[0].bestWindowId).toBeNull();
+    expect(response.days[0].exclusionReasons).toEqual([]);
     expect(firstWindow).toMatchObject({
       beachId: expect.any(String),
       start: expect.any(String),
@@ -473,6 +597,7 @@ describe('generateWeekScoutForecast', () => {
     expect(response.days[0].windows[0].forecast.waveHeight).toBe('3.5');
     expect(response.days[0].windows[0].conditionScore).toBeNull();
     expect(response.days[0].bestWindowId).toBeNull();
+    expect(response.days[0].exclusionReasons).toEqual([]);
     expect(response.recommendationAvailability).toMatchObject({
       state: 'none',
       reasonCode: 'hold_state_unavailable',

--- a/__tests__/lib/services/discovery/weekend-scout.test.ts
+++ b/__tests__/lib/services/discovery/weekend-scout.test.ts
@@ -73,8 +73,18 @@ function forecast(windows: WeekScoutWindowResponse[]): MajorEventHoldWeekScoutRe
     scorerVersion: 'week-scout-v1:discovery-hero-v1',
     candidateFingerprint: 'fingerprint',
     days: [
-      { localDate: '2026-07-25', windows, bestWindowId: windows[0]?.id ?? null },
-      { localDate: '2026-07-26', windows: [], bestWindowId: null },
+      {
+        localDate: '2026-07-25',
+        windows,
+        bestWindowId: windows[0]?.id ?? null,
+        exclusionReasons: [],
+      },
+      {
+        localDate: '2026-07-26',
+        windows: [],
+        bestWindowId: null,
+        exclusionReasons: ['no_forecasts'],
+      },
     ],
     recommendationAvailability: {
       state: 'available',

--- a/app/api/surf/discover/route.ts
+++ b/app/api/surf/discover/route.ts
@@ -14,7 +14,11 @@ import { gateSurfDiscoveryResponse } from '@/lib/services/discovery/surf-discove
 import { sanitizeSurfDiscoveryForSerializationMajorEventHold } from '@/lib/services/discovery/major-event-hold';
 import { getProfileExperienceLevel } from '@/lib/profile/skill-level';
 import { buildCanonicalDecisionFromSurfDiscovery } from '@/lib/recommendations/canonical-decision';
-import type { SurfDiscoveryEntitlement, TimeSlot } from '@/types/personalization';
+import type {
+  SurfDiscoveryEntitlement,
+  SurfDiscoveryRecommendation,
+  TimeSlot,
+} from '@/types/personalization';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 30; // Allow 30s for GPS discovery + batch forecast fetching
@@ -107,6 +111,39 @@ function hasExplicitMajorEventHold(
     discovery.recommendationAvailability?.state === 'none' &&
     discovery.recommendationAvailability.reasonCode === 'major_event_hold'
   );
+}
+
+function recommendationPoolKey(
+  recommendation: SurfDiscoveryRecommendation,
+): string {
+  if (recommendation.recommendationId) {
+    return recommendation.recommendationId;
+  }
+  const kind = recommendation.kind ?? 'beach';
+  const targetId = kind === 'custom_spot'
+    ? recommendation.customSpotId ?? recommendation.beach.id
+    : recommendation.beach.id;
+  const forecastAt = recommendation.forecast?.forecast_at ?? '';
+  const windowStart = recommendation.window?.start instanceof Date
+    ? recommendation.window.start.toISOString()
+    : String(recommendation.window?.start ?? '');
+  return `${kind}:${targetId}:${forecastAt}:${windowStart}`;
+}
+
+function dedupeReturnedRecommendationPool(
+  discovery: Awaited<ReturnType<typeof discoverSurfSpots>>,
+): SurfDiscoveryRecommendation[] {
+  const byId = new Map<string, SurfDiscoveryRecommendation>();
+  for (const recommendation of [
+    ...discovery.recommendations,
+    ...(discovery.includedRecommendations ?? []),
+  ]) {
+    const key = recommendationPoolKey(recommendation);
+    if (!byId.has(key)) {
+      byId.set(key, recommendation);
+    }
+  }
+  return Array.from(byId.values());
 }
 
 /**
@@ -313,8 +350,13 @@ async function surfDiscoveryHandler(
   );
 
   const decisionTimezone =
-    gatedDiscovery.recommendations[0]?.window?.timezone ?? 'UTC';
+    gatedDiscovery.recommendations[0]?.window?.timezone
+    ?? gatedDiscovery.includedRecommendations?.[0]?.window?.timezone
+    ?? 'UTC';
   const decisionHorizonHours = horizonHours ?? 24;
+  const decisionRecommendations = dedupeReturnedRecommendationPool(
+    gatedDiscovery,
+  );
   gatedDiscovery.sessionDecision = buildCanonicalDecisionFromSurfDiscovery({
     anchorTime: anchor.toISOString(),
     scope: {
@@ -331,7 +373,7 @@ async function surfDiscoveryHandler(
       reasonCode: 'hold_state_unavailable',
       holdEpoch: 'hold-state-unavailable',
     },
-    recommendations: gatedDiscovery.recommendations,
+    recommendations: decisionRecommendations,
   });
 
   return createSuccessResponse(gatedDiscovery);

--- a/app/api/surf/week-scout/route.ts
+++ b/app/api/surf/week-scout/route.ts
@@ -10,7 +10,7 @@ import {
 import { generateWeekScoutForecast } from '@/lib/services/discovery/week-scout';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 30;
+export const maxDuration = 60;
 
 function isValidLocalDate(value: string): boolean {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
@@ -42,7 +42,7 @@ const WeekScoutRequestSchema = z.object({
     .array(z.string().uuid())
     .min(1)
     .transform((ids) => Array.from(new Set(ids)))
-    .refine((ids) => ids.length <= 30, 'At most 30 candidate beaches are allowed'),
+    .refine((ids) => ids.length <= 100, 'At most 100 candidate beaches are allowed'),
   localTimezone: z.string().min(1).refine(isValidTimezone, 'Invalid IANA timezone'),
   startLocalDate: z.string().refine(isValidLocalDate, 'Invalid local date'),
   dayCount: z.literal(7),
@@ -71,10 +71,7 @@ async function weekScoutHandler(
     return createValidationError('Invalid Week Scout request', parsed.error.flatten());
   }
 
-  const forecast = await generateWeekScoutForecast(user.id, {
-    ...parsed.data,
-    candidateBeachIds: parsed.data.candidateBeachIds.slice(0, 8),
-  });
+  const forecast = await generateWeekScoutForecast(user.id, parsed.data);
   if (
     forecast.recommendationAvailability?.state === 'none'
     && forecast.recommendationAvailability.reasonCode === 'hold_state_unavailable'

--- a/lib/domains/user-preferences/index.ts
+++ b/lib/domains/user-preferences/index.ts
@@ -20,6 +20,7 @@ export type { SkillLevel, SkillWaveRanges } from './skill-level';
 export {
   DEFAULT_SKILL_LEVEL,
   SKILL_LEVELS,
+  parseBeachSkillRequirement,
   parseSkillLevel,
   getSkillLevelOrDefault,
   SKILL_WAVE_RANGES,

--- a/lib/domains/user-preferences/skill-level.ts
+++ b/lib/domains/user-preferences/skill-level.ts
@@ -59,6 +59,32 @@ export function parseSkillLevel(value: string | null | undefined): SkillLevel | 
   return null;
 }
 
+/**
+ * Parse the minimum skill requirement stored on a beach.
+ *
+ * Beach taxonomy includes bounded labels that are not valid profile skill
+ * values. Keep this normalization separate so profile parsing remains strict.
+ */
+export function parseBeachSkillRequirement(
+  value: string | null | undefined,
+): SkillLevel | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return null;
+
+  switch (normalized) {
+    case 'all':
+      return 'beginner';
+    case 'beginner-intermediate':
+    case 'lower-intermediate':
+    case 'upper-intermediate':
+      return 'intermediate';
+    case 'intermediate-advanced':
+      return 'advanced';
+    default:
+      return parseSkillLevel(normalized);
+  }
+}
+
 // ============================================================================
 // Wave Threshold Data
 // ============================================================================

--- a/lib/recommendations/canonical-decision/engine.ts
+++ b/lib/recommendations/canonical-decision/engine.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { createHash } from "node:crypto";
 
 import {
+  parseBeachSkillRequirement,
   parseSkillLevel,
   SKILL_WAVE_RANGES,
 } from "@/lib/domains/user-preferences/skill-level";
@@ -61,7 +62,7 @@ function candidateSafetyReasons(
   if (!isValidCandidate(candidate)) {
     reasons.push("invalid_candidate");
   }
-  const beachSkill = parseSkillLevel(
+  const beachSkill = parseBeachSkillRequirement(
     typeof candidate.beachSkillLevel === "string"
       ? candidate.beachSkillLevel
       : null,
@@ -134,7 +135,7 @@ function decisionId(input: BuildCanonicalSessionDecisionInput): string {
         candidateId: candidate.candidateId,
         beachId: candidate.beachId,
         beachName: candidate.beachName,
-        beachSkillLevel: parseSkillLevel(
+        beachSkillLevel: parseBeachSkillRequirement(
           typeof candidate.beachSkillLevel === "string"
             ? candidate.beachSkillLevel
             : null,

--- a/lib/recommendations/major-event-hold/adapters/week-scout.ts
+++ b/lib/recommendations/major-event-hold/adapters/week-scout.ts
@@ -133,6 +133,16 @@ export function sanitizeWeekScoutForMajorEventHold(
       ...day,
       windows,
       bestWindowId: bestAllowedWindow?.id ?? null,
+      exclusionReasons:
+        boundary.recommendationAvailability.state === "available" &&
+        day.bestWindowId === null
+          ? day.exclusionReasons
+          : boundary.recommendationAvailability.state === "available" &&
+              bestAllowedWindow === null &&
+              day.bestWindowId !== null &&
+              !boundary.allowedCandidateIds.has(day.bestWindowId)
+            ? ["major_event_hold"]
+          : [],
     };
   });
 

--- a/lib/services/discovery/surf-discovery-orchestrator.ts
+++ b/lib/services/discovery/surf-discovery-orchestrator.ts
@@ -837,17 +837,63 @@ function buildCustomSpotBeach(
   };
 }
 
-function mergeCandidatePools(nearbyCandidates: Beach[], includedCandidates: Beach[]): Beach[] {
+function mergeCandidatePools(...candidatePools: readonly Beach[][]): Beach[] {
   const byId = new Map<string, Beach>();
-  for (const beach of nearbyCandidates) {
-    if (beach?.id) byId.set(beach.id, beach);
-  }
-  for (const beach of includedCandidates) {
-    if (beach?.id && !byId.has(beach.id)) {
-      byId.set(beach.id, beach);
+  for (const candidates of candidatePools) {
+    for (const beach of candidates) {
+      if (beach?.id && !byId.has(beach.id)) {
+        byId.set(beach.id, beach);
+      }
     }
   }
   return Array.from(byId.values());
+}
+
+function sortCandidatesByDistance(
+  candidates: readonly Beach[],
+  userLocation: { lat: number; lon: number },
+): Beach[] {
+  return [...candidates].sort((left, right) => (
+    calculateDistance(userLocation, { lat: left.lat ?? 0, lon: left.lon ?? 0 })
+    - calculateDistance(userLocation, { lat: right.lat ?? 0, lon: right.lon ?? 0 })
+  ));
+}
+
+function buildBoundedCandidatePool(args: {
+  nearbyCandidates: Beach[];
+  includedCandidates: Beach[];
+  customNearestCandidates: Beach[];
+  userLocation: { lat: number; lon: number };
+  limit: number;
+  minimumNearbyCount: number;
+}): Beach[] {
+  const nearby = sortCandidatesByDistance(
+    mergeCandidatePools(args.nearbyCandidates),
+    args.userLocation,
+  );
+  const reservedNearby = nearby.slice(
+    0,
+    Math.min(args.limit, args.minimumNearbyCount),
+  );
+  const selectedIds = new Set(reservedNearby.map((beach) => beach.id));
+  const selected = [...reservedNearby];
+  const merged = sortCandidatesByDistance(
+    mergeCandidatePools(
+      nearby,
+      args.includedCandidates,
+      args.customNearestCandidates,
+    ),
+    args.userLocation,
+  );
+
+  for (const beach of merged) {
+    if (selected.length >= args.limit) break;
+    if (selectedIds.has(beach.id)) continue;
+    selected.push(beach);
+    selectedIds.add(beach.id);
+  }
+
+  return sortCandidatesByDistance(selected, args.userLocation);
 }
 
 function recommendationKey(rec: Pick<SurfDiscoveryRecommendation, 'kind' | 'customSpotId' | 'beach'>): string {
@@ -1417,22 +1463,19 @@ async function discoverSurfSpotsInner(
     buildCustomSpotCandidates(userId, userLocation, radiusMiles),
   ]);
 
-  // Limit nearby candidates to prevent excessive forecast work, then append
-  // explicit include targets. Included beaches are capped separately at the
-  // route boundary so saved/home targets can be scored without N native calls.
   const customNearestCandidates = customSpotCandidates.map((candidate) => candidate.nearestBeach);
-  const maxNearbyCandidates = Math.min(
-    candidates.length,
-    Math.max(
-      0,
-      effectiveCandidatePoolLimit - includedCandidates.length - customNearestCandidates.length
-    )
-  );
-  const nearbyCandidates = candidates.slice(0, maxNearbyCandidates);
-  const finalCandidates = mergeCandidatePools(
-    mergeCandidatePools(nearbyCandidates, includedCandidates),
+  const finalCandidates = buildBoundedCandidatePool({
+    nearbyCandidates: candidates,
+    includedCandidates,
     customNearestCandidates,
-  ).slice(0, effectiveCandidatePoolLimit);
+    userLocation,
+    limit: effectiveCandidatePoolLimit,
+    minimumNearbyCount: Math.min(maxResults, effectiveCandidatePoolLimit),
+  });
+  const nearbyCandidateIds = new Set(candidates.map((beach) => beach.id));
+  const nearbyCandidates = finalCandidates.filter((beach) =>
+    nearbyCandidateIds.has(beach.id),
+  );
   // A custom spot is only "primary" (eligible for the Now/Best feeds) when it's
   // as close as the nearby beaches — the same nearest-within-radius cut curated
   // beaches pass. Without this an own custom spot surfaces in Now/Best from
@@ -1441,11 +1484,18 @@ async function discoverSurfSpotsInner(
   // (My spots only); far public spots drop out entirely, same as a far beach.
   // ponytail: boundary is the furthest nearby beach once the 20-spot cap bites;
   // before that every in-radius beach is nearby, so the boundary is the radius.
+  const selectedNearbyIds = new Set(nearbyCandidates.map((beach) => beach.id));
   const nearbyMaxMiles =
-    candidates.length > maxNearbyCandidates
+    candidates.some((beach) => !selectedNearbyIds.has(beach.id))
       ? nearbyCandidates.reduce(
           (miles, beach) =>
-            Math.max(miles, calculateDistance(userLocation, { lat: beach.lat || 0, lon: beach.lon || 0 })),
+            Math.max(
+              miles,
+              calculateDistance(userLocation, {
+                lat: beach.lat ?? 0,
+                lon: beach.lon ?? 0,
+              }),
+            ),
           0,
         )
       : radiusMiles;
@@ -1473,7 +1523,7 @@ async function discoverSurfSpotsInner(
 
   log.debug(
     `Found ${finalCandidates.length} candidate beaches ` +
-    `(${maxNearbyCandidates} nearby, ${includedCandidates.length} included, ` +
+    `(${nearbyCandidates.length} nearby, ${includedCandidates.length} included, ` +
     `${customSpotCandidates.length} custom spots)`
   );
 

--- a/lib/services/discovery/week-scout.ts
+++ b/lib/services/discovery/week-scout.ts
@@ -49,9 +49,16 @@ import {
 } from '@/lib/recommendations/canonical-decision';
 
 export const WEEK_SCOUT_SCORER_VERSION = 'week-scout-v1:discovery-hero-v1';
+const WEEK_SCOUT_RESPONSE_RANK_LIMIT = 8;
 
 export type WeekScoutBucket = 'morning' | 'midday' | 'evening';
 export type WeekScoutVerdict = 'worth_it' | 'maybe' | 'skip';
+export type WeekScoutDayExclusionReason =
+  | 'no_forecasts'
+  | 'no_safe_windows'
+  | 'no_rideable_windows'
+  | 'no_recommendable_windows'
+  | 'major_event_hold';
 
 export interface WeekScoutRequest {
   candidateBeachIds: string[];
@@ -103,6 +110,7 @@ export interface WeekScoutDayResponse {
   localDate: string;
   windows: WeekScoutWindowResponse[];
   bestWindowId: string | null;
+  exclusionReasons: WeekScoutDayExclusionReason[];
 }
 
 export interface WeekScoutResponse {
@@ -526,42 +534,67 @@ function applyCanonicalDecisionToWeekScout(
   response: MajorEventHoldWeekScoutResponse,
   sessionDecision: CanonicalSessionDecision,
 ): CanonicalWeekScoutResponse {
-  const selectedCandidateId = sessionDecision.selection?.candidateId ?? null;
-  const selectedBeachId = sessionDecision.selection?.beachId ?? null;
+  return {
+    ...response,
+    sessionDecision,
+  };
+}
 
+function exclusionReasonsForDay(
+  windows: readonly WeekScoutWindowResponse[],
+  bestWindowId: string | null,
+): WeekScoutDayExclusionReason[] {
+  if (bestWindowId !== null) return [];
+  if (windows.length === 0) return ['no_forecasts'];
+  const safeWindows = windows.filter((window) => window.safe);
+  if (safeWindows.length === 0) return ['no_safe_windows'];
+  const rideableWindows = safeWindows.filter((window) => window.rideable);
+  if (rideableWindows.length === 0) return ['no_rideable_windows'];
+  const recommendableWindows = rideableWindows.filter(
+    (window) => window.verdict !== 'skip',
+  );
+  if (recommendableWindows.length === 0) {
+    return ['no_recommendable_windows'];
+  }
+  return [];
+}
+
+function compactHeldResponse(
+  response: MajorEventHoldWeekScoutResponse,
+): MajorEventHoldWeekScoutResponse {
   return {
     ...response,
     days: response.days.map((day) => {
-      const hasSelection = day.windows.some((window) => (
-        window.id === selectedCandidateId
-        && window.beachId === selectedBeachId
-      ));
+      const windows = BUCKETS.flatMap(({ bucket }) => {
+        const bucketWindows = day.windows.filter((window) => window.bucket === bucket);
+        const visibleWindows = bucketWindows.filter((window) => window.rankingScore !== null);
+        const selected = (
+          visibleWindows.length > 0 ? visibleWindows : bucketWindows
+        ).slice(0, WEEK_SCOUT_RESPONSE_RANK_LIMIT);
+        const bestWindow = bucketWindows.find((window) => window.id === day.bestWindowId);
+
+        if (
+          bestWindow
+          && !selected.some((window) => window.id === bestWindow.id)
+        ) {
+          selected.splice(
+            Math.max(0, selected.length - 1),
+            selected.length === 0 ? 0 : 1,
+            bestWindow,
+          );
+        }
+
+        return selected.map((window) => ({
+          ...window,
+          rankedSpots: window.rankedSpots.slice(0, WEEK_SCOUT_RESPONSE_RANK_LIMIT),
+        }));
+      });
+
       return {
         ...day,
-        bestWindowId: hasSelection ? selectedCandidateId : null,
-        windows: day.windows.map((window) => {
-          const isSelected = (
-            window.id === selectedCandidateId
-            && window.beachId === selectedBeachId
-          );
-          return {
-            ...window,
-            conditionScore: null,
-            rankingScore: null,
-            verdict: isSelected
-              ? sessionDecision.verdict === 'go'
-                ? 'worth_it' as const
-                : 'maybe' as const
-              : null,
-            rideable: null,
-            safe: null,
-            takeaway: null,
-            rankedSpots: [],
-          };
-        }),
+        windows,
       };
     }),
-    sessionDecision,
   };
 }
 
@@ -632,6 +665,7 @@ async function generateWeekScoutForecastInternal(
       localDate,
       windows,
       bestWindowId: best?.id ?? null,
+      exclusionReasons: exclusionReasonsForDay(windows, best?.id ?? null),
     };
   });
 
@@ -653,11 +687,11 @@ async function generateWeekScoutForecastInternal(
     candidates,
     profileExperience: userSkillLevel,
   });
-  const heldResponse = sanitizeWeekScoutForMajorEventHold(
+  const heldResponse = compactHeldResponse(sanitizeWeekScoutForMajorEventHold(
     response,
     candidates,
     decisions,
-  );
+  ));
 
   return {
     heldResponse,


### PR DESCRIPTION
## User-visible change
- keeps viable Home and Week Scout candidates in parity for the same authenticated user/location
- accepts compound skill labels
- returns daily ranked Week Scout picks instead of redacting every day except one weekly winner
- preserves explicit major-event holds, retryable errors, and exclusion reasons
- expands no-limit Week Scout discovery before scoring and compacts the response afterward

## Surface
Quiver web recommendation APIs and canonical decision engine. Native adapter changes are in the paired quiver-native release commit.

## Local verification
- `yarn typecheck` — passed
- `yarn lint` — passed
- focused route/service tests — 24 passed
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=test SUPABASE_SERVICE_ROLE_KEY=test NEXT_PUBLIC_SITE_URL=http://localhost:3000 yarn test:unit --runInBand` — passed: 1,267 suites, 16,622 tests

## Production impact
Production API behavior changes. No database migration or environment-variable change. Android OTA remains gated on successful production deployment and payload verification.