### PR TITLE
fix(db): restore user beach exclusions migration history

### DIFF
--- a/__tests__/migrations/user-beach-exclusions-history.test.ts
+++ b/__tests__/migrations/user-beach-exclusions-history.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const MIGRATION_PATH = join(
+  process.cwd(),
+  "supabase",
+  "migrations",
+  "20260719110000_create_user_beach_exclusions.sql"
+);
+
+function readMigration(): string {
+  return readFileSync(MIGRATION_PATH, "utf8");
+}
+
+describe("user beach exclusions history migration", () => {
+  it("reconstructs the production table before Weekend Scout references it", () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(/CREATE TABLE public\.user_beach_exclusions/i);
+    expect(sql).toMatch(
+      /user_id uuid NOT NULL REFERENCES public\.profiles\(id\) ON DELETE CASCADE/i
+    );
+    expect(sql).toMatch(
+      /beach_id uuid NOT NULL REFERENCES public\.beaches\(id\) ON DELETE CASCADE/i
+    );
+    expect(sql).toMatch(/PRIMARY KEY \(user_id, beach_id\)/i);
+    expect(sql).toMatch(/created_at timestamptz NOT NULL DEFAULT now\(\)/i);
+    expect(sql).toMatch(/user_beach_exclusions_user_id_idx/i);
+  });
+
+  it("matches the production row-level security contract", () => {
+    const sql = readMigration();
+
+    expect(sql).toMatch(
+      /ALTER TABLE public\.user_beach_exclusions ENABLE ROW LEVEL SECURITY/i
+    );
+    expect(sql).toMatch(/CREATE POLICY user_beach_exclusions_select_own/i);
+    expect(sql).toMatch(/CREATE POLICY user_beach_exclusions_insert_own/i);
+    expect(sql).toMatch(/CREATE POLICY user_beach_exclusions_delete_own/i);
+    expect(sql).toMatch(/\(SELECT auth\.uid\(\)\) = user_id/i);
+    expect(sql).toMatch(
+      /GRANT ALL ON TABLE public\.user_beach_exclusions TO anon, authenticated, service_role/i
+    );
+  });
+});

--- a/supabase/migrations/20260719110000_create_user_beach_exclusions.sql
+++ b/supabase/migrations/20260719110000_create_user_beach_exclusions.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+CREATE TABLE public.user_beach_exclusions (
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  beach_id uuid NOT NULL REFERENCES public.beaches(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, beach_id)
+);
+
+COMMENT ON TABLE public.user_beach_exclusions IS
+  'Per-user beach blocklist used to remove disliked beaches from personalized discovery candidates.';
+
+CREATE INDEX user_beach_exclusions_user_id_idx
+  ON public.user_beach_exclusions(user_id);
+
+ALTER TABLE public.user_beach_exclusions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_beach_exclusions_select_own
+  ON public.user_beach_exclusions
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY user_beach_exclusions_insert_own
+  ON public.user_beach_exclusions
+  FOR INSERT
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY user_beach_exclusions_delete_own
+  ON public.user_beach_exclusions
+  FOR DELETE
+  USING ((SELECT auth.uid()) = user_id);
+
+REVOKE ALL ON TABLE public.user_beach_exclusions FROM PUBLIC;
+GRANT ALL ON TABLE public.user_beach_exclusions TO anon, authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- restore the missing historical migration for `public.user_beach_exclusions` before Weekend Scout first references it
- reproduce the current production columns, constraints, indexes, RLS policies, comment, and grants exactly
- add a focused migration contract test

## Why
Production contains this table, but no migration in the repository creates it. That prevents a clean local replay at `20260719120000_create_weekend_scout_location_snapshots.sql` and blocks the approved centroid-rounding promotion.

## Verification
- production/local catalog parity: PASS (SHA-256 `557c1f8659fd11b2fb4cad888bd03487e3b225f6157fab98b1baadc8aec938ef` on both)
- focused migration suites: PASS (3 suites, 10 tests)
- scoped ESLint: PASS
- Node 22 typecheck: PASS
- migration replay: PASS through `20260727230000` after applying the existing Phase 0 migration in its required approved database session
- local `compute_implicit_preferences(NULL)` transaction: PASS

## Production safety
This PR does not recreate or alter the production table. After merge, production migration history must be reconciled by marking version `20260719110000` as applied under a separate exact approval plan before the centroid migration is pushed.