### PR TITLE
fix: dedupe native install attribution joins

### DIFF
--- a/__tests__/migrations/native-install-attribution-dedupe.test.ts
+++ b/__tests__/migrations/native-install-attribution-dedupe.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSQL = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql",
+  ),
+  "utf8",
+);
+
+describe("native install attribution join dedupe migration", () => {
+  it("repairs legacy duplicates before enforcing owner-scoped event IDs", () => {
+    expect(migrationSQL).toMatch(/^BEGIN;$/m);
+    expect(migrationSQL).toMatch(/^COMMIT;$/m);
+    expect(migrationSQL).toContain(
+      "LOCK TABLE public.user_events IN SHARE ROW EXCLUSIVE MODE",
+    );
+    expect(migrationSQL).toContain("PARTITION BY user_id, metadata ->> 'event_id'");
+    expect(migrationSQL).toContain("ranked_duplicates.duplicate_rank > 1");
+    expect(migrationSQL).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS user_events_native_install_attribution_event_id_uidx/,
+    );
+    expect(migrationSQL).toContain(
+      "WHERE event_type = 'native_install_attribution_joined'",
+    );
+  });
+});

--- a/supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql
+++ b/supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+LOCK TABLE public.user_events IN SHARE ROW EXCLUSIVE MODE;
+
+-- The native client retries an install-to-user join until local durable
+-- acknowledgement. Enforce its deterministic event_id at the database edge
+-- so a process death after insert cannot create a second attribution row.
+WITH ranked_duplicates AS (
+  SELECT
+    id,
+    metadata ->> 'event_id' AS event_id,
+    row_number() OVER (
+      PARTITION BY user_id, metadata ->> 'event_id'
+      ORDER BY created_at, id
+    ) AS duplicate_rank
+  FROM public.user_events
+  WHERE event_type = 'native_install_attribution_joined'
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> ''
+)
+UPDATE public.user_events AS user_event
+SET metadata = jsonb_set(
+  user_event.metadata,
+  '{event_id}',
+  to_jsonb(
+    ranked_duplicates.event_id
+      || ':legacy-duplicate:'
+      || user_event.id::text
+  ),
+  false
+)
+FROM ranked_duplicates
+WHERE user_event.id = ranked_duplicates.id
+  AND ranked_duplicates.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_events_native_install_attribution_event_id_uidx
+  ON public.user_events (user_id, ((metadata ->> 'event_id')))
+  WHERE event_type = 'native_install_attribution_joined'
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> '';
+
+COMMENT ON INDEX public.user_events_native_install_attribution_event_id_uidx IS
+  'Idempotency guard for owner-scoped native install attribution joins.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- repair any legacy duplicate install-attribution event IDs transactionally
- enforce one owner-scoped `native_install_attribution_joined` row per deterministic event ID
- add a migration contract test for the lock, repair, and partial unique index

## Validation
- [x] production read-only duplicate preflight: 0 current join rows / 0 duplicate keys
- [x] migration contract Jest test
- [x] PostgreSQL 15 apply/repair/duplicate-rejection test
- [x] TypeScript
- [x] full Jest: 1,276 suites / 16,689 tests passed; four production-env-dependent suites rerun cleanly (192/192)
- [x] changed-file ESLint
- [x] diff check
- [x] fresh production backup verified (`user_events` + migration tracking; SHA-256 aa985b6a...)
- [ ] production migration apply and index verification (requires explicit production approval)