### PR TITLE
feat(analytics): promote acquisition-source event contract to prod before iOS 1.0.2

### DIFF
--- a/__tests__/api/events-allowlist-db-sync.test.ts
+++ b/__tests__/api/events-allowlist-db-sync.test.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { VALID_EVENTS } from "@/app/api/events/route";
 import { KNOWN_REJECTED_USER_EVENT_EMITTERS } from "@/lib/analytics/event-taxonomy";
 
+const ACQUISITION_SOURCE_SELF_REPORTED_EVENT =
+  "acquisition_source_self_reported";
+
 /**
  * Parses user_events_event_type_check migrations and extracts event names from
  * both full static CHECK arrays and additive dynamic migrations that preserve
@@ -75,5 +78,12 @@ describe("user_events allowlist / DB CHECK sync", () => {
       .sort();
 
     expect(dbOnlyEvents).toEqual([]);
+  });
+
+  it("keeps acquisition self-report synchronized across the API and DB CHECK", () => {
+    expect(VALID_EVENTS).toContain(ACQUISITION_SOURCE_SELF_REPORTED_EVENT);
+    expect(userEventsCheckMigrationEventTypes()).toContain(
+      ACQUISITION_SOURCE_SELF_REPORTED_EVENT
+    );
   });
 });

--- a/__tests__/api/events-taxonomy-characterization.test.ts
+++ b/__tests__/api/events-taxonomy-characterization.test.ts
@@ -21,7 +21,7 @@ import {
 import { EVENT_WEIGHTS } from "@/types/implicit-preferences";
 
 const CURRENT_EVENT_SET_HASHES = {
-  valid: "fa4d6036dce7f646c4cd64af57427851d4a99a98a66e22cf8305fe99a890767b",
+  valid: "29eb6fadcde8f5e5ede83c3c3c6e713e4007c0350025d84139805a46bbf5d85b",
   anonymousAllowed:
     "960579b65b52600bf0ef4da9bc8b20548651c29813edabdf5763f65bc13ccd24",
   preAuthOnly:

--- a/__tests__/lib/analytics/event-taxonomy.test.ts
+++ b/__tests__/lib/analytics/event-taxonomy.test.ts
@@ -17,6 +17,9 @@ const appHandoffEvents = [
   "app_handoff_native_open",
 ] as const satisfies readonly EventType[];
 
+const acquisitionSourceSelfReportedEvent =
+  "acquisition_source_self_reported" as const satisfies EventType;
+
 describe("event taxonomy", () => {
   it("allows app handoff funnel events for anonymous and signed-in users", () => {
     for (const event of appHandoffEvents) {
@@ -26,5 +29,19 @@ describe("event taxonomy", () => {
       expect(EXTERNAL_ANALYTICS_ONLY_EVENTS).not.toContain(event);
       expect(EVENT_WEIGHTS[event]).toBe(0);
     }
+  });
+
+  it("keeps acquisition self-report authenticated-only and zero-weight", () => {
+    expect(VALID_EVENTS).toContain(acquisitionSourceSelfReportedEvent);
+    expect(ANONYMOUS_ALLOWED_EVENTS).not.toContain(
+      acquisitionSourceSelfReportedEvent
+    );
+    expect(PRE_AUTH_ONLY_EVENTS).not.toContain(
+      acquisitionSourceSelfReportedEvent
+    );
+    expect(EXTERNAL_ANALYTICS_ONLY_EVENTS).not.toContain(
+      acquisitionSourceSelfReportedEvent
+    );
+    expect(EVENT_WEIGHTS[acquisitionSourceSelfReportedEvent]).toBe(0);
   });
 });

--- a/__tests__/migrations/acquisition-source-self-reported.test.ts
+++ b/__tests__/migrations/acquisition-source-self-reported.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSQL = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260730121000_add_acquisition_source_self_reported_event.sql"
+  ),
+  "utf8"
+);
+
+const TARGET_EVENT = "acquisition_source_self_reported";
+
+describe("acquisition source self-reported event migration", () => {
+  it("preserves the current CHECK expression and widens only its constraint", () => {
+    expect(migrationSQL).toContain("pg_get_constraintdef");
+    expect(migrationSQL).toContain("current_check");
+    expect(migrationSQL).toContain(
+      "RAISE EXCEPTION 'user_events_event_type_check constraint not found'"
+    );
+    expect(migrationSQL).toContain(
+      "DROP CONSTRAINT user_events_event_type_check"
+    );
+    expect(migrationSQL).toContain(
+      "ADD CONSTRAINT user_events_event_type_check CHECK ((%s) OR event_type = ANY (%L::text[]))"
+    );
+    expect(migrationSQL.match(/\bDROP CONSTRAINT\b/g)).toHaveLength(1);
+    expect(migrationSQL).toContain("NOTIFY pgrst, 'reload schema'");
+  });
+
+  it("no-ops when the exact event is already present", () => {
+    expect(migrationSQL).toContain(
+      "'(^|[^[:alnum:]_])' || event_name || '([^[:alnum:]_]|$)'"
+    );
+    expect(migrationSQL).toMatch(
+      /IF missing_events IS NULL OR array_length\(missing_events, 1\) IS NULL THEN[\s\S]*RAISE NOTICE[\s\S]*RETURN;[\s\S]*END IF;/
+    );
+
+    const returnPosition = migrationSQL.indexOf("RETURN;");
+    const dropPosition = migrationSQL.indexOf("DROP CONSTRAINT");
+    expect(returnPosition).toBeGreaterThanOrEqual(0);
+    expect(dropPosition).toBeGreaterThan(returnPosition);
+  });
+
+  it("contains exactly the locked event spelling without a static allowlist", () => {
+    const candidateEvents = migrationSQL.match(
+      /candidate_events text\[\] := ARRAY\[(.*?)\];/
+    );
+
+    expect(candidateEvents?.[1]).toBe(`'${TARGET_EVENT}'`);
+    expect(migrationSQL.match(new RegExp(TARGET_EVENT, "g"))).toHaveLength(1);
+  });
+
+  it("uses explicit transaction boundaries and performs no data deletion", () => {
+    expect(migrationSQL.trim()).toMatch(/^BEGIN;[\s\S]*COMMIT;$/);
+    expect(migrationSQL.match(/^BEGIN;$/gm)).toHaveLength(1);
+    expect(migrationSQL.match(/^COMMIT;$/gm)).toHaveLength(1);
+    expect(migrationSQL).not.toMatch(/\bDELETE\b/i);
+    expect(migrationSQL).not.toMatch(/\bTRUNCATE\b/i);
+    expect(migrationSQL).not.toMatch(/\bDROP TABLE\b/i);
+  });
+});

--- a/__tests__/migrations/native-install-attribution-dedupe.test.ts
+++ b/__tests__/migrations/native-install-attribution-dedupe.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migrationSQL = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql",
+  ),
+  "utf8",
+);
+
+describe("native install attribution join dedupe migration", () => {
+  it("repairs legacy duplicates before enforcing owner-scoped event IDs", () => {
+    expect(migrationSQL).toMatch(/^BEGIN;$/m);
+    expect(migrationSQL).toMatch(/^COMMIT;$/m);
+    expect(migrationSQL).toContain(
+      "LOCK TABLE public.user_events IN SHARE ROW EXCLUSIVE MODE",
+    );
+    expect(migrationSQL).toContain("PARTITION BY user_id, metadata ->> 'event_id'");
+    expect(migrationSQL).toContain("ranked_duplicates.duplicate_rank > 1");
+    expect(migrationSQL).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS user_events_native_install_attribution_event_id_uidx/,
+    );
+    expect(migrationSQL).toContain(
+      "WHERE event_type = 'native_install_attribution_joined'",
+    );
+  });
+});

--- a/lib/analytics/event-taxonomy.ts
+++ b/lib/analytics/event-taxonomy.ts
@@ -191,6 +191,7 @@ export const VALID_EVENTS = [
   // Search
   'beach_search_result_click',
   // Growth markers
+  'acquisition_source_self_reported',
   'first_beach_view_post_signup',
   'first_session_logged',
   // Empty states & impressions

--- a/supabase/migrations/20260730121000_add_acquisition_source_self_reported_event.sql
+++ b/supabase/migrations/20260730121000_add_acquisition_source_self_reported_event.sql
@@ -1,0 +1,43 @@
+BEGIN;
+
+DO $$
+DECLARE
+  current_check text;
+  candidate_events text[] := ARRAY['acquisition_source_self_reported'];
+  missing_events text[];
+BEGIN
+  SELECT regexp_replace(pg_get_constraintdef(oid), '^CHECK \((.*)\)$', '\1')
+    INTO current_check
+  FROM pg_constraint
+  WHERE conrelid = 'public.user_events'::regclass
+    AND conname = 'user_events_event_type_check';
+
+  IF current_check IS NULL THEN
+    RAISE EXCEPTION 'user_events_event_type_check constraint not found';
+  END IF;
+
+  SELECT array_agg(event_name ORDER BY ord)
+    INTO missing_events
+  FROM unnest(candidate_events) WITH ORDINALITY AS candidate(event_name, ord)
+  WHERE current_check !~ (
+    '(^|[^[:alnum:]_])' || event_name || '([^[:alnum:]_]|$)'
+  );
+
+  IF missing_events IS NULL OR array_length(missing_events, 1) IS NULL THEN
+    RAISE NOTICE 'Acquisition source self-report event already present; no change.';
+    RETURN;
+  END IF;
+
+  ALTER TABLE public.user_events
+    DROP CONSTRAINT user_events_event_type_check;
+
+  EXECUTE format(
+    'ALTER TABLE public.user_events ADD CONSTRAINT user_events_event_type_check CHECK ((%s) OR event_type = ANY (%L::text[]))',
+    current_check,
+    missing_events
+  );
+END $$;
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql
+++ b/supabase/migrations/20260802150000_dedupe_native_install_attribution_joins.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+LOCK TABLE public.user_events IN SHARE ROW EXCLUSIVE MODE;
+
+-- The native client retries an install-to-user join until local durable
+-- acknowledgement. Enforce its deterministic event_id at the database edge
+-- so a process death after insert cannot create a second attribution row.
+WITH ranked_duplicates AS (
+  SELECT
+    id,
+    metadata ->> 'event_id' AS event_id,
+    row_number() OVER (
+      PARTITION BY user_id, metadata ->> 'event_id'
+      ORDER BY created_at, id
+    ) AS duplicate_rank
+  FROM public.user_events
+  WHERE event_type = 'native_install_attribution_joined'
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> ''
+)
+UPDATE public.user_events AS user_event
+SET metadata = jsonb_set(
+  user_event.metadata,
+  '{event_id}',
+  to_jsonb(
+    ranked_duplicates.event_id
+      || ':legacy-duplicate:'
+      || user_event.id::text
+  ),
+  false
+)
+FROM ranked_duplicates
+WHERE user_event.id = ranked_duplicates.id
+  AND ranked_duplicates.duplicate_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_events_native_install_attribution_event_id_uidx
+  ON public.user_events (user_id, ((metadata ->> 'event_id')))
+  WHERE event_type = 'native_install_attribution_joined'
+    AND metadata ->> 'event_id' IS NOT NULL
+    AND metadata ->> 'event_id' <> '';
+
+COMMENT ON INDEX public.user_events_native_install_attribution_event_id_uidx IS
+  'Idempotency guard for owner-scoped native install attribution joins.';
+
+COMMIT;

--- a/types/implicit-preferences.ts
+++ b/types/implicit-preferences.ts
@@ -203,6 +203,7 @@ export const EVENT_WEIGHTS: Record<ImplicitEventType, number> = {
   // Search
   beach_search_result_click: 0,
   // Growth markers
+  acquisition_source_self_reported: 0,
   first_beach_view_post_signup: 0,
   first_session_logged: 0,
   // Empty states & impressions


### PR DESCRIPTION
## Summary
Clean cherry-picks of `9022bc91d` + `f3ade4a78` from main. Launch-blocking for the iOS 1.0.2 binary now in prep.

- Registers `acquisition_source_self_reported` in the web event taxonomy (`lib/analytics/event-taxonomy.ts`, `types/implicit-preferences.ts`). Native 1.0.2 ships a one-time acquisition-source prompt on Home; without this, every answer 400s at prod `/api/events` and is silently dropped (the known allowlist failure mode).
- Brings the install-attribution join-dedupe migration file + its test for migration-dir consistency. The migration is already applied to the shared database, so no runtime change from that commit — code parity only.

## Verification (local, Node 22 — repo Actions disabled)
- `yarn typecheck` — pass
- `yarn test:unit --bail=0` — full suite pass, including the new allowlist-db-sync, taxonomy, and dedupe tests riding the slice
- `VERCEL_ENV=preview yarn build` — pass

## Rollback
Revert the deploy. Taxonomy-entry + inert migration file; no flags. DB CHECK constraint already live in the shared database (applied from main); code and DB stay consistent either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)