### PR TITLE
fix(embed): show stale conditions with a timestamp instead of blanking

### DIFF
--- a/__tests__/app/embed/conditions-embed-page.test.tsx
+++ b/__tests__/app/embed/conditions-embed-page.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+
+const mockGetBeachBySlugOrId = jest.fn();
+const mockGetFreshForecastFromCache = jest.fn();
+const mockForecastToConditionsData = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+jest.mock("@/lib/utils/beach-lookup-utils", () => ({
+  getBeachBySlugOrId: (...args: unknown[]) =>
+    mockGetBeachBySlugOrId(...args),
+}));
+jest.mock("@/lib/utils/forecast-server-utils", () => ({
+  getFreshForecastFromCache: (...args: unknown[]) =>
+    mockGetFreshForecastFromCache(...args),
+}));
+jest.mock("@/lib/mappers/conditions-mappers", () => ({
+  forecastToConditionsData: (...args: unknown[]) =>
+    mockForecastToConditionsData(...args),
+}));
+jest.mock("@/lib/utils/beach-url-utils", () => ({
+  buildBeachUrl: jest.fn(() => "/ca/test-city/test-beach"),
+}));
+jest.mock("@/hooks/use-embed-impression", () => ({
+  useEmbedImpression: jest.fn(),
+}));
+
+import EmbedConditionsPage from "@/app/embed/conditions/[slug]/page";
+
+const SLUG = "test-beach";
+const BEACH = {
+  id: "beach-1",
+  name: "Test Beach",
+  timezone: "Pacific/Honolulu",
+};
+const FORECAST = {
+  forecast_at: "2026-08-05T10:00:00Z",
+  forecast_date: "2026-08-05",
+  forecast_time: "10:00:00",
+};
+const CONDITIONS = {
+  waveHeight: "3 ft",
+  wavePeriod: "12 s",
+  waveDirection: "W",
+};
+
+function cacheResult({
+  stale = false,
+  missing = false,
+  forecasts = [FORECAST],
+  lastUpdated = "2026-08-05T09:30:00Z",
+}: {
+  stale?: boolean;
+  missing?: boolean;
+  forecasts?: typeof FORECAST[];
+  lastUpdated?: string;
+}) {
+  return {
+    forecasts,
+    metadata: {
+      cached: !missing,
+      stale,
+      missing,
+      reason: missing ? "No forecast data in cache" : null,
+      dataSource: "CDIP",
+      lastUpdated,
+    },
+  };
+}
+
+async function renderPage() {
+  const ui = await EmbedConditionsPage({
+    params: Promise.resolve({ slug: SLUG }),
+    searchParams: Promise.resolve({}),
+  });
+
+  return render(ui);
+}
+
+describe("conditions embed page freshness states", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBeachBySlugOrId.mockResolvedValue(BEACH);
+    mockForecastToConditionsData.mockReturnValue(CONDITIONS);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders fresh conditions with no as-of label", async () => {
+    mockGetFreshForecastFromCache.mockResolvedValue(cacheResult({}));
+
+    await renderPage();
+
+    expect(screen.getByText("3 ft @ 12 s W")).toBeInTheDocument();
+    expect(screen.queryByText(/^as of /i)).not.toBeInTheDocument();
+    expect(mockGetFreshForecastFromCache).toHaveBeenCalledWith(
+      BEACH.id,
+      24,
+      { allowStale: true, maxStaleHours: 24 }
+    );
+  });
+
+  it("renders stale conditions with beach-local last-updated time", async () => {
+    mockGetFreshForecastFromCache.mockResolvedValue(
+      cacheResult({ stale: true })
+    );
+
+    await renderPage();
+
+    expect(screen.getByText("3 ft @ 12 s W")).toBeInTheDocument();
+    expect(
+      screen.getByText("as of Tue, Aug 4 at 11:30 PM")
+    ).toBeInTheDocument();
+  });
+
+  it("renders an honest unavailable state with a beach-page link", async () => {
+    mockGetFreshForecastFromCache.mockResolvedValue(
+      cacheResult({ missing: true, forecasts: [] })
+    );
+
+    await renderPage();
+
+    expect(
+      screen.getByText("Conditions are temporarily unavailable.")
+    ).toBeInTheDocument();
+    const href = screen
+      .getByRole("link", { name: "View Test Beach forecast" })
+      .getAttribute("href");
+    if (!href) throw new Error("Expected unavailable-state beach link");
+    const beachUrl = new URL(href);
+    expect(`${beachUrl.pathname}${beachUrl.search}`).toBe(
+      "/ca/test-city/test-beach?utm_source=embed&utm_medium=widget&utm_campaign=conditions"
+    );
+  });
+
+  it("renders unavailable and logs the slug when forecast loading throws", async () => {
+    const error = new Error("database offline");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockGetFreshForecastFromCache.mockRejectedValue(error);
+
+    await renderPage();
+
+    expect(
+      screen.getByText("Conditions are temporarily unavailable.")
+    ).toBeInTheDocument();
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[EmbedConditionsPage] Failed to load forecast for beach ${SLUG}:`,
+      error
+    );
+  });
+});

--- a/__tests__/components/embed/embed-ticker-widget.test.tsx
+++ b/__tests__/components/embed/embed-ticker-widget.test.tsx
@@ -32,7 +32,9 @@ const ALL_DATA: ConditionsData = {
 function renderWidget(
   data: ConditionsData,
   theme: "light" | "dark" = "light",
-  slug = SLUG
+  slug = SLUG,
+  status: "fresh" | "stale" | "unavailable" = "fresh",
+  staleAsOf?: string
 ) {
   return render(
     <EmbedTickerWidget
@@ -40,6 +42,8 @@ function renderWidget(
       beachUrl={BEACH_URL}
       slug={slug}
       data={data}
+      status={status}
+      staleAsOf={staleAsOf}
       theme={theme}
     />
   );
@@ -180,16 +184,19 @@ describe("EmbedTickerWidget - partial data", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. "no data" when ALL fields are null / empty object
+// 3. Unavailable state when ALL fields are null / empty object
 // ---------------------------------------------------------------------------
 
-describe("EmbedTickerWidget - no data", () => {
-  it("shows 'no data' text when data is an empty object", () => {
+describe("EmbedTickerWidget - unavailable", () => {
+  it("shows an unavailable message and forecast link for an empty object", () => {
     renderWidget({});
-    expect(screen.getByText("no data")).toBeInTheDocument();
+    const link = screen.getByRole("link", {
+      name: "Conditions temporarily unavailable · View forecast",
+    });
+    expect(link).toHaveAttribute("href", BEACH_URL);
   });
 
-  it("shows 'no data' when all fields are explicitly null", () => {
+  it("shows the unavailable message when all fields are explicitly null", () => {
     const emptyData: ConditionsData = {
       waveHeight: null,
       wavePeriod: null,
@@ -201,7 +208,9 @@ describe("EmbedTickerWidget - no data", () => {
       tideHeight: null,
     };
     renderWidget(emptyData);
-    expect(screen.getByText("no data")).toBeInTheDocument();
+    expect(
+      screen.getByText("Conditions temporarily unavailable · View forecast")
+    ).toBeInTheDocument();
   });
 
   it("does NOT render any card labels when there is no data", () => {
@@ -218,10 +227,35 @@ describe("EmbedTickerWidget - no data", () => {
     expect(screen.queryByText("Powered by Quiver")).not.toBeInTheDocument();
   });
 
-  it("includes the beach name in the no-data container's title attribute", () => {
+  it("includes the beach name in the unavailable link's title attribute", () => {
     renderWidget({});
-    const noDataSpan = screen.getByText("no data");
-    expect(noDataSpan).toHaveAttribute("title", BEACH_NAME);
+    const unavailableLink = screen.getByRole("link");
+    expect(unavailableLink).toHaveAttribute("title", BEACH_NAME);
+  });
+
+  it("uses the unavailable state even when data cards are present", () => {
+    renderWidget(ALL_DATA, "light", SLUG, "unavailable");
+    expect(
+      screen.getByText("Conditions temporarily unavailable · View forecast")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Waves")).not.toBeInTheDocument();
+  });
+});
+
+describe("EmbedTickerWidget - stale", () => {
+  it("renders cards and the understated as-of label", () => {
+    renderWidget(
+      ALL_DATA,
+      "light",
+      SLUG,
+      "stale",
+      "Tue, Aug 4 at 11:30 PM"
+    );
+
+    expect(screen.getAllByText("Waves").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("as of Tue, Aug 4 at 11:30 PM").length
+    ).toBeGreaterThan(0);
   });
 });
 

--- a/app/embed/conditions/[slug]/embed-conditions-widget.tsx
+++ b/app/embed/conditions/[slug]/embed-conditions-widget.tsx
@@ -9,6 +9,8 @@ interface EmbedConditionsWidgetProps {
   beachUrl: string;
   slug: string;
   conditions: ConditionsData;
+  status: "fresh" | "stale" | "unavailable";
+  staleAsOf?: string;
   theme: "light" | "dark";
 }
 
@@ -39,12 +41,17 @@ export function EmbedConditionsWidget({
   beachUrl,
   slug,
   conditions,
+  status,
+  staleAsOf,
   theme,
 }: EmbedConditionsWidgetProps) {
   useEmbedImpression("conditions", slug);
 
   const isDark = theme === "dark";
   const hasData = Object.values(conditions).some(Boolean);
+  const isUnavailable = status === "unavailable" || !hasData;
+  const staleLabel =
+    status === "stale" ? `as of ${staleAsOf ?? "an earlier update"}` : null;
 
   return (
     <div
@@ -64,46 +71,69 @@ export function EmbedConditionsWidget({
 
       {/* Conditions */}
       <div className="flex-1 min-h-0 px-3 overflow-auto">
-        {hasData ? (
-          <div
-            className={`divide-y ${isDark ? "divide-slate-700" : "divide-slate-100"}`}
-          >
-            <ConditionRow
-              label="Waves"
-              value={
-                conditions.waveHeight
-                  ? `${conditions.waveHeight}${conditions.wavePeriod ? ` @ ${conditions.wavePeriod}` : ""}${conditions.waveDirection ? ` ${conditions.waveDirection}` : ""}`
-                  : null
-              }
-              isDark={isDark}
-            />
-            <ConditionRow
-              label="Wind"
-              value={
-                conditions.windSpeed
-                  ? `${conditions.windSpeed}${conditions.windDirection ? ` ${conditions.windDirection}` : ""}`
-                  : null
-              }
-              isDark={isDark}
-            />
-            <ConditionRow
-              label="Water Temp"
-              value={conditions.waterTemp}
-              isDark={isDark}
-            />
-            <ConditionRow
-              label="Tide"
-              value={
-                conditions.tideStatus
-                  ? `${conditions.tideStatus}${conditions.tideHeight ? ` (${conditions.tideHeight})` : ""}`
-                  : null
-              }
-              isDark={isDark}
-            />
-          </div>
+        {!isUnavailable ? (
+          <>
+            <div
+              className={`divide-y ${isDark ? "divide-slate-700" : "divide-slate-100"}`}
+            >
+              <ConditionRow
+                label="Waves"
+                value={
+                  conditions.waveHeight
+                    ? `${conditions.waveHeight}${conditions.wavePeriod ? ` @ ${conditions.wavePeriod}` : ""}${conditions.waveDirection ? ` ${conditions.waveDirection}` : ""}`
+                    : null
+                }
+                isDark={isDark}
+              />
+              <ConditionRow
+                label="Wind"
+                value={
+                  conditions.windSpeed
+                    ? `${conditions.windSpeed}${conditions.windDirection ? ` ${conditions.windDirection}` : ""}`
+                    : null
+                }
+                isDark={isDark}
+              />
+              <ConditionRow
+                label="Water Temp"
+                value={conditions.waterTemp}
+                isDark={isDark}
+              />
+              <ConditionRow
+                label="Tide"
+                value={
+                  conditions.tideStatus
+                    ? `${conditions.tideStatus}${conditions.tideHeight ? ` (${conditions.tideHeight})` : ""}`
+                    : null
+                }
+                isDark={isDark}
+              />
+            </div>
+            {staleLabel && (
+              <p
+                className={`pt-1 text-[10px] ${isDark ? "text-slate-500" : "text-slate-400"}`}
+              >
+                {staleLabel}
+              </p>
+            )}
+          </>
         ) : (
-          <div className="flex items-center justify-center h-full text-sm text-slate-400">
-            No conditions available
+          <div className="flex flex-col items-center justify-center gap-1 h-full text-center">
+            <p className="text-sm text-slate-400">
+              Conditions are temporarily unavailable.
+            </p>
+            <a
+              href={beachUrl}
+              target="_blank"
+              rel="noopener"
+              className={`text-xs font-medium hover:underline ${
+                isDark
+                  ? "text-slate-400 hover:text-slate-300"
+                  : "text-slate-500 hover:text-ocean-blue"
+              }`}
+            >
+              View {beachName} forecast
+            </a>
           </div>
         )}
       </div>

--- a/app/embed/conditions/[slug]/page.tsx
+++ b/app/embed/conditions/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { getBeachBySlugOrId } from "@/lib/utils/beach-lookup-utils";
 import { getFreshForecastFromCache } from "@/lib/utils/forecast-server-utils";
 import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
 import { forecastToConditionsData } from "@/lib/mappers/conditions-mappers";
+import { formatBeachDateTime } from "@/lib/utils/date-time";
+import { resolveBeachTimezone } from "@/lib/utils/timezone-utils";
 import type { ConditionsData } from "@/types/conditions";
 import { EmbedConditionsWidget } from "./embed-conditions-widget";
 
@@ -25,9 +27,18 @@ export default async function EmbedConditionsPage({
 
   // Fetch current forecast
   let currentConditions: ConditionsData = {};
+  let forecastStatus: "fresh" | "stale" | "unavailable" = "unavailable";
+  let staleAsOf: string | undefined;
   try {
-    const result = await getFreshForecastFromCache(beach.id, 2);
-    if (result?.forecasts?.length) {
+    const result = await getFreshForecastFromCache(beach.id, 24, {
+      allowStale: true,
+      maxStaleHours: 24,
+    });
+    if (
+      result.metadata.cached &&
+      !result.metadata.missing &&
+      result.forecasts.length > 0
+    ) {
       // Use the most recent forecast as "current conditions"
       const now = Date.now();
       const sorted = [...result.forecasts].sort((a, b) => {
@@ -38,10 +49,29 @@ export default async function EmbedConditionsPage({
       const closest = sorted[0];
       if (closest) {
         currentConditions = forecastToConditionsData(closest);
+        forecastStatus = result.metadata.stale ? "stale" : "fresh";
+
+        if (result.metadata.stale && result.metadata.lastUpdated) {
+          const timezone = resolveBeachTimezone(beach.timezone);
+          const updatedDate = formatBeachDateTime(
+            result.metadata.lastUpdated,
+            timezone,
+            "EEE, MMM d"
+          );
+          const updatedTime = formatBeachDateTime(
+            result.metadata.lastUpdated,
+            timezone,
+            "h:mm a"
+          );
+          staleAsOf = `${updatedDate} at ${updatedTime}`;
+        }
       }
     }
-  } catch {
-    // Render with empty data
+  } catch (error) {
+    console.warn(
+      `[EmbedConditionsPage] Failed to load forecast for beach ${slug}:`,
+      error
+    );
   }
 
   const siteUrl =
@@ -57,6 +87,8 @@ export default async function EmbedConditionsPage({
       beachUrl={beachUrl}
       slug={slug}
       conditions={currentConditions}
+      status={forecastStatus}
+      staleAsOf={staleAsOf}
       theme={theme === "dark" ? "dark" : "light"}
     />
   );

--- a/app/embed/ticker/[slug]/embed-ticker-widget.tsx
+++ b/app/embed/ticker/[slug]/embed-ticker-widget.tsx
@@ -9,6 +9,8 @@ interface EmbedTickerWidgetProps {
   beachUrl: string;
   slug: string;
   data: ConditionsData;
+  status: "fresh" | "stale" | "unavailable";
+  staleAsOf?: string;
   theme: "light" | "dark";
 }
 
@@ -243,11 +245,23 @@ function BrandingCard({ beachUrl, isDark }: BrandingCardProps) {
   );
 }
 
+function StaleCard({ label, isDark }: { label: string; isDark: boolean }) {
+  return (
+    <span
+      className={`px-4 shrink-0 text-[10px] ${isDark ? "text-slate-500" : "text-slate-400"}`}
+    >
+      {label}
+    </span>
+  );
+}
+
 export function EmbedTickerWidget({
   beachName,
   beachUrl,
   slug,
   data,
+  status,
+  staleAsOf,
   theme,
 }: EmbedTickerWidgetProps) {
   useEmbedImpression("ticker", slug);
@@ -255,15 +269,25 @@ export function EmbedTickerWidget({
   const isDark = theme === "dark";
   const cards = buildCards(data);
   const hasCards = cards.length > 0;
+  const staleLabel =
+    status === "stale" ? `as of ${staleAsOf ?? "an earlier update"}` : null;
 
-  if (!hasCards) {
+  if (status === "unavailable" || !hasCards) {
     return (
       <div
         className={`flex items-center justify-center h-[55px] w-full text-sm ${
           isDark ? "bg-slate-900 text-slate-400" : "bg-white text-slate-500"
         }`}
       >
-        <span title={beachName}>no data</span>
+        <a
+          href={beachUrl}
+          target="_blank"
+          rel="noopener"
+          title={beachName}
+          className="text-xs font-medium hover:underline"
+        >
+          Conditions temporarily unavailable · View forecast
+        </a>
       </div>
     );
   }
@@ -279,6 +303,12 @@ export function EmbedTickerWidget({
             {i < cards.length - 1 && <Divider isDark={isDark} />}
           </span>
         ))}
+        {staleLabel && (
+          <>
+            <Divider isDark={isDark} />
+            <StaleCard label={staleLabel} isDark={isDark} />
+          </>
+        )}
         <Divider isDark={isDark} />
         <BrandingCard beachUrl={beachUrl} isDark={isDark} />
         {/* trailing separator before the loop restarts */}
@@ -337,6 +367,12 @@ export function EmbedTickerWidget({
               {i < cards.length - 1 && <Divider isDark={isDark} />}
             </span>
           ))}
+          {staleLabel && (
+            <>
+              <Divider isDark={isDark} />
+              <StaleCard label={staleLabel} isDark={isDark} />
+            </>
+          )}
           <Divider isDark={isDark} />
           <BrandingCard beachUrl={beachUrl} isDark={isDark} />
         </div>

--- a/app/embed/ticker/[slug]/page.tsx
+++ b/app/embed/ticker/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { getBeachBySlugOrId } from "@/lib/utils/beach-lookup-utils";
 import { getFreshForecastFromCache } from "@/lib/utils/forecast-server-utils";
 import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
 import { forecastToConditionsData } from "@/lib/mappers/conditions-mappers";
+import { formatBeachDateTime } from "@/lib/utils/date-time";
+import { resolveBeachTimezone } from "@/lib/utils/timezone-utils";
 import type { ConditionsData } from "@/types/conditions";
 import { EmbedTickerWidget } from "./embed-ticker-widget";
 
@@ -25,9 +27,18 @@ export default async function EmbedTickerPage({
 
   // Fetch current forecast
   let tickerData: ConditionsData = {};
+  let forecastStatus: "fresh" | "stale" | "unavailable" = "unavailable";
+  let staleAsOf: string | undefined;
   try {
-    const result = await getFreshForecastFromCache(beach.id, 2);
-    if (result?.forecasts?.length) {
+    const result = await getFreshForecastFromCache(beach.id, 24, {
+      allowStale: true,
+      maxStaleHours: 24,
+    });
+    if (
+      result.metadata.cached &&
+      !result.metadata.missing &&
+      result.forecasts.length > 0
+    ) {
       // Find the forecast closest to now by time proximity
       const now = Date.now();
       const sorted = [...result.forecasts].sort((a, b) => {
@@ -38,10 +49,29 @@ export default async function EmbedTickerPage({
       const closest = sorted[0];
       if (closest) {
         tickerData = forecastToConditionsData(closest);
+        forecastStatus = result.metadata.stale ? "stale" : "fresh";
+
+        if (result.metadata.stale && result.metadata.lastUpdated) {
+          const timezone = resolveBeachTimezone(beach.timezone);
+          const updatedDate = formatBeachDateTime(
+            result.metadata.lastUpdated,
+            timezone,
+            "EEE, MMM d"
+          );
+          const updatedTime = formatBeachDateTime(
+            result.metadata.lastUpdated,
+            timezone,
+            "h:mm a"
+          );
+          staleAsOf = `${updatedDate} at ${updatedTime}`;
+        }
       }
     }
-  } catch {
-    // Render with empty data on fetch failure
+  } catch (error) {
+    console.warn(
+      `[EmbedTickerPage] Failed to load forecast for beach ${slug}:`,
+      error
+    );
   }
 
   const siteUrl =
@@ -57,6 +87,8 @@ export default async function EmbedTickerPage({
       beachUrl={beachUrl}
       slug={slug}
       data={tickerData}
+      status={forecastStatus}
+      staleAsOf={staleAsOf}
       theme={theme === "dark" ? "dark" : "light"}
     />
   );

--- a/app/embed/tides/[slug]/embed-tide-widget.tsx
+++ b/app/embed/tides/[slug]/embed-tide-widget.tsx
@@ -11,6 +11,8 @@ interface EmbedTideWidgetProps {
   slug: string;
   forecasts: EnhancedForecastEntity[];
   windowHours: number;
+  status: "fresh" | "stale" | "unavailable";
+  staleAsOf?: string;
   theme: "light" | "dark";
 }
 
@@ -20,11 +22,16 @@ export function EmbedTideWidget({
   slug,
   forecasts,
   windowHours,
+  status,
+  staleAsOf,
   theme,
 }: EmbedTideWidgetProps) {
   useEmbedImpression("tides", slug);
 
   const isDark = theme === "dark";
+  const isUnavailable = status === "unavailable" || forecasts.length === 0;
+  const staleLabel =
+    status === "stale" ? `as of ${staleAsOf ?? "an earlier update"}` : null;
 
   return (
     <div
@@ -35,30 +42,57 @@ export function EmbedTideWidget({
       {/* Header */}
       <div className="flex items-center justify-between px-3 pt-2 pb-1">
         <h2 className="text-sm font-semibold truncate">{beachName} Tides</h2>
+        {staleLabel && (
+          <p
+            className={`shrink-0 text-[10px] ${isDark ? "text-slate-500" : "text-slate-400"}`}
+          >
+            {staleLabel}
+          </p>
+        )}
       </div>
 
       {/* Chart */}
       <div className="flex-1 min-h-0 px-1">
-        <Suspense
-          fallback={
-            <div className="flex items-center justify-center h-full text-sm text-slate-400">
-              Loading tide data...
-            </div>
-          }
-        >
-          <TideChartEnhanced
-            forecasts={forecasts}
-            windowHours={windowHours}
-            compact
-            compactLayout
-            showDiagnostics={false}
-            showNextExtreme={false}
-            showHourlyTable={false}
-            showWarnings={false}
-            showVerifiedBadge={false}
-            className="h-full"
-          />
-        </Suspense>
+        {isUnavailable ? (
+          <div className="flex flex-col items-center justify-center gap-1 h-full text-center">
+            <p className="text-sm text-slate-400">
+              Tide conditions are temporarily unavailable.
+            </p>
+            <a
+              href={beachUrl}
+              target="_blank"
+              rel="noopener"
+              className={`text-xs font-medium hover:underline ${
+                isDark
+                  ? "text-slate-400 hover:text-slate-300"
+                  : "text-slate-500 hover:text-ocean-blue"
+              }`}
+            >
+              View {beachName} forecast
+            </a>
+          </div>
+        ) : (
+          <Suspense
+            fallback={
+              <div className="flex items-center justify-center h-full text-sm text-slate-400">
+                Loading tide data...
+              </div>
+            }
+          >
+            <TideChartEnhanced
+              forecasts={forecasts}
+              windowHours={windowHours}
+              compact
+              compactLayout
+              showDiagnostics={false}
+              showNextExtreme={false}
+              showHourlyTable={false}
+              showWarnings={false}
+              showVerifiedBadge={false}
+              className="h-full"
+            />
+          </Suspense>
+        )}
       </div>
 
       {/* Attribution */}

--- a/app/embed/tides/[slug]/page.tsx
+++ b/app/embed/tides/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 import { getBeachBySlugOrId } from "@/lib/utils/beach-lookup-utils";
 import { getFreshForecastFromCache } from "@/lib/utils/forecast-server-utils";
 import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+import { formatBeachDateTime } from "@/lib/utils/date-time";
+import { resolveBeachTimezone } from "@/lib/utils/timezone-utils";
 import { EmbedTideWidget } from "./embed-tide-widget";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 
@@ -24,13 +26,41 @@ export default async function EmbedTidePage({
 
   // Fetch forecast data for tide chart
   let forecasts: EnhancedForecastEntity[] = [];
+  let forecastStatus: "fresh" | "stale" | "unavailable" = "unavailable";
+  let staleAsOf: string | undefined;
   try {
-    const result = await getFreshForecastFromCache(beach.id, 2);
-    if (result?.forecasts) {
+    const result = await getFreshForecastFromCache(beach.id, 24, {
+      allowStale: true,
+      maxStaleHours: 24,
+    });
+    if (
+      result.metadata.cached &&
+      !result.metadata.missing &&
+      result.forecasts.length > 0
+    ) {
       forecasts = result.forecasts;
+      forecastStatus = result.metadata.stale ? "stale" : "fresh";
+
+      if (result.metadata.stale && result.metadata.lastUpdated) {
+        const timezone = resolveBeachTimezone(beach.timezone);
+        const updatedDate = formatBeachDateTime(
+          result.metadata.lastUpdated,
+          timezone,
+          "EEE, MMM d"
+        );
+        const updatedTime = formatBeachDateTime(
+          result.metadata.lastUpdated,
+          timezone,
+          "h:mm a"
+        );
+        staleAsOf = `${updatedDate} at ${updatedTime}`;
+      }
     }
-  } catch {
-    // Render with empty data — chart will show "No tide data"
+  } catch (error) {
+    console.warn(
+      `[EmbedTidePage] Failed to load forecast for beach ${slug}:`,
+      error
+    );
   }
 
   const windowHours = hours ? parseInt(hours, 10) : 18;
@@ -50,6 +80,8 @@ export default async function EmbedTidePage({
       slug={slug}
       forecasts={forecasts}
       windowHours={validHours}
+      status={forecastStatus}
+      staleAsOf={staleAsOf}
       theme={theme === "dark" ? "dark" : "light"}
     />
   );


### PR DESCRIPTION
`/embed/conditions` intermittently rendered "No conditions available" for beaches that had data. Measured: `waikiki-beach` and `cannon-beach-ecolaindian` blank on 5/5 fetches while `huntington-beach-pier` rendered fine — and the sets swap over hours.

**Cause:** the pages asked for a forecast under **2 hours** old from a pipeline that refreshes each beach roughly every **3 hours** (marine cron is hourly but capped at `maxBeaches=130` against 318 beaches), so beaches routinely fell outside the window.

`ForecastCacheOptions` already documents the policy — *"Return stale cached rows for display-only surfaces"* — and beach detail already honours it (`allowStale: true, maxStaleHours: 24`). The embeds were the only display-only surfaces that didn't.

Opts conditions/ticker/tides into `allowStale` and renders three states instead of one: fresh, stale with an "as of" line in beach-local time, and genuinely unavailable. Replaces the bare `catch {}` that made this invisible.

**Verified against live data:** `cannon-beach-ecolaindian` renders blank on prod and renders conditions + "as of Wed, Aug 5 at 5:30 AM" with this change. Fresh beaches unchanged, no timestamp.

**Blocks:** embed distribution to 37 researched surf shops/schools — a widget that blanks part of every refresh cycle is worse than not shipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)