### PR TITLE
feat(embed): preselect beach on embed landing pages via ?beach=

### DIFF
--- a/__tests__/app/embed-promo-beach-preselection.test.tsx
+++ b/__tests__/app/embed-promo-beach-preselection.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+
+import { getBeaches } from "@/actions/beach/beach-query-actions";
+import ForBusinessesPage from "@/app/for-businesses/page";
+import ForSurfSchoolsPage from "@/app/for-surf-schools/page";
+import { EmbedPromoPage } from "@/components/embed-promo/embed-promo-page";
+import {
+  DEFAULT_PREVIEW_SLUG,
+  resolvePreviewSlug,
+  validateInitialBeachSlug,
+} from "@/components/embed-promo/beach-selection";
+import type { Beach } from "@/types/database";
+
+jest.mock("@/actions/beach/beach-query-actions", () => ({
+  getBeaches: jest.fn(),
+}));
+
+// The landing pages read beaches through an `unstable_cache` wrapper, which
+// needs Next's incremental cache context that jest does not provide. Use the
+// repo's pass-through mock (see __tests__/setup/mock-next-cache.ts).
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+  revalidateTag: jest.fn(),
+  unstable_cache: (fn: unknown) => fn,
+}));
+
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/components/ui/scroll-reveal", () => ({
+  ScrollReveal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/components/zine", () => ({
+  QuiverSticker: () => null,
+  ZineSurface: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const BEACHES = [
+  {
+    name: "12th Street Jetty",
+    slug: "12th-street-jetty-sea-isle-city-nj",
+    city: "Sea Isle City",
+    state: "NJ",
+  },
+  {
+    name: "Huntington Beach Pier",
+    slug: DEFAULT_PREVIEW_SLUG,
+    city: "Huntington Beach",
+    state: "CA",
+  },
+  {
+    name: "La Jolla Shores",
+    slug: "la-jolla-shores",
+    city: "San Diego",
+    state: "CA",
+  },
+];
+
+const BEACH_ROWS = BEACHES as unknown as Beach[];
+const mockGetBeaches = getBeaches as jest.MockedFunction<typeof getBeaches>;
+
+type PromoPage = (props: {
+  searchParams: Promise<{ beach?: string | string[] }>;
+}) => Promise<ReactElement>;
+
+async function renderPage(
+  Page: PromoPage,
+  beach?: string | string[]
+): Promise<ReturnType<typeof render>> {
+  return render(
+    await Page({
+      searchParams: Promise.resolve(beach === undefined ? {} : { beach }),
+    })
+  );
+}
+
+function expectSelectedBeach(
+  container: HTMLElement,
+  expectedSlug: string
+): void {
+  expect(screen.getByRole("combobox", { name: "Select a beach" })).toHaveValue(
+    expectedSlug
+  );
+
+  const previews = screen.getAllByTitle("Widget preview");
+  previews.forEach((preview) => {
+    expect(preview).toHaveAttribute(
+      "src",
+      expect.stringContaining(`/embed/conditions/${expectedSlug}`)
+    );
+  });
+
+  expect(container.querySelector("pre")).toHaveTextContent(
+    `/embed/conditions/${expectedSlug}`
+  );
+}
+
+describe("embed promo beach preselection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBeaches.mockResolvedValue({ success: true, data: BEACH_ROWS });
+  });
+
+  it.each([
+    ["businesses", ForBusinessesPage],
+    ["surf schools", ForSurfSchoolsPage],
+  ])("preselects a valid slug on the %s page", async (_label, Page) => {
+    const { container } = await renderPage(Page, "la-jolla-shores");
+
+    expectSelectedBeach(container, "la-jolla-shores");
+    expect(screen.getByRole("combobox")).toHaveValue("la-jolla-shores");
+  });
+
+  it("falls back silently for an unknown slug", async () => {
+    const { container } = await renderPage(
+      ForBusinessesPage,
+      "unknown-beach"
+    );
+
+    expectSelectedBeach(container, DEFAULT_PREVIEW_SLUG);
+    expect(container).not.toHaveTextContent("unknown-beach");
+  });
+
+  it("falls back silently for a malformed repeated beach parameter", async () => {
+    const { container } = await renderPage(ForSurfSchoolsPage, [
+      "la-jolla-shores",
+      "unknown-beach",
+    ]);
+
+    expectSelectedBeach(container, DEFAULT_PREVIEW_SLUG);
+    expect(screen.getByRole("combobox")).not.toHaveValue(BEACHES[0]?.slug);
+  });
+
+  it("uses the named default when the beach parameter is missing", async () => {
+    const { container } = await renderPage(ForSurfSchoolsPage);
+
+    expectSelectedBeach(container, DEFAULT_PREVIEW_SLUG);
+    expect(screen.getByRole("combobox")).toHaveValue(DEFAULT_PREVIEW_SLUG);
+  });
+
+  it("uses the named default instead of the first beach", () => {
+    expect(BEACHES[0]?.slug).not.toBe(DEFAULT_PREVIEW_SLUG);
+    expect(resolvePreviewSlug(BEACHES)).toBe(DEFAULT_PREVIEW_SLUG);
+  });
+
+  it("uses the first beach when the named default is unavailable", () => {
+    expect(resolvePreviewSlug([BEACHES[0], BEACHES[2]])).toBe(
+      BEACHES[0]?.slug
+    );
+  });
+
+  it("rejects slugs that are not in the fetched beach list", () => {
+    expect(validateInitialBeachSlug(BEACHES, "unknown-beach")).toBeUndefined();
+    expect(
+      validateInitialBeachSlug(BEACHES, ["la-jolla-shores"])
+    ).toBeUndefined();
+  });
+
+  it("preselects the shared EmbedPromoPage without a default flash", () => {
+    const { container } = render(
+      <EmbedPromoPage
+        variant="businesses"
+        beaches={BEACHES}
+        initialSlug="la-jolla-shores"
+      />
+    );
+
+    expectSelectedBeach(container, "la-jolla-shores");
+    expect(screen.getByRole("combobox")).toHaveValue("la-jolla-shores");
+  });
+});

--- a/app/for-businesses/_components/businesses-embed-promo.tsx
+++ b/app/for-businesses/_components/businesses-embed-promo.tsx
@@ -13,6 +13,7 @@ import type { LucideIcon } from "lucide-react";
 
 import { ScrollReveal } from "@/components/ui/scroll-reveal";
 import { QuiverSticker } from "@/components/zine";
+import { resolvePreviewSlug } from "@/components/embed-promo/beach-selection";
 import { SITE_URL } from "@/lib/constants/seo";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,8 @@ type WidgetType = "conditions" | "tides";
 interface BusinessesEmbedPromoProps {
   /** Pre-fetched beach options for the dropdown */
   beaches: BeachOption[];
+  /** Validated beach slug selected by the server page */
+  initialSlug?: string;
 }
 
 interface ValueProp {
@@ -176,9 +179,12 @@ function CopyButton({ code }: { code: string }) {
 // Main Component
 // ---------------------------------------------------------------------------
 
-export function BusinessesEmbedPromo({ beaches }: BusinessesEmbedPromoProps) {
-  const [selectedSlug, setSelectedSlug] = useState(
-    beaches[0]?.slug ?? "blacks"
+export function BusinessesEmbedPromo({
+  beaches,
+  initialSlug,
+}: BusinessesEmbedPromoProps) {
+  const [selectedSlug, setSelectedSlug] = useState(() =>
+    resolvePreviewSlug(beaches, initialSlug)
   );
   const [widgetType, setWidgetType] = useState<WidgetType>("conditions");
 

--- a/app/for-businesses/page.tsx
+++ b/app/for-businesses/page.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/seo/meta";
-import { getBeaches } from "@/actions/beach/beach-query-actions";
 import { ZineSurface } from "@/components/zine";
 import {
   BusinessesEmbedPromo,
   type BeachOption,
 } from "./_components/businesses-embed-promo";
+import { validateInitialBeachSlug } from "@/components/embed-promo/beach-selection";
+import { getEmbedPromoBeachOptions } from "@/components/embed-promo/cached-beach-options";
+
+interface Props {
+  searchParams: Promise<{ beach?: string | string[] }>;
+}
 
 export const revalidate = 86400;
 
@@ -23,19 +28,10 @@ export const metadata: Metadata = buildPageMetadata({
   ],
 });
 
-export default async function ForBusinessesPage() {
-  const response = await getBeaches();
-  const beaches: BeachOption[] =
-    response.success && response.data
-      ? response.data
-          .filter((b) => b.slug && b.name)
-          .map((b) => ({
-            name: b.name,
-            slug: b.slug!,
-            city: b.city,
-            state: b.state,
-          }))
-      : [];
+export default async function ForBusinessesPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const beaches: BeachOption[] = await getEmbedPromoBeachOptions();
+  const initialSlug = validateInitialBeachSlug(beaches, params.beach);
 
   return (
     <ZineSurface
@@ -43,7 +39,7 @@ export default async function ForBusinessesPage() {
       editionLabel="Embed the surf, free"
       data-testid="for-businesses-zine-surface"
     >
-      <BusinessesEmbedPromo beaches={beaches} />
+      <BusinessesEmbedPromo beaches={beaches} initialSlug={initialSlug} />
     </ZineSurface>
   );
 }

--- a/app/for-surf-schools/_components/surf-schools-zine-page.tsx
+++ b/app/for-surf-schools/_components/surf-schools-zine-page.tsx
@@ -13,6 +13,7 @@ import type { LucideIcon } from "lucide-react";
 
 import { ScrollReveal } from "@/components/ui/scroll-reveal";
 import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { resolvePreviewSlug } from "@/components/embed-promo/beach-selection";
 import { SITE_URL } from "@/lib/constants/seo";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,8 @@ type WidgetType = "conditions" | "tides";
 interface SurfSchoolsZinePageProps {
   /** Pre-fetched beach options for the dropdown */
   beaches: BeachOption[];
+  /** Validated beach slug selected by the server page */
+  initialSlug?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -163,9 +166,12 @@ function CopyButton({ code }: { code: string }) {
 // Main Component
 // ---------------------------------------------------------------------------
 
-export function SurfSchoolsZinePage({ beaches }: SurfSchoolsZinePageProps) {
-  const [selectedSlug, setSelectedSlug] = useState(
-    beaches[0]?.slug ?? "blacks"
+export function SurfSchoolsZinePage({
+  beaches,
+  initialSlug,
+}: SurfSchoolsZinePageProps) {
+  const [selectedSlug, setSelectedSlug] = useState(() =>
+    resolvePreviewSlug(beaches, initialSlug)
   );
   const [widgetType, setWidgetType] = useState<WidgetType>("conditions");
 

--- a/app/for-surf-schools/page.tsx
+++ b/app/for-surf-schools/page.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/seo/meta";
-import { getBeaches } from "@/actions/beach/beach-query-actions";
 import {
   SurfSchoolsZinePage,
   type BeachOption,
 } from "./_components/surf-schools-zine-page";
+import { validateInitialBeachSlug } from "@/components/embed-promo/beach-selection";
+import { getEmbedPromoBeachOptions } from "@/components/embed-promo/cached-beach-options";
+
+interface Props {
+  searchParams: Promise<{ beach?: string | string[] }>;
+}
 
 export const revalidate = 86400;
 
@@ -22,21 +27,12 @@ export const metadata: Metadata = buildPageMetadata({
   ],
 });
 
-export default async function ForSurfSchoolsPage() {
-  const response = await getBeaches();
-  const beaches: BeachOption[] =
-    response.success && response.data
-      ? response.data
-          .filter((b) => b.slug && b.name)
-          .map((b) => ({
-            name: b.name,
-            slug: b.slug!,
-            city: b.city,
-            state: b.state,
-          }))
-      : [];
+export default async function ForSurfSchoolsPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const beaches: BeachOption[] = await getEmbedPromoBeachOptions();
+  const initialSlug = validateInitialBeachSlug(beaches, params.beach);
 
   return (
-    <SurfSchoolsZinePage beaches={beaches} />
+    <SurfSchoolsZinePage beaches={beaches} initialSlug={initialSlug} />
   );
 }

--- a/components/embed-promo/beach-selection.ts
+++ b/components/embed-promo/beach-selection.ts
@@ -1,0 +1,32 @@
+interface BeachSlugOption {
+  slug: string;
+}
+
+// `beaches[0]` is arbitrary and previously selected a beach with no conditions data.
+export const DEFAULT_PREVIEW_SLUG = "huntington-beach-pier";
+
+export function validateInitialBeachSlug(
+  beaches: readonly BeachSlugOption[],
+  requestedSlug: string | string[] | undefined
+): string | undefined {
+  if (typeof requestedSlug !== "string") return undefined;
+
+  return beaches.some((beach) => beach.slug === requestedSlug)
+    ? requestedSlug
+    : undefined;
+}
+
+export function resolvePreviewSlug(
+  beaches: readonly BeachSlugOption[],
+  initialSlug?: string
+): string {
+  const validatedInitialSlug = validateInitialBeachSlug(beaches, initialSlug);
+  if (validatedInitialSlug) return validatedInitialSlug;
+
+  const defaultBeach = beaches.find(
+    (beach) => beach.slug === DEFAULT_PREVIEW_SLUG
+  );
+  if (defaultBeach) return defaultBeach.slug;
+
+  return beaches[0]?.slug ?? DEFAULT_PREVIEW_SLUG;
+}

--- a/components/embed-promo/cached-beach-options.ts
+++ b/components/embed-promo/cached-beach-options.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { getBeaches } from "@/actions/beach/beach-query-actions";
+
+export interface CachedBeachOption {
+  name: string;
+  slug: string;
+  city: string | null;
+  state: string | null;
+}
+
+/**
+ * Beach options for the embed-promo landing pages (/for-businesses,
+ * /for-surf-schools).
+ *
+ * Those pages read `?beach=` from searchParams, which opts them into dynamic
+ * rendering — their `revalidate = 86400` no longer keeps the beach query off
+ * the request path. `getBeaches()` is an uncached passthrough to the DB, so
+ * without this wrapper every visit would re-query the full beach table.
+ *
+ * Matches the `unstable_cache` pattern already used for the other bulk beach
+ * queries in `actions/beach/beach-query-actions.ts`.
+ */
+const getCachedBeachOptions = unstable_cache(
+  async (): Promise<CachedBeachOption[]> => {
+    const response = await getBeaches();
+
+    if (!response.success || !response.data) return [];
+
+    return response.data
+      .filter((b) => b.slug)
+      .map((b) => ({
+        name: b.name,
+        slug: b.slug as string,
+        city: b.city,
+        state: b.state,
+      }));
+  },
+  ["embed-promo-beach-options"],
+  {
+    revalidate: 86400, // matches the landing pages' own revalidate
+    tags: ["beaches"],
+  }
+);
+
+export function getEmbedPromoBeachOptions(): Promise<CachedBeachOption[]> {
+  return getCachedBeachOptions();
+}

--- a/components/embed-promo/embed-promo-page.tsx
+++ b/components/embed-promo/embed-promo-page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SectionWrapper } from "@/components/ui/section-wrapper";
+import { resolvePreviewSlug } from "@/components/embed-promo/beach-selection";
 import { SITE_URL } from "@/lib/constants/seo";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,8 @@ interface EmbedPromoPageProps {
   variant: "surf-schools" | "businesses";
   /** Pre-fetched beach options for the dropdown */
   beaches: BeachOption[];
+  /** Validated beach slug selected by the server page */
+  initialSlug?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,10 +187,14 @@ function CopyButton({ code }: { code: string }) {
 // Main Component
 // ---------------------------------------------------------------------------
 
-export function EmbedPromoPage({ variant, beaches }: EmbedPromoPageProps) {
+export function EmbedPromoPage({
+  variant,
+  beaches,
+  initialSlug,
+}: EmbedPromoPageProps) {
   const copy = VARIANT_COPY[variant];
-  const [selectedSlug, setSelectedSlug] = useState(
-    beaches[0]?.slug ?? "blacks"
+  const [selectedSlug, setSelectedSlug] = useState(() =>
+    resolvePreviewSlug(beaches, initialSlug)
   );
   const [widgetType, setWidgetType] = useState<WidgetType>("conditions");
 


### PR DESCRIPTION
Outreach sends surf shops and schools to `/for-businesses` and `/for-surf-schools` to grab their embed code. The hero preview defaulted to `beaches[0]`, which resolved to `12th-street-jetty-sea-isle-city-nj` — a beach whose widget rendered empty. **The page selling the widget demoed an empty widget.**

Adds `?beach=<slug>` so a recipient's own break is preselected on first paint, and replaces `beaches[0]` with a named `DEFAULT_PREVIEW_SLUG`. Unknown or repeated params fall back silently and never reach the DOM.

`searchParams` opts these pages into dynamic rendering, which defeats their `revalidate = 86400` — and `getBeaches()` is uncached, unlike its siblings in the same file — so every visit would re-query the full beach table. Wrapped in `unstable_cache` matching the existing pattern.

**Verified at runtime:** default preview is now `huntington-beach-pier`; `?beach=nags-head-nags-head-nc` preselects Nags Head. typecheck, lint, 16,859 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)