### PR TITLE
feat(seo): decision-first titles for best-time-to-surf pages

### DIFF
--- a/__tests__/app/best-time-city-page.test.ts
+++ b/__tests__/app/best-time-city-page.test.ts
@@ -4,6 +4,7 @@
 
 import {
   buildBestTimeLiveHandoffSteps,
+  buildBestTimeMetadataCopy,
   generateMetadata,
 } from "@/app/best-time-to-surf/[city]/page";
 import { findCityBySlug } from "@/actions/city/city-metadata-actions";
@@ -64,12 +65,15 @@ describe("best-time city SEO page", () => {
       params: Promise.resolve({ city: "san-diego" }),
     });
 
-    expect(metadata.title).toContain("Best Time to Surf San Diego Today & This Week");
-    expect(metadata.description).toContain("today and this week");
-    expect(metadata.description).toContain("live surf report");
-    expect(metadata.description).toContain("tides");
+    expect(metadata.title).toContain(
+      "Best San Diego surf window today: tide & wind",
+    );
+    expect(metadata.description).toContain(
+      "San Diego's best surf window today",
+    );
+    expect(metadata.description).toContain("tide");
     expect(metadata.description).toContain("wind");
-    expect(metadata.description).toContain("nearby spots");
+    expect(metadata.description).toContain("live conditions");
   });
 
   it("noindexes a city without approved best-time editorial", async () => {
@@ -124,24 +128,18 @@ describe("best-time city SEO page", () => {
     {
       citySlug: "la-jolla",
       cityName: "La Jolla",
-      title: "Best Time to Surf La Jolla: Shores, Scripps & Wind",
-      descriptionNeedle: "Scripps Pier, Shores, Tourmaline",
     },
     {
       citySlug: "newport-beach",
       cityName: "Newport Beach",
-      title: "Best Time to Surf Newport Beach: Season & Today",
-      descriptionNeedle: "live Newport Beach surf report",
     },
     {
       citySlug: "malibu",
       cityName: "Malibu",
-      title: "Best Time to Surf Malibu: Tide, Season & Crowd",
-      descriptionNeedle: "live Malibu surf report",
     },
   ])(
-    "uses scoped CTR metadata for $cityName without changing the generic template",
-    async ({ citySlug, cityName, title, descriptionNeedle }) => {
+    "uses the shared decision-first metadata for $cityName",
+    async ({ citySlug, cityName }) => {
       (findCityBySlug as jest.Mock).mockResolvedValue({
         success: true,
         data: {
@@ -154,11 +152,38 @@ describe("best-time city SEO page", () => {
       const metadata = await generateMetadata({
         params: Promise.resolve({ city: citySlug }),
       });
+      const copy = buildBestTimeMetadataCopy(cityName);
 
-      expect(metadata.title).toContain(title);
-      expect(metadata.description).toContain(descriptionNeedle);
+      expect(metadata.title).toBe(copy.title);
+      expect(metadata.description).toBe(copy.description);
     },
   );
+
+  it.each([
+    "La Jolla",
+    "Huntington Beach",
+    "Santa Cruz",
+    "Laguna Beach",
+    "Pacifica",
+    "Melbourne Beach",
+    "Surfside Beach",
+  ])("keeps %s SERP copy direct and within display targets", (cityName) => {
+    const copy = buildBestTimeMetadataCopy(cityName);
+    const renderedTitle = `${copy.title} | Quiver`;
+
+    expect(renderedTitle.length).toBeLessThanOrEqual(60);
+    expect(copy.description.length).toBeGreaterThanOrEqual(150);
+    expect(copy.description.length).toBeLessThanOrEqual(160);
+    expect(copy.title).toContain(`${cityName} surf window today`);
+    expect(copy.title).toContain("tide & wind");
+    expect(copy.description).toContain(
+      `${cityName}'s best surf window today`,
+    );
+    expect(copy.description).toContain("wind, swell, and live conditions");
+    expect(copy.h1).toBe(
+      `Best ${cityName} surf window today: tide and conditions`,
+    );
+  });
 
   it("builds live surf report handoff steps from the city's top spots", () => {
     const steps = buildBestTimeLiveHandoffSteps({
@@ -362,7 +387,10 @@ describe("best-time city SEO page", () => {
       "utf8"
     );
 
-    expect(source).toContain("Best Time to Surf ${cityName} Today");
+    expect(source).toContain(
+      "Best ${cityName} surf window today: tide and conditions",
+    );
+    expect(source).toContain("{liveAnswerCopy.todayAnswer}");
     expect(source).toContain("Surf Score by Month");
     expect(source).toContain("Monthly Breakdown");
     expect(source).toContain("path: `/best-time-to-surf/${citySlug}`");

--- a/__tests__/app/best-time-la-jolla-live-answer.test.ts
+++ b/__tests__/app/best-time-la-jolla-live-answer.test.ts
@@ -22,6 +22,9 @@ describe("best-time La Jolla live answer copy", () => {
       surfReportCue: expect.stringContaining("surf report"),
     });
     expect(copy.todayAnswer).toContain("La Jolla");
+    expect(copy.todayAnswer).toMatch(
+      /^La Jolla's best surf window today starts with the live report:/,
+    );
     expect(copy.todayAnswer).toContain("Scripps Pier");
     expect(copy.todayAnswer).toContain("2-4 ft");
     expect(copy.surfReportCue).toContain("Scripps Pier");
@@ -65,7 +68,9 @@ describe("best-time La Jolla live answer copy", () => {
       },
     });
 
-    expect(copy.todayAnswer).toContain("6:00 AM-9:00 AM");
+    expect(copy.todayAnswer).toMatch(
+      /^La Jolla's best surf window today is 6:00 AM-9:00 AM, with rising tide, light W wind, and 2-3 ft swell;/,
+    );
     expect(copy.todayAnswer).toContain("incoming tide, light winds");
     expect(copy.todayAnswer).toContain("La Jolla Shores");
     expect(copy.todayAnswer).toContain("2-3 ft");

--- a/__tests__/app/best-time-santa-cruz-ctr.test.ts
+++ b/__tests__/app/best-time-santa-cruz-ctr.test.ts
@@ -2,11 +2,9 @@
  * @jest-environment node
  */
 
-import { readFileSync } from "fs";
-import { join } from "path";
-
 import {
   buildBestTimeLiveHandoffSteps,
+  buildBestTimeMetadataCopy,
   buildBestTimeTodayAnswerCopy,
   generateMetadata,
 } from "@/app/best-time-to-surf/[city]/page";
@@ -62,26 +60,16 @@ describe("best-time Santa Cruz CTR treatment", () => {
     });
   });
 
-  it("serves Santa Cruz-specific metadata, H1, and hero copy", async () => {
+  it("serves decision-first metadata and H1 for Santa Cruz", async () => {
     const metadata = await generateMetadata({
       params: Promise.resolve({ city: "santa-cruz" }),
     });
+    const copy = buildBestTimeMetadataCopy("Santa Cruz");
 
-    expect(metadata.title).toContain(
-      "Best Time to Surf Santa Cruz: Wind, Tide & Season",
-    );
-    expect(metadata.description).toContain("Steamer Lane");
-    expect(metadata.description).toContain("Cowell's and Capitola");
-    expect(metadata.description).toContain("water temperature");
-
-    const source = readFileSync(
-      join(process.cwd(), "app/best-time-to-surf/[city]/page.tsx"),
-      "utf8",
-    );
-
-    expect(source).toContain('h1: "Best Time to Surf Santa Cruz Today"');
-    expect(source).toContain(
-      'heroDek:\n      "Steamer Lane, Cowell\'s and Capitola windows, wind, tide, cold water, and season"',
+    expect(metadata.title).toBe(copy.title);
+    expect(metadata.description).toBe(copy.description);
+    expect(copy.h1).toBe(
+      "Best Santa Cruz surf window today: tide and conditions",
     );
   });
 
@@ -99,6 +87,9 @@ describe("best-time Santa Cruz CTR treatment", () => {
     });
 
     expect(copy.todayAnswer).toContain("Steamer Lane");
+    expect(copy.todayAnswer).toMatch(
+      /^Santa Cruz's best surf window today starts with the live report:/,
+    );
     expect(copy.todayAnswer).toContain("Cowell's");
     expect(copy.todayAnswer).toContain("Capitola");
     expect(copy.todayAnswer).toContain("wind");

--- a/app/best-time-to-surf/[city]/page.tsx
+++ b/app/best-time-to-surf/[city]/page.tsx
@@ -69,12 +69,39 @@ const MONTH_ABBREVS = [
 
 const YEAR_ROUND_THRESHOLD = 10;
 const SOLID_SEASON_THRESHOLD = 6;
+const BEST_TIME_SERP_TITLE_MAX_LENGTH = 60;
+const BEST_TIME_SERP_TITLE_SUFFIX = " | Quiver";
+const BEST_TIME_META_DESCRIPTION_MAX_LENGTH = 160;
+
+interface BestTimeMetadataCopy {
+  title: string;
+  description: string;
+  h1: string;
+}
+
+export function buildBestTimeMetadataCopy(
+  cityName: string,
+): BestTimeMetadataCopy {
+  const detailedTitle = `Best ${cityName} surf window today: tide & wind`;
+  const compactTitle = `${cityName} surf window today: tide & wind`;
+  const detailedDescription = `${cityName}'s best surf window today: check tide, wind, swell, and live conditions at nearby spots, plus seasonal patterns for planning your next session.`;
+  const compactDescription = `${cityName}'s surf window today: check tide, wind, swell, and live spot conditions, plus seasonal patterns for planning your next session.`;
+
+  return {
+    title:
+      `${detailedTitle}${BEST_TIME_SERP_TITLE_SUFFIX}`.length <=
+      BEST_TIME_SERP_TITLE_MAX_LENGTH
+        ? detailedTitle
+        : compactTitle,
+    description:
+      detailedDescription.length <= BEST_TIME_META_DESCRIPTION_MAX_LENGTH
+        ? detailedDescription
+        : compactDescription,
+    h1: `Best ${cityName} surf window today: tide and conditions`,
+  };
+}
 
 interface BestTimeCtrOverride {
-  metadataTitle: string;
-  metadataDescription: string;
-  h1: string;
-  heroDek: string;
   answerPrefix: string;
   weekSuffix: string;
   surfReportCue: string;
@@ -83,12 +110,6 @@ interface BestTimeCtrOverride {
 
 const BEST_TIME_CTR_OVERRIDES: Record<string, BestTimeCtrOverride> = {
   "la-jolla": {
-    metadataTitle: "Best Time to Surf La Jolla: Shores, Scripps & Wind",
-    metadataDescription:
-      "Find the best time to surf La Jolla today with Scripps Pier, Shores, Tourmaline, wind, tide, and seasonal windows before you drive.",
-    h1: "Best Time to Surf La Jolla Today",
-    heroDek:
-      "Shores, Scripps, Tourmaline, today's live report, and the seasonal pattern",
     answerPrefix:
       "For La Jolla, use Scripps Pier, Shores, and Tourmaline as the live proof points before trusting the seasonal pattern.",
     weekSuffix:
@@ -103,12 +124,6 @@ const BEST_TIME_CTR_OVERRIDES: Record<string, BestTimeCtrOverride> = {
     },
   },
   "newport-beach": {
-    metadataTitle: "Best Time to Surf Newport Beach: Season & Today",
-    metadataDescription:
-      "Find the best time to surf Newport Beach today with Blackies, tide, morning wind, crowd context, and the live Newport Beach surf report.",
-    h1: "Best Time to Surf Newport Beach Today",
-    heroDek:
-      "Blackies, Newport jetties, morning wind, today's live report, and the seasonal pattern",
     answerPrefix:
       "For Newport Beach, separate the seasonal calendar from the live Blackies and jetty read before you commit.",
     weekSuffix:
@@ -123,12 +138,6 @@ const BEST_TIME_CTR_OVERRIDES: Record<string, BestTimeCtrOverride> = {
     },
   },
   malibu: {
-    metadataTitle: "Best Time to Surf Malibu: Tide, Season & Crowd",
-    metadataDescription:
-      "Find the best time to surf Malibu today with First Point, tide, morning wind, crowd context, and the live Malibu surf report.",
-    h1: "Best Time to Surf Malibu Today",
-    heroDek:
-      "First Point, tide, crowd, today's live report, and the seasonal pattern",
     answerPrefix:
       "For Malibu, treat crowd and tide as part of the forecast before the seasonal score makes the call.",
     weekSuffix:
@@ -143,12 +152,6 @@ const BEST_TIME_CTR_OVERRIDES: Record<string, BestTimeCtrOverride> = {
     },
   },
   "santa-cruz": {
-    metadataTitle: "Best Time to Surf Santa Cruz: Wind, Tide & Season",
-    metadataDescription:
-      "Find the best time to surf Santa Cruz today. Compare Steamer Lane with Cowell's and Capitola windows, then check wind, tide, water temperature, and season.",
-    h1: "Best Time to Surf Santa Cruz Today",
-    heroDek:
-      "Steamer Lane, Cowell's and Capitola windows, wind, tide, cold water, and season",
     answerPrefix:
       "For Santa Cruz, separate Steamer Lane's experienced reef setup from smaller Cowell's and Capitola beginner windows; the same swell, tide, and wind do not suit both.",
     weekSuffix:
@@ -308,13 +311,18 @@ export function buildBestTimeTodayAnswerCopy({
     currentBestMonthCount > 0
       ? `${currentBestMonthCount} of ${totalBeaches} local beaches are in peak season`
       : `${cityName} is between peak-season windows`;
-  const waveText = waveHeightRange ? ` with ${waveHeightRange} surf` : "";
-  const waterText = waterTempF != null ? ` and ${waterTempF}°F water` : "";
+  const seasonalConditions = [
+    waveHeightRange ? `${waveHeightRange} surf` : null,
+    waterTempF != null ? `${waterTempF}°F water` : null,
+  ].filter((condition): condition is string => condition !== null);
+  const seasonalContext = seasonalConditions.length > 0
+    ? ` Seasonal context: ${seasonalConditions.join(" and ")}.`
+    : "";
   const forecastDay = forecastSummary?.isTomorrow ? "tomorrow" : "today";
   const topPick = forecastSummary?.topPicks[0];
   const liveTodayAnswer =
     forecastSummary?.bestWindow
-      ? `${cityName}'s best surf window ${forecastDay} is ${forecastSummary.bestWindow.start}-${forecastSummary.bestWindow.end}: ${forecastSummary.bestWindow.reason}. ${
+      ? `${cityName}'s best surf window ${forecastDay} is ${forecastSummary.bestWindow.start}-${forecastSummary.bestWindow.end}, with ${forecastSummary.conditions.tide.toLowerCase()} tide, ${forecastSummary.conditions.wind} wind, and ${forecastSummary.conditions.swell} swell; ${forecastSummary.bestWindow.reason}. ${
           topPick
             ? `${topPick.name} is the top pick at ${topPick.waveHeight}.`
             : "Check the live report before you drive."
@@ -326,7 +334,7 @@ export function buildBestTimeTodayAnswerCopy({
   const ctrOverride = citySlug ? getBestTimeCtrOverride(citySlug) : null;
   const baseTodayAnswer =
     liveTodayAnswer ??
-    `${cityName}'s best surf window today starts with the live report: check tide, wind, and swell before you drive${waveText}${waterText}.`;
+    `${cityName}'s best surf window today starts with the live report: check tide, wind, and swell before you drive.${seasonalContext}`;
   const baseThisWeekAnswer = `${currentMonthName} rates ${currentMonthScore}/100 for ${cityName}. ${seasonStrength}; ${peakMonthName} is the historical peak if this week's surf report looks marginal.`;
 
   return {
@@ -334,7 +342,7 @@ export function buildBestTimeTodayAnswerCopy({
     heading: `Best time to surf ${cityName} today`,
     weekHeading: `Best time to surf ${cityName} this week`,
     todayAnswer: ctrOverride
-      ? `${ctrOverride.answerPrefix} ${baseTodayAnswer}`
+      ? `${baseTodayAnswer} ${ctrOverride.answerPrefix}`
       : baseTodayAnswer,
     thisWeekAnswer: ctrOverride
       ? `${baseThisWeekAnswer} ${ctrOverride.weekSuffix}`
@@ -357,15 +365,11 @@ export async function generateMetadata(props: PageParams): Promise<Metadata> {
   }
 
   const { cityName, stateName } = cityResult.data;
-  const ctrOverride = getBestTimeCtrOverride(citySlug);
+  const metadataCopy = buildBestTimeMetadataCopy(cityName);
 
   const metadata = buildPageMetadata({
-    title:
-      ctrOverride?.metadataTitle ??
-      `Best Time to Surf ${cityName} Today & This Week`,
-    description:
-      ctrOverride?.metadataDescription ??
-      `Best time to surf ${cityName} today and this week. Start with the live surf report, then use seasonal windows, tides, wind, and nearby spots.`,
+    title: metadataCopy.title,
+    description: metadataCopy.description,
     path: `/best-time-to-surf/${citySlug}`,
     keywords: [
       `best time to surf ${cityName}`,
@@ -416,7 +420,7 @@ export default async function BestTimeToSurfPage(props: PageParams) {
   const stateSlug = state.toLowerCase();
   const heroScene = getBestTimeSeoScene(citySlug);
   const sessionScene = getBestTimeSessionSeoScene(citySlug);
-  const ctrOverride = getBestTimeCtrOverride(citySlug);
+  const metadataCopy = buildBestTimeMetadataCopy(cityName);
 
   const [dataResult, excludeIntents, forecastBeachesResult, cityEditorial] = await Promise.all([
     getBestTimeToSurfData(cityName, state),
@@ -566,19 +570,16 @@ export default async function BestTimeToSurfPage(props: PageParams) {
           <span className="text-gray-800 font-medium">Surf Calendar</span>
         </nav>
 
-        <ReviewedCityEditorialSection editorial={cityEditorial} />
-
         {/* Hero Section */}
         <ScrollReveal>
           <header className="mb-10">
             <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(360px,460px)] lg:items-stretch">
               <div>
                 <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-2">
-                  {ctrOverride?.h1 ?? `Best Time to Surf ${cityName} Today`}
+                  {metadataCopy.h1}
                 </h1>
                 <p className="text-lg text-gray-600 mb-6">
-                  {ctrOverride?.heroDek ??
-                    `${cityName}, ${stateName} - today, this week, and the seasonal pattern`}
+                  {liveAnswerCopy.todayAnswer}
                 </p>
 
                 <div className="mb-5 rounded-lg border border-[#11100D]/15 bg-white p-5 text-[#11100D] shadow-sm">
@@ -586,15 +587,12 @@ export default async function BestTimeToSurfPage(props: PageParams) {
                     {liveAnswerCopy.eyebrow}
                   </p>
                   <h2 className="mb-3 text-2xl font-semibold text-gray-900">
-                    Today&apos;s surf call
+                    Plan around the live conditions
                   </h2>
-                  <p className="text-sm leading-6 text-gray-700">
-                    {liveAnswerCopy.todayAnswer}
-                  </p>
                   <div className="mt-4 grid gap-3 sm:grid-cols-2">
                     <div className="rounded-md bg-[#FBF6E8] p-3">
                       <h3 className="text-sm font-semibold text-gray-900">
-                        This week&apos;s surf window
+                        {liveAnswerCopy.weekHeading}
                       </h3>
                       <p className="mt-1 text-sm leading-6 text-gray-700">
                         {liveAnswerCopy.thisWeekAnswer}
@@ -659,6 +657,8 @@ export default async function BestTimeToSurfPage(props: PageParams) {
             </div>
           </header>
         </ScrollReveal>
+
+        <ReviewedCityEditorialSection editorial={cityEditorial} />
 
         <SeoFunnelNextSteps
           variant="paper"

--- a/e2e/guest-seo-updated-surfaces.spec.ts
+++ b/e2e/guest-seo-updated-surfaces.spec.ts
@@ -38,22 +38,22 @@ const UPDATED_SURF_REPORT_SLUGS = [
 const UPDATED_BEST_TIME_PAGES = [
   {
     path: "/best-time-to-surf/la-jolla",
-    title: "Best Time to Surf La Jolla: Shores, Scripps & Wind",
-    h1: "Best Time to Surf La Jolla Today",
+    title: "Best La Jolla surf window today: tide & wind",
+    h1: "Best La Jolla surf window today: tide and conditions",
     surfReportLabel: "Open today's Scripps Pier surf report",
     surfReportHref: "/surf-report/scripps-pier-today",
   },
   {
     path: "/best-time-to-surf/newport-beach",
-    title: "Best Time to Surf Newport Beach: Season & Today",
-    h1: "Best Time to Surf Newport Beach Today",
+    title: "Best Newport Beach surf window today: tide & wind",
+    h1: "Best Newport Beach surf window today: tide and conditions",
     surfReportLabel: "Open today's Newport Beach surf report",
     surfReportHref: "/surf-report/newport-beach-today",
   },
   {
     path: "/best-time-to-surf/malibu",
-    title: "Best Time to Surf Malibu: Tide, Season & Crowd",
-    h1: "Best Time to Surf Malibu Today",
+    title: "Best Malibu surf window today: tide & wind",
+    h1: "Best Malibu surf window today: tide and conditions",
     surfReportLabel: "Open today's Malibu surf report",
     surfReportHref: "/surf-report/malibu-today",
   },
@@ -194,6 +194,10 @@ test.describe("Updated SEO public surfaces", () => {
       await expect(
         page.getByRole("heading", { name: bestTimePage.h1, level: 1 }),
       ).toBeVisible();
+      const openingCopy = page.locator("h1 + p");
+      await expect(openingCopy).toContainText(/best surf window/i);
+      await expect(openingCopy).toContainText(/tide/i);
+      await expect(openingCopy).toContainText(/wind/i);
       await expect(
         page.getByRole("link", { name: bestTimePage.surfReportLabel }).first(),
       ).toHaveAttribute("href", bestTimePage.surfReportHref);


### PR DESCRIPTION
`/best-time-to-surf/la-jolla` earned **18,174 impressions and 7 clicks** in 28 days at average position 7.9 — a **0.04% CTR**, the worst-converting high-volume page on the site. The whole family runs 105 clicks / 29,394 impressions = 0.36%. Ranking is fine; the snippet isn't earning the click.

Retitles to the concrete, time-bound answer the query wants and leads the page with the live window, tide, wind and swell. Titles stay under ~60 chars and descriptions 150–160 so they don't truncate, with a compact fallback for longer city names.

**Verified at runtime:** `/best-time-to-surf/la-jolla` now titles *Best La Jolla surf window today: tide & wind*. typecheck, lint, 16,857 tests.

CTR impact requires post-release GSC measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)