### PR TITLE
feat(api): add forecast availability state and opt-in stale payload

### DIFF
--- a/__tests__/app/api/forecasts/current/route.test.ts
+++ b/__tests__/app/api/forecasts/current/route.test.ts
@@ -176,6 +176,7 @@ describe("GET /api/forecasts/current", () => {
         refreshAttempted: false,
         stale: false,
         missing: false,
+        availability: "fresh",
         dataSource: "OPEN_METEO",
       }),
     );
@@ -270,6 +271,108 @@ describe("GET /api/forecasts/current", () => {
     expect(body.data.metadata.stale).toBe(false);
   });
 
+  it("keeps the stale response byte-identical when includeStale is omitted", async () => {
+    const staleUpdatedAt = new Date(
+      NOW.getTime() - 13 * 60 * 60 * 1000,
+    ).toISOString();
+    setupQueries({
+      current: [{ data: currentRow(), error: null }],
+      latest: [
+        {
+          data: {
+            updated_at: staleUpdatedAt,
+            data_source: "OPEN_METEO",
+          },
+          error: null,
+        },
+      ],
+      tide: [{ data: { tide_ft: 2.7 }, error: null }],
+    });
+
+    const response = await callRoute(
+      `http://localhost:3000/api/forecasts/current?beachId=${BEACH_ID}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(
+      JSON.stringify({
+        success: true,
+        data: {
+          current: null,
+          metadata: {
+            refreshed: false,
+            refreshAttempted: false,
+            stale: true,
+            // Phase C deletes this assertion when the legacy `missing` semantics are corrected.
+            missing: true,
+            availability: "stale",
+            dataSource: "OPEN_METEO",
+            lastUpdated: staleUpdatedAt,
+            reason: "Data is 13.0h old (threshold: 6h)",
+          },
+        },
+        timestamp: NOW.toISOString(),
+      }),
+    );
+  });
+
+  it("includes a stale current row when includeStale is enabled", async () => {
+    setupQueries({
+      current: [{ data: currentRow(), error: null }],
+      latest: [
+        {
+          data: {
+            updated_at: new Date(
+              NOW.getTime() - 13 * 60 * 60 * 1000,
+            ).toISOString(),
+            data_source: "OPEN_METEO",
+          },
+          error: null,
+        },
+      ],
+      tide: [{ data: { tide_ft: 2.7 }, error: null }],
+    });
+
+    const response = await callRoute(
+      `http://localhost:3000/api/forecasts/current?beachId=${BEACH_ID}&includeStale=1`,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.current).toEqual(
+      expect.objectContaining({
+        wave_height: "3-4 ft",
+        tide_height: "2.7 ft",
+      }),
+    );
+    expect(body.data.metadata.availability).toBe("stale");
+    expect(body.data.metadata.stale).toBe(true);
+    expect(body.data.metadata.missing).toBe(true);
+  });
+
+  it("withholds the current row when includeStale is enabled but data is unavailable", async () => {
+    setupQueries({
+      current: [{ data: null, error: null }],
+      latest: [{ data: null, error: null }],
+    });
+
+    const response = await callRoute(
+      `http://localhost:3000/api/forecasts/current?beachId=${BEACH_ID}&includeStale=1`,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.current).toBeNull();
+    expect(body.data.metadata).toEqual(
+      expect.objectContaining({
+        stale: false,
+        missing: true,
+        availability: "unavailable",
+        reason: "No forecast data in cache",
+      }),
+    );
+  });
+
   it("returns unavailable metadata when refresh fails", async () => {
     mockUpdateBeachForecast.mockRejectedValueOnce(new Error("provider timeout"));
     setupQueries({
@@ -299,6 +402,7 @@ describe("GET /api/forecasts/current", () => {
         refreshAttempted: true,
         stale: true,
         missing: true,
+        availability: "unavailable",
         refreshError: "provider timeout",
       }),
     );

--- a/app/api/forecasts/current/route.ts
+++ b/app/api/forecasts/current/route.ts
@@ -19,6 +19,7 @@ export const maxDuration = 30;
 const QuerySchema = z.object({
   beachId: z.string().uuid({ message: "beachId must be a valid UUID" }),
   refresh: z.enum(["if-stale"]).optional(),
+  includeStale: z.enum(["1"]).optional(),
 });
 
 type CurrentForecastRow = EnhancedForecastEntity & {
@@ -32,6 +33,17 @@ type CurrentMetadata = {
   refreshAttempted: boolean;
   stale: boolean;
   missing: boolean;
+  /**
+   * Authoritative freshness state. Prefer this over `stale`/`missing`.
+   *
+   * fresh       — usable data within the staleness threshold
+   * stale       — usable data past the threshold. Render it WITH `lastUpdated`.
+   * unavailable — no usable data. Render an explicit empty state.
+   *
+   * `missing` is retained for pre-adoption native builds and currently also
+   * returns true for `stale`. It is corrected in a later phase.
+   */
+  availability: "fresh" | "stale" | "unavailable";
   dataSource: string | null;
   lastUpdated: string | null;
   reason: string | null;
@@ -154,11 +166,18 @@ function buildMetadata(args: {
   refreshError?: string;
 }): CurrentMetadata {
   const unavailable = args.current == null || args.freshness.missing || args.freshness.stale;
+  const availability =
+    args.current == null || args.freshness.missing
+      ? "unavailable"
+      : args.freshness.stale
+        ? "stale"
+        : "fresh";
   return {
     refreshed: args.refreshed,
     refreshAttempted: args.refreshAttempted,
     stale: args.freshness.stale,
     missing: unavailable,
+    availability,
     dataSource: args.freshness.dataSource,
     lastUpdated: args.freshness.lastUpdated,
     reason: unavailable
@@ -176,10 +195,11 @@ async function currentForecastHandler(
   const validation = validateOrError(QuerySchema, {
     beachId: searchParams.get("beachId") ?? undefined,
     refresh: searchParams.get("refresh") ?? undefined,
+    includeStale: searchParams.get("includeStale") ?? undefined,
   });
   if ("error" in validation) return validation.error;
 
-  const { beachId, refresh } = validation.data;
+  const { beachId, refresh, includeStale } = validation.data;
   const beachExists = await readBeachExists(supabase, beachId);
   if (!beachExists) {
     return createErrorResponse("Beach not found", null, 404);
@@ -211,7 +231,11 @@ async function currentForecastHandler(
     freshness,
     refreshError,
   });
-  const currentForDisplay = metadata.missing || metadata.stale ? null : current;
+  const shouldIncludeCurrent =
+    includeStale === "1"
+      ? metadata.availability !== "unavailable"
+      : !metadata.missing && !metadata.stale;
+  const currentForDisplay = shouldIncludeCurrent ? current : null;
   const response = createSuccessResponse({
     current: currentForDisplay,
     metadata,


### PR DESCRIPTION
`/api/forecasts/current` folded stale into missing:

```ts
missing: unavailable   // where unavailable includes freshness.stale
```

so a beach with real but aging data returned `stale: true, missing: true`, and native (`beach-detail.tsx:738` branches on `missing`) **hid conditions that had merely aged** — the same failure the web embeds had, reached through this contract.

Adds `availability: 'fresh' | 'stale' | 'unavailable'` as the authoritative state. Every existing field keeps its current value.

The route also nulled the payload when stale, which would have left the new state inert. Sending it unconditionally is **not** safe: native feeds `currentForecastRow` to sub-components independently of its unavailable flag, so installed builds would render stale readings in some sections while flagging conditions unavailable in others. The payload is gated behind `includeStale=1`, matching the existing `refresh=if-stale` pattern.

**Non-breaking by construction**, proven by a test named *"keeps the stale response byte-identical when includeStale is omitted"*. The phase-C regression assertion is tagged in-code for deletion when `missing` is corrected.

Pairs with quiver-native `feat/forecast-availability-adopt`. **Land this first** — though native's fallback makes either order safe.

**Verified:** typecheck, lint, 16,853 tests. Integrated with the other four Aug 5 branches: 0 conflicts, 16,871 tests + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)