### PR TITLE
refactor(forecast): unify duplicated freshness-metadata implementations

### DIFF
--- a/__tests__/lib/utils/forecast-latest-metadata.test.ts
+++ b/__tests__/lib/utils/forecast-latest-metadata.test.ts
@@ -1,0 +1,121 @@
+import {
+  readLatestForecastMetadata,
+  type LatestForecastMetadataOptions,
+} from "@/lib/utils/forecast-service-utils";
+
+type LatestRow = {
+  updated_at: string;
+  data_source: string | null;
+};
+
+type QueryResult = {
+  data: LatestRow | null;
+  error: { message: string } | null;
+};
+
+function createMetadataClient(result: QueryResult) {
+  const maybeSingle = jest.fn(async () => result);
+  const eq = jest.fn(() => ({ maybeSingle }));
+  const select = jest.fn(() => ({ eq }));
+  const from = jest.fn(() => ({ select }));
+
+  return {
+    client: { from } as unknown as Parameters<
+      typeof readLatestForecastMetadata
+    >[0],
+    from,
+    select,
+    eq,
+  };
+}
+
+async function readWithSource(
+  dataSource: string | null,
+  options?: LatestForecastMetadataOptions,
+) {
+  const eightHoursAgo = new Date(
+    Date.now() - 8 * 60 * 60 * 1000,
+  ).toISOString();
+  const { client } = createMetadataClient({
+    data: { updated_at: eightHoursAgo, data_source: dataSource },
+    error: null,
+  });
+
+  return readLatestForecastMetadata(client, "beach-id", options);
+}
+
+describe("readLatestForecastMetadata", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-06T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("queries the latest view and returns missing metadata", async () => {
+    const { client, from, select, eq } = createMetadataClient({
+      data: null,
+      error: null,
+    });
+
+    const result = await readLatestForecastMetadata(client, "beach-id");
+
+    expect(from).toHaveBeenCalledWith("v_enhanced_forecast_latest");
+    expect(select).toHaveBeenCalledWith("updated_at, data_source");
+    expect(eq).toHaveBeenCalledWith("beach_id", "beach-id");
+    expect(result).toEqual({
+      cached: false,
+      stale: false,
+      missing: true,
+      dataSource: null,
+      stalenessDataSource: null,
+      lastUpdated: null,
+      reason: "No forecast data in cache",
+      stalenessDetails: null,
+    });
+  });
+
+  it("preserves a null source and the default threshold when no fallback is requested", async () => {
+    const result = await readWithSource(null);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        stale: true,
+        missing: false,
+        dataSource: null,
+        stalenessDataSource: null,
+        reason: "Data is 8.0h old (threshold: 6h)",
+      }),
+    );
+  });
+
+  it("uses the requested fallback source for staleness without replacing the raw source", async () => {
+    const result = await readWithSource(null, {
+      fallbackDataSource: "FALLBACK",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        stale: false,
+        missing: false,
+        dataSource: null,
+        stalenessDataSource: "FALLBACK",
+        reason: null,
+      }),
+    );
+    expect(result.stalenessDetails?.threshold).toBe(12);
+  });
+
+  it("propagates view query errors", async () => {
+    const { client } = createMetadataClient({
+      data: null,
+      error: { message: "metadata query failed" },
+    });
+
+    await expect(
+      readLatestForecastMetadata(client, "beach-id"),
+    ).rejects.toThrow("metadata query failed");
+  });
+});

--- a/app/api/forecasts/current/route.ts
+++ b/app/api/forecasts/current/route.ts
@@ -9,7 +9,7 @@ import {
   type AuthenticatedContext,
 } from "@/lib/middleware/api-wrappers";
 import { updateBeachForecast } from "@/lib/utils/forecast-server-utils";
-import { getStalenessDetails } from "@/lib/utils/forecast-service-utils";
+import { readLatestForecastMetadata } from "@/lib/utils/forecast-service-utils";
 import { applyV51DisplayOverrideToForecasts } from "@/lib/services/forecast/v5-display-gate";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 
@@ -72,46 +72,6 @@ async function readBeachExists(
   return Boolean(data);
 }
 
-async function readLatestMetadata(
-  supabase: AuthenticatedContext["supabase"],
-  beachId: string,
-): Promise<{
-  stale: boolean;
-  missing: boolean;
-  dataSource: string | null;
-  lastUpdated: string | null;
-  reason: string | null;
-}> {
-  const { data, error } = await supabase
-    .from("v_enhanced_forecast_latest")
-    .select("updated_at, data_source")
-    .eq("beach_id", beachId)
-    .maybeSingle();
-
-  if (error) throw new Error(error.message);
-  if (!data?.updated_at) {
-    return {
-      stale: false,
-      missing: true,
-      dataSource: null,
-      lastUpdated: null,
-      reason: "No forecast data in cache",
-    };
-  }
-
-  const dataSource = data.data_source ?? null;
-  const details = getStalenessDetails(data.updated_at, dataSource);
-  return {
-    stale: details.isStale,
-    missing: false,
-    dataSource,
-    lastUpdated: data.updated_at,
-    reason: details.isStale
-      ? `Data is ${details.hoursSinceUpdate.toFixed(1)}h old (threshold: ${details.threshold}h)`
-      : null,
-  };
-}
-
 async function readLatestHourlyTide(
   supabase: AuthenticatedContext["supabase"],
   beachId: string,
@@ -162,7 +122,7 @@ function buildMetadata(args: {
   refreshed: boolean;
   refreshAttempted: boolean;
   current: CurrentForecastRow | null;
-  freshness: Awaited<ReturnType<typeof readLatestMetadata>>;
+  freshness: Awaited<ReturnType<typeof readLatestForecastMetadata>>;
   refreshError?: string;
 }): CurrentMetadata {
   const unavailable = args.current == null || args.freshness.missing || args.freshness.stale;
@@ -207,7 +167,7 @@ async function currentForecastHandler(
 
   const now = new Date();
   let current = await readCurrentRow(supabase, beachId, now);
-  let freshness = await readLatestMetadata(supabase, beachId);
+  let freshness = await readLatestForecastMetadata(supabase, beachId);
   const shouldRefresh = refresh === "if-stale" && (current == null || freshness.missing || freshness.stale);
   let refreshed = false;
   let refreshError: string | undefined;
@@ -217,7 +177,7 @@ async function currentForecastHandler(
       await updateBeachForecast(beachId);
       refreshed = true;
       current = await readCurrentRow(supabase, beachId, new Date());
-      freshness = await readLatestMetadata(supabase, beachId);
+      freshness = await readLatestForecastMetadata(supabase, beachId);
     } catch (error) {
       refreshError = error instanceof Error ? error.message : "Current conditions refresh failed";
       current = null;

--- a/lib/utils/forecast-service-utils.ts
+++ b/lib/utils/forecast-service-utils.ts
@@ -4,6 +4,8 @@ import { getStalenessThreshold } from "@/lib/config/forecast-staleness";
 import { extractForecastDate } from "@/lib/utils/forecast-at-adapter";
 import { fetchNowcastAnchors } from "@/lib/services/observations/nowcast-anchor";
 import { fetchSouthOcSanoShadowZoneSnapshot } from "@/lib/services/forecast/south-oc-sano-shadow-guardrail";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/supabase";
 import type { EnhancedForecastEntity } from "@/types/forecast";
 // Removed unused type import to satisfy TS6133
 
@@ -85,6 +87,115 @@ export function getStalenessDetails(
   };
 }
 
+type ForecastMetadataClient = Pick<SupabaseClient<Database>, "from">;
+
+export type LatestForecastMetadata =
+  | {
+      cached: false;
+      stale: false;
+      missing: true;
+      dataSource: null;
+      stalenessDataSource: null;
+      lastUpdated: null;
+      reason: "No forecast data in cache";
+      stalenessDetails: null;
+    }
+  | {
+      cached: true;
+      stale: false;
+      missing: false;
+      dataSource: string | null;
+      stalenessDataSource: string | null;
+      lastUpdated: string;
+      reason: null;
+      stalenessDetails: ReturnType<typeof getStalenessDetails>;
+    }
+  | {
+      cached: true;
+      stale: true;
+      missing: false;
+      dataSource: string | null;
+      stalenessDataSource: string | null;
+      lastUpdated: string;
+      reason: string;
+      stalenessDetails: ReturnType<typeof getStalenessDetails>;
+    };
+
+export interface LatestForecastMetadataOptions {
+  /** Substitute this source for null/empty view values when computing staleness. */
+  fallbackDataSource?: string;
+}
+
+/**
+ * Read the latest forecast write metadata and compute source-aware freshness.
+ *
+ * The latest view is the source of truth because forecast rows are ordered by
+ * forecast_at, not write time. Query errors are intentionally propagated so
+ * each caller can retain its existing error boundary.
+ */
+export async function readLatestForecastMetadata(
+  supabase: ForecastMetadataClient,
+  beachId: string,
+  options: LatestForecastMetadataOptions = {},
+): Promise<LatestForecastMetadata> {
+  const { data, error } = await supabase
+    .from("v_enhanced_forecast_latest")
+    .select("updated_at, data_source")
+    .eq("beach_id", beachId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data?.updated_at) {
+    return {
+      cached: false,
+      stale: false,
+      missing: true,
+      dataSource: null,
+      stalenessDataSource: null,
+      lastUpdated: null,
+      reason: "No forecast data in cache",
+      stalenessDetails: null,
+    };
+  }
+
+  const dataSource = data.data_source ?? null;
+  const stalenessDataSource =
+    dataSource === null || dataSource === ""
+      ? options.fallbackDataSource ?? dataSource
+      : dataSource;
+  const stalenessDetails = getStalenessDetails(
+    data.updated_at,
+    stalenessDataSource,
+  );
+
+  if (!stalenessDetails.isStale) {
+    return {
+      cached: true,
+      stale: false,
+      missing: false,
+      dataSource,
+      stalenessDataSource,
+      lastUpdated: data.updated_at,
+      reason: null,
+      stalenessDetails,
+    };
+  }
+
+  return {
+    cached: true,
+    stale: true,
+    missing: false,
+    dataSource,
+    stalenessDataSource,
+    lastUpdated: data.updated_at,
+    reason: `Data is ${stalenessDetails.hoursSinceUpdate.toFixed(1)}h old (threshold: ${stalenessDetails.threshold}h)`,
+    stalenessDetails,
+  };
+}
+
 export interface ForecastCacheMetadata {
   cached: boolean;
   stale: boolean;
@@ -136,27 +247,14 @@ export async function getFreshForecastFromCache(
   const startTime = Date.now();
 
   try {
-    /**
-     * IMPORTANT:
-     * `fetchBeachForecasts()` returns rows ordered by forecast_at ASC,
-     * which is not a reliable proxy for the *latest write* time. Using `forecasts[0]`
-     * here can incorrectly flag fresh beaches as stale (it’s often the oldest row).
-     *
-     * Instead, use `v_enhanced_forecast_latest` (1 row/beach) as the source of truth
-     * for staleness checks.
-     */
     const supabase = await createSupabaseServiceRoleClient();
-    const latestResult = await supabase
-      .from("v_enhanced_forecast_latest")
-      .select("updated_at, data_source")
-      .eq("beach_id", beachId)
-      .maybeSingle();
+    const latestMetadata = await readLatestForecastMetadata(
+      supabase,
+      beachId,
+      { fallbackDataSource: "FALLBACK" },
+    );
 
-    if (latestResult.error) {
-      throw new Error(latestResult.error.message);
-    }
-
-    if (!latestResult.data || !(latestResult.data as any).updated_at) {
+    if (latestMetadata.missing) {
       console.warn(`⚠️ [getFreshForecastFromCache] No cached data for beach ${beachId}`);
       return {
         forecasts: [],
@@ -169,9 +267,8 @@ export async function getFreshForecastFromCache(
       };
     }
 
-    const latest = latestResult.data as { updated_at: string; data_source: string | null };
-    const dataSource = latest.data_source || "FALLBACK";
-    const stalenessDetails = getStalenessDetails(latest.updated_at, dataSource);
+    const dataSource = latestMetadata.stalenessDataSource;
+    const stalenessDetails = latestMetadata.stalenessDetails;
 
     const duration = Date.now() - startTime;
 
@@ -196,7 +293,7 @@ export async function getFreshForecastFromCache(
               missing: true,
               reason: "No forecast rows returned - waiting for background job",
               dataSource,
-              lastUpdated: latest.updated_at,
+              lastUpdated: latestMetadata.lastUpdated,
             },
           };
         }
@@ -212,10 +309,10 @@ export async function getFreshForecastFromCache(
             stale: true,
             missing: false,
             displayStale: true,
-            reason: `Data is ${stalenessDetails.hoursSinceUpdate.toFixed(1)}h old (threshold: ${stalenessDetails.threshold}h) - serving cached forecast for display`,
+            reason: `${latestMetadata.reason} - serving cached forecast for display`,
             stalenessDetails,
             dataSource,
-            lastUpdated: latest.updated_at,
+            lastUpdated: latestMetadata.lastUpdated,
           },
         };
       }
@@ -229,10 +326,10 @@ export async function getFreshForecastFromCache(
           cached: true,
           stale: true,
           missing: false,
-          reason: `Data is ${stalenessDetails.hoursSinceUpdate.toFixed(1)}h old (threshold: ${stalenessDetails.threshold}h) - refusing to serve stale cache (waiting for background refresh)`,
+          reason: `${latestMetadata.reason} - refusing to serve stale cache (waiting for background refresh)`,
           stalenessDetails,
           dataSource,
-          lastUpdated: latest.updated_at,
+          lastUpdated: latestMetadata.lastUpdated,
         },
       };
     }
@@ -267,7 +364,7 @@ export async function getFreshForecastFromCache(
         reason: null,
         stalenessDetails,
         dataSource,
-        lastUpdated: latest.updated_at,
+        lastUpdated: latestMetadata.lastUpdated,
       },
     };
   } catch (error) {


### PR DESCRIPTION
**Stacked on #494** — targets `feat/forecast-availability-contract`, not `main`, because it touches the same file. Merge #494 first; this retargets to main automatically.

Step 2 of [the freshness refactor plan](https://github.com/SteveChandler/quiver/blob/main/.planning/embed-freshness-fix-and-refactor-20260805.md).

## The duplication

Two implementations computed the same thing from the same source:

| Where | What it did |
|---|---|
| `lib/utils/forecast-service-utils.ts` — `getFreshForecastFromCache` | query `v_enhanced_forecast_latest` for `updated_at, data_source` → `getStalenessDetails()` → `{cached, stale, missing, reason, dataSource, lastUpdated}` |
| `app/api/forecasts/current/route.ts` — `readLatestMetadata` | **the same view, the same columns, the same `getStalenessDetails`** (already imported from that module) |

Two implementations of one rule drift. This is the "written twice" fault named in the plan, and it is why the stale/missing conflation could exist in one place and not the other.

## The change

Extracts `readLatestForecastMetadata` into `forecast-service-utils` — which already owned `getStalenessDetails` and the view query, so the dependency direction was already established — and deletes the route's copy (−48 lines).

## Behaviour is unchanged, and one real divergence was preserved

The two implementations **did** differ observably: the route reported `"No forecast data in cache"` while the cache path reported `"No forecast data in cache - waiting for background job"`. Both strings are **kept on their original paths** rather than collapsed to one, so every caller's output is byte-identical.

That divergence is the whole reason this task existed — silently picking one would have been a behaviour change disguised as a refactor.

**No existing test assertion was modified** — only a new test file added. For a no-behaviour-change refactor the untouched existing suite is the proof.

**Verified:** typecheck, lint, 1295 suites / 16,857 tests, 0 failures.

## Not in scope

Steps 4, 6, 7, 8 — shared view-model presenter, named freshness policy + derived-window regression test, observability, `forecast_at` migration. Embed pages untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)