### PR TITLE
fix(holds): report why hold resolution failed in the repository layer

### DIFF
--- a/__tests__/lib/recommendations/major-event-hold/repository.test.ts
+++ b/__tests__/lib/recommendations/major-event-hold/repository.test.ts
@@ -1,5 +1,6 @@
 import { resolveMajorEventHolds } from "@/lib/recommendations/major-event-hold/repository";
 import type { MajorEventHoldCandidate } from "@/lib/recommendations/major-event-hold/types";
+import { expectConsoleErrors } from "@/__tests__/setup/test-utils";
 
 const BEACH_A = "11111111-1111-4111-8111-111111111111";
 const BEACH_B = "22222222-2222-4222-8222-222222222222";
@@ -60,6 +61,55 @@ function makeClient(data: unknown, error: unknown = null) {
   return {
     rpc: jest.fn().mockResolvedValue({ data, error }),
   };
+}
+
+const diagnosticContext = {
+  candidateCount: 3,
+  beachCount: 2,
+  asOf: "2026-07-19T12:00:00.000Z",
+};
+
+function expectSanitizedDiagnosticPayload(payload: unknown): void {
+  expect(payload).toEqual(expect.any(Object));
+
+  for (const [key, value] of Object.entries(
+    payload as Record<string, unknown>,
+  )) {
+    if (key !== "issues") {
+      expect(["number", "string"]).toContain(typeof value);
+      continue;
+    }
+
+    expect(Array.isArray(value)).toBe(true);
+    for (const issue of value as unknown[]) {
+      expect(issue).toEqual(expect.any(Object));
+      expect(Object.keys(issue as Record<string, unknown>).sort()).toEqual([
+        "message",
+        "path",
+      ]);
+      const { message, path } = issue as {
+        message: unknown;
+        path: unknown;
+      };
+      expect(typeof message).toBe("string");
+      expect(Array.isArray(path)).toBe(true);
+      for (const segment of path as unknown[]) {
+        expect(["number", "string"]).toContain(typeof segment);
+      }
+    }
+  }
+}
+
+function expectDiagnostic(
+  consoleErrorSpy: jest.SpyInstance,
+  tag: string,
+  payload: unknown,
+): void {
+  expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  const [actualTag, actualPayload] = consoleErrorSpy.mock.calls[0];
+  expect(actualTag).toBe(tag);
+  expect(actualPayload).toEqual(payload);
+  expectSanitizedDiagnosticPayload(actualPayload);
 }
 
 describe("major-event hold repository", () => {
@@ -137,32 +187,233 @@ describe("major-event hold repository", () => {
     });
   });
 
+  it("logs a sanitized diagnostic when the RPC returns an error", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const rawError = {
+      message: "database unavailable",
+      code: "08006",
+      details: { connection: "primary" },
+    };
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client: makeClient([], rawError),
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:rpc-error]",
+        {
+          ...diagnosticContext,
+          error: rawError.message,
+          code: rawError.code,
+        },
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs a sanitized diagnostic for a non-array RPC response", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const rawResponse = { rows: [rpcRow] };
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client: makeClient(rawResponse),
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:invalid-response-shape]",
+        diagnosticContext,
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs sanitized validation issues for an invalid hold row", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const invalidRow = { ...rpcRow, version: 0 };
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client: makeClient([invalidRow]),
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:invalid-hold-row]",
+        {
+          ...diagnosticContext,
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              path: ["version"],
+              message: expect.any(String),
+            }),
+          ]),
+        },
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs sanitized identifiers when a hold is invalidated", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const invalidatedRow = {
+      ...rpcRow,
+      scope_exposure_classes: ["fully_exposed"],
+    };
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client: makeClient([invalidatedRow]),
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:hold-invalidated]",
+        {
+          ...diagnosticContext,
+          recordId: rpcRow.record_id,
+          holdId: rpcRow.hold_id,
+        },
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs a sanitized hold ID for duplicate resolver rows", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client: makeClient([
+          rpcRow,
+          {
+            ...rpcRow,
+            record_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+          },
+        ]),
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:duplicate-hold-ids]",
+        {
+          ...diagnosticContext,
+          holdId: rpcRow.hold_id,
+        },
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("logs a sanitized diagnostic when resolution throws", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const thrownError = Object.assign(new Error("network failure"), {
+      raw: { response: "do not log" },
+    });
+    const client = {
+      rpc: jest.fn().mockRejectedValue(thrownError),
+    };
+
+    try {
+      const resolution = await resolveMajorEventHolds(candidates, {
+        client,
+        asOf: new Date(diagnosticContext.asOf),
+      });
+
+      expect(resolution).toEqual({ state: "unresolved", holds: [] });
+      expectDiagnostic(
+        consoleErrorSpy,
+        "[major-event-hold:repository:resolution-threw]",
+        {
+          ...diagnosticContext,
+          error: thrownError.message,
+        },
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it.each([
-    ["non-array payload", {}, null],
-    ["RPC error", [], { message: "database unavailable" }],
-    ["malformed row", [{ ...rpcRow, version: 0 }], null],
-    ["non-active status", [{ ...rpcRow, status: "cancelled" }], null],
+    [
+      "non-array payload",
+      {},
+      null,
+      /\[major-event-hold:repository:invalid-response-shape\]/,
+    ],
+    [
+      "RPC error",
+      [],
+      { message: "database unavailable" },
+      /\[major-event-hold:repository:rpc-error\]/,
+    ],
+    [
+      "malformed row",
+      [{ ...rpcRow, version: 0 }],
+      null,
+      /\[major-event-hold:repository:invalid-hold-row\]/,
+    ],
+    [
+      "non-active status",
+      [{ ...rpcRow, status: "cancelled" }],
+      null,
+      /\[major-event-hold:repository:invalid-hold-row\]/,
+    ],
     [
       "duplicate cohort scope",
       [{ ...rpcRow, affected_cohorts: ["beginner", "beginner"] }],
       null,
+      /\[major-event-hold:repository:invalid-hold-row\]/,
     ],
     [
       "duplicate beach scope",
       [{ ...rpcRow, scope_beach_ids: [BEACH_A, BEACH_A] }],
       null,
+      /\[major-event-hold:repository:invalid-hold-row\]/,
     ],
     [
       "unresolvable exposure scope",
       [{ ...rpcRow, scope_exposure_classes: ["fully_exposed"] }],
       null,
+      /\[major-event-hold:repository:hold-invalidated\]/,
     ],
     [
       "expiry beyond seven days",
       [{ ...rpcRow, expires_at: "2026-07-27T10:00:00.001Z" }],
       null,
+      /\[major-event-hold:repository:invalid-hold-row\]/,
     ],
-  ])("returns unresolved for %s", async (_name, data, error) => {
+  ])("returns unresolved for %s", async (_name, data, error, errorTag) => {
     const client = makeClient(data, error);
     await expect(
       resolveMajorEventHolds(candidates, {
@@ -170,6 +421,7 @@ describe("major-event hold repository", () => {
         asOf: new Date("2026-07-19T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ state: "unresolved", holds: [] });
+    expectConsoleErrors([errorTag]);
   });
 
   it("returns unresolved when the RPC throws", async () => {
@@ -182,6 +434,9 @@ describe("major-event hold repository", () => {
         asOf: new Date("2026-07-19T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ state: "unresolved", holds: [] });
+    expectConsoleErrors([
+      /\[major-event-hold:repository:resolution-threw\]/,
+    ]);
   });
 
   it("rejects duplicate hold IDs as an impossible resolver shape", async () => {
@@ -198,6 +453,9 @@ describe("major-event hold repository", () => {
         asOf: new Date("2026-07-19T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ state: "unresolved", holds: [] });
+    expectConsoleErrors([
+      /\[major-event-hold:repository:duplicate-hold-ids\]/,
+    ]);
   });
 
   it.each([
@@ -220,6 +478,9 @@ describe("major-event hold repository", () => {
         asOf: new Date("2026-07-19T12:00:00.000Z"),
       }),
     ).resolves.toEqual({ state: "unresolved", holds: [] });
+    expectConsoleErrors([
+      /\[major-event-hold:repository:invalid-hold-row\]/,
+    ]);
   });
 
   it("does not call the RPC for an invalid candidate", async () => {

--- a/lib/recommendations/major-event-hold/repository.ts
+++ b/lib/recommendations/major-event-hold/repository.ts
@@ -333,6 +333,11 @@ export async function resolveMajorEventHolds(
   const windowEnd = endsAt.reduce((latest, value) =>
     Date.parse(value) > Date.parse(latest) ? value : latest,
   );
+  const diagnostics = {
+    candidateCount: parsedCandidates.length,
+    beachCount: beachIds.length,
+    asOf: asOf.toISOString(),
+  };
 
   try {
     const client = options.client ?? createSupabaseServiceRoleClient();
@@ -347,14 +352,43 @@ export async function resolveMajorEventHolds(
         p_window_end: windowEnd,
       },
     );
-    if (error !== null && error !== undefined) return UNRESOLVED;
-    if (!Array.isArray(data)) return UNRESOLVED;
+    if (error !== null && error !== undefined) {
+      const rpcError =
+        typeof error === "object"
+          ? (error as { code?: unknown; message?: unknown })
+          : null;
+      console.error("[major-event-hold:repository:rpc-error]", {
+        ...diagnostics,
+        error:
+          typeof rpcError?.message === "string"
+            ? rpcError.message
+            : String(error),
+        code: typeof rpcError?.code === "string" ? rpcError.code : undefined,
+      });
+      return UNRESOLVED;
+    }
+    if (!Array.isArray(data)) {
+      console.error(
+        "[major-event-hold:repository:invalid-response-shape]",
+        diagnostics,
+      );
+      return UNRESOLVED;
+    }
 
     const records: RegionalRecommendationHoldRecord[] = [];
     const holds: ResolvedMajorEventHold[] = [];
     for (const row of data) {
       const parsedRow = resolvedHoldRowSchema.safeParse(row);
-      if (!parsedRow.success) return UNRESOLVED;
+      if (!parsedRow.success) {
+        console.error("[major-event-hold:repository:invalid-hold-row]", {
+          ...diagnostics,
+          issues: parsedRow.error.issues.map(({ path, message }) => ({
+            path,
+            message,
+          })),
+        });
+        return UNRESOLVED;
+      }
       const record = toApplicationHoldRecord(parsedRow.data);
       records.push(record);
       holds.push(toResolvedHold(record));
@@ -366,24 +400,44 @@ export async function resolveMajorEventHolds(
     if (
       holds.some((hold, index) => {
         const record = records[index];
-        return (
+        const invalidated =
           record.status !== "active" ||
           record.scopeExposureClasses.length !== 0 ||
           Date.parse(record.effectiveAt) > asOfMilliseconds ||
           Date.parse(hold.expiresAt) <= asOfMilliseconds ||
           Date.parse(hold.validFrom) >= windowEndMilliseconds ||
           Date.parse(hold.validUntil) <= windowStartMilliseconds ||
-          !hold.scopeBeachIds.some((beachId) => requestedBeachIds.has(beachId))
-        );
+          !hold.scopeBeachIds.some((beachId) => requestedBeachIds.has(beachId));
+        if (invalidated) {
+          console.error("[major-event-hold:repository:hold-invalidated]", {
+            ...diagnostics,
+            recordId: record.recordId,
+            holdId: hold.holdId,
+          });
+        }
+        return invalidated;
       })
     ) {
       return UNRESOLVED;
     }
     const holdIds = holds.map(({ holdId }) => holdId);
-    if (new Set(holdIds).size !== holdIds.length) return UNRESOLVED;
+    if (new Set(holdIds).size !== holdIds.length) {
+      const duplicateHoldId = holdIds.find(
+        (holdId, index) => holdIds.indexOf(holdId) !== index,
+      );
+      console.error("[major-event-hold:repository:duplicate-hold-ids]", {
+        ...diagnostics,
+        holdId: duplicateHoldId,
+      });
+      return UNRESOLVED;
+    }
 
     return { state: "resolved", holds };
-  } catch {
+  } catch (error) {
+    console.error("[major-event-hold:repository:resolution-threw]", {
+      ...diagnostics,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return UNRESOLVED;
   }
 }


### PR DESCRIPTION
Companion to b17651924, which did this for the service layer. The three
silent `return UNRESOLVED` paths in resolveMajorEventHolds - RPC error,
non-array response, and a row failing schema validation - were mutually
indistinguishable in production.

Logs candidate count, beach count and asOf alongside the RPC error code
and message, or the failing Zod issue paths. Fail-closed behaviour is
unchanged.

Split out of #488 so that issue stays the single reviewed commit it
describes.
