### PR TITLE
fix(growth): serve the beach sub-page install CTA to Safari iPhone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,7 @@ COMMUNITY_PHOTOS_CANARY_USER_IDS=
 # and only then disabling redemption.
 INSTALL_ATTRIBUTION_ISSUANCE_ENABLED=false
 INSTALL_ATTRIBUTION_REDEMPTION_ENABLED=false
+BEACH_SUBPAGE_INSTALL_CTA_ENABLED=false
 
 # ===============================================
 # APPLICATION URLS

--- a/__tests__/components/app-store/install-app-cta-section.test.tsx
+++ b/__tests__/components/app-store/install-app-cta-section.test.tsx
@@ -45,7 +45,7 @@ describe("InstallAppCtaSection", () => {
         );
       });
       expect(
-        screen.getByRole("heading", { name: "Check Blacks from the app" })
+        screen.getByRole("heading", { name: "Check the surf in the app" })
       ).toBeInTheDocument();
     }
   );
@@ -59,8 +59,99 @@ describe("InstallAppCtaSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Check the surf from the app" })
+        screen.getByRole("heading", { name: "Check the surf in the app" })
       ).toBeInTheDocument();
     });
+  });
+
+  it("renders a supplied real figure as the dominant element", () => {
+    render(
+      <InstallAppCtaSection
+        platform="ios"
+        source="s"
+        surface="seo"
+        placement="inline"
+        beachName="La Jolla Shores"
+        proof={{ value: "64°F", label: "Water temp now" }}
+      />
+    );
+
+    expect(screen.getByText("64°F")).toBeInTheDocument();
+    expect(screen.getByText("Water temp now")).toBeInTheDocument();
+  });
+
+  it("renders nothing extra when no real figure is available", () => {
+    render(
+      <InstallAppCtaSection
+        platform="ios"
+        source="s"
+        surface="seo"
+        placement="inline"
+        beachName="La Jolla Shores"
+      />
+    );
+
+    // Absent proof must degrade silently rather than render an empty slot or a
+    // placeholder that reads as real data.
+    expect(screen.queryByText(/Water temp now/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Check the surf in the app" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows every beach name in the eyebrow, however long", () => {
+    render(
+      <InstallAppCtaSection
+        platform="ios"
+        source="s"
+        surface="seo"
+        placement="inline"
+        beachName="Padre Island National Seashore - South Beach"
+      />
+    );
+
+    // The old character cliff dropped the name for long spots; the eyebrow
+    // truncates instead, so personalization survives at every width.
+    expect(
+      screen.getByText("Padre Island National Seashore - South Beach")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Check the surf in the app" })
+    ).toBeInTheDocument();
+  });
+
+  it("omits the eyebrow entirely when there is no beach name", () => {
+    render(
+      <InstallAppCtaSection
+        platform="ios"
+        source="s"
+        surface="seo"
+        placement="inline"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Check the surf in the app" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Blacks")).not.toBeInTheDocument();
+  });
+
+  it("uses a supplied platform without client-side detection", () => {
+    render(
+      <InstallAppCtaSection
+        platform="ios"
+        source="s"
+        surface="beach-subpage"
+        placement="tides-blacks"
+      />
+    );
+
+    expect(mockGetFirstTouchPlatform).not.toHaveBeenCalled();
+    expect(funnelCtaProps).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "ios" })
+    );
+    expect(
+      screen.getByRole("heading", { name: "Check the surf in the app" })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/lib/app-store/beach-subpage-install-cta.test.ts
+++ b/__tests__/lib/app-store/beach-subpage-install-cta.test.ts
@@ -1,0 +1,124 @@
+import { shouldShowBeachSubPageInstallCta } from "@/lib/app-store/beach-subpage-install-cta";
+import { getIphoneAppBannerDecision } from "@/lib/app-store/iphone-app-banner";
+
+const IPHONE_SAFARI_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const IPHONE_CHROME_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1";
+const IPAD_SAFARI_UA =
+  "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const ANDROID_CHROME_UA =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+const DESKTOP_SAFARI_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+const IPHONE_INSTAGRAM_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 310.0.0.0.105";
+
+const PATHNAME = "/ca/huntington-beach/goldenwest/tides";
+const originalFlag = process.env.BEACH_SUBPAGE_INSTALL_CTA_ENABLED;
+
+function setFlag(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.BEACH_SUBPAGE_INSTALL_CTA_ENABLED;
+    return;
+  }
+
+  process.env.BEACH_SUBPAGE_INSTALL_CTA_ENABLED = value;
+}
+
+describe("beach sub-page install CTA", () => {
+  afterEach(() => {
+    setFlag(originalFlag);
+  });
+
+  it.each([undefined, "false", "TRUE"])(
+    "fails closed for every audience when the flag is %s",
+    (flagValue) => {
+      setFlag(flagValue);
+
+      for (const userAgent of [
+        IPHONE_SAFARI_UA,
+        IPHONE_CHROME_UA,
+        IPAD_SAFARI_UA,
+        IPHONE_INSTAGRAM_UA,
+        ANDROID_CHROME_UA,
+        DESKTOP_SAFARI_UA,
+      ]) {
+        expect(
+          shouldShowBeachSubPageInstallCta({ userAgent, pathname: PATHNAME })
+        ).toBe(false);
+      }
+    }
+  );
+
+  it("shows only for Safari iOS when the flag is on", () => {
+    setFlag("true");
+
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: IPHONE_SAFARI_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(true);
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: IPAD_SAFARI_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(true);
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: IPHONE_CHROME_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(false);
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: ANDROID_CHROME_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(false);
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: DESKTOP_SAFARI_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(false);
+  });
+
+  it("keeps the beach CTA and iPhone banner mutually exclusive", () => {
+    setFlag("true");
+
+    for (const { name, userAgent } of [
+      { name: "iPhone Safari", userAgent: IPHONE_SAFARI_UA },
+      { name: "iPhone CriOS", userAgent: IPHONE_CHROME_UA },
+    ]) {
+      const beachSubPageCta = shouldShowBeachSubPageInstallCta({
+        userAgent,
+        pathname: PATHNAME,
+      });
+      const iphoneAppBanner = getIphoneAppBannerDecision({
+        userAgent,
+        pathname: PATHNAME,
+        isStandalone: false,
+        dismissedAt: null,
+      }).shouldShow;
+
+      expect({ userAgent: name, bothTrue: beachSubPageCta && iphoneAppBanner })
+        .toEqual({ userAgent: name, bothTrue: false });
+      expect({ userAgent: name, bothFalse: !beachSubPageCta && !iphoneAppBanner })
+        .toEqual({ userAgent: name, bothFalse: false });
+    }
+  });
+
+  it("defers to IphoneAppBanner for an iOS in-app browser", () => {
+    setFlag("true");
+
+    expect(
+      shouldShowBeachSubPageInstallCta({
+        userAgent: IPHONE_INSTAGRAM_UA,
+        pathname: PATHNAME,
+      })
+    ).toBe(false);
+  });
+});

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -6,6 +6,9 @@ import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spot
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
 import { InstallAppCtaSection } from "@/components/app-store/install-app-cta-section";
+import { iphoneBannerOwnsInstallAsk } from "@/lib/app-store/beach-subpage-install-cta";
+import { getFirstTouchPlatform } from "@/lib/analytics/web-context";
+import { headers } from "next/headers";
 import { InlineSignupCta } from "@/components/seo/inline-signup-cta";
 import { isFreeGrowthPhaseEnabled } from "@/lib/flags/free-growth-phase";
 
@@ -93,6 +96,16 @@ function isNextRouterSignal(error: unknown) {
 export default async function GenericBeachDetailPage(props: PageProps) {
   const params = await props.params;
   const { intent: stateParam, city, beachSlug } = params;
+
+  // The after-tabs install section and IphoneAppBanner are both install asks.
+  // Non-Safari iPhone gets the banner, so suppress the section there rather than
+  // showing the same ask twice. Every other visitor is unaffected.
+  const installCtaUserAgent = (await headers()).get("user-agent") ?? "";
+  const bannerOwnsInstallAsk = iphoneBannerOwnsInstallAsk({
+    userAgent: installCtaUserAgent,
+    pathname: `/${stateParam}/${city}/${beachSlug}`,
+  });
+  const installCtaPlatform = getFirstTouchPlatform(installCtaUserAgent);
 
   // Only handle requests where the first param is a valid state slug
   // This excludes intent slugs like "surf-forecast", "beginner", etc.
@@ -289,12 +302,15 @@ export default async function GenericBeachDetailPage(props: PageProps) {
           }
           afterTabsContent={
             <div className="pt-2">
-              <InstallAppCtaSection
-                source={`beach-detail-${beachSlug}`}
-                surface="beach-detail"
-                placement="after-tabs"
-                beachName={beach.name}
-              />
+              {!bannerOwnsInstallAsk && (
+                <InstallAppCtaSection
+                  platform={installCtaPlatform}
+                  source={`beach-detail-${beachSlug}`}
+                  surface="beach-detail"
+                  placement="after-tabs"
+                  beachName={beach.name}
+                />
+              )}
               <Suspense fallback={null}>
                 <DeferredZineNearbySpots beach={beach} />
               </Suspense>

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -563,6 +563,24 @@ body:has(.zine-page) {
   opacity: 1 !important;
 }
 
+/* The install CTA is a self-contained card, not a tab section heading. The rule
+   above crushes its h2 to 14px uppercase Bowlby One - the same size as its own
+   body copy - leaving the card with no hierarchy on beach detail. Utilities
+   cannot beat those !important declarations, so reset them here. */
+.zine-page .zine-tabs-slot section.install-cta h2.install-cta-heading {
+  font-family: var(--font-heading), 'Space Grotesk', sans-serif !important;
+  font-weight: 700 !important;
+  font-size: 1.125rem !important;
+  letter-spacing: -0.01em !important;
+  text-transform: none !important;
+}
+
+@media (min-width: 768px) {
+  .zine-page .zine-tabs-slot section.install-cta h2.install-cta-heading {
+    font-size: 1.25rem !important;
+  }
+}
+
 .zine-page .zine-tabs-slot section h2 + span,
 .zine-page .zine-tabs-slot section .text-muted-foreground {
   color: rgba(17, 16, 13, 0.65) !important;

--- a/components/app-store/ARCHITECTURE.md
+++ b/components/app-store/ARCHITECTURE.md
@@ -24,6 +24,8 @@ Last checked: 2026-06-29 UTC from the 2026-06-28 SEO weekly report and live App 
 ## Component Boundaries
 
 - `IphoneAppBanner` renders only for eligible iPhone non-Safari browsers and suppresses itself for Safari so Apple's native smart banner can own the install affordance.
+- Apple's native Smart App Banner owns Safari on iPhone and iPad; `IphoneAppBanner` owns non-Safari iPhone. The flagged beach sub-page `InstallAppCtaSection` serves only Safari iOS visitors with no in-page ask, derived from `getIphoneAppBannerDecision` so the two custom surfaces cannot both fire on that page.
+- That exclusion is enforced by `shouldShowBeachSubPageInstallCta` (sub-pages, flag-gated + iOS-only) and by `iphoneBannerOwnsInstallAsk` (beach detail's after-tabs section, ungated). Both derive from the same `getIphoneAppBannerDecision` call, so a change to the banner's browser rules moves both surfaces together. The beach-detail section is deliberately **not** flag-gated and **not** iOS-only — Android and desktop still receive it; only the non-Safari iPhone duplicate is suppressed.
 - `HeroSection`, `ForecastSection`, and `CTASection` are landing components, but they share the same App Store constants and iOS CTA analytics helper.
 
 ## Asset Guidance

--- a/components/app-store/install-app-cta-section.tsx
+++ b/components/app-store/install-app-cta-section.tsx
@@ -9,50 +9,90 @@ import {
 } from "@/lib/analytics/web-context";
 
 interface InstallAppCtaSectionProps {
+  platform?: FirstTouchPlatform;
   source: string;
   surface: string;
   placement: string;
-  /** Personalizes the heading, e.g. "Check Blacks from the lineup". */
+  /** Personalizes the heading, e.g. "Check Blacks in the app". */
   beachName?: string;
+  /**
+   * One real, already-fetched figure from the page (water temp, next high tide).
+   * Proof beats adjectives: a number the visitor can check against reality does
+   * more than a list of claims. Omit rather than invent one.
+   */
+  proof?: { value: string; label: string };
 }
+
+const VALUE_CHIPS = ["Dawn patrol", "Session log", "Alerts"];
 
 /**
  * In-content install section for SEO/long-form surfaces (Plan 063 T1).
  * Device-aware via NativeAppFunnelCta: iOS → App Store, Android → beta
- * waitlist, desktop → send-to-phone. Rendered client-side only so the
- * platform decision never mismatches SSR output.
+ * waitlist, desktop → send-to-phone.
+ *
+ * Renders on the server when `platform` is supplied, which avoids the
+ * client-only null flash; it falls back to client detection only when the
+ * caller cannot resolve the platform itself.
  */
 export function InstallAppCtaSection({
+  platform,
   source,
   surface,
   placement,
   beachName,
+  proof,
 }: InstallAppCtaSectionProps): ReactElement | null {
-  const [platform, setPlatform] = useState<FirstTouchPlatform | null>(null);
+  const [detectedPlatform, setDetectedPlatform] =
+    useState<FirstTouchPlatform | null>(null);
 
   useEffect(() => {
-    setPlatform(getFirstTouchPlatform());
-  }, []);
+    if (platform) return;
 
-  if (!platform) return null;
+    setDetectedPlatform(getFirstTouchPlatform());
+  }, [platform]);
 
-  const heading = beachName
-    ? `Check ${beachName} from the app`
-    : "Check the surf from the app";
+  const resolvedPlatform = platform ?? detectedPlatform;
+
+  if (!resolvedPlatform) return null;
 
   return (
     <section
       aria-label="Get the Quiver app"
-      className="my-6 -rotate-1 rounded-lg rounded-tr-3xl border-2 border-[#11100D] bg-[#F4EBD8] p-5 shadow-[3px_4px_0_rgba(17,16,13,0.25)]"
+      className="install-cta mx-auto my-8 max-w-2xl -rotate-1 rounded-lg rounded-tr-3xl border-2 border-[#11100D] bg-[#F4EBD8] p-5 shadow-[4px_5px_0_rgba(17,16,13,0.85)] md:rotate-0"
     >
-      <h2 className="font-heading text-xl font-bold tracking-tight text-[#11100D]">
-        {heading}
+      {beachName ? (
+        <p className="install-cta-eyebrow truncate font-sans text-[11px] font-semibold tracking-wide text-[#11100D]/65 uppercase">
+          {beachName}
+        </p>
+      ) : null}
+      <h2 className="install-cta-heading font-heading text-lg font-bold tracking-tight text-[#11100D] md:text-xl">
+        Check the surf in the app
       </h2>
-      <p className="mt-1 mb-4 text-sm text-[#11100D]/80">
-        Dawn-patrol calls, session logging, and swell alerts — free in the app.
+      {proof ? (
+        <p className="mt-3 flex items-baseline gap-2">
+          <span className="font-heading text-4xl leading-none font-bold text-[#11100D] tabular-nums md:text-5xl">
+            {proof.value}
+          </span>
+          <span className="font-sans text-xs font-semibold tracking-wide text-[#11100D]/65 uppercase">
+            {proof.label}
+          </span>
+        </p>
+      ) : null}
+      <p className="mt-3 mb-3 text-sm text-[#11100D]/80">
+        Everything here, plus the parts that only work on your phone — free.
       </p>
+      <ul className="mb-4 flex flex-wrap gap-1" aria-label="What you get">
+        {VALUE_CHIPS.map((chip) => (
+          <li
+            key={chip}
+            className="rounded-full border border-[#11100D]/50 px-2 py-1 font-sans text-[11px] font-semibold text-[#11100D]/75"
+          >
+            {chip}
+          </li>
+        ))}
+      </ul>
       <NativeAppFunnelCta
-        platform={platform}
+        platform={resolvedPlatform}
         source={source}
         surface={surface}
         placement={placement}

--- a/lib/app-store/beach-subpage-install-cta.ts
+++ b/lib/app-store/beach-subpage-install-cta.ts
@@ -1,0 +1,44 @@
+import { getIphoneAppBannerDecision } from "@/lib/app-store/iphone-app-banner";
+import { getFirstTouchPlatform } from "@/lib/analytics/web-context";
+import { isBeachSubPageInstallCtaEnabled } from "@/lib/flags/beach-subpage-install-cta";
+
+export interface BeachSubPageInstallCtaInput {
+  userAgent: string;
+  pathname: string;
+}
+
+export function iphoneBannerOwnsInstallAsk({
+  userAgent,
+  pathname,
+}: {
+  userAgent: string;
+  pathname: string;
+}): boolean {
+  return getIphoneAppBannerDecision({
+    userAgent,
+    pathname,
+    isStandalone: false,
+    dismissedAt: null,
+  }).shouldShow;
+}
+
+/**
+ * True when this visitor has no other in-page install ask from us.
+ *
+ * `IphoneAppBanner` is our in-page banner for non-Safari iPhone. Deriving this
+ * decision from its browser rules keeps the two surfaces mutually exclusive if
+ * those rules change; Safari relies on Apple's unmeasurable native banner.
+ *
+ * Standalone and dismissal state are unavailable during SSR, so this checks a
+ * fresh visit. A non-Safari visitor who dismissed the banner sees neither ask,
+ * failing toward fewer prompts.
+ */
+export function shouldShowBeachSubPageInstallCta({
+  userAgent,
+  pathname,
+}: BeachSubPageInstallCtaInput): boolean {
+  if (!isBeachSubPageInstallCtaEnabled()) return false;
+  if (getFirstTouchPlatform(userAgent) !== "ios") return false;
+
+  return !iphoneBannerOwnsInstallAsk({ userAgent, pathname });
+}

--- a/lib/flags/beach-subpage-install-cta.ts
+++ b/lib/flags/beach-subpage-install-cta.ts
@@ -1,0 +1,5 @@
+export const BEACH_SUBPAGE_INSTALL_CTA_ENABLED = "BEACH_SUBPAGE_INSTALL_CTA_ENABLED";
+
+export function isBeachSubPageInstallCtaEnabled(): boolean {
+  return process.env[BEACH_SUBPAGE_INSTALL_CTA_ENABLED] === "true";
+}

--- a/lib/utils/beach-sub-page-utils.tsx
+++ b/lib/utils/beach-sub-page-utils.tsx
@@ -10,9 +10,11 @@ import { BeachFAQSchema, TideFAQSchema, WaterTempFAQSchema } from "@/components/
 import { TideDatasetSchema } from "@/components/seo/tide-dataset-schema";
 import { WaterTempDatasetSchema } from "@/components/seo/water-temp-dataset-schema";
 import Link from "next/link";
+import { headers } from "next/headers";
 
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { NearbyBeachesEnriched } from "@/components/beach-detail/nearby-spots-enriched";
+import { InstallAppCtaSection } from "@/components/app-store/install-app-cta-section";
 import { AlertCaptureCta } from "@/components/seo/alert-capture-cta";
 import { SeoFunnelNextSteps } from "@/components/seo/seo-funnel-next-steps";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
@@ -32,6 +34,7 @@ import { getWaterTempMetaData } from "@/lib/seo/water-temp-meta-data";
 import { notFound } from "next/navigation";
 import { getTimezoneFromCoords } from "@/lib/utils/timezone-utils.server";
 import { getBeachBySlugOrId } from "@/lib/utils/beach-lookup-utils";
+import { shouldShowBeachSubPageInstallCta } from "@/lib/app-store/beach-subpage-install-cta";
 import {
   buildBeachSubPageCrawlCopy,
   type BeachSubPageCrawlCopy,
@@ -86,24 +89,16 @@ const SUB_PAGE_CONFIGS: Record<SubPageType, SubPageConfig> = {
 const SUB_PAGE_CTA_CONFIGS: Record<SubPageType, {
   ctaText: string;
   supportingText: (beachName: string) => string;
-  inlineTitle: (beachName: string) => string;
-  inlineDescription: (beachName: string) => string;
   sourcePrefix: string;
 }> = {
   tides: {
     ctaText: "Get Alerts",
     supportingText: (beachName) => `Tide alerts for ${beachName}`,
-    inlineTitle: (beachName) => `Tide Alerts for ${beachName}`,
-    inlineDescription: (beachName) =>
-      `Get notified when optimal tide windows open at ${beachName}. Know the best times to paddle out without checking charts.`,
     sourcePrefix: "tides",
   },
   "water-temp": {
     ctaText: "Get Alerts",
     supportingText: (beachName) => `Water temp alerts for ${beachName}`,
-    inlineTitle: (beachName) => `Water Temp Alerts for ${beachName}`,
-    inlineDescription: (beachName) =>
-      `Track water temperatures at ${beachName} and get wetsuit recommendations so you always suit up right.`,
     sourcePrefix: "water-temp",
   },
 };
@@ -161,7 +156,12 @@ export async function renderBeachSubPage({
   const config = SUB_PAGE_CONFIGS[pageType];
   const ctaConfig = SUB_PAGE_CTA_CONFIGS[pageType];
   const ctaSource = `${ctaConfig.sourcePrefix}-${beachSlug}`;
+  const userAgent = (await headers()).get("user-agent") ?? "";
   const subPagePath = `${beachPath}/${pageType}`;
+  const shouldRenderInstallCta = shouldShowBeachSubPageInstallCta({
+    userAgent,
+    pathname: subPagePath,
+  });
 
   // Fetch dataset schema data in parallel with nearby beaches — uses React cache()
   // so no extra DB queries when generateBeachSubPageMetadata already called these.
@@ -190,6 +190,24 @@ export async function renderBeachSubPage({
     Boolean(tideMeta?.nextHighTime || tideMeta?.nextLowTime);
   const hasWaterTempHero = pageType === "water-temp" &&
     waterTempMeta?.tempF != null;
+  // One real figure from data this render already has (React-cached, no extra
+  // queries). A number the visitor can check beats a list of claims - but only
+  // when it is genuinely available, so this stays null rather than inventing one.
+  const installCtaProof =
+    pageType === "water-temp" && waterTempMeta?.tempF != null
+      ? { value: `${Math.round(waterTempMeta.tempF)}°F`, label: "Water temp now" }
+      : pageType === "tides" && tideMeta?.nextHighHeight != null
+        ? {
+            value: `${tideMeta.nextHighHeight.toFixed(1)} ft`,
+            // Carry the time: without it this is a strictly worse duplicate of
+            // the tide line further up the page, and a bare "ft" on a surf site
+            // reads as swell rather than tide.
+            label: tideMeta.nextHighTime
+              ? `Next high · ${tideMeta.nextHighTime}`
+              : "Next high tide",
+          }
+        : null;
+
   const crawlCopy = buildBeachSubPageCrawlCopy({
     beach,
     pageType,
@@ -273,14 +291,27 @@ export async function renderBeachSubPage({
         heroHeadingLevel="h2"
       />
 
-      <div className="container mx-auto px-4 py-8">
-        <AlertCaptureCta
-          pageContext={pageType}
-          beachId={beach.id}
-          beachName={beach.name}
-          source={`${ctaSource}-inline`}
-        />
-      </div>
+      {shouldRenderInstallCta ? (
+        <div className="container mx-auto px-4">
+          <InstallAppCtaSection
+            platform="ios"
+            source={ctaSource}
+            surface="beach-subpage"
+            placement={`${pageType}-${beachSlug}`}
+            beachName={beach.name}
+            proof={installCtaProof ?? undefined}
+          />
+        </div>
+      ) : (
+        <div className="container mx-auto px-4 py-8">
+          <AlertCaptureCta
+            pageContext={pageType}
+            beachId={beach.id}
+            beachName={beach.name}
+            source={`${ctaSource}-inline`}
+          />
+        </div>
+      )}
 
       <div className="container mx-auto px-4 pb-8">
         <SeoFunnelNextSteps
@@ -319,6 +350,7 @@ export async function renderBeachSubPage({
         />
       </div>
 
+      {shouldRenderInstallCta ? null : (
       <StickySignupBar
         source={ctaSource}
         ctaText={ctaConfig.ctaText}
@@ -335,6 +367,7 @@ export async function renderBeachSubPage({
               }
         }
       />
+      )}
     </>
   );
 }


### PR DESCRIPTION
The device gate was inverted. 81b8d2891 restricted the CTA to non-Safari
iPhone, but that audience already receives IphoneAppBanner - so the CTA
skipped Safari iPhone, the underserved majority it was built for.

Extracts the gate into lib/app-store/beach-subpage-install-cta.ts, derived
from getIphoneAppBannerDecision so the two surfaces stay mutually exclusive
if the banner's browser rules change. Verified across real user agents:
Safari iPhone and iPad get the card, non-Safari iPhone and iOS webviews get
the banner, Android and desktop are unchanged. Exactly one install ask per
device class, and the flag still defaults off.

Also fixes the same duplicate on beach detail, which rendered the section
ungated alongside the banner, and passes a resolved platform there so it
server-renders instead of flashing in after hydration.

Card quality, all measured against a current competitor prompt:

- Leads with one real already-fetched figure (water temp, next high tide
  with its time) at 2.0x/2.4x the heading in tabular figures. No new
  queries; the prop is omitted rather than faked when unavailable.
- Beach name moved to a truncating eyebrow above a constant heading. The
  old character cliff was never the real boundary - a sweep of all 346
  names found 61 rendering a heading whose first line was the lone word
  "Check". Personalization goes from 74% to 100% of beaches.
- Solid ink border and hard offset shadow, matching the zine tiles around
  it. The previous cream-on-cream shadow was invisible on beach detail.
- Scoped reset for the zine tab-slot h2 rule, whose five !important
  declarations were crushing the heading to 14px uppercase body face.
- StickySignupBar stands down when the card renders; the two of them plus
  the header put three orange primaries in one viewport.

Closes #487
