### PR TITLE
test(beach-detail): mock next/headers in slug-resolution suite

### DIFF
--- a/__tests__/app/generic-beach-detail-resolution.test.ts
+++ b/__tests__/app/generic-beach-detail-resolution.test.ts
@@ -22,6 +22,14 @@ jest.mock("@/actions/beach/beach-query-actions", () => ({
   getBeachesBySlug: jest.fn(),
 }));
 
+// The page reads the user agent to decide whether the iPhone Safari banner owns
+// the install ask (app/[intent]/[city]/[beachSlug]/page.tsx, added in #497).
+// Without this mock `headers()` throws "called outside a request scope" and every
+// case in this suite fails before reaching its assertion.
+jest.mock("next/headers", () => ({
+  headers: jest.fn(async () => new Headers()),
+}));
+
 jest.mock("next/navigation", () => ({
   notFound: jest.fn(() => {
     const err = new Error("NEXT_NOT_FOUND");


### PR DESCRIPTION
**`origin/main` is currently red.** 4 of 8 tests in `__tests__/app/generic-beach-detail-resolution.test.ts` have been failing since #497 merged. Verified on a clean detached checkout of `origin/main` — unrelated to any open PR.

## Cause

#497 added the Safari-iPhone install-CTA device gate, which calls `await headers()` at `app/[intent]/[city]/[beachSlug]/page.tsx:103`. The suite mocks ten modules but not `next/headers`, so every case throws:

```
headers was called outside a request scope
```

before reaching its assertion. Source is fine; the test just never learned about the new dependency.

## Fix

Adds the missing `next/headers` mock. **No source change.** 8/8 pass; full suite green at 1295 suites / 16,868 tests / 0 failures.

Worth merging before the other open PRs so they land on a green main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)