### PR TITLE
ci: gate pull requests into main with typecheck, lint, unit tests and build

### DIFF
--- a/.github/workflows/main-gate.yml
+++ b/.github/workflows/main-gate.yml
@@ -1,0 +1,122 @@
+name: Main Gate
+
+# Gates pull requests into `main`.
+#
+# Why this exists: on 2026-08-06 PR #497 merged to `main` with 4 failing tests in
+# __tests__/app/generic-beach-detail-resolution.test.ts and sat red until someone
+# happened to re-verify against the moved base. `prod-gate.yml` already ran these
+# checks, but only for pull requests into `prod` — `main` had no gate at all.
+#
+# Mirrors prod-gate's job structure deliberately. Smoke tests are intentionally
+# omitted: they run Playwright against the deployed dev environment, which tests a
+# deployment rather than the pull request, and needs a bypass token.
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  NODE_VERSION: "22"
+
+concurrency:
+  group: main-gate-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: TypeScript Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Type check
+        run: yarn typecheck
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # No env block: the equivalent prod-gate job runs green without Supabase
+      # credentials because the unit suite mocks its data layer.
+      - name: Run unit tests
+        run: yarn test:unit
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "yarn"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_MAPBOX_TOKEN: ${{ secrets.NEXT_PUBLIC_MAPBOX_TOKEN }}


### PR DESCRIPTION
**This PR is its own test** — it targets `main`, so the workflow it adds runs against it. Green checks below are the verification.

## Why

PR #497 merged to `main` with **4 failing tests** in `__tests__/app/generic-beach-detail-resolution.test.ts` and sat red until it was found by chance while re-verifying an unrelated branch against the moved base (fixed in #498).

`prod-gate.yml` already ran exactly these checks — but only on `pull_request: branches: [prod]`. **`main` had no gate at all**, so nothing would have caught it.

## What

Mirrors prod-gate's job structure for `main`: **typecheck, lint, unit-tests, build**.

**Smoke tests omitted deliberately** — they run Playwright against deployed `dev.quiversurf.app`, so they test a deployment rather than the pull request, and need a bypass token. Those stay on prod-gate, where deploy risk actually lives.

**No env block on unit-tests**, matching prod-gate — its Unit Tests job is green without Supabase credentials because the suite mocks its data layer. Verified against prod-gate's most recent run (all five jobs succeeded).

Build keeps the same three secrets prod-gate uses.

## Note

prod-gate's last run was **2026-05-06**, three months ago — worth a look separately as to whether prod PRs are actually being gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)