### PR TITLE
fix(discovery): bound session-decision expiry timer (int32 setTimeout overflow)

### DIFF
--- a/__tests__/hooks/use-surf-discovery-hold.test.tsx
+++ b/__tests__/hooks/use-surf-discovery-hold.test.tsx
@@ -261,6 +261,186 @@ describe("useSurfDiscovery major-event hold precedence", () => {
     expect(result.current.hasRecommendations).toBe(false);
   });
 
+  it("waits out authority that outlasts the max timer delay, then revalidates", async () => {
+    const maxTimerDelayMs = 2_147_483_647;
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-19T12:00:00.000Z"));
+    const allowed = discoveryResponse(
+      { state: "available", holdEpoch: "clear" },
+      1,
+    );
+    // 30 days of authority — longer than a timer can hold in one hop.
+    const grantedMs = 30 * 24 * 60 * 60 * 1000;
+    allowed.sessionDecision!.expiresAt = new Date(
+      Date.parse(allowed.sessionDecision!.createdAt) + grantedMs,
+    ).toISOString();
+    const held = discoveryResponse(
+      { state: "none", reasonCode: "major_event_hold", holdEpoch: "active-hold" },
+      1,
+    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(allowed) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(held) }),
+      });
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.hasRecommendations).toBe(true));
+
+    // First hop: authority is still live, so nothing may be revalidated yet.
+    act(() => {
+      jest.advanceTimersByTime(maxTimerDelayMs);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result.current.hasRecommendations).toBe(true);
+
+    // Past the granted window the re-armed timer must still fire, and the hold
+    // that comes back must be what wins.
+    await act(async () => {
+      jest.advanceTimersByTime(grantedMs - maxTimerDelayMs);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.discovery?.recommendationAvailability?.state).toBe(
+      "none",
+    );
+    expect(result.current.hasRecommendations).toBe(false);
+  });
+
+  it("bounds authority by the server-authored lifetime when the client clock lags", async () => {
+    // Client clock 30 days behind the server: a normal 15-minute decision would
+    // otherwise look like 30 days of authority.
+    jest.useFakeTimers().setSystemTime(new Date("2026-06-19T12:00:00.000Z"));
+    const allowed = discoveryResponse(
+      { state: "available", holdEpoch: "clear" },
+      1,
+    );
+    allowed.sessionDecision!.createdAt = "2026-07-19T12:00:00.000Z";
+    allowed.sessionDecision!.expiresAt = "2026-07-19T12:15:00.000Z";
+    const held = discoveryResponse(
+      { state: "none", reasonCode: "major_event_hold", holdEpoch: "active-hold" },
+      1,
+    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(allowed) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(held) }),
+      });
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.hasRecommendations).toBe(true));
+    await act(async () => {
+      jest.advanceTimersByTime(15 * 60 * 1000 + 1);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.discovery?.recommendationAvailability?.state).toBe(
+      "none",
+    );
+    expect(result.current.hasRecommendations).toBe(false);
+  });
+
+  it("expires on schedule even if the clock is moved backward mid-session", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-19T12:00:00.000Z"));
+    const allowed = discoveryResponse(
+      { state: "available", holdEpoch: "clear" },
+      1,
+    );
+    allowed.sessionDecision!.expiresAt = "2026-07-19T12:15:00.000Z";
+    const held = discoveryResponse(
+      { state: "none", reasonCode: "major_event_hold", holdEpoch: "active-hold" },
+      1,
+    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(allowed) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(held) }),
+      });
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.hasRecommendations).toBe(true));
+
+    // Clock yanked 30 days backward after the timer was armed.
+    jest.setSystemTime(new Date("2026-06-19T12:00:00.000Z"));
+    await act(async () => {
+      jest.advanceTimersByTime(15 * 60 * 1000 + 1);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.hasRecommendations).toBe(false);
+  });
+
+  it("does not extend authority when a hop fires late", async () => {
+    const maxTimerDelayMs = 2_147_483_647;
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-19T12:00:00.000Z"));
+    const allowed = discoveryResponse(
+      { state: "available", holdEpoch: "clear" },
+      1,
+    );
+    const grantedMs = 30 * 24 * 60 * 60 * 1000;
+    allowed.sessionDecision!.expiresAt = new Date(
+      Date.parse(allowed.sessionDecision!.createdAt) + grantedMs,
+    ).toISOString();
+    const held = discoveryResponse(
+      { state: "none", reasonCode: "major_event_hold", holdEpoch: "active-hold" },
+      1,
+    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(allowed) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: serialized(held) }),
+      });
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.hasRecommendations).toBe(true));
+
+    // Tab suspended: the wall clock runs past the whole grant before the first
+    // hop is delivered. The delayed hop must expire, not re-arm the remainder.
+    jest.setSystemTime(new Date(Date.now() + grantedMs));
+    await act(async () => {
+      jest.advanceTimersByTime(maxTimerDelayMs);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.current.hasRecommendations).toBe(false);
+  });
+
+  it("stays fail-closed when the decision carries an unreadable createdAt", async () => {
+    const allowed = discoveryResponse(
+      { state: "available", holdEpoch: "clear" },
+      1,
+    );
+    allowed.sessionDecision!.createdAt = "not-a-timestamp";
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: serialized(allowed) }),
+    });
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.discovery).toBeNull();
+    expect(result.current.hasRecommendations).toBe(false);
+  });
+
   it("revalidates a visible session and replaces a prior positive with explicit none", async () => {
     const allowed = discoveryResponse(
       { state: "available", holdEpoch: "before-hold" },

--- a/hooks/use-surf-discovery.ts
+++ b/hooks/use-surf-discovery.ts
@@ -10,6 +10,9 @@ import {
 import { projectCanonicalDiscoverySurface } from "@/lib/recommendations/canonical-decision/client-projection";
 import type { SurfDiscoveryResponse, TimeSlot } from "@/types/personalization";
 
+/** Largest delay setTimeout can hold without overflowing to an immediate fire. */
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
 /**
  * Options for useSurfDiscovery hook
  */
@@ -387,7 +390,8 @@ export function useSurfDiscovery(
     }
 
     const expiresAt = Date.parse(decision.expiresAt);
-    if (!Number.isFinite(expiresAt)) {
+    const authoredAt = Date.parse(decision.createdAt);
+    if (!Number.isFinite(expiresAt) || !Number.isFinite(authoredAt)) {
       reset();
       return;
     }
@@ -399,13 +403,35 @@ export function useSurfDiscovery(
       }
       reset();
     };
-    const remainingMs = expiresAt - Date.now();
-    if (remainingMs <= 0) {
+    // A client clock behind the server would stretch `expiresAt - now` far past
+    // the authority the server actually granted. Both stamps are server-authored,
+    // so their difference is skew-independent — bound the grant by it.
+    const grantedMs = Math.min(expiresAt - Date.now(), expiresAt - authoredAt);
+    if (grantedMs <= 0) {
       expireAndRevalidate();
       return;
     }
 
-    const timeoutId = window.setTimeout(expireAndRevalidate, remainingMs);
+    // setTimeout coerces its delay to a signed 32-bit int, so authority running
+    // past ~24.8 days would fire immediately and revalidate in a loop. Re-arm in
+    // bounded hops, and let whichever limit runs out first end the grant: the
+    // wall clock catches a hop delayed by a suspended tab, while the budget spent
+    // down per hop catches a clock moved backward mid-session. Neither alone is
+    // enough, and both can only shorten the grant.
+    const deadline = Date.now() + grantedMs;
+    let budgetMs = grantedMs;
+    let timeoutId = 0;
+    const armExpiry = () => {
+      const remainingMs = Math.min(deadline - Date.now(), budgetMs);
+      if (remainingMs <= 0) {
+        expireAndRevalidate();
+        return;
+      }
+      const hopMs = Math.min(remainingMs, MAX_TIMEOUT_DELAY_MS);
+      budgetMs -= hopMs;
+      timeoutId = window.setTimeout(armExpiry, hopMs);
+    };
+    armExpiry();
     return () => window.clearTimeout(timeoutId);
   }, [enabled, freshData, immediate, refreshDiscovery, reset, user]);
 


### PR DESCRIPTION
Cherry-pick of 82b0184ca from growth/seo-install-handoff onto main as a clean single-concern slice.

The expiry-revalidation timer passed the full remaining lifetime to setTimeout, which coerces to int32 — a far-future expiry fired immediately and looped (request storm + perpetual discovery reset; this is what kept the use-surf-discovery-hold suite red). The fix re-arms in bounded hops, ending the grant at whichever limit expires first (wall-clock deadline, per-hop budget, server-authored lifetime) so it stays fail-closed under clock skew and suspended tabs.

Gates on this branch: yarn typecheck PASS; full unit suite FULLY GREEN — 16,373 passed, 0 failed (first fully-green run since the cleanup began).

Follow-up noted in session memory: createdAt validation belongs in projectCanonicalDiscoverySurface; currently caught one render late in the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)