### PR TITLE
feat(map): send spot conditions in the embed spotSelected payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -176,7 +176,7 @@ CRON_SECRET=your_secure_random_token_here
 # ENHANCED FORECAST SYNC CONFIGURATION
 # ===============================================
 # Controls the background forecast cron job behavior
-# See docs/forecast/README.md for details
+# See docs/FORECAST_CRON_ARCHITECTURE.md for details
 
 # Maximum beaches to update per cron run (default: 45)
 # Tuned to stay under Vercel's 5-minute timeout

--- a/__tests__/components/map/interactive-map.test.tsx
+++ b/__tests__/components/map/interactive-map.test.tsx
@@ -994,12 +994,94 @@ describe("InteractiveMap", () => {
       fireEvent.click(getBeachMarkerBadge(beach.id));
       expect(onLocationClick).toHaveBeenCalledTimes(1);
       expect(onLocationClick).toHaveBeenCalledWith(
-        expect.objectContaining({ id: beach.id })
+        expect.objectContaining({ id: beach.id }),
+        expect.objectContaining({ tideState: null, tideHeight: null }),
       );
       expect(calloutMarkerCallCount()).toBe(1);
 
       fireEvent.click(getBeachMarkerBadge(beach.id));
       expect(onLocationClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes the displayed spot conditions to the embed host", async () => {
+      const { InteractiveMap } = await import(
+        "@/components/map/interactive-map"
+      );
+      const onLocationClick = jest.fn();
+      const onDisplayForecastsChange = jest.fn();
+      const partition = {
+        s1Dir: 280,
+        swellDirOm: 292.5,
+        s1PeriodS: 13.6,
+        s1HeightFt: 2.4,
+        s2Dir: null,
+        s2PeriodS: null,
+        s2HeightFt: null,
+        windDir: 270,
+        windMph: 5.6,
+      };
+      global.fetch = jest.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            forecasts: { [beach.id]: 2.4 },
+            displayForecasts: { [beach.id]: { label: "2-3ft" } },
+            waterTemps: {},
+            conditionScores: { [beach.id]: 82 },
+            conditionSummaries: { [beach.id]: "GOOD" },
+            isCalibrated: { [beach.id]: false },
+            swellPartitions: { [beach.id]: partition },
+            hourlySwellTimeline: {
+              timestamps: ["2026-07-10T20:00:00.000Z"],
+              partitionsByBeach: { [beach.id]: [partition] },
+              hasMore: false,
+              nextStart: null,
+            },
+          },
+        }),
+      })) as jest.Mock;
+
+      render(
+        <InteractiveMap
+          beaches={[beach]}
+          autoNavigateOnMarkerClick={false}
+          disableBeachClustering
+          markerDisplay="points"
+          showConditionsOnTap
+          swellTimelineMode="hourly"
+          swellTimelineIndex={0}
+          onDisplayForecastsChange={onDisplayForecastsChange}
+          onLocationClick={onLocationClick}
+        />
+      );
+
+      await waitFor(() => {
+        expect(onDisplayForecastsChange).toHaveBeenCalledWith(
+          expect.objectContaining({ get: expect.any(Function) }),
+        );
+        expect(getBeachMarkerBadge(beach.id)).toHaveAttribute(
+          "data-marker-badge",
+          "true",
+        );
+      });
+
+      fireEvent.click(getBeachMarkerBadge(beach.id));
+
+      expect(onLocationClick).toHaveBeenCalledWith(
+        expect.objectContaining({ id: beach.id }),
+        {
+          conditionSummary: "GOOD",
+          waveHeight: "2-3ft",
+          swellPeriod: "14s",
+          swellDirection: "WNW",
+          isCalibrated: false,
+          windSpeed: "6 mph",
+          windDirection: "W",
+          tideState: null,
+          tideHeight: null,
+        },
+      );
     });
   });
 

--- a/__tests__/components/map/map-beach-loader-partitions.test.ts
+++ b/__tests__/components/map/map-beach-loader-partitions.test.ts
@@ -23,6 +23,7 @@ describe("loadBeachesAndWaveHeights — swell partitions", () => {
           waterTemps: {},
           conditionScores: {},
           conditionSummaries: {},
+          isCalibrated: { a: false },
           swellPartitions: {
             a: {
               s1Dir: 270,
@@ -56,6 +57,7 @@ describe("loadBeachesAndWaveHeights — swell partitions", () => {
       windDir: 310,
       windMph: 12,
     });
+    expect(result.isCalibratedMap.get("a")).toBe(false);
   });
 
   it("parses swellPartitionTimeline from the bulk response into partitionsTimelineMap", async () => {

--- a/app/embed/map/embed-map-client.tsx
+++ b/app/embed/map/embed-map-client.tsx
@@ -7,6 +7,7 @@ import type mapboxgl from "mapbox-gl";
 import type { Beach } from "@/types/database";
 import type { HourlySwellTimeline } from "@/app/api/forecasts/bulk/route";
 import type { SwellLayerId } from "@/components/map/swell-map-theme";
+import type { MapSpotConditions } from "@/components/map/interactive-map";
 import {
   parseEmbedMapCommand,
   serializeEmbedMapEvent,
@@ -411,7 +412,7 @@ export function EmbedMapClient() {
   }, [postEvent]);
 
   const handleBeachSelect = useCallback(
-    (beach: Beach): void => {
+    (beach: Beach, conditions?: MapSpotConditions): void => {
       postEvent({
         type: "spotSelected",
         payload: {
@@ -420,6 +421,15 @@ export function EmbedMapClient() {
           lat: beach.lat ?? initialCenter.lat,
           lon: beach.lon ?? initialCenter.lon,
           slug: beach.slug,
+          conditionSummary: conditions?.conditionSummary ?? null,
+          waveHeight: conditions?.waveHeight ?? null,
+          swellPeriod: conditions?.swellPeriod ?? null,
+          swellDirection: conditions?.swellDirection ?? null,
+          isCalibrated: conditions?.isCalibrated ?? null,
+          windSpeed: conditions?.windSpeed ?? null,
+          windDirection: conditions?.windDirection ?? null,
+          tideState: conditions?.tideState ?? null,
+          tideHeight: conditions?.tideHeight ?? null,
         },
       });
     },

--- a/components/map/ARCHITECTURE.md
+++ b/components/map/ARCHITECTURE.md
@@ -196,6 +196,16 @@ const populateLocations = async (lat: number, lng: number) => {
 };
 ```
 
+### **Embedded Native Selection Contract**
+
+`EmbedMapEvent`'s `spotSelected` payload is additive because installed native
+clients may consume older shapes. Its required fields remain `beachId`, `name`,
+`lat`, and `lon`; `slug`, `conditionSummary`, `waveHeight`, `swellPeriod`,
+`swellDirection`, `isCalibrated`, `windSpeed`, `windDirection`, `tideState`, and
+`tideHeight` are optional and nullable. Display metrics come from the same bulk
+forecast maps and active swell/wind partition used by the marker and conditions
+callout. The embed does not retain tide readings, so its tide fields remain null.
+
 ## **COMPONENT RESPONSIBILITIES**
 
 ### **MapContent** (Primary Container)

--- a/components/map/__tests__/embed-map-bridge.test.ts
+++ b/components/map/__tests__/embed-map-bridge.test.ts
@@ -5,6 +5,8 @@ import {
   serializeEmbedMapEvent,
 } from "@/components/map/embed-map-bridge";
 import type { HourlySwellTimeline } from "@/app/api/forecasts/bulk/route";
+import type { MapSpotConditions } from "@/components/map/interactive-map";
+import type { Beach } from "@/types/database";
 
 let mockSearchParams = new URLSearchParams();
 let mockInteractiveMapProps: Record<string, unknown> = {};
@@ -147,6 +149,65 @@ describe("embed map bridge", () => {
     ).toBe(
       '{"type":"forecastTimeChanged","payload":{"index":42,"forecastAt":"2026-07-12T14:00:00.000Z"}}',
     );
+  });
+
+  it("posts an enriched spotSelected payload from the map's displayed conditions", async () => {
+    mockSearchParams = new URLSearchParams("lat=32.86&lon=-117.25");
+    const postMessage = jest.fn();
+    Object.defineProperty(window, "ReactNativeWebView", {
+      configurable: true,
+      value: { postMessage },
+    });
+    const { EmbedMapClient } = await import("@/app/embed/map/embed-map-client");
+    const beach = {
+      id: "beach-1",
+      name: "Blacks Beach",
+      lat: 32.88,
+      lon: -117.25,
+      slug: "blacks-beach",
+    } as Beach;
+    const conditions: MapSpotConditions = {
+      conditionSummary: "GOOD",
+      waveHeight: "2-3ft",
+      swellPeriod: "14s",
+      swellDirection: "WNW",
+      isCalibrated: false,
+      windSpeed: "6 mph",
+      windDirection: "W",
+      tideState: null,
+      tideHeight: null,
+    };
+
+    render(React.createElement(EmbedMapClient));
+
+    const onLocationClick = mockInteractiveMapProps.onLocationClick as
+      | ((selectedBeach: Beach, selectedConditions: MapSpotConditions) => void)
+      | undefined;
+    expect(onLocationClick).toEqual(expect.any(Function));
+
+    act(() => {
+      onLocationClick?.(beach, conditions);
+    });
+
+    expect(postMessage.mock.calls.map(([message]) => JSON.parse(message))).toContainEqual({
+      type: "spotSelected",
+      payload: {
+        beachId: "beach-1",
+        name: "Blacks Beach",
+        lat: 32.88,
+        lon: -117.25,
+        slug: "blacks-beach",
+        conditionSummary: "GOOD",
+        waveHeight: "2-3ft",
+        swellPeriod: "14s",
+        swellDirection: "WNW",
+        isCalibrated: false,
+        windSpeed: "6 mph",
+        windDirection: "W",
+        tideState: null,
+        tideHeight: null,
+      },
+    });
   });
 
   it("keeps legacy native forecast events index-only", async () => {

--- a/components/map/embed-map-bridge.ts
+++ b/components/map/embed-map-bridge.ts
@@ -45,6 +45,14 @@ export type EmbedMapEvent =
         lon: number;
         slug?: string | null;
         conditionSummary?: string | null;
+        waveHeight?: string | null;
+        swellPeriod?: string | null;
+        swellDirection?: string | null;
+        isCalibrated?: boolean | null;
+        windSpeed?: string | null;
+        windDirection?: string | null;
+        tideState?: string | null;
+        tideHeight?: string | null;
       };
     }
   | { type: "clusterSelected"; payload: { clusterId: number; lat: number; lon: number } }

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -61,6 +61,7 @@ import type {
   SwellPartition,
 } from "@/app/api/forecasts/bulk/route";
 import {
+  degreesToCompass,
   SWELL_FIELD_PARTICLE_COLOR,
   SWELL_MAP_LEGEND_SURFACE,
   SWELL_MAP_SURFACE,
@@ -93,6 +94,11 @@ import type { CustomSpot } from "@/hooks/use-custom-spots";
 import { trackSignupCtaClick } from "@/lib/analytics/signup-conversion-tracking";
 import type { ForecastDisplay } from "@/lib/services/forecast/today-headline";
 import type { MapCameraCommand } from "@/components/map/map-camera-command";
+import {
+  formatSwellPeriod,
+  formatWaveHeightRange,
+  formatWindSpeed,
+} from "@/lib/formatters/surf-data";
 
 // Mapbox CSS is imported globally in app/globals.css
 
@@ -266,10 +272,73 @@ interface CapturedZoomLimits {
   maxZoom: number;
 }
 
+export interface MapSpotConditions {
+  conditionSummary: string | null;
+  waveHeight: string | null;
+  swellPeriod: string | null;
+  swellDirection: string | null;
+  isCalibrated: boolean | null;
+  windSpeed: string | null;
+  windDirection: string | null;
+  tideState: string | null;
+  tideHeight: string | null;
+}
+
+interface MapSpotConditionsContext {
+  partitionsMap: Map<string, SwellPartition>;
+  partitionsTimelineMap: Map<string, SwellPartition[]>;
+  timelineIndex: number;
+  waveHeightMap: Map<string, number | undefined>;
+  displayForecastMap: Map<string, ForecastDisplay | undefined>;
+  conditionSummaryMap: Map<string, ConditionSummary>;
+  isCalibratedMap: Map<string, boolean>;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function mapSpotConditions(
+  beachId: string,
+  context: MapSpotConditionsContext,
+): MapSpotConditions {
+  const partition = partitionAtTimelinePosition(
+    beachId,
+    context.timelineIndex,
+    context.partitionsTimelineMap,
+    context.partitionsMap,
+  );
+  const waveLabel = context.displayForecastMap.get(beachId)?.label?.trim();
+  const rawWaveHeight = context.waveHeightMap.get(beachId);
+  const swellDirection = partition?.swellDirOm ?? partition?.s1Dir;
+
+  return {
+    conditionSummary: context.conditionSummaryMap.get(beachId) ?? null,
+    waveHeight: waveLabel || (isFiniteNumber(rawWaveHeight)
+      ? formatWaveHeightRange(rawWaveHeight)
+      : null),
+    swellPeriod: isFiniteNumber(partition?.s1PeriodS) && partition.s1PeriodS > 0
+      ? formatSwellPeriod(partition.s1PeriodS)
+      : null,
+    swellDirection: isFiniteNumber(swellDirection)
+      ? degreesToCompass(swellDirection)
+      : null,
+    isCalibrated: context.isCalibratedMap.get(beachId) ?? null,
+    windSpeed: isFiniteNumber(partition?.windMph) && partition.windMph >= 0
+      ? formatWindSpeed(partition.windMph)
+      : null,
+    windDirection: isFiniteNumber(partition?.windDir)
+      ? degreesToCompass(partition.windDir)
+      : null,
+    tideState: null,
+    tideHeight: null,
+  };
+}
+
 interface InteractiveMapProps {
   initialCenter?: [number, number]; // [lat, lng]
   initialZoom?: number;
-  onLocationClick?: (beach: Beach) => void;
+  onLocationClick?: (beach: Beach, conditions: MapSpotConditions) => void;
   onMapClick?: (latlng: mapboxgl.LngLat) => void;
   cameraCommand?: MapCameraCommand | null;
   onUserCameraInteraction?: (interaction: {
@@ -479,6 +548,10 @@ export function InteractiveMap({
     stepsLen: 0,
     bounds: { west: -118, south: 32, east: -117, north: 33 },
     waterTempMap: new Map<string, string | undefined>(),
+    waveHeightMap: new Map<string, number | undefined>(),
+    displayForecastMap: new Map<string, ForecastDisplay | undefined>(),
+    conditionSummaryMap: new Map<string, ConditionSummary>(),
+    isCalibratedMap: new Map<string, boolean>(),
   });
   const beachPreviewCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
@@ -512,6 +585,7 @@ export function InteractiveMap({
   const [waterTempMap, setWaterTempMap] = useState<Map<string, string | undefined>>(new Map());
   const [conditionScoreMap, setConditionScoreMap] = useState<Map<string, number | undefined>>(new Map());
   const [conditionSummaryMap, setConditionSummaryMap] = useState<Map<string, ConditionSummary>>(new Map());
+  const [isCalibratedMap, setIsCalibratedMap] = useState<Map<string, boolean>>(new Map());
   const [partitionsMap, setPartitionsMap] = useState<Map<string, SwellPartition>>(new Map());
   const [partitionsTimelineMap, setPartitionsTimelineMap] = useState<
     Map<string, SwellPartition[]>
@@ -783,6 +857,10 @@ export function InteractiveMap({
       stepsLen: usesAbsoluteTimeline ? 1 : swellTimelineSteps.length,
       bounds: mapBounds || { west: -118, south: 32, east: -117, north: 33 },
       waterTempMap,
+      waveHeightMap,
+      displayForecastMap,
+      conditionSummaryMap,
+      isCalibratedMap,
     };
   }, [
     activeHourlyPartitionsMap,
@@ -791,12 +869,16 @@ export function InteractiveMap({
     isEmbedHourlyTimeline,
     isExpandableTimeline,
     mapBounds,
+    conditionSummaryMap,
+    displayForecastMap,
+    isCalibratedMap,
     partitionsMap,
     partitionsTimelineMap,
     swellFieldBeaches,
     swellTimelineIndex,
     swellTimelineSteps.length,
     waterTempMap,
+    waveHeightMap,
   ]);
 
   const trackTimelineAction = useCallback(
@@ -1211,11 +1293,17 @@ export function InteractiveMap({
               return;
             }
             showCalloutForBeach(beach);
-            onLocationClick?.(beach);
+            onLocationClick?.(
+              beach,
+              mapSpotConditions(beach.id, conditionsCtxRef.current),
+            );
             return;
           }
           removeActiveCallout();
-          onLocationClick?.(beach);
+          onLocationClick?.(
+            beach,
+            mapSpotConditions(beach.id, conditionsCtxRef.current),
+          );
         },
         router,
         autoNavigate: showConditionsOnTap ? false : autoNavigateOnMarkerClick,
@@ -1372,6 +1460,7 @@ export function InteractiveMap({
         setWaterTempMap(result.waterTempMap);
         setConditionScoreMap(result.conditionScoreMap);
         setConditionSummaryMap(result.conditionSummaryMap);
+        setIsCalibratedMap(result.isCalibratedMap);
         setPartitionsMap(result.partitionsMap);
         setPartitionsTimelineMap(result.partitionsTimelineMap);
         setSwellFieldBeaches(result.locations);

--- a/components/map/map-beach-loader.ts
+++ b/components/map/map-beach-loader.ts
@@ -41,6 +41,8 @@ export interface BeachLoaderResult {
   conditionScoreMap: Map<string, number | undefined>;
   /** Map from beach ID to native-aligned condition summary */
   conditionSummaryMap: Map<string, ConditionSummary>;
+  /** Map from beach ID to whether the displayed height uses beach calibration */
+  isCalibratedMap: Map<string, boolean>;
   /** Map from beach ID to parsed swell/wind partition for the flow field */
   partitionsMap: Map<string, SwellPartition>;
   /** Map from beach ID to parsed swell/wind partitions by forecast timeline step */
@@ -209,6 +211,7 @@ export async function loadBeachesAndWaveHeights(
   const waterTempMap = new Map<string, string | undefined>();
   const conditionScoreMap = new Map<string, number | undefined>();
   const conditionSummaryMap = new Map<string, ConditionSummary>();
+  const isCalibratedMap = new Map<string, boolean>();
   const partitionsMap = new Map<string, SwellPartition>();
   const partitionsTimelineMap = new Map<string, SwellPartition[]>();
   let hourlySwellTimeline: HourlySwellTimeline | null = null;
@@ -296,6 +299,13 @@ export async function loadBeachesAndWaveHeights(
           }
         });
 
+        const calibrationStatuses = data?.data?.isCalibrated || {};
+        Object.entries(calibrationStatuses).forEach(([beachId, isCalibrated]) => {
+          if (typeof isCalibrated === "boolean") {
+            isCalibratedMap.set(beachId, isCalibrated);
+          }
+        });
+
         const swellPartitions = data?.data?.swellPartitions || {};
         Object.entries(swellPartitions).forEach(([beachId, partition]) => {
           if (partition && typeof partition === "object") {
@@ -340,6 +350,7 @@ export async function loadBeachesAndWaveHeights(
     waterTempMap,
     conditionScoreMap,
     conditionSummaryMap,
+    isCalibratedMap,
     partitionsMap,
     partitionsTimelineMap,
     hourlySwellTimeline,


### PR DESCRIPTION
Additive native↔web contract change: the embed's `spotSelected` postMessage now carries `waveHeight`, `swellPeriod`, `swellDirection`, `isCalibrated`, `windSpeed`, `windDirection`, `tideState`, `tideHeight` (all optional/nullable), sourced from the same display-forecast/partition data the map labels already render, timeline-aware. `conditionSummary` is now actually sent (it was typed but never emitted). Tide fields emit `null` until the embed response carries tide data — nothing is fabricated. Existing fields byte-compatible; old native clients ignore the new fields.

Fixes the native WebView spot sheet's `--` WAVES/WIND cells (native counterpart: SteveChandler/quiver-native#125).

Verification: targeted suites 3/3 (48 tests), `yarn typecheck`, scoped ESLint 0 warnings. Implemented by Codex Sol; reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)