### PR TITLE
fix(ui): improve wave height label contrast

### DIFF
--- a/__tests__/components/ui/wave-height-display.test.tsx
+++ b/__tests__/components/ui/wave-height-display.test.tsx
@@ -70,6 +70,8 @@ describe("WaveHeightDisplay", () => {
       const label = screen.getByTestId("wave-height-label");
       expect(label).toBeInTheDocument();
       expect(label).toHaveTextContent("Face height");
+      expect(label).toHaveClass("text-[#3F382E]");
+      expect(label).toHaveClass("font-medium");
       // 'Forecast height' must NOT be present
       expect(screen.queryByText("Forecast height")).toBeNull();
     });

--- a/components/ui/wave-height-display.tsx
+++ b/components/ui/wave-height-display.tsx
@@ -121,7 +121,7 @@ export function WaveHeightDisplay({
       ? null
       : (
           <span
-            className="text-[11px] leading-tight text-muted-foreground/80"
+            className="text-[11px] font-medium leading-tight text-[#3F382E]"
             data-testid="wave-height-label"
           >
             {isCalibrated ? "Face height" : "Forecast height"}


### PR DESCRIPTION
## What changed\n- Use readable ink-colored, medium-weight styling for Face height and Forecast height labels.\n- Assert the calibrated label's visual classes.\n\n## Why\nThe honesty-layer source label needs stronger contrast and hierarchy while preserving the existing wording and behavior.\n\nOne concern: wave-height label presentation.