### PR TITLE
fix(forecast): improve marginal horizon color contrast

### DIFF
--- a/lib/utils/horizon-strip-utils.ts
+++ b/lib/utils/horizon-strip-utils.ts
@@ -102,7 +102,7 @@ export const TIER_COLOR_HEX: Record<ConditionTier, string> = {
   great: "#f59e0b",
   good: "#10b981",
   fair: "#60a5fa",
-  marginal: "#e2e8f0",
+  marginal: "#7F96AD",
 };
 
 /**


### PR DESCRIPTION
## What changed\n- Change the marginal horizon-strip chart color from pale slate to #7F96AD.\n\n## Why\nThe marginal tier needs a more legible, intentional color in the SVG/chart presentation while preserving all tier semantics.\n\nOne concern: marginal horizon-strip color.