### PR TITLE
fix(beaches): correct Tourmaline Surf Park coordinates

### DIFF
--- a/__tests__/migrations/tourmaline-beach-coordinates.test.ts
+++ b/__tests__/migrations/tourmaline-beach-coordinates.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Tourmaline beach coordinate correction migration", () => {
+  const migrationSQL = readFileSync(
+    join(
+      __dirname,
+      "../../supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql",
+    ),
+    "utf8",
+  );
+  const normalizedSQL = migrationSQL.replace(/\s+/g, " ").toLowerCase();
+
+  it("wraps the correction in a transaction", () => {
+    expect(migrationSQL).toMatch(/^\s*BEGIN;\s*$/m);
+    expect(migrationSQL).toMatch(/^\s*COMMIT;\s*$/m);
+  });
+
+  it("moves only the canonical Tourmaline row to the shoreline", () => {
+    expect(normalizedSQL).toContain("lat = 32.805149");
+    expect(normalizedSQL).toContain("lon = -117.262364");
+    expect(normalizedSQL).toContain(
+      "where id = '17628f35-9ed1-4257-aad6-070c4bd73bb8'::uuid",
+    );
+    expect(normalizedSQL).toContain("and slug = 'tourmaline'");
+    expect(normalizedSQL).toContain("and deleted_at is null");
+    expect(normalizedSQL).not.toContain("delete from");
+  });
+});

--- a/lib/constants/beach-coordinates.ts
+++ b/lib/constants/beach-coordinates.ts
@@ -37,7 +37,7 @@ export const beachCoordinates: Record<string, BeachCoordinates> = {
   "blacks beach": { lat: 32.9016, lon: -117.2524 },
   "windansea beach": { lat: 32.8217, lon: -117.2837 },
   "la jolla shores": { lat: 32.8507, lon: -117.2726 },
-  "tourmaline surf park": { lat: 32.8563, lon: -117.256 },
+  "tourmaline surf park": { lat: 32.805149, lon: -117.262364 },
   "crystal pier": { lat: 32.811, lon: -117.2544 },
   "pacific beach": { lat: 32.803, lon: -117.2405 },
   "mission beach": { lat: 32.7801, lon: -117.2549 },

--- a/supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql
+++ b/supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- California DFG site 6-3-SD-133-D places Tourmaline Surfing Park at the
+-- shoreline. The previous point was roughly 300 m inland in Pacific Beach.
+UPDATE public.beaches
+SET
+  lat = 32.805149,
+  lon = -117.262364
+WHERE id = '17628f35-9ed1-4257-aad6-070c4bd73bb8'::uuid
+  AND slug = 'tourmaline'
+  AND deleted_at IS NULL
+  AND (
+    lat IS DISTINCT FROM 32.805149
+    OR lon IS DISTINCT FROM -117.262364
+  );
+
+COMMIT;


### PR DESCRIPTION
## What changed\n- Move the canonical Tourmaline Surf Park coordinate to the shoreline in the coordinate lookup.\n- Add a guarded, transactional migration for the canonical Tourmaline row.\n- Add migration assertions covering the UUID, slug, soft-delete guard, and non-destructive update.\n\n## Why\nThe existing point is inland; the lookup and database row need to resolve to the actual Tourmaline Surfing Park shoreline.\n\nOne concern: Tourmaline beach coordinates.