### PR TITLE
fix(forecast): keep zero-score outlook bars visible

### DIFF
--- a/__tests__/components/forecast/conditions-overview/outlook-bar-chart.test.tsx
+++ b/__tests__/components/forecast/conditions-overview/outlook-bar-chart.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { OutlookBarChart } from "@/components/forecast/conditions-overview/outlook-bar-chart";
+import type { EnrichedDaySummary } from "@/lib/utils/enriched-day-summary";
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({
+    children,
+    minPointSize,
+  }: {
+    children: React.ReactNode;
+    minPointSize?: number;
+  }) => (
+    <div data-testid="score-bars" data-min-point-size={minPointSize}>
+      {children}
+    </div>
+  ),
+  Cell: ({ fill }: { fill?: string }) => (
+    <span data-testid="score-bar" data-fill={fill} />
+  ),
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  ReferenceLine: () => null,
+}));
+
+function createDay(overrides: Partial<EnrichedDaySummary>): EnrichedDaySummary {
+  return {
+    date: "Aug 4",
+    dayName: "Today",
+    minHeight: 1,
+    maxHeight: 2,
+    tier: "marginal",
+    score: 0,
+    fullDate: "2026-08-04",
+    isToday: false,
+    bestTime: "06:00",
+    period: 10,
+    windConditions: "light",
+    bestTimeSlot: "morning",
+    windSpeed: "3 mph",
+    ...overrides,
+  };
+}
+
+describe("OutlookBarChart", () => {
+  it("keeps zero-score days visible as minimum-height bars", () => {
+    const days = [
+      createDay({ score: 65, tier: "good", isToday: true }),
+      createDay({
+        date: "Aug 5",
+        dayName: "Wed",
+        fullDate: "2026-08-05",
+        score: 0,
+      }),
+    ];
+
+    render(<OutlookBarChart days={days} />);
+
+    expect(screen.getByTestId("score-bars")).toHaveAttribute(
+      "data-min-point-size",
+      "4",
+    );
+    const bars = screen.getAllByTestId("score-bar");
+    expect(bars).toHaveLength(2);
+    expect(bars[1]).toHaveAttribute("data-fill", "#7F96AD");
+  });
+});

--- a/components/forecast/conditions-overview/outlook-bar-chart.tsx
+++ b/components/forecast/conditions-overview/outlook-bar-chart.tsx
@@ -105,7 +105,12 @@ export function OutlookBarChart({ days }: OutlookBarChartProps) {
           <ReferenceLine y={40} stroke="#0B3A75" strokeDasharray="3 3" />
           <ReferenceLine y={60} stroke="#0B3A75" strokeDasharray="3 3" />
           <ReferenceLine y={80} stroke="#0B3A75" strokeDasharray="3 3" />
-          <Bar dataKey="score" radius={[4, 4, 0, 0]} maxBarSize={40}>
+          <Bar
+            dataKey="score"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+            minPointSize={4}
+          >
             {days.map((day, i) => (
               <Cell
                 key={i}


### PR DESCRIPTION
## What changed\n- Give every outlook bar a four-pixel minimum height.\n- Add a focused chart test covering a zero-score marginal day and the resulting bar color.\n\n## Why\nA score of zero currently collapses to an invisible bar, making a forecast day disappear from the outlook. A minimum point size keeps the day represented without changing its score.\n\nOne concern: zero-score outlook bar visibility.