### PR TITLE
fix(e2e): assert the android-beta route, not its attribution query string

### DIFF
--- a/e2e/guest-smoke.spec.ts
+++ b/e2e/guest-smoke.spec.ts
@@ -58,7 +58,9 @@ test.describe('Guest Smoke: Critical Pages', () => {
     ).toHaveAttribute('href', iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN));
     await expect(
       page.getByRole('link', { name: /get the android beta/i }).first(),
-    ).toHaveAttribute('href', '/android-beta');
+      // The CTA carries waitlist attribution (source/surface/placement), which
+      // varies per placement — assert the route, not the query string.
+    ).toHaveAttribute('href', /^\/android-beta(\?|$)/);
     await expect(page.getByText(/home-break finder/i)).toHaveCount(0);
 
     // Page should have substantive content


### PR DESCRIPTION
Same one-line fix already merged to `prod` via #515, brought back to `main`.

The features-page CTA carries waitlist attribution params (`source`/`surface`/`placement`/`campaign`) so the canonical roster can record where a signup came from. The smoke assertion still pinned a bare `/android-beta`, so it fails against any deployed environment.

**Why nobody noticed:** Main Gate deliberately omits Playwright smoke tests (they run against a deployed environment rather than the PR), so this only surfaces on a PR into `prod` — which is exactly where it blocked #515. Left unfixed here, the next prod slice re-hits it.

Verified green on the Prod Gate smoke run in #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)