### PR TITLE
test(db): match get_nearby_beaches cap assertions to the shipped ceilings

### DIFF
--- a/__tests__/migrations/get-nearby-beaches-public-visibility.test.ts
+++ b/__tests__/migrations/get-nearby-beaches-public-visibility.test.ts
@@ -15,11 +15,20 @@ describe("get_nearby_beaches public visibility migration", () => {
     expect(sql).toContain("b.deleted_at IS NULL");
   });
 
+  // Ceilings sit at the widest any live caller legitimately asks for, not at
+  // the defaults: native's use-nearest-beach requests 160934 m, and discovery's
+  // candidate pool wants 60 rows. Clamping tighter returns zero beaches for
+  // users far from a break, in binaries already shipped.
   it("caps direct RPC calls to the public map contract", () => {
     expect(sql).toContain(
-      "LEAST(GREATEST(max_distance_meters, 0), 80467)",
+      "LEAST(GREATEST(max_distance_meters, 0), 160934)",
     );
-    expect(sql).toContain("LEAST(GREATEST(limit_count, 1), 50)");
+    expect(sql).toContain("LEAST(GREATEST(limit_count, 1), 100)");
+  });
+
+  it("leaves the narrower defaults in place for callers that omit arguments", () => {
+    expect(sql).toContain("max_distance_meters INTEGER DEFAULT 80467");
+    expect(sql).toContain("limit_count INTEGER DEFAULT 50");
   });
 
   it("does not grant execution to the implicit public role", () => {


### PR DESCRIPTION
`main` is currently red: `__tests__/migrations/get-nearby-beaches-public-visibility.test.ts` fails on a clean checkout, so Main Gate blocks every open PR.

**Cause.** [`444daaa75`](https://github.com/SteveChandler/quiver/commit/444daaa75) deliberately raised the `get_nearby_beaches` ceilings from 80467 m / 50 rows to 160934 m / 100 rows — native's `use-nearest-beach` already requests 160934 m in a shipped iOS binary, and clamping tighter returned zero beaches for users more than 50 mi from a break. That commit updated the migration but not this test, which still asserted the old values.

**Fix.** The migration is correct; the assertions were stale. They now point at the shipped ceilings, plus a new case pins the defaults (80467 / 50), which `444daaa75` deliberately left alone — so a future change to a ceiling or a default fails loudly instead of one drifting silently past the other.

No production code changes. Verified: 4/4 in this suite, scoped ESLint clean.