### PR TITLE
feat(zine): show the real beach location in the zine map cue

### DIFF
--- a/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
+++ b/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
@@ -28,6 +28,38 @@ describe("ZineHero heading level", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("uses the beach coordinates to render a real static location map", () => {
+    const previousToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+    process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = "test-map-token";
+    const beach = createMockBeach({
+      name: "Tourmaline Beach",
+      city: "San Diego",
+      state: "CA",
+      lat: 32.805149,
+      lon: -117.262364,
+    });
+
+    try {
+      render(<ZineHero beach={beach} />);
+
+      const map = screen.getByRole("img", {
+        name: "Map showing Tourmaline Beach at its actual location",
+      });
+      const mapImage = map.querySelector("img");
+
+      expect(mapImage).toHaveAttribute(
+        "src",
+        expect.stringContaining("-117.262364,32.805149,15,0"),
+      );
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+      } else {
+        process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = previousToken;
+      }
+    }
+  });
+
   it("renders a stored cam still in the hero when the live stream URL is unavailable", () => {
     const beach = createMockBeach({
       name: "Inches",

--- a/components/beach-detail/zine/atoms/index.tsx
+++ b/components/beach-detail/zine/atoms/index.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { getOptimizedImageUrl } from "@/lib/image-proxy";
+import { getStaticMapImageUrl } from "@/lib/map-utils";
 import { buildZineMapScene, type ZineMapCue } from "../map-doodle-scene";
 
 export function RoughEdgeFilter() {
@@ -332,42 +333,78 @@ export function MapDoodle({
   const approachStartX = scene.oceanSide === "left" ? 30 : 370;
   const approachEndX = scene.oceanSide === "left" ? markerX - 18 : markerX + 18;
   const locationFontSize = locationName.length > 18 ? 15 : locationName.length > 14 ? 17 : 20;
+  const mapUrl = lat != null && lon != null
+    ? getStaticMapImageUrl(lat, lon, {
+        width: 800,
+        height: 480,
+        zoom: 15,
+      })
+    : null;
+  const hasRealMap = mapUrl != null && !mapUrl.startsWith("data:image");
+
   return (
-    <div style={{ position: "relative", width: "100%", height, background: "#EBDFC2", overflow: "hidden" }} aria-hidden>
+    <div
+      style={{ position: "relative", width: "100%", height, background: "#EBDFC2", overflow: "hidden" }}
+      role="img"
+      aria-label={`Map showing ${beachName || locationName} at its actual location`}
+    >
+      {hasRealMap && (
+        // eslint-disable-next-line @next/next/no-img-element -- static map providers are already optimized and can fall back independently
+        <img
+          src={mapUrl}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          style={{ filter: "sepia(0.16) saturate(0.72) contrast(1.08)", opacity: 0.88 }}
+        />
+      )}
       <svg viewBox="0 0 400 240" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
         <pattern id={scene.patternId} x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse">
           <circle cx="3" cy="3" r="1.1" fill="#7FA7B8" opacity="0.55" />
         </pattern>
-        <path d={scene.oceanPath} fill="#C9D8DD" />
-        <path d={scene.oceanPath} fill={`url(#${scene.patternId})`} />
-        <path d={scene.landPath} fill="#EBDFC2" />
-        <path d={scene.coastPath} stroke="#11100D" strokeWidth="2" fill="none" filter="url(#zine-rough-edge)" />
-        <g stroke="#11100D" strokeWidth="0.6" opacity="0.55">
-          {scene.gridLines.map((path) => (
-            <path key={path} d={path} />
-          ))}
-        </g>
-        <g transform={scene.cueTransform} data-testid={`zine-map-cue-${scene.cue}`}>
-          <MapCue cue={scene.cue} />
-        </g>
-        <g transform={`translate(${markerX},${markerY})`}>
-          <circle r="14" fill="none" stroke="#11100D" strokeWidth="2" filter="url(#zine-rough-edge)" />
-          <path d="M-7,-7 L7,7 M-7,7 L7,-7" stroke="#11100D" strokeWidth="2.2" strokeLinecap="round" />
-        </g>
-        <g stroke="#0B3A75" strokeWidth="1.6" fill="none" strokeDasharray="3,3">
-          <path d={`M${approachStartX},${markerY - 30} C${approachStartX - 18},${markerY - 25} ${approachEndX},${markerY - 28} ${approachEndX},${markerY - 12}`} />
-          <path d={`M${approachStartX},${markerY + 30} C${approachStartX - 18},${markerY + 25} ${approachEndX},${markerY + 28} ${approachEndX},${markerY + 12}`} />
-        </g>
-        <path d={`M${approachEndX},${markerY - 17} L${markerX},${markerY - 12} L${approachEndX},${markerY - 7}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
-        <path d={`M${approachEndX},${markerY + 7} L${markerX},${markerY + 12} L${approachEndX},${markerY + 17}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+        {hasRealMap ? (
+          <>
+            <rect width="400" height="240" fill={`url(#${scene.patternId})`} opacity="0.18" />
+            <circle cx="200" cy="120" r="16" fill="none" stroke="#11100D" strokeWidth="2.5" filter="url(#zine-rough-edge)" />
+            <path d="M192,112 L208,128 M192,128 L208,112" stroke="#11100D" strokeWidth="2.4" strokeLinecap="round" />
+          </>
+        ) : (
+          <>
+            <path d={scene.oceanPath} fill="#C9D8DD" />
+            <path d={scene.oceanPath} fill={`url(#${scene.patternId})`} />
+            <path d={scene.landPath} fill="#EBDFC2" />
+            <path d={scene.coastPath} stroke="#11100D" strokeWidth="2" fill="none" filter="url(#zine-rough-edge)" />
+            <g stroke="#11100D" strokeWidth="0.6" opacity="0.55">
+              {scene.gridLines.map((path) => (
+                <path key={path} d={path} />
+              ))}
+            </g>
+            <g transform={scene.cueTransform} data-testid={`zine-map-cue-${scene.cue}`}>
+              <MapCue cue={scene.cue} />
+            </g>
+            <g transform={`translate(${markerX},${markerY})`}>
+              <circle r="14" fill="none" stroke="#11100D" strokeWidth="2" filter="url(#zine-rough-edge)" />
+              <path d="M-7,-7 L7,7 M-7,7 L7,-7" stroke="#11100D" strokeWidth="2.2" strokeLinecap="round" />
+            </g>
+            <g stroke="#0B3A75" strokeWidth="1.6" fill="none" strokeDasharray="3,3">
+              <path d={`M${approachStartX},${markerY - 30} C${approachStartX - 18},${markerY - 25} ${approachEndX},${markerY - 28} ${approachEndX},${markerY - 12}`} />
+              <path d={`M${approachStartX},${markerY + 30} C${approachStartX - 18},${markerY + 25} ${approachEndX},${markerY + 28} ${approachEndX},${markerY + 12}`} />
+            </g>
+            <path d={`M${approachEndX},${markerY - 17} L${markerX},${markerY - 12} L${approachEndX},${markerY - 7}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+            <path d={`M${approachEndX},${markerY + 7} L${markerX},${markerY + 12} L${approachEndX},${markerY + 17}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+          </>
+        )}
         <text
-          x={scene.label.x}
-          y={scene.label.y}
+          x={hasRealMap ? 302 : scene.label.x}
+          y={hasRealMap ? 214 : scene.label.y}
           fontFamily="var(--font-handwritten), cursive"
           fontSize={locationFontSize}
           fill="#11100D"
           fontWeight="700"
           textAnchor="middle"
+          paintOrder="stroke"
+          stroke="#F4EBD8"
+          strokeWidth={hasRealMap ? 4 : 0}
+          strokeLinejoin="round"
         >
           {locationName}
         </text>


### PR DESCRIPTION
Thin slice off the uncommitted pile on `growth/seo-install-handoff`.

The zine map cue drew a stylised placeholder regardless of where the beach actually is. It now renders the static map for the beach's coordinates when they resolve, falling back to the existing doodle when they don't, or when the provider hands back a `data:` URI placeholder. The cue also gets a real `aria-label` naming the beach rather than being hidden from assistive tech as decoration. Plus added ZineHero heading coverage.

`atoms/index.tsx` is live — imported by the signed-in home shell, blog pages, the landing field-guide, the download view and `zine-surface`, among others.

**Deliberately excluded:** the sibling `zine-tab.test.tsx` change from the same WIP pile. `ZineTab` was imported only by its own test, and main already deleted `zine-tab.tsx` as a verified orphan in [`9201b9bcc`](https://github.com/SteveChandler/quiver/commit/9201b9bcc) — that test change would have resurrected coverage for a component nothing ships.

Verified against main: full unit suite 16,449 passing / 0 failing, `tsc --noEmit` clean, scoped ESLint clean.