### PR TITLE
refactor(zine): drop the duplicate masthead from zine surfaces

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -108,14 +108,8 @@ export default async function BlogPostPage({ params }: Props) {
       <div className="zine-page zine-tab min-h-screen bg-[#0D1020]">
         <RoughEdgeFilter />
         <div className="zine-stage pt-24">
-          <div className="zine-masthead">
-            <div className="left">
-              <span className="logo">Quiver</span>
-              <span className="rule" aria-hidden />
-              <span>Founder Notes</span>
-            </div>
-            <div>{formatPostDate(post.datePublished).toUpperCase()}</div>
-          </div>
+          {/* No masthead: the app header above already carries the Quiver
+              wordmark, so a masthead reads as a second header. */}
 
           <article
             className="zine-paper overflow-hidden"

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -93,14 +93,8 @@ export default function BlogIndexPage() {
       <div className="zine-page zine-tab min-h-screen bg-[#0D1020]">
         <RoughEdgeFilter />
         <div className="zine-stage pt-24">
-          <div className="zine-masthead">
-            <div className="left">
-              <span className="logo">Quiver</span>
-              <span className="rule" aria-hidden />
-              <span>Blog Desk</span>
-            </div>
-            <div>Founder notes / field reports</div>
-          </div>
+          {/* No masthead: the app header above already carries the Quiver
+              wordmark, so a masthead reads as a second header. */}
 
           <main className="zine-paper overflow-hidden">
             <QuiverSticker

--- a/components/beach-detail/zine/zine-page-shell.tsx
+++ b/components/beach-detail/zine/zine-page-shell.tsx
@@ -37,22 +37,9 @@ export function ZinePageShell({
     <div className="zine-page zine-tab">
       <RoughEdgeFilter />
       <div className="zine-stage">
-        <div className="zine-masthead">
-          <div className="left">
-            <span>Field Guide · Vol. 03</span>
-            <span className="rule" aria-hidden />
-            <span>
-              {beach.city
-                ? `${beach.city.toUpperCase()}${beach.state ? `, ${beach.state.toUpperCase()}` : ""}`
-                : "FIELD"}
-            </span>
-          </div>
-          <div>
-            {new Date()
-              .toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
-              .toUpperCase()}
-          </div>
-        </div>
+        {/* No masthead: the app header already sits above this page with the
+            Quiver wordmark in it, so a masthead reads as a second header. The
+            edition byline still runs in ZineFooter. */}
 
         <div className="zine-paper">
           <ZineHero

--- a/components/zine/zine-surface.tsx
+++ b/components/zine/zine-surface.tsx
@@ -23,7 +23,11 @@ export function ZineSurface({
   className,
   stageClassName,
   paperClassName,
-  showMasthead = true,
+  // Off by default: the app header already sits directly above every zine
+  // surface with the Quiver wordmark in it, so a masthead renders as a second
+  // header repeating the brand mark. Stacked-section pages got two or three of
+  // them. Opt back in per-surface if a page ever needs an editorial masthead.
+  showMasthead = false,
   "data-testid": dataTestId = "zine-surface",
 }: ZineSurfaceProps) {
   return (


### PR DESCRIPTION
Re-sliced from `af3c1a0f7` on `growth/seo-install-handoff`.

The app header already carries the Quiver wordmark, so every zine masthead rendered as a second header — stacked-section pages showed two or three. `ZineSurface`'s `showMasthead` now defaults off, and the remaining explicit mastheads are removed from the blog pages and `ZinePageShell`. The edition byline still runs in `ZineFooter`, and any surface that genuinely wants an editorial masthead can opt back in.

**One hunk deliberately dropped.** The original commit also edited `components/beach-detail/zine/zine-tab.tsx`, which main removed in [`9201b9bcc`](https://github.com/SteveChandler/quiver/commit/9201b9bcc) as a verified orphan — `ZineTab` was imported by nothing except its own test. That hunk is the modify/delete half of the conflict blocking the parent branch; the other four files are live and are what this PR carries.

Verified against main: full unit suite 16,449 passing / 0 failing, `tsc --noEmit` clean, scoped ESLint clean.