### PR TITLE
fix(discovery): keep resume rechecks and stop duplicate requests

### DIFF
--- a/__tests__/hooks/use-surf-discovery.resume-revalidation.test.tsx
+++ b/__tests__/hooks/use-surf-discovery.resume-revalidation.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Resume revalidation must stay fail-closed (covered in
+ * use-surf-discovery-hold.test.tsx) WITHOUT amplifying requests.
+ *
+ * A single tab switch fires both `focus` and `visibilitychange`. Each one
+ * used to produce its own discovery request: the second event queued behind
+ * the first and drained into a follow-up fetch once the first settled. That
+ * doubled load on `/api/surf/discover` — an uncacheable route with a 30s
+ * budget — and doubled the time the home screen spent with no payload.
+ *
+ * A resume revalidation already in flight reflects state as of its own
+ * response, so it covers every resume event raised while it runs.
+ */
+
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useSurfDiscovery } from "@/hooks/use-surf-discovery";
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+jest.mock("@/context/auth-context", () => ({
+  useAuth: jest.fn(() => ({ user: mockUser })),
+}));
+
+const response = {
+  sessionDecision: null,
+  recommendations: [
+    {
+      recommendationId: "candidate-1",
+      beach: { id: "beach-1", name: "Ocean Beach", slug: "ocean-beach" },
+      window: {
+        start: "2025-12-16T15:00:00.000Z",
+        end: "2025-12-16T18:00:00.000Z",
+        timezone: "America/Los_Angeles",
+      },
+      forecast: {},
+      score: 85,
+      summary: "Good",
+      reasons: [],
+      warnings: [],
+    },
+  ],
+  searchCriteria: { maxResults: 5 },
+  metadata: {},
+  regionalCall: "",
+};
+
+describe("useSurfDiscovery resume revalidation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ data: response }) });
+    window.localStorage?.clear();
+  });
+
+  it("issues one revalidation for a tab switch that fires focus and visibilitychange", async () => {
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("queues a resume that arrives after the coalescing window, mid-flight", async () => {
+    // A hold can activate after the in-flight request already read hold state
+    // server-side, so a genuinely later resume signal must not be swallowed by
+    // the request it overlaps — it has to earn its own recheck.
+    let releaseResume: (() => void) | undefined;
+    global.fetch = jest
+      .fn()
+      // initial
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: response }) })
+      // resume request — held open so a later signal lands mid-flight
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseResume = () =>
+              resolve({ ok: true, json: async () => ({ data: response }) });
+          })
+      )
+      .mockResolvedValue({ ok: true, json: async () => ({ data: response }) });
+
+    const nowSpy = jest.spyOn(Date, "now");
+    const base = 1_000_000;
+    nowSpy.mockReturnValue(base);
+
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+    // Well past the pairing window — a separate resume, not the focus/
+    // visibilitychange pair from one tab switch.
+    nowSpy.mockReturnValue(base + 5_000);
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    act(() => {
+      releaseResume?.();
+    });
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    nowSpy.mockRestore();
+  });
+
+  it("still revalidates on a later, separate resume", async () => {
+    const { result } = renderHook(() => useSurfDiscovery({ immediate: true }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/hooks/use-surf-discovery.ts
+++ b/hooks/use-surf-discovery.ts
@@ -14,6 +14,13 @@ import type { SurfDiscoveryResponse, TimeSlot } from "@/types/personalization";
 const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
 
 /**
+ * How close together two resume signals must be to count as one tab switch.
+ * `focus` and `visibilitychange` fire within a frame of each other; anything
+ * beyond this is treated as a separate resume that earns its own recheck.
+ */
+const RESUME_COALESCE_MS = 1_000;
+
+/**
  * Options for useSurfDiscovery hook
  */
 interface UseSurfDiscoveryOptions {
@@ -287,6 +294,7 @@ export function useSurfDiscovery(
 
   const resumeRevalidationRef = useRef<Promise<unknown> | null>(null);
   const resumeRevalidationQueuedRef = useRef(false);
+  const resumeStartedAtRef = useRef(0);
   const [resumeRevalidationPending, setResumeRevalidationPending] =
     useState(false);
 
@@ -303,6 +311,7 @@ export function useSurfDiscovery(
 
     resumeRevalidationQueuedRef.current = false;
     setResumeRevalidationPending(true);
+    resumeStartedAtRef.current = Date.now();
     const pending = refreshDiscovery();
     resumeRevalidationRef.current = pending;
     const settle = () => {
@@ -319,7 +328,25 @@ export function useSurfDiscovery(
     if (!enabled || !immediate || !user) return;
 
     setResumeRevalidationPending(true);
-    if (loading || resumeRevalidationRef.current) {
+
+    if (resumeRevalidationRef.current) {
+      // One tab switch raises `focus` and `visibilitychange` back to back, and
+      // firing a request for each doubled load on an uncacheable route. Those
+      // paired events describe the same resume, so collapse them.
+      //
+      // Anything arriving after that pairing window is a genuinely separate
+      // resume, and the in-flight request cannot answer for it: the server may
+      // have already read hold state before whatever changed. Dropping it
+      // would lose a recheck, so queue it — a duplicate request is the cheap
+      // failure here, a stale positive call is not.
+      if (Date.now() - resumeStartedAtRef.current <= RESUME_COALESCE_MS) return;
+      resumeRevalidationQueuedRef.current = true;
+      return;
+    }
+    if (loading) {
+      // Work that started BEFORE this resume (the initial fetch, or an options
+      // refresh) can predate whatever changed while the tab was away, so it
+      // cannot stand in for a recheck either.
       resumeRevalidationQueuedRef.current = true;
       return;
     }


### PR DESCRIPTION
Re-sliced from `f1b588cde` on `growth/seo-install-handoff`; cherry-picked onto main unchanged.

One tab switch raises `focus` and `visibilitychange` back to back, and firing a request for each doubled load on an uncacheable route. Those paired events describe the same resume, so they now collapse — but only inside a 1s pairing window.

The fail-closed behaviour is preserved deliberately: anything arriving after that window is a genuinely separate resume that the in-flight request cannot answer for (the server may already have read hold state before whatever changed), so it is queued rather than dropped. Same for work that started *before* the resume — the initial fetch or an options refresh can predate the change, so it can't stand in for a recheck either. As the code comment puts it, a duplicate request is the cheap failure here; a stale positive call is not.

Verified against main: full unit suite 16,452 passing / 0 failing (includes the commit's own 136-line resume-revalidation suite), `tsc --noEmit` clean, scoped ESLint clean.