### PR TITLE
fix: keep all public beach forecasts fresh

### DIFF
--- a/__tests__/app/api/surf-week-scout-route.test.ts
+++ b/__tests__/app/api/surf-week-scout-route.test.ts
@@ -24,8 +24,13 @@ jest.mock(
 
 import { NextRequest } from 'next/server';
 import { POST } from '@/app/api/surf/week-scout/route';
+import {
+  WEEK_SCOUT_CONTRACT_BEACH_ID,
+  WEEK_SCOUT_CONTRACT_FIXTURE,
+  WEEK_SCOUT_CONTRACT_GENERATED_AT,
+} from '@/__tests__/fixtures/week-scout-contract';
 
-const BEACH_A = '11111111-1111-4111-8111-111111111111';
+const BEACH_A = WEEK_SCOUT_CONTRACT_BEACH_ID;
 const BEACH_B = '22222222-2222-4222-8222-222222222222';
 
 function request(body: unknown): NextRequest {
@@ -48,12 +53,7 @@ describe('POST /api/surf/week-scout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.WEEK_SCOUT_ENDPOINT_ENABLED = 'true';
-    mockGenerateWeekScoutForecast.mockResolvedValue({
-      generatedAt: '2026-07-15T18:00:00.000Z',
-      scorerVersion: 'week-scout-v1',
-      candidateFingerprint: 'candidate-fingerprint',
-      days: [],
-    });
+    mockGenerateWeekScoutForecast.mockResolvedValue(WEEK_SCOUT_CONTRACT_FIXTURE);
   });
 
   it('deduplicates candidate IDs and returns the exact private no-store response', async () => {
@@ -142,8 +142,58 @@ describe('POST /api/surf/week-scout', () => {
     expect(mockGenerateWeekScoutForecast).not.toHaveBeenCalled();
   });
 
-  it('returns 404 without running discovery when the rollout flag is disabled', async () => {
+  it('keeps the endpoint enabled for installed clients when the rollout flag is unset', async () => {
     delete process.env.WEEK_SCOUT_ENDPOINT_ENABLED;
+    const response = await callRoute({
+      candidateBeachIds: [BEACH_A],
+      localTimezone: 'Pacific/Honolulu',
+      startLocalDate: '2026-07-15',
+      dayCount: 7,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockGenerateWeekScoutForecast).toHaveBeenCalledWith(
+      'user-week-scout',
+      expect.objectContaining({ candidateBeachIds: [BEACH_A] }),
+    );
+    expect(response.headers.get('Cache-Control')).toBe(
+      'private, no-store, no-cache, must-revalidate',
+    );
+  });
+
+  it('returns the non-empty canonical mobile contract fixture', async () => {
+    delete process.env.WEEK_SCOUT_ENDPOINT_ENABLED;
+    const response = await callRoute({
+      candidateBeachIds: [BEACH_A],
+      localTimezone: 'Pacific/Honolulu',
+      startLocalDate: '2026-07-15',
+      dayCount: 7,
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.data).toMatchObject({
+      generatedAt: WEEK_SCOUT_CONTRACT_GENERATED_AT,
+      recommendationAvailability: {
+        state: 'available',
+        holdEpoch: 'available-epoch',
+      },
+      sessionDecision: expect.objectContaining({
+        verdict: 'go',
+        selection: expect.objectContaining({ beachId: BEACH_A }),
+      }),
+    });
+    expect(payload.data.days[0]).toMatchObject({
+      bestWindowId: 'window-a',
+      windows: [expect.objectContaining({
+        beachId: BEACH_A,
+        forecast: expect.objectContaining({ waveHeight: '3-4 ft' }),
+      })],
+    });
+  });
+
+  it('returns 404 without running discovery when the emergency kill switch is enabled', async () => {
+    process.env.WEEK_SCOUT_ENDPOINT_ENABLED = 'false';
     const response = await callRoute({
       candidateBeachIds: [BEACH_A],
       localTimezone: 'Pacific/Honolulu',

--- a/__tests__/fixtures/week-scout-contract-v1.json
+++ b/__tests__/fixtures/week-scout-contract-v1.json
@@ -1,0 +1,133 @@
+{
+  "generatedAt": "2026-07-15T18:00:00.000Z",
+  "scorerVersion": "week-scout-v1:discovery-hero-v1",
+  "candidateFingerprint": "candidate-fingerprint-v1",
+  "recommendationAvailability": {
+    "state": "available",
+    "holdEpoch": "available-epoch"
+  },
+  "sessionDecision": {
+    "schemaVersion": "canonical-session-decision.v1",
+    "engineVersion": "rules.v1",
+    "decisionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "createdAt": "2026-07-15T18:00:00.000Z",
+    "expiresAt": "2026-07-15T18:05:00.000Z",
+    "scope": {
+      "kind": "plan_next_session",
+      "windowStart": "2026-07-15T18:00:00.000Z",
+      "windowEnd": "2026-07-22T18:00:00.000Z",
+      "timezone": "Pacific/Honolulu"
+    },
+    "verdict": "go",
+    "decisionBasis": "physical_fallback",
+    "reasonCode": "selected_go",
+    "selection": {
+      "candidateId": "window-a",
+      "beachId": "11111111-1111-4111-8111-111111111111",
+      "beachName": "Ala Moana",
+      "windowStart": "2026-07-15T16:00:00.000Z",
+      "windowEnd": "2026-07-15T19:00:00.000Z",
+      "timezone": "Pacific/Honolulu",
+      "forecastRef": {
+        "forecastId": "forecast-a",
+        "beachId": "11111111-1111-4111-8111-111111111111",
+        "forecastAt": "2026-07-15T17:00:00.000Z"
+      },
+      "skillEligibility": {
+        "skill": "intermediate",
+        "state": "eligible",
+        "reasonCodes": []
+      },
+      "evidence": {
+        "conditionScore": 84,
+        "recommendationLabel": "Worth it",
+        "personalMatch": null
+      }
+    },
+    "skillEligibility": {
+      "skill": "intermediate",
+      "state": "eligible",
+      "reasonCodes": []
+    },
+    "holdEpoch": "available-epoch"
+  },
+  "days": [
+    {
+      "localDate": "2026-07-15",
+      "windows": [
+        {
+          "id": "window-a",
+          "bucket": "morning",
+          "start": "2026-07-15T16:00:00.000Z",
+          "end": "2026-07-15T19:00:00.000Z",
+          "peakTime": "2026-07-15T17:00:00.000Z",
+          "beachId": "11111111-1111-4111-8111-111111111111",
+          "conditionScore": 84,
+          "rankingScore": 88,
+          "verdict": "worth_it",
+          "rideable": true,
+          "safe": true,
+          "confidence": 82,
+          "forecast": {
+            "waveHeight": "3-4 ft",
+            "period": "12s",
+            "swellDirection": "S",
+            "windSpeed": "5 mph",
+            "windDirection": "NE",
+            "tideHeightFt": 1.4,
+            "tidePhase": "Rising",
+            "freshnessAt": "2026-07-15T18:00:00.000Z"
+          },
+          "takeaway": "Cleanest before the trades fill in.",
+          "rankedSpots": [
+            {
+              "beachId": "11111111-1111-4111-8111-111111111111",
+              "beachName": "Ala Moana",
+              "conditionScore": 84,
+              "rankingScore": 88,
+              "verdict": "worth_it"
+            }
+          ]
+        }
+      ],
+      "bestWindowId": "window-a",
+      "exclusionReasons": []
+    },
+    {
+      "localDate": "2026-07-16",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-17",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-18",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-19",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-20",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-21",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    }
+  ]
+}

--- a/__tests__/fixtures/week-scout-contract.ts
+++ b/__tests__/fixtures/week-scout-contract.ts
@@ -1,0 +1,9 @@
+import type { CanonicalWeekScoutResponse } from '@/lib/services/discovery/week-scout';
+import weekScoutContractFixtureJson from './week-scout-contract-v1.json';
+
+export const WEEK_SCOUT_CONTRACT_BEACH_ID = '11111111-1111-4111-8111-111111111111';
+export const WEEK_SCOUT_CONTRACT_GENERATED_AT = '2026-07-15T18:00:00.000Z';
+
+export const WEEK_SCOUT_CONTRACT_FIXTURE = (
+  weekScoutContractFixtureJson as unknown as CanonicalWeekScoutResponse
+);

--- a/__tests__/lib/seo/forecast-authority-benchmark.test.ts
+++ b/__tests__/lib/seo/forecast-authority-benchmark.test.ts
@@ -1,7 +1,10 @@
 import {
   buildForecastBenchmarkQueries,
   classifyForecastBenchmarkRegion,
+  createUnmeasuredForecastRetrievalBenchmark,
   extractForecastAnswerContractFacts,
+  summarizeForecastCompetitiveBenchmark,
+  summarizeForecastRetrievalEvidence,
   type ForecastBenchmarkSpot,
 } from "@/lib/seo/forecast-authority-benchmark";
 
@@ -16,12 +19,14 @@ const spot = (overrides: Partial<ForecastBenchmarkSpot> = {}): ForecastBenchmark
 });
 
 describe("forecast authority benchmark", () => {
-  it("samples California, Hawaii, East Coast, Gulf, and international inventory", () => {
+  it("samples every domestic coast and international inventory", () => {
     const spots = [
       spot(),
       spot({ id: "hi", state: "HI", country: "USA" }),
       spot({ id: "east", state: "NC", country: "USA" }),
       spot({ id: "gulf", state: "TX", country: "USA" }),
+      spot({ id: "west", state: "OR", country: "USA" }),
+      spot({ id: "florida", state: "FL", country: "USA" }),
       spot({ id: "intl", state: "Jalisco", country: "Mexico" }),
     ];
 
@@ -30,9 +35,11 @@ describe("forecast authority benchmark", () => {
       "Hawaii",
       "East Coast",
       "Gulf Coast",
+      "West Coast",
+      "East Coast",
       "International",
     ]);
-    expect(buildForecastBenchmarkQueries(spots, 1)).toHaveLength(50);
+    expect(buildForecastBenchmarkQueries(spots, 1)).toHaveLength(60);
   });
 
   it("extracts the server-rendered answer contract from raw HTML", () => {
@@ -59,6 +66,151 @@ describe("forecast authority benchmark", () => {
       freshness: true,
       provenance: true,
       score: 1,
+    });
+  });
+
+  it("calculates Answer Share, citations, and canonical selection from query evidence", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query, index) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath === null
+        ? null
+        : index === 1
+          ? "https://www.surfline.com/surf-report/oceanside-harbor"
+          : index === 2
+            ? null
+            : "https://www.quiversurf.app/ca/oceanside/oceanside-harbor",
+      answerUrl: index === 1
+        ? "https://www.surfline.com/surf-report/oceanside-harbor"
+        : query.canonicalPath === null
+          ? null
+          : "https://www.quiversurf.app/ca/oceanside/oceanside-harbor",
+      citedUrl: index < 5
+        ? "https://www.quiversurf.app/ca/oceanside/oceanside-harbor"
+        : null,
+      answerComplete: index < 8,
+      current: index < 7,
+    }));
+
+    const benchmark = summarizeForecastRetrievalEvidence(
+      queries,
+      evidence,
+      "fixture-search",
+      "https://www.quiversurf.app",
+    );
+    const competitive = summarizeForecastCompetitiveBenchmark(queries, evidence, benchmark);
+
+    expect(benchmark).toMatchObject({
+      status: "measured",
+      provider: "fixture-search",
+      expectedQueries: 10,
+      measuredQueries: 10,
+      retrievedShare: 0.6,
+      answerShare: 0.7,
+      currentAnswerShare: 0.6,
+      citationShare: 0.5,
+      canonicalSelectionShare: 0.75,
+      missingQueryIds: [],
+      unexpectedQueryIds: [],
+      duplicateQueryIds: [],
+      reason: null,
+    });
+    expect(competitive).toMatchObject({
+      status: "measured",
+      competitors: [
+        {
+          name: "Surfline",
+          selectedShare: 0.1,
+          answerShare: 0.1,
+          citationShare: 0,
+        },
+        {
+          name: "Surf Captain",
+          selectedShare: 0,
+          answerShare: 0,
+          citationShare: 0,
+        },
+      ],
+    });
+  });
+
+  it("does not credit a competitor that uses the canonical Quiver path", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath === null
+        ? null
+        : `https://competitor.example${query.canonicalPath}`,
+      answerUrl: "https://competitor.example/answer",
+      citedUrl: "https://competitor.example/citation",
+      answerComplete: true,
+      current: true,
+    }));
+
+    const benchmark = summarizeForecastRetrievalEvidence(queries, evidence, "fixture-search");
+
+    expect(benchmark).toMatchObject({
+      retrievedShare: 0,
+      answerShare: 0,
+      currentAnswerShare: 0,
+      citationShare: 0,
+      canonicalSelectionShare: 0,
+    });
+  });
+
+  it("does not credit relative or malformed retrieval values as Quiver URLs", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath,
+      answerUrl: "not a URL",
+      citedUrl: "/ca/oceanside/oceanside-harbor",
+      answerComplete: true,
+      current: true,
+    }));
+
+    expect(summarizeForecastRetrievalEvidence(queries, evidence, "fixture-search")).toMatchObject({
+      retrievedShare: 0,
+      answerShare: 0,
+      currentAnswerShare: 0,
+      citationShare: 0,
+      canonicalSelectionShare: 0,
+    });
+  });
+
+  it("rejects incomplete retrieval evidence instead of reporting partial coverage as measured", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const benchmark = summarizeForecastRetrievalEvidence(
+      queries,
+      queries.slice(0, -1).map((query) => ({
+        queryId: query.queryId,
+        selectedUrl: null,
+        answerUrl: null,
+        citedUrl: null,
+        answerComplete: false,
+        current: false,
+      })),
+      "fixture-search",
+    );
+
+    expect(benchmark.status).toBe("invalid");
+    expect(benchmark.missingQueryIds).toEqual([queries.at(-1)?.queryId]);
+    expect(benchmark.answerShare).toBeNull();
+  });
+
+  it("marks raw-HTML-only runs as unmeasured retrieval benchmarks", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const benchmark = createUnmeasuredForecastRetrievalBenchmark(
+      queries,
+      "provider not configured",
+    );
+
+    expect(benchmark).toMatchObject({
+      status: "not-run",
+      expectedQueries: 10,
+      measuredQueries: 0,
+      answerShare: null,
+      reason: "provider not configured",
     });
   });
 });

--- a/__tests__/lib/services/enhanced-forecast-update-selection.test.ts
+++ b/__tests__/lib/services/enhanced-forecast-update-selection.test.ts
@@ -8,7 +8,7 @@ function makeBeach(id: string, name?: string): MockBeach {
  * This test verifies the beach selection logic used by the background refresh:
  * - Prioritize beaches with NO forecasts (missing coverage)
  * - Then prioritize beaches with the OLDEST `updated_at`
- * - Do not repeatedly re-select recently updated beaches due to too-short freshness window
+ * - Select beaches before the public freshness window expires
  */
 describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     jest.useRealTimers();
   });
 
-  it("prioritizes missing beaches, then oldest stale beaches", async () => {
+  it("prioritizes missing beaches, then oldest beaches due for proactive refresh", async () => {
     const beaches = [
       makeBeach("b1", "Missing 1"),
       makeBeach("b2", "Missing 2"),
@@ -35,7 +35,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     // by updateAllEnhancedForecasts().
     const latestRows = [
       { beach_id: "b5", updated_at: "2025-12-11T06:30:00Z" }, // 5.5h old (fresh within 12h)
-      { beach_id: "b4", updated_at: "2025-12-10T10:00:00Z" }, // older
+      { beach_id: "b4", updated_at: "2025-12-11T02:00:00Z" }, // 10h old (fresh, but inside 4h refresh lead)
       { beach_id: "b3", updated_at: "2025-12-09T10:00:00Z" }, // oldest
     ];
 
@@ -81,6 +81,9 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     );
     const service = new Service() as any;
 
+    process.env.FORECAST_FRESHNESS_WINDOW_HOURS = "12";
+    process.env.FORECAST_REFRESH_LEAD_HOURS = "4";
+
     // Avoid network calls and DB writes during the test; capture chosen beaches via the forecast generator stub.
     const processedBeachIds: string[] = [];
     jest
@@ -105,7 +108,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     expect(processedBeachIds[0]).toBe("b1");
     expect(processedBeachIds[1]).toBe("b2");
 
-    // Then oldest stale next (b3 older than b4)
+    // Then oldest due next. b4 proves selection begins before the 12h stale cutoff.
     expect(processedBeachIds).toContain("b3");
     expect(processedBeachIds).toContain("b4");
 

--- a/__tests__/lib/services/forecast/batch-beach-processor.test.ts
+++ b/__tests__/lib/services/forecast/batch-beach-processor.test.ts
@@ -13,6 +13,7 @@ import {
   DeadlineTracker,
   loadBatchConfig,
   loadCdipBatchConfig,
+  getRefreshSelectionWindowHours,
   processBeachesInBatches,
   createBeachProcessor,
 } from "@/lib/services/forecast/batch-beach-processor";
@@ -155,12 +156,15 @@ describe("loadBatchConfig", () => {
     delete process.env.FORECAST_BATCH_DELAY_MS;
     delete process.env.FORECAST_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_FRESHNESS_WINDOW_HOURS;
+    delete process.env.FORECAST_REFRESH_LEAD_HOURS;
 
     const config = loadBatchConfig();
     expect(config.batchSize).toBe(3);
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(45);
     expect(config.freshnessWindowHours).toBe(12);
+    expect(config.refreshLeadHours).toBe(4);
+    expect(getRefreshSelectionWindowHours(config)).toBe(8);
   });
 
   it("reads values from environment variables", () => {
@@ -168,12 +172,15 @@ describe("loadBatchConfig", () => {
     process.env.FORECAST_BATCH_DELAY_MS = "2000";
     process.env.FORECAST_MAX_BEACHES_PER_RUN = "100";
     process.env.FORECAST_FRESHNESS_WINDOW_HOURS = "6";
+    process.env.FORECAST_REFRESH_LEAD_HOURS = "2";
 
     const config = loadBatchConfig();
     expect(config.batchSize).toBe(5);
     expect(config.batchDelayMs).toBe(2000);
     expect(config.maxBeachesPerRun).toBe(100);
     expect(config.freshnessWindowHours).toBe(6);
+    expect(config.refreshLeadHours).toBe(2);
+    expect(getRefreshSelectionWindowHours(config)).toBe(4);
   });
 
   it("applies overrides over env vars", () => {
@@ -191,6 +198,7 @@ describe("loadBatchConfig", () => {
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(45);
     expect(config.freshnessWindowHours).toBe(12);
+    expect(config.refreshLeadHours).toBe(4);
   });
 });
 
@@ -206,6 +214,7 @@ describe("loadCdipBatchConfig", () => {
     delete process.env.FORECAST_CDIP_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_CDIP_FRESHNESS_WINDOW_HOURS;
+    delete process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS;
   });
 
   afterAll(() => {
@@ -218,6 +227,8 @@ describe("loadCdipBatchConfig", () => {
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(25);
     expect(config.freshnessWindowHours).toBe(2);
+    expect(config.refreshLeadHours).toBe(0.5);
+    expect(getRefreshSelectionWindowHours(config)).toBe(1.5);
   });
 
   it("reads FORECAST_CDIP_MAX_BEACHES_PER_RUN when set", () => {
@@ -244,6 +255,29 @@ describe("loadCdipBatchConfig", () => {
     const config = loadCdipBatchConfig();
     expect(config.freshnessWindowHours).toBe(4);
   });
+
+  it("reads FORECAST_CDIP_REFRESH_LEAD_HOURS when set", () => {
+    process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS = "1";
+    const config = loadCdipBatchConfig();
+    expect(config.refreshLeadHours).toBe(1);
+    expect(getRefreshSelectionWindowHours(config)).toBe(1);
+  });
+});
+
+describe("getRefreshSelectionWindowHours", () => {
+  it("never returns a negative selection window", () => {
+    expect(getRefreshSelectionWindowHours({
+      freshnessWindowHours: 2,
+      refreshLeadHours: 3,
+    })).toBe(0);
+  });
+
+  it("fails safe to immediate selection for an invalid freshness window", () => {
+    expect(getRefreshSelectionWindowHours({
+      freshnessWindowHours: Number.NaN,
+      refreshLeadHours: 1,
+    })).toBe(0);
+  });
 });
 
 // ─── processBeachesInBatches ──────────────────────────────────────────────────
@@ -254,6 +288,7 @@ describe("processBeachesInBatches", () => {
     batchDelayMs: 0, // No delay in tests for speed
     maxBeachesPerRun: 100,
     freshnessWindowHours: 12,
+    refreshLeadHours: 4,
   };
 
   it("processes all beaches and returns success results", async () => {
@@ -352,6 +387,7 @@ describe("processBeachesInBatches", () => {
       batchDelayMs: 200, // larger than deadline window
       maxBeachesPerRun: 100,
       freshnessWindowHours: 12,
+      refreshLeadHours: 4,
     };
 
     const result = await processBeachesInBatches({
@@ -637,6 +673,7 @@ describe("createBeachProcessor", () => {
         batchDelayMs: 0,
         maxBeachesPerRun: 10,
         freshnessWindowHours: 12,
+        refreshLeadHours: 4,
       },
       deadlineTracker: new DeadlineTracker(),
       processBeach,

--- a/app/api/surf/week-scout/route.ts
+++ b/app/api/surf/week-scout/route.ts
@@ -82,7 +82,10 @@ async function weekScoutHandler(
   request: NextRequest,
   { user }: AuthenticatedContext,
 ): Promise<NextResponse> {
-  if (process.env.WEEK_SCOUT_ENDPOINT_ENABLED !== 'true') {
+  // Installed native clients need a stable canonical contract. Keep the flag
+  // as an emergency kill switch, but default the endpoint on so an omitted
+  // preview/production env value cannot turn every mobile forecast into a 404.
+  if (process.env.WEEK_SCOUT_ENDPOINT_ENABLED === 'false') {
     return NextResponse.json(
       { success: false, error: 'Week Scout endpoint is not enabled' },
       { status: 404 },

--- a/e2e/guest-forecast-authority.spec.ts
+++ b/e2e/guest-forecast-authority.spec.ts
@@ -1,0 +1,304 @@
+import { expect, test } from "@playwright/test";
+import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+
+interface PublicBeach {
+  id: string;
+  slug: string | null;
+  name: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+}
+
+interface BeachesResponse {
+  data?: {
+    beaches?: PublicBeach[];
+    count?: number;
+  };
+}
+
+interface ForecastResponse {
+  success?: boolean;
+  data?: {
+    days?: number;
+    forecasts?: Array<{
+      id?: string | null;
+      beach_id?: string | null;
+      forecast_at?: string | null;
+      wave_height?: string | number | null;
+      water_temp?: string | number | null;
+      confidence_score?: number | null;
+      data_source?: string | null;
+      created_at?: string | null;
+      updated_at?: string | null;
+    }>;
+    metadata?: {
+      missing?: boolean;
+      stale?: boolean;
+      lastUpdated?: string;
+    };
+  };
+}
+
+const EXPECTED_PUBLIC_BEACH_COUNT = 346;
+const REQUESTED_FORECAST_DAYS = 3;
+const HORIZON_TOLERANCE_HOURS = 6;
+const FORECAST_CADENCE_HOURS = 3;
+const FORECAST_CADENCE_TOLERANCE_HOURS = 1;
+const HOUR_MS = 60 * 60 * 1000;
+
+function decodeXml(value: string): string {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'");
+}
+
+function extractSitemapPaths(xml: string): Set<string> {
+  const paths = new Set<string>();
+
+  for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const url = new URL(decodeXml(match[1]));
+    paths.add(url.pathname);
+  }
+
+  return paths;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  let nextIndex = 0;
+  const results: R[] = new Array(items.length);
+
+  async function run(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, items.length) },
+      () => run(),
+    ),
+  );
+
+  return results;
+}
+
+function assertPublicBeachInventory(beaches: PublicBeach[]): void {
+  expect(beaches.length).toBe(EXPECTED_PUBLIC_BEACH_COUNT);
+  expect(new Set(beaches.map((beach) => beach.id)).size).toBe(beaches.length);
+  expect(beaches.every((beach) => beach.id && beach.name)).toBe(true);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidWaveHeight(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value) && value >= 0;
+  if (typeof value !== 'string') return false;
+  const match = /^(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?\s*(?:ft|feet)?$/i.exec(
+    value.trim(),
+  );
+  if (!match) return false;
+  const low = Number(match[1]);
+  const high = match[2] === undefined ? low : Number(match[2]);
+  return Number.isFinite(low) && Number.isFinite(high) && low >= 0 && high >= low;
+}
+
+function isValidTemperature(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string') return false;
+  return /^-?\d+(?:\.\d+)?\s*°?\s*[FC]?$/i.test(value.trim());
+}
+
+function validateForecastRows(
+  beach: PublicBeach,
+  payload: ForecastResponse,
+  status: number,
+  now: number,
+): string[] {
+  const label = beach.slug ?? beach.id;
+  const failures: string[] = [];
+  const forecasts = payload.data?.forecasts ?? [];
+  const forecastTimes = forecasts.map((forecast) => Date.parse(forecast.forecast_at ?? ''));
+  const lastUpdated = Date.parse(payload.data?.metadata?.lastUpdated ?? '');
+
+  if (status !== 200) failures.push(`${label}: HTTP ${status}`);
+  if (payload.success !== true) failures.push(`${label}: success was not true`);
+  if (payload.data?.days !== REQUESTED_FORECAST_DAYS) {
+    failures.push(`${label}: days was ${String(payload.data?.days)}`);
+  }
+  if (payload.data?.metadata?.missing !== false) failures.push(`${label}: forecast missing`);
+  if (payload.data?.metadata?.stale !== false) failures.push(`${label}: forecast stale`);
+  if (forecasts.length === 0) failures.push(`${label}: no forecast rows`);
+
+  const invalidTimestampCount = forecastTimes.filter((time) => !Number.isFinite(time)).length;
+  if (invalidTimestampCount > 0) {
+    failures.push(`${label}: ${invalidTimestampCount} invalid forecast timestamps`);
+  }
+  const outOfOrder = forecastTimes.some((time, index) => (
+    index > 0 && time < forecastTimes[index - 1]
+  ));
+  if (outOfOrder) failures.push(`${label}: forecast rows are not ordered`);
+  if (new Set(forecastTimes).size !== forecasts.length) {
+    failures.push(`${label}: duplicate forecast timestamps`);
+  }
+
+  const rowIds = forecasts.map((forecast) => forecast.id);
+  if (!rowIds.every(isNonEmptyString)) failures.push(`${label}: missing forecast row id`);
+  if (new Set(rowIds).size !== rowIds.length) failures.push(`${label}: duplicate forecast row ids`);
+
+  forecasts.forEach((forecast, index) => {
+    const rowLabel = `${label}: row ${index}`;
+    if (forecast.beach_id !== beach.id) {
+      failures.push(`${rowLabel} belongs to ${String(forecast.beach_id)}, expected ${beach.id}`);
+    }
+    for (const field of ['wave_height', 'water_temp', 'confidence_score'] as const) {
+      if (!Object.prototype.hasOwnProperty.call(forecast, field)) {
+        failures.push(`${rowLabel} missing ${field}`);
+      }
+    }
+    if (!isValidWaveHeight(forecast.wave_height)) {
+      failures.push(`${rowLabel} invalid wave_height`);
+    }
+    if (!isValidTemperature(forecast.water_temp)) {
+      failures.push(`${rowLabel} invalid water_temp`);
+    }
+    if (
+      typeof forecast.confidence_score !== 'number'
+      || !Number.isFinite(forecast.confidence_score)
+      || forecast.confidence_score < 0
+      || forecast.confidence_score > 100
+    ) {
+      failures.push(`${rowLabel} invalid confidence_score`);
+    }
+    if (!isNonEmptyString(forecast.data_source)) {
+      failures.push(`${rowLabel} missing data_source`);
+    }
+    if (!Number.isFinite(Date.parse(forecast.created_at ?? ''))) {
+      failures.push(`${rowLabel} invalid created_at`);
+    }
+    if (!Number.isFinite(Date.parse(forecast.updated_at ?? ''))) {
+      failures.push(`${rowLabel} invalid updated_at`);
+    }
+  });
+
+  const horizonStart = now - HORIZON_TOLERANCE_HOURS * HOUR_MS;
+  const horizonEnd = now + REQUESTED_FORECAST_DAYS * 24 * HOUR_MS;
+  const horizonTimes = forecastTimes.filter((time) => (
+    Number.isFinite(time) && time >= horizonStart && time <= horizonEnd
+  ));
+  const coverageBuckets = Array.from({ length: REQUESTED_FORECAST_DAYS }, (_, dayIndex) => {
+    const bucketStart = now + dayIndex * 24 * HOUR_MS;
+    const bucketEnd = now + (dayIndex + 1) * 24 * HOUR_MS;
+    return horizonTimes.filter((time) => time >= bucketStart && time < bucketEnd).length;
+  });
+  coverageBuckets.forEach((count, dayIndex) => {
+    if (count === 0) failures.push(`${label}: no forecast coverage in day ${dayIndex + 1}`);
+  });
+
+  const futureTimes = horizonTimes.filter((time) => time >= now).sort((a, b) => a - b);
+  const maxAllowedGap = (FORECAST_CADENCE_HOURS + FORECAST_CADENCE_TOLERANCE_HOURS) * HOUR_MS;
+  if (futureTimes.length > 0 && futureTimes[0] - now > maxAllowedGap) {
+    failures.push(`${label}: first forecast starts more than 4h from now`);
+  }
+  const sparseGap = futureTimes.findIndex((time, index) => (
+    index > 0 && time - futureTimes[index - 1] > maxAllowedGap
+  ));
+  if (sparseGap > 0) {
+    failures.push(
+      `${label}: forecast gap exceeds ${FORECAST_CADENCE_HOURS + FORECAST_CADENCE_TOLERANCE_HOURS}h`,
+    );
+  }
+  const maxFutureTime = futureTimes.at(-1) ?? Number.NaN;
+  if (maxFutureTime < now + (REQUESTED_FORECAST_DAYS * 24 - HORIZON_TOLERANCE_HOURS) * HOUR_MS) {
+    failures.push(`${label}: forecast horizon ends too early`);
+  }
+
+  if (!Number.isFinite(lastUpdated)) failures.push(`${label}: invalid metadata lastUpdated`);
+  if (lastUpdated > now + 5 * 60 * 1000) failures.push(`${label}: metadata lastUpdated is in the future`);
+
+  return failures;
+}
+
+test.describe("Forecast authority API contracts", () => {
+  test("serves a fresh three-day forecast for every public beach @requires-data", async ({
+    request,
+  }) => {
+    test.setTimeout(120_000);
+
+    const beachesResponse = await request.get("/api/beaches");
+    expect(beachesResponse.status()).toBe(200);
+    const beachesPayload = (await beachesResponse.json()) as BeachesResponse;
+    const beaches = beachesPayload.data?.beaches ?? [];
+    assertPublicBeachInventory(beaches);
+    expect(beachesPayload.data?.count).toBe(beaches.length);
+
+    const validationStart = Date.now();
+    const validationResults = await mapWithConcurrency(beaches, 8, async (beach) => {
+      try {
+        const forecastResponse = await request.get(
+          "/api/forecasts/update-enhanced",
+          { params: { beachId: beach.id, days: String(REQUESTED_FORECAST_DAYS) } },
+        );
+        const forecastPayload = (await forecastResponse.json()) as ForecastResponse;
+        return validateForecastRows(
+          beach,
+          forecastPayload,
+          forecastResponse.status(),
+          validationStart,
+        );
+      } catch (error) {
+        return [`${beach.slug ?? beach.id}: ${error instanceof Error ? error.message : String(error)}`];
+      }
+    });
+    const failures = validationResults.flat();
+
+    expect(validationResults).toHaveLength(EXPECTED_PUBLIC_BEACH_COUNT);
+    expect(failures).toEqual([]);
+
+    test.info().annotations.push({
+      type: "forecast-authority",
+      description: `Fresh three-day forecasts validated for ${beaches.length} public beaches`,
+    });
+  });
+
+  test("publishes every public beach with a canonical sitemap forecast page @requires-data", async ({
+    request,
+  }) => {
+    const beachesResponse = await request.get("/api/beaches");
+    expect(beachesResponse.status()).toBe(200);
+
+    const beachesPayload = (await beachesResponse.json()) as BeachesResponse;
+    const beaches = beachesPayload.data?.beaches ?? [];
+    assertPublicBeachInventory(beaches);
+    expect(beachesPayload.data?.count).toBe(beaches.length);
+
+    const canonicalPaths = beaches.map((beach) => buildBeachUrl(beach));
+    expect(canonicalPaths.every((path) => !path.startsWith("/beach/"))).toBe(true);
+    expect(new Set(canonicalPaths).size).toBe(EXPECTED_PUBLIC_BEACH_COUNT);
+
+    const sitemapResponse = await request.get("/sitemap.xml");
+    expect(sitemapResponse.status()).toBe(200);
+    const sitemapPaths = extractSitemapPaths(await sitemapResponse.text());
+    const missingPaths = canonicalPaths.filter((path) => !sitemapPaths.has(path));
+
+    test.info().annotations.push({
+      type: "forecast-authority",
+      description: `Public beaches: ${beaches.length}; canonical sitemap entries: ${sitemapPaths.size}; missing: ${missingPaths.length}`,
+    });
+
+    expect(missingPaths).toEqual([]);
+  });
+});

--- a/lib/seo/forecast-authority-benchmark.ts
+++ b/lib/seo/forecast-authority-benchmark.ts
@@ -35,12 +35,65 @@ export interface ForecastBenchmarkSpot {
 }
 
 export interface ForecastBenchmarkQuery {
+  queryId: string;
   queryClass: ForecastBenchmarkQueryClass;
   query: string;
   spotId: string | null;
   region: string;
   canonicalPath: string | null;
 }
+
+export interface ForecastRetrievalEvidence {
+  queryId: string;
+  selectedUrl: string | null;
+  answerUrl: string | null;
+  citedUrl: string | null;
+  answerComplete: boolean;
+  current: boolean;
+}
+
+export interface ForecastBenchmarkCompetitor {
+  name: string;
+  domains: string[];
+}
+
+export interface ForecastCompetitiveSourceResult {
+  name: string;
+  domains: string[];
+  selectedShare: number | null;
+  answerShare: number | null;
+  citationShare: number | null;
+}
+
+export interface ForecastCompetitiveBenchmark {
+  status: ForecastRetrievalBenchmark["status"];
+  provider: string | null;
+  competitors: ForecastCompetitiveSourceResult[];
+  reason: string | null;
+}
+
+export interface ForecastRetrievalBenchmark {
+  status: "measured" | "not-run" | "invalid";
+  provider: string | null;
+  expectedQueries: number;
+  measuredQueries: number;
+  retrievedShare: number | null;
+  answerShare: number | null;
+  currentAnswerShare: number | null;
+  citationShare: number | null;
+  canonicalSelectionShare: number | null;
+  missingQueryIds: string[];
+  unexpectedQueryIds: string[];
+  duplicateQueryIds: string[];
+  reason: string | null;
+}
+
+export const DEFAULT_FORECAST_BENCHMARK_COMPETITORS: ForecastBenchmarkCompetitor[] = [
+  { name: "Surfline", domains: ["surfline.com"] },
+  { name: "Surf Captain", domains: ["surfcaptain.com"] },
+];
+
+export const DEFAULT_QUIVER_BENCHMARK_ORIGIN = "https://www.quiversurf.app";
 
 export interface ForecastAnswerContractFacts {
   answerLayer: boolean;
@@ -56,7 +109,8 @@ export interface ForecastAnswerContractFacts {
 const EAST_COAST_STATES = new Set([
   "ct", "de", "fl", "ga", "ma", "md", "me", "nc", "nh", "nj", "ny", "ri", "sc", "va",
 ]);
-const GULF_STATES = new Set(["al", "fl", "la", "ms", "tx"]);
+const GULF_STATES = new Set(["al", "la", "ms", "tx"]);
+const WEST_COAST_STATES = new Set(["or", "wa"]);
 
 function normalized(value: string | null | undefined): string {
   return value?.trim().toLowerCase() ?? "";
@@ -68,6 +122,7 @@ export function classifyForecastBenchmarkRegion(spot: ForecastBenchmarkSpot): st
   if (country === "usa" || country === "us" || country === "united states") {
     if (state === "ca" || state === "california") return "California";
     if (state === "hi" || state === "hawaii") return "Hawaii";
+    if (WEST_COAST_STATES.has(state)) return "West Coast";
     if (GULF_STATES.has(state)) return "Gulf Coast";
     if (EAST_COAST_STATES.has(state)) return "East Coast";
   }
@@ -91,6 +146,14 @@ function spotQuery(
   }
 }
 
+function queryId(
+  queryClass: ForecastBenchmarkQueryClass,
+  spotId: string | null,
+  region: string,
+): string {
+  return `${region}:${spotId ?? "region"}:${queryClass}`;
+}
+
 export function buildForecastBenchmarkQueries(
   spots: ForecastBenchmarkSpot[],
   spotsPerRegion = 5,
@@ -112,6 +175,7 @@ export function buildForecastBenchmarkQueries(
     for (const spot of sampledSpots) {
       for (const queryClass of SPOT_QUERY_CLASSES) {
         queries.push({
+          queryId: queryId(queryClass, spot.id, region),
           queryClass,
           query: spotQuery(spot, queryClass),
           spotId: spot.id,
@@ -126,18 +190,234 @@ export function buildForecastBenchmarkQueries(
       "where-should-i-surf-region-tomorrow",
     ] as const) {
       queries.push({
+        queryId: queryId(queryClass, null, region),
         queryClass,
         query: queryClass === "best-surf-region-tomorrow"
           ? `best surf ${region} tomorrow`
           : `where should I surf ${region} tomorrow`,
         spotId: null,
         region,
-        canonicalPath: sampledSpots[0]?.canonicalPath ?? null,
+        canonicalPath: null,
       });
     }
   }
 
   return queries;
+}
+
+function normalizedUrl(value: string | null): URL | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedPath(value: string): string {
+  return value.length > 1 ? value.replace(/\/$/, "") : value;
+}
+
+function normalizedHost(value: string): string {
+  return value.toLowerCase().replace(/^www\./, "");
+}
+
+function urlBelongsToDomains(url: URL | null, domains: string[]): boolean {
+  if (!url) return false;
+  const host = normalizedHost(url.hostname);
+  return domains.some((domain) => {
+    const normalizedDomain = normalizedHost(domain);
+    return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+  });
+}
+
+function isQuiverUrl(value: string | null, quiverOrigin: string): boolean {
+  const originUrl = normalizedUrl(quiverOrigin);
+  if (!originUrl) return false;
+  return urlBelongsToDomains(
+    normalizedUrl(value),
+    [originUrl.hostname],
+  );
+}
+
+function isCanonicalQuiverUrl(
+  value: string | null,
+  canonicalPath: string,
+  quiverOrigin: string,
+): boolean {
+  const url = normalizedUrl(value);
+  return (
+    isQuiverUrl(value, quiverOrigin)
+    && url !== null
+    && normalizedPath(url.pathname) === normalizedPath(canonicalPath)
+  );
+}
+
+function isRetrievalEvidence(value: unknown): value is ForecastRetrievalEvidence {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.queryId === "string"
+    && (record.selectedUrl === null || typeof record.selectedUrl === "string")
+    && (record.answerUrl === null || typeof record.answerUrl === "string")
+    && (record.citedUrl === null || typeof record.citedUrl === "string")
+    && typeof record.answerComplete === "boolean"
+    && typeof record.current === "boolean"
+  );
+}
+
+export function parseForecastRetrievalEvidence(value: unknown): ForecastRetrievalEvidence[] {
+  if (!Array.isArray(value) || !value.every(isRetrievalEvidence)) {
+    throw new Error(
+      "Retrieval evidence must be an array of { queryId, selectedUrl, answerUrl, citedUrl, answerComplete, current } objects.",
+    );
+  }
+
+  return value;
+}
+
+function share(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+export function createUnmeasuredForecastRetrievalBenchmark(
+  queries: ForecastBenchmarkQuery[],
+  reason: string,
+): ForecastRetrievalBenchmark {
+  return {
+    status: "not-run",
+    provider: null,
+    expectedQueries: queries.length,
+    measuredQueries: 0,
+    retrievedShare: null,
+    answerShare: null,
+    currentAnswerShare: null,
+    citationShare: null,
+    canonicalSelectionShare: null,
+    missingQueryIds: queries.map((query) => query.queryId),
+    unexpectedQueryIds: [],
+    duplicateQueryIds: [],
+    reason,
+  };
+}
+
+export function summarizeForecastRetrievalEvidence(
+  queries: ForecastBenchmarkQuery[],
+  evidence: ForecastRetrievalEvidence[],
+  provider: string,
+  quiverOrigin = DEFAULT_QUIVER_BENCHMARK_ORIGIN,
+): ForecastRetrievalBenchmark {
+  const expectedById = new Map(queries.map((query) => [query.queryId, query]));
+  const evidenceCounts = new Map<string, number>();
+  for (const result of evidence) {
+    evidenceCounts.set(result.queryId, (evidenceCounts.get(result.queryId) ?? 0) + 1);
+  }
+
+  const duplicateQueryIds = [...evidenceCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([queryId]) => queryId);
+  const unexpectedQueryIds = [...evidenceCounts.keys()]
+    .filter((queryId) => !expectedById.has(queryId));
+  const missingQueryIds = queries
+    .map((query) => query.queryId)
+    .filter((queryId) => !evidenceCounts.has(queryId));
+
+  if (duplicateQueryIds.length > 0 || unexpectedQueryIds.length > 0 || missingQueryIds.length > 0) {
+    return {
+      status: "invalid",
+      provider,
+      expectedQueries: queries.length,
+      measuredQueries: evidence.length,
+      retrievedShare: null,
+      answerShare: null,
+      currentAnswerShare: null,
+      citationShare: null,
+      canonicalSelectionShare: null,
+      missingQueryIds,
+      unexpectedQueryIds,
+      duplicateQueryIds,
+      reason: "Retrieval evidence must contain exactly one result for every generated query.",
+    };
+  }
+
+  const expectedCanonicalQueries = queries.filter((query) => query.canonicalPath !== null);
+  const measuredById = new Map(evidence.map((result) => [result.queryId, result]));
+  const retrieved = evidence.filter((result) => isQuiverUrl(result.selectedUrl, quiverOrigin)).length;
+  const answered = evidence.filter((result) => (
+    result.answerComplete && isQuiverUrl(result.answerUrl, quiverOrigin)
+  )).length;
+  const currentAnswers = evidence.filter((result) => (
+    result.answerComplete
+    && result.current
+    && isQuiverUrl(result.answerUrl, quiverOrigin)
+  )).length;
+  const cited = evidence.filter((result) => isQuiverUrl(result.citedUrl, quiverOrigin)).length;
+  const canonicalSelections = expectedCanonicalQueries.filter((query) => {
+    const result = measuredById.get(query.queryId);
+    return isCanonicalQuiverUrl(
+      result?.selectedUrl ?? null,
+      query.canonicalPath!,
+      quiverOrigin,
+    );
+  }).length;
+
+  return {
+    status: "measured",
+    provider,
+    expectedQueries: queries.length,
+    measuredQueries: evidence.length,
+    retrievedShare: share(retrieved, queries.length),
+    answerShare: share(answered, queries.length),
+    currentAnswerShare: share(currentAnswers, queries.length),
+    citationShare: share(cited, queries.length),
+    canonicalSelectionShare: share(canonicalSelections, expectedCanonicalQueries.length),
+    missingQueryIds: [],
+    unexpectedQueryIds: [],
+    duplicateQueryIds: [],
+    reason: null,
+  };
+}
+
+export function summarizeForecastCompetitiveBenchmark(
+  queries: ForecastBenchmarkQuery[],
+  evidence: ForecastRetrievalEvidence[],
+  retrieval: ForecastRetrievalBenchmark,
+  competitors: ForecastBenchmarkCompetitor[] = DEFAULT_FORECAST_BENCHMARK_COMPETITORS,
+): ForecastCompetitiveBenchmark {
+  const sourceResults = competitors.map((competitor): ForecastCompetitiveSourceResult => {
+    const selected = evidence.filter((result) => urlBelongsToDomains(
+      normalizedUrl(result.selectedUrl),
+      competitor.domains,
+    )).length;
+    const answered = evidence.filter((result) => (
+      result.answerComplete
+      && urlBelongsToDomains(
+        normalizedUrl(result.answerUrl),
+        competitor.domains,
+      )
+    )).length;
+    const cited = evidence.filter((result) => urlBelongsToDomains(
+      normalizedUrl(result.citedUrl),
+      competitor.domains,
+    )).length;
+
+    return {
+      name: competitor.name,
+      domains: competitor.domains,
+      selectedShare: retrieval.status === "measured" ? share(selected, queries.length) : null,
+      answerShare: retrieval.status === "measured" ? share(answered, queries.length) : null,
+      citationShare: retrieval.status === "measured" ? share(cited, queries.length) : null,
+    };
+  });
+
+  return {
+    status: retrieval.status,
+    provider: retrieval.provider,
+    competitors: sourceResults,
+    reason: retrieval.reason,
+  };
 }
 
 function hasAny(html: string, patterns: RegExp[]): boolean {

--- a/lib/services/enhanced-forecast-service.ts
+++ b/lib/services/enhanced-forecast-service.ts
@@ -8,9 +8,11 @@ import {
 import { hashString } from "./forecast/batch-update-coordinator";
 import {
   DeadlineTracker,
+  getRefreshSelectionWindowHours,
   loadBatchConfig,
   loadCdipBatchConfig,
   processBeachesInBatches,
+  type BatchProcessConfig,
   type BatchProcessResult,
   type BeachProcessResult,
 } from "./forecast/batch-beach-processor";
@@ -723,7 +725,7 @@ export class EnhancedForecastService {
     const { shard, shardCount } = options;
     const isSharded = typeof shard === "number" && typeof shardCount === "number" && shardCount > 0;
     const shardInfo = isSharded ? ` [shard ${shard}/${shardCount}]` : "";
-    log.info(`updateAllEnhancedForecasts() starting (v3 with stale-only updates)${shardInfo}`);
+    log.info(`updateAllEnhancedForecasts() starting (v3 with proactive refresh)${shardInfo}`);
 
     const config = loadBatchConfig();
     const deadlineTracker = new DeadlineTracker(options.deadlineMs);
@@ -736,7 +738,8 @@ export class EnhancedForecastService {
 
       log.info(
         `Starting batch forecast update for ${beaches.selected.length}/${beaches.eligible.length} beaches${shardInfo} ` +
-        `(missing: ${beaches.stats.missing}, stale>${config.freshnessWindowHours}h: ${beaches.stats.stale}, ` +
+        `(missing: ${beaches.stats.missing}, due>${beaches.refreshSelectionWindowHours}h: ${beaches.stats.dueForRefresh}, ` +
+        `stale at ${config.freshnessWindowHours}h, ` +
         `selectedMissing: ${beaches.stats.selectedMissing}, max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
       );
 
@@ -785,17 +788,18 @@ export class EnhancedForecastService {
   }
 
   /**
-   * Select beaches for update based on staleness and sharding
+   * Select beaches for update before staleness, with optional sharding.
    */
   private async selectBeachesForUpdate(
-    config: { freshnessWindowHours: number; maxBeachesPerRun: number },
+    config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours" | "maxBeachesPerRun">,
     shard?: number,
     shardCount?: number
   ) {
     const supabase = await createSupabaseServiceRoleClient();
     const isSharded = typeof shard === "number" && typeof shardCount === "number" && shardCount > 0;
     const shardInfo = isSharded ? ` [shard ${shard}/${shardCount}]` : "";
-    const staleThresholdMs = Date.now() - config.freshnessWindowHours * 60 * 60 * 1000;
+    const refreshSelectionWindowHours = getRefreshSelectionWindowHours(config);
+    const refreshThresholdMs = Date.now() - refreshSelectionWindowHours * 60 * 60 * 1000;
 
     // Get all beaches
     const { data: allBeaches, error: beachError } = await supabase
@@ -831,14 +835,14 @@ export class EnhancedForecastService {
 
     // Filter beaches
     const missingBeaches = eligibleBeaches.filter((b) => !latestUpdatedAtByBeachMs.has(b.id));
-    const staleBeaches = eligibleBeaches
+    const dueForRefreshBeaches = eligibleBeaches
       .filter((b) => {
         const updatedAtMs = latestUpdatedAtByBeachMs.get(b.id);
-        return Boolean(updatedAtMs && updatedAtMs < staleThresholdMs);
+        return Boolean(updatedAtMs && updatedAtMs < refreshThresholdMs);
       })
       .sort((a, b) => (latestUpdatedAtByBeachMs.get(a.id) ?? 0) - (latestUpdatedAtByBeachMs.get(b.id) ?? 0));
 
-    let beachesToUpdate = [...missingBeaches, ...staleBeaches];
+    let beachesToUpdate = [...missingBeaches, ...dueForRefreshBeaches];
 
     // If everything is fresh, rotate oldest 5
     if (beachesToUpdate.length === 0) {
@@ -853,9 +857,10 @@ export class EnhancedForecastService {
     return {
       selected,
       eligible: eligibleBeaches,
+      refreshSelectionWindowHours,
       stats: {
         missing: missingBeaches.length,
-        stale: staleBeaches.length,
+        dueForRefresh: dueForRefreshBeaches.length,
         selectedMissing: selected.filter((b) => !latestUpdatedAtByBeachMs.has(b.id)).length,
       },
     };
@@ -883,8 +888,9 @@ export class EnhancedForecastService {
       }
 
       log.info(
-        `Starting CDIP-only update for ${beaches.selected.length}/${beaches.totalStale} CDIP-stale beaches ` +
-        `(stale>${config.freshnessWindowHours}h, max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
+        `Starting CDIP-only update for ${beaches.selected.length}/${beaches.totalDueForRefresh} CDIP beaches due for refresh ` +
+        `(due>${beaches.refreshSelectionWindowHours}h, target ${config.freshnessWindowHours}h, ` +
+        `max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
       );
 
       // Fetch nowcast observation anchors once per CDIP cron invocation, mirroring
@@ -933,16 +939,19 @@ export class EnhancedForecastService {
   }
 
   /**
-   * Select CDIP beaches for update based on staleness
+   * Select CDIP beaches before their refresh target expires.
    *
    * FIXED: Previously this method only selected beaches that already had data_source='CDIP',
    * which meant beaches not initially seeded with CDIP data were never updated by the CDIP cron.
    * Now we use the cdip_eligible column to determine which beaches should receive CDIP updates,
    * regardless of their current data_source.
    */
-  private async selectCdipBeachesForUpdate(config: { freshnessWindowHours: number; maxBeachesPerRun: number }) {
+  private async selectCdipBeachesForUpdate(
+    config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours" | "maxBeachesPerRun">
+  ) {
     const supabase = await createSupabaseServiceRoleClient();
-    const staleThresholdMs = Date.now() - config.freshnessWindowHours * 60 * 60 * 1000;
+    const refreshSelectionWindowHours = getRefreshSelectionWindowHours(config);
+    const refreshThresholdMs = Date.now() - refreshSelectionWindowHours * 60 * 60 * 1000;
 
     // Load CDIP-eligible beaches from DB (not all beaches)
     const { data: cdipBeaches, error: beachError } = await supabase
@@ -969,15 +978,15 @@ export class EnhancedForecastService {
       latestByBeach.set(row.beach_id, { updated_at: row.updated_at, data_source: row.data_source ?? null });
     }
 
-    // Select stale OR missing beaches (DO NOT filter by data_source)
-    const cdipStale = cdipBeaches
+    // Select due OR missing beaches (DO NOT filter by data_source)
+    const cdipDueForRefresh = cdipBeaches
       .filter((b) => {
         const latest = latestByBeach.get(b.id);
         // FIXED: Missing forecast data = needs update (was incorrectly returning false)
         if (!latest) return true;
         // FIXED: Removed data_source check - we want to update based on eligibility, not current source
         const ts = new Date(latest.updated_at).getTime();
-        return Number.isFinite(ts) && ts < staleThresholdMs;
+        return Number.isFinite(ts) && ts < refreshThresholdMs;
       })
       .sort((a, b) => {
         // Sort missing first, then by oldest updated
@@ -990,8 +999,9 @@ export class EnhancedForecastService {
       });
 
     return {
-      selected: cdipStale.slice(0, config.maxBeachesPerRun),
-      totalStale: cdipStale.length,
+      selected: cdipDueForRefresh.slice(0, config.maxBeachesPerRun),
+      totalDueForRefresh: cdipDueForRefresh.length,
+      refreshSelectionWindowHours,
     };
   }
 

--- a/lib/services/forecast/batch-beach-processor.ts
+++ b/lib/services/forecast/batch-beach-processor.ts
@@ -53,6 +53,24 @@ export interface BatchProcessConfig {
   batchDelayMs: number;
   maxBeachesPerRun: number;
   freshnessWindowHours: number;
+  refreshLeadHours: number;
+}
+
+/**
+ * Start refresh work before the public freshness window expires so cron
+ * cadence and execution time cannot create a rotating stale queue.
+ */
+export function getRefreshSelectionWindowHours(
+  config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours">
+): number {
+  const freshnessWindowHours = Number.isFinite(config.freshnessWindowHours)
+    ? Math.max(0, config.freshnessWindowHours)
+    : 0;
+  const refreshLeadHours = Number.isFinite(config.refreshLeadHours)
+    ? Math.max(0, config.refreshLeadHours)
+    : 0;
+
+  return Math.max(0, freshnessWindowHours - refreshLeadHours);
 }
 
 /**
@@ -64,6 +82,7 @@ export function loadBatchConfig(overrides?: Partial<BatchProcessConfig>): BatchP
     batchDelayMs: Number(process.env.FORECAST_BATCH_DELAY_MS ?? 1000),
     maxBeachesPerRun: Number(process.env.FORECAST_MAX_BEACHES_PER_RUN ?? 45),
     freshnessWindowHours: Number(process.env.FORECAST_FRESHNESS_WINDOW_HOURS ?? 12),
+    refreshLeadHours: Number(process.env.FORECAST_REFRESH_LEAD_HOURS ?? 4),
     ...overrides,
   };
 }
@@ -81,6 +100,7 @@ export function loadCdipBatchConfig(): BatchProcessConfig {
         25
     ),
     freshnessWindowHours: Number(process.env.FORECAST_CDIP_FRESHNESS_WINDOW_HOURS ?? 2),
+    refreshLeadHours: Number(process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS ?? 0.5),
   };
 }
 

--- a/scripts/seo/forecast-authority-benchmark.ts
+++ b/scripts/seo/forecast-authority-benchmark.ts
@@ -3,8 +3,15 @@ import path from "node:path";
 
 import {
   buildForecastBenchmarkQueries,
+  createUnmeasuredForecastRetrievalBenchmark,
+  DEFAULT_QUIVER_BENCHMARK_ORIGIN,
   extractForecastAnswerContractFacts,
+  parseForecastRetrievalEvidence,
+  summarizeForecastCompetitiveBenchmark,
+  summarizeForecastRetrievalEvidence,
   type ForecastBenchmarkSpot,
+  type ForecastRetrievalBenchmark,
+  type ForecastRetrievalEvidence,
 } from "../../lib/seo/forecast-authority-benchmark";
 import { loadSeoEnv } from "./load-env";
 
@@ -25,10 +32,18 @@ const outputPath = getFlag("--output") ?? path.join(
 const baseUrl = (
   getFlag("--base-url") ?? process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
 ).replace(/\/$/, "");
+const quiverOrigin = (
+  getFlag("--quiver-origin") ?? DEFAULT_QUIVER_BENCHMARK_ORIGIN
+).replace(/\/$/, "");
 
 interface AuditInput {
   generatedAt: string;
   eligibleSpots: Array<Omit<ForecastBenchmarkSpot, "name"> & { name: string | null }>;
+}
+
+interface LoadedRetrievalBenchmark {
+  benchmark: ForecastRetrievalBenchmark;
+  evidence: ForecastRetrievalEvidence[];
 }
 
 void main();
@@ -43,18 +58,33 @@ async function main(): Promise<void> {
     spot.name ? [{ ...spot, name: spot.name }] : []
   );
   const queries = buildForecastBenchmarkQueries(benchmarkSpots);
+  const retrieval = await loadRetrievalBenchmark(queries);
+  if (retrieval.benchmark.status === "invalid") {
+    throw new Error(retrieval.benchmark.reason ?? "Retrieval evidence is invalid.");
+  }
+  if (hasFlag("--require-retrieval") && retrieval.benchmark.status !== "measured") {
+    throw new Error(
+      retrieval.benchmark.reason ?? "A measured retrieval benchmark is required.",
+    );
+  }
   const uniquePaths = [...new Set(
     queries.flatMap((query) => query.canonicalPath ? [query.canonicalPath] : []),
   )];
   const pageResults = await Promise.all(uniquePaths.map(fetchPage));
   const pagesByPath = new Map(pageResults.map((result) => [result.path, result]));
+  const retrievalByQueryId = new Map(
+    retrieval.evidence.map((result) => [result.queryId, result]),
+  );
   const queryResults = queries.map((query) => {
     const page = query.canonicalPath ? pagesByPath.get(query.canonicalPath) : undefined;
     return {
       ...query,
-      status: page?.status ?? null,
-      facts: page?.facts ?? null,
-      error: page?.error ?? null,
+      rawHtml: {
+        status: page?.status ?? null,
+        facts: page?.facts ?? null,
+        error: page?.error ?? null,
+      },
+      retrieval: retrievalByQueryId.get(query.queryId) ?? null,
     };
   });
 
@@ -66,6 +96,7 @@ async function main(): Promise<void> {
     generatedAt: new Date().toISOString(),
     auditGeneratedAt: audit.generatedAt,
     baseUrl,
+    quiverOrigin,
     queryClasses: [...new Set(queries.map((query) => query.queryClass))],
     regions: [...new Set(queries.map((query) => query.region))],
     sampledSpots: [...new Set(queries.map((query) => query.spotId).filter(Boolean))].length,
@@ -76,22 +107,13 @@ async function main(): Promise<void> {
       averageContractScore,
       pages: pageResults,
     },
+    retrievalBenchmark: retrieval.benchmark,
     queries: queryResults,
-    competitiveBenchmark: {
-      competitors: ["Surfline", "Surf Captain"],
-      criteria: [
-        "search discoverability",
-        "canonical-page selection",
-        "raw HTML completeness",
-        "surf facts available",
-        "freshness transparency",
-        "forecast reasoning",
-        "provenance",
-        "citation suitability",
-      ],
-      status: "manual-evidence-required",
-      note: "Provide a dated SERP capture or page fixture before recording competitor claims.",
-    },
+    competitiveBenchmark: summarizeForecastCompetitiveBenchmark(
+      queries,
+      retrieval.evidence,
+      retrieval.benchmark,
+    ),
   };
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -102,8 +124,95 @@ async function main(): Promise<void> {
     pagesChecked: report.rawHtml.pagesChecked,
     answeredPages: report.rawHtml.answeredPages,
     averageContractScore: report.rawHtml.averageContractScore,
-    competitiveBenchmark: report.competitiveBenchmark.status,
+    retrievalStatus: report.retrievalBenchmark.status,
+    retrievalProvider: report.retrievalBenchmark.provider,
+    answerShare: report.retrievalBenchmark.answerShare,
+    citationShare: report.retrievalBenchmark.citationShare,
+    canonicalSelectionShare: report.retrievalBenchmark.canonicalSelectionShare,
+    competitiveBenchmarkStatus: report.competitiveBenchmark.status,
   }, null, 2));
+}
+
+async function loadRetrievalBenchmark(
+  queries: ReturnType<typeof buildForecastBenchmarkQueries>,
+): Promise<LoadedRetrievalBenchmark> {
+  const retrievalUrl = getFlag("--retrieval-url");
+  const retrievalEvidencePath = getFlag("--retrieval-evidence");
+
+  if (retrievalUrl && retrievalEvidencePath) {
+    throw new Error("Use only one of --retrieval-url or --retrieval-evidence.");
+  }
+
+  if (!retrievalUrl && !retrievalEvidencePath) {
+    return {
+      benchmark: createUnmeasuredForecastRetrievalBenchmark(
+        queries,
+        "No retrieval provider or evidence supplied. Raw HTML is not Answer Share evidence.",
+      ),
+      evidence: [],
+    };
+  }
+
+  const payload = retrievalUrl
+    ? await fetchRetrievalProvider(retrievalUrl, queries)
+    : JSON.parse(fs.readFileSync(retrievalEvidencePath!, "utf8")) as unknown;
+  const parsed = parseRetrievalPayload(
+    payload,
+    retrievalUrl ? "retrieval-provider" : "evidence-file",
+  );
+
+  return {
+    benchmark: summarizeForecastRetrievalEvidence(
+      queries,
+      parsed.results,
+      parsed.provider,
+      quiverOrigin,
+    ),
+    evidence: parsed.results,
+  };
+}
+
+async function fetchRetrievalProvider(
+  retrievalUrl: string,
+  queries: ReturnType<typeof buildForecastBenchmarkQueries>,
+): Promise<unknown> {
+  const response = await fetch(retrievalUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ queries }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Retrieval provider returned HTTP ${response.status}.`);
+  }
+
+  return response.json() as Promise<unknown>;
+}
+
+function parseRetrievalPayload(
+  value: unknown,
+  fallbackProvider: string,
+): { provider: string; results: ForecastRetrievalEvidence[] } {
+  if (Array.isArray(value)) {
+    return {
+      provider: fallbackProvider,
+      results: parseForecastRetrievalEvidence(value),
+    };
+  }
+
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Retrieval provider response must be an array or an object with results.");
+  }
+
+  const record = value as Record<string, unknown>;
+  const provider = typeof record.provider === "string" && record.provider.trim().length > 0
+    ? record.provider
+    : fallbackProvider;
+
+  return {
+    provider,
+    results: parseForecastRetrievalEvidence(record.results),
+  };
 }
 
 async function fetchPage(pagePath: string): Promise<{
@@ -134,4 +243,8 @@ async function fetchPage(pagePath: string): Promise<{
 function getFlag(name: string): string | null {
   const index = process.argv.indexOf(name);
   return index === -1 ? null : process.argv[index + 1] ?? null;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
 }


### PR DESCRIPTION
## Summary
- refresh enhanced forecasts before public freshness thresholds expire
- keep the Week Scout v1 API contract available to installed mobile clients
- add strict all-346-beach and retrieval authority validation

## Verification
- web unit suite: 16,506 passed
- focused forecast/Week Scout/benchmark suite: 67 passed
- typecheck and targeted lint passed
- Preview Week Scout contract passed with mobile 1.0.1 and 1.0.2
- mobile prod-readonly Maestro: 4/4 passed

## Production follow-up
Monitor the enhanced forecast cron hourly for two hours and rerun the 346-beach data gate after the stale queue drains.