### PR TITLE
fix(prod): keep all public beach forecasts fresh

### DIFF
--- a/__tests__/app/api/surf-week-scout-route.test.ts
+++ b/__tests__/app/api/surf-week-scout-route.test.ts
@@ -24,8 +24,13 @@ jest.mock(
 
 import { NextRequest } from 'next/server';
 import { POST } from '@/app/api/surf/week-scout/route';
+import {
+  WEEK_SCOUT_CONTRACT_BEACH_ID,
+  WEEK_SCOUT_CONTRACT_FIXTURE,
+  WEEK_SCOUT_CONTRACT_GENERATED_AT,
+} from '@/__tests__/fixtures/week-scout-contract';
 
-const BEACH_A = '11111111-1111-4111-8111-111111111111';
+const BEACH_A = WEEK_SCOUT_CONTRACT_BEACH_ID;
 const BEACH_B = '22222222-2222-4222-8222-222222222222';
 
 function request(body: unknown): NextRequest {
@@ -48,12 +53,7 @@ describe('POST /api/surf/week-scout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.WEEK_SCOUT_ENDPOINT_ENABLED = 'true';
-    mockGenerateWeekScoutForecast.mockResolvedValue({
-      generatedAt: '2026-07-15T18:00:00.000Z',
-      scorerVersion: 'week-scout-v1',
-      candidateFingerprint: 'candidate-fingerprint',
-      days: [],
-    });
+    mockGenerateWeekScoutForecast.mockResolvedValue(WEEK_SCOUT_CONTRACT_FIXTURE);
   });
 
   it('deduplicates candidate IDs and returns the exact private no-store response', async () => {
@@ -142,8 +142,58 @@ describe('POST /api/surf/week-scout', () => {
     expect(mockGenerateWeekScoutForecast).not.toHaveBeenCalled();
   });
 
-  it('returns 404 without running discovery when the rollout flag is disabled', async () => {
+  it('keeps the endpoint enabled for installed clients when the rollout flag is unset', async () => {
     delete process.env.WEEK_SCOUT_ENDPOINT_ENABLED;
+    const response = await callRoute({
+      candidateBeachIds: [BEACH_A],
+      localTimezone: 'Pacific/Honolulu',
+      startLocalDate: '2026-07-15',
+      dayCount: 7,
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockGenerateWeekScoutForecast).toHaveBeenCalledWith(
+      'user-week-scout',
+      expect.objectContaining({ candidateBeachIds: [BEACH_A] }),
+    );
+    expect(response.headers.get('Cache-Control')).toBe(
+      'private, no-store, no-cache, must-revalidate',
+    );
+  });
+
+  it('returns the non-empty canonical mobile contract fixture', async () => {
+    delete process.env.WEEK_SCOUT_ENDPOINT_ENABLED;
+    const response = await callRoute({
+      candidateBeachIds: [BEACH_A],
+      localTimezone: 'Pacific/Honolulu',
+      startLocalDate: '2026-07-15',
+      dayCount: 7,
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.data).toMatchObject({
+      generatedAt: WEEK_SCOUT_CONTRACT_GENERATED_AT,
+      recommendationAvailability: {
+        state: 'available',
+        holdEpoch: 'available-epoch',
+      },
+      sessionDecision: expect.objectContaining({
+        verdict: 'go',
+        selection: expect.objectContaining({ beachId: BEACH_A }),
+      }),
+    });
+    expect(payload.data.days[0]).toMatchObject({
+      bestWindowId: 'window-a',
+      windows: [expect.objectContaining({
+        beachId: BEACH_A,
+        forecast: expect.objectContaining({ waveHeight: '3-4 ft' }),
+      })],
+    });
+  });
+
+  it('returns 404 without running discovery when the emergency kill switch is enabled', async () => {
+    process.env.WEEK_SCOUT_ENDPOINT_ENABLED = 'false';
     const response = await callRoute({
       candidateBeachIds: [BEACH_A],
       localTimezone: 'Pacific/Honolulu',

--- a/__tests__/fixtures/week-scout-contract-v1.json
+++ b/__tests__/fixtures/week-scout-contract-v1.json
@@ -1,0 +1,133 @@
+{
+  "generatedAt": "2026-07-15T18:00:00.000Z",
+  "scorerVersion": "week-scout-v1:discovery-hero-v1",
+  "candidateFingerprint": "candidate-fingerprint-v1",
+  "recommendationAvailability": {
+    "state": "available",
+    "holdEpoch": "available-epoch"
+  },
+  "sessionDecision": {
+    "schemaVersion": "canonical-session-decision.v1",
+    "engineVersion": "rules.v1",
+    "decisionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "createdAt": "2026-07-15T18:00:00.000Z",
+    "expiresAt": "2026-07-15T18:05:00.000Z",
+    "scope": {
+      "kind": "plan_next_session",
+      "windowStart": "2026-07-15T18:00:00.000Z",
+      "windowEnd": "2026-07-22T18:00:00.000Z",
+      "timezone": "Pacific/Honolulu"
+    },
+    "verdict": "go",
+    "decisionBasis": "physical_fallback",
+    "reasonCode": "selected_go",
+    "selection": {
+      "candidateId": "window-a",
+      "beachId": "11111111-1111-4111-8111-111111111111",
+      "beachName": "Ala Moana",
+      "windowStart": "2026-07-15T16:00:00.000Z",
+      "windowEnd": "2026-07-15T19:00:00.000Z",
+      "timezone": "Pacific/Honolulu",
+      "forecastRef": {
+        "forecastId": "forecast-a",
+        "beachId": "11111111-1111-4111-8111-111111111111",
+        "forecastAt": "2026-07-15T17:00:00.000Z"
+      },
+      "skillEligibility": {
+        "skill": "intermediate",
+        "state": "eligible",
+        "reasonCodes": []
+      },
+      "evidence": {
+        "conditionScore": 84,
+        "recommendationLabel": "Worth it",
+        "personalMatch": null
+      }
+    },
+    "skillEligibility": {
+      "skill": "intermediate",
+      "state": "eligible",
+      "reasonCodes": []
+    },
+    "holdEpoch": "available-epoch"
+  },
+  "days": [
+    {
+      "localDate": "2026-07-15",
+      "windows": [
+        {
+          "id": "window-a",
+          "bucket": "morning",
+          "start": "2026-07-15T16:00:00.000Z",
+          "end": "2026-07-15T19:00:00.000Z",
+          "peakTime": "2026-07-15T17:00:00.000Z",
+          "beachId": "11111111-1111-4111-8111-111111111111",
+          "conditionScore": 84,
+          "rankingScore": 88,
+          "verdict": "worth_it",
+          "rideable": true,
+          "safe": true,
+          "confidence": 82,
+          "forecast": {
+            "waveHeight": "3-4 ft",
+            "period": "12s",
+            "swellDirection": "S",
+            "windSpeed": "5 mph",
+            "windDirection": "NE",
+            "tideHeightFt": 1.4,
+            "tidePhase": "Rising",
+            "freshnessAt": "2026-07-15T18:00:00.000Z"
+          },
+          "takeaway": "Cleanest before the trades fill in.",
+          "rankedSpots": [
+            {
+              "beachId": "11111111-1111-4111-8111-111111111111",
+              "beachName": "Ala Moana",
+              "conditionScore": 84,
+              "rankingScore": 88,
+              "verdict": "worth_it"
+            }
+          ]
+        }
+      ],
+      "bestWindowId": "window-a",
+      "exclusionReasons": []
+    },
+    {
+      "localDate": "2026-07-16",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-17",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-18",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-19",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-20",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    },
+    {
+      "localDate": "2026-07-21",
+      "windows": [],
+      "bestWindowId": null,
+      "exclusionReasons": ["no_forecasts"]
+    }
+  ]
+}

--- a/__tests__/fixtures/week-scout-contract.ts
+++ b/__tests__/fixtures/week-scout-contract.ts
@@ -1,0 +1,9 @@
+import type { CanonicalWeekScoutResponse } from '@/lib/services/discovery/week-scout';
+import weekScoutContractFixtureJson from './week-scout-contract-v1.json';
+
+export const WEEK_SCOUT_CONTRACT_BEACH_ID = '11111111-1111-4111-8111-111111111111';
+export const WEEK_SCOUT_CONTRACT_GENERATED_AT = '2026-07-15T18:00:00.000Z';
+
+export const WEEK_SCOUT_CONTRACT_FIXTURE = (
+  weekScoutContractFixtureJson as unknown as CanonicalWeekScoutResponse
+);

--- a/__tests__/lib/services/enhanced-forecast-update-selection.test.ts
+++ b/__tests__/lib/services/enhanced-forecast-update-selection.test.ts
@@ -8,7 +8,7 @@ function makeBeach(id: string, name?: string): MockBeach {
  * This test verifies the beach selection logic used by the background refresh:
  * - Prioritize beaches with NO forecasts (missing coverage)
  * - Then prioritize beaches with the OLDEST `updated_at`
- * - Do not repeatedly re-select recently updated beaches due to too-short freshness window
+ * - Select beaches before the public freshness window expires
  */
 describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     jest.useRealTimers();
   });
 
-  it("prioritizes missing beaches, then oldest stale beaches", async () => {
+  it("prioritizes missing beaches, then oldest beaches due for proactive refresh", async () => {
     const beaches = [
       makeBeach("b1", "Missing 1"),
       makeBeach("b2", "Missing 2"),
@@ -35,7 +35,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     // by updateAllEnhancedForecasts().
     const latestRows = [
       { beach_id: "b5", updated_at: "2025-12-11T06:30:00Z" }, // 5.5h old (fresh within 12h)
-      { beach_id: "b4", updated_at: "2025-12-10T10:00:00Z" }, // older
+      { beach_id: "b4", updated_at: "2025-12-11T02:00:00Z" }, // 10h old (fresh, but inside 4h refresh lead)
       { beach_id: "b3", updated_at: "2025-12-09T10:00:00Z" }, // oldest
     ];
 
@@ -81,6 +81,9 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     );
     const service = new Service() as any;
 
+    process.env.FORECAST_FRESHNESS_WINDOW_HOURS = "12";
+    process.env.FORECAST_REFRESH_LEAD_HOURS = "4";
+
     // Avoid network calls and DB writes during the test; capture chosen beaches via the forecast generator stub.
     const processedBeachIds: string[] = [];
     jest
@@ -105,7 +108,7 @@ describe("EnhancedForecastService.updateAllEnhancedForecasts selection", () => {
     expect(processedBeachIds[0]).toBe("b1");
     expect(processedBeachIds[1]).toBe("b2");
 
-    // Then oldest stale next (b3 older than b4)
+    // Then oldest due next. b4 proves selection begins before the 12h stale cutoff.
     expect(processedBeachIds).toContain("b3");
     expect(processedBeachIds).toContain("b4");
 

--- a/__tests__/lib/services/forecast/batch-beach-processor.test.ts
+++ b/__tests__/lib/services/forecast/batch-beach-processor.test.ts
@@ -13,6 +13,7 @@ import {
   DeadlineTracker,
   loadBatchConfig,
   loadCdipBatchConfig,
+  getRefreshSelectionWindowHours,
   processBeachesInBatches,
   createBeachProcessor,
 } from "@/lib/services/forecast/batch-beach-processor";
@@ -155,12 +156,15 @@ describe("loadBatchConfig", () => {
     delete process.env.FORECAST_BATCH_DELAY_MS;
     delete process.env.FORECAST_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_FRESHNESS_WINDOW_HOURS;
+    delete process.env.FORECAST_REFRESH_LEAD_HOURS;
 
     const config = loadBatchConfig();
     expect(config.batchSize).toBe(3);
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(45);
     expect(config.freshnessWindowHours).toBe(12);
+    expect(config.refreshLeadHours).toBe(4);
+    expect(getRefreshSelectionWindowHours(config)).toBe(8);
   });
 
   it("reads values from environment variables", () => {
@@ -168,12 +172,15 @@ describe("loadBatchConfig", () => {
     process.env.FORECAST_BATCH_DELAY_MS = "2000";
     process.env.FORECAST_MAX_BEACHES_PER_RUN = "100";
     process.env.FORECAST_FRESHNESS_WINDOW_HOURS = "6";
+    process.env.FORECAST_REFRESH_LEAD_HOURS = "2";
 
     const config = loadBatchConfig();
     expect(config.batchSize).toBe(5);
     expect(config.batchDelayMs).toBe(2000);
     expect(config.maxBeachesPerRun).toBe(100);
     expect(config.freshnessWindowHours).toBe(6);
+    expect(config.refreshLeadHours).toBe(2);
+    expect(getRefreshSelectionWindowHours(config)).toBe(4);
   });
 
   it("applies overrides over env vars", () => {
@@ -191,6 +198,7 @@ describe("loadBatchConfig", () => {
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(45);
     expect(config.freshnessWindowHours).toBe(12);
+    expect(config.refreshLeadHours).toBe(4);
   });
 });
 
@@ -206,6 +214,7 @@ describe("loadCdipBatchConfig", () => {
     delete process.env.FORECAST_CDIP_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_MAX_BEACHES_PER_RUN;
     delete process.env.FORECAST_CDIP_FRESHNESS_WINDOW_HOURS;
+    delete process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS;
   });
 
   afterAll(() => {
@@ -218,6 +227,8 @@ describe("loadCdipBatchConfig", () => {
     expect(config.batchDelayMs).toBe(1000);
     expect(config.maxBeachesPerRun).toBe(25);
     expect(config.freshnessWindowHours).toBe(2);
+    expect(config.refreshLeadHours).toBe(0.5);
+    expect(getRefreshSelectionWindowHours(config)).toBe(1.5);
   });
 
   it("reads FORECAST_CDIP_MAX_BEACHES_PER_RUN when set", () => {
@@ -244,6 +255,29 @@ describe("loadCdipBatchConfig", () => {
     const config = loadCdipBatchConfig();
     expect(config.freshnessWindowHours).toBe(4);
   });
+
+  it("reads FORECAST_CDIP_REFRESH_LEAD_HOURS when set", () => {
+    process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS = "1";
+    const config = loadCdipBatchConfig();
+    expect(config.refreshLeadHours).toBe(1);
+    expect(getRefreshSelectionWindowHours(config)).toBe(1);
+  });
+});
+
+describe("getRefreshSelectionWindowHours", () => {
+  it("never returns a negative selection window", () => {
+    expect(getRefreshSelectionWindowHours({
+      freshnessWindowHours: 2,
+      refreshLeadHours: 3,
+    })).toBe(0);
+  });
+
+  it("fails safe to immediate selection for an invalid freshness window", () => {
+    expect(getRefreshSelectionWindowHours({
+      freshnessWindowHours: Number.NaN,
+      refreshLeadHours: 1,
+    })).toBe(0);
+  });
 });
 
 // ─── processBeachesInBatches ──────────────────────────────────────────────────
@@ -254,6 +288,7 @@ describe("processBeachesInBatches", () => {
     batchDelayMs: 0, // No delay in tests for speed
     maxBeachesPerRun: 100,
     freshnessWindowHours: 12,
+    refreshLeadHours: 4,
   };
 
   it("processes all beaches and returns success results", async () => {
@@ -352,6 +387,7 @@ describe("processBeachesInBatches", () => {
       batchDelayMs: 200, // larger than deadline window
       maxBeachesPerRun: 100,
       freshnessWindowHours: 12,
+      refreshLeadHours: 4,
     };
 
     const result = await processBeachesInBatches({
@@ -637,6 +673,7 @@ describe("createBeachProcessor", () => {
         batchDelayMs: 0,
         maxBeachesPerRun: 10,
         freshnessWindowHours: 12,
+        refreshLeadHours: 4,
       },
       deadlineTracker: new DeadlineTracker(),
       processBeach,

--- a/app/api/surf/week-scout/route.ts
+++ b/app/api/surf/week-scout/route.ts
@@ -82,7 +82,10 @@ async function weekScoutHandler(
   request: NextRequest,
   { user }: AuthenticatedContext,
 ): Promise<NextResponse> {
-  if (process.env.WEEK_SCOUT_ENDPOINT_ENABLED !== 'true') {
+  // Installed native clients need a stable canonical contract. Keep the flag
+  // as an emergency kill switch, but default the endpoint on so an omitted
+  // preview/production env value cannot turn every mobile forecast into a 404.
+  if (process.env.WEEK_SCOUT_ENDPOINT_ENABLED === 'false') {
     return NextResponse.json(
       { success: false, error: 'Week Scout endpoint is not enabled' },
       { status: 404 },

--- a/lib/services/enhanced-forecast-service.ts
+++ b/lib/services/enhanced-forecast-service.ts
@@ -8,9 +8,11 @@ import {
 import { hashString } from "./forecast/batch-update-coordinator";
 import {
   DeadlineTracker,
+  getRefreshSelectionWindowHours,
   loadBatchConfig,
   loadCdipBatchConfig,
   processBeachesInBatches,
+  type BatchProcessConfig,
   type BatchProcessResult,
   type BeachProcessResult,
 } from "./forecast/batch-beach-processor";
@@ -723,7 +725,7 @@ export class EnhancedForecastService {
     const { shard, shardCount } = options;
     const isSharded = typeof shard === "number" && typeof shardCount === "number" && shardCount > 0;
     const shardInfo = isSharded ? ` [shard ${shard}/${shardCount}]` : "";
-    log.info(`updateAllEnhancedForecasts() starting (v3 with stale-only updates)${shardInfo}`);
+    log.info(`updateAllEnhancedForecasts() starting (v3 with proactive refresh)${shardInfo}`);
 
     const config = loadBatchConfig();
     const deadlineTracker = new DeadlineTracker(options.deadlineMs);
@@ -736,7 +738,8 @@ export class EnhancedForecastService {
 
       log.info(
         `Starting batch forecast update for ${beaches.selected.length}/${beaches.eligible.length} beaches${shardInfo} ` +
-        `(missing: ${beaches.stats.missing}, stale>${config.freshnessWindowHours}h: ${beaches.stats.stale}, ` +
+        `(missing: ${beaches.stats.missing}, due>${beaches.refreshSelectionWindowHours}h: ${beaches.stats.dueForRefresh}, ` +
+        `stale at ${config.freshnessWindowHours}h, ` +
         `selectedMissing: ${beaches.stats.selectedMissing}, max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
       );
 
@@ -785,17 +788,18 @@ export class EnhancedForecastService {
   }
 
   /**
-   * Select beaches for update based on staleness and sharding
+   * Select beaches for update before staleness, with optional sharding.
    */
   private async selectBeachesForUpdate(
-    config: { freshnessWindowHours: number; maxBeachesPerRun: number },
+    config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours" | "maxBeachesPerRun">,
     shard?: number,
     shardCount?: number
   ) {
     const supabase = await createSupabaseServiceRoleClient();
     const isSharded = typeof shard === "number" && typeof shardCount === "number" && shardCount > 0;
     const shardInfo = isSharded ? ` [shard ${shard}/${shardCount}]` : "";
-    const staleThresholdMs = Date.now() - config.freshnessWindowHours * 60 * 60 * 1000;
+    const refreshSelectionWindowHours = getRefreshSelectionWindowHours(config);
+    const refreshThresholdMs = Date.now() - refreshSelectionWindowHours * 60 * 60 * 1000;
 
     // Get all beaches
     const { data: allBeaches, error: beachError } = await supabase
@@ -831,14 +835,14 @@ export class EnhancedForecastService {
 
     // Filter beaches
     const missingBeaches = eligibleBeaches.filter((b) => !latestUpdatedAtByBeachMs.has(b.id));
-    const staleBeaches = eligibleBeaches
+    const dueForRefreshBeaches = eligibleBeaches
       .filter((b) => {
         const updatedAtMs = latestUpdatedAtByBeachMs.get(b.id);
-        return Boolean(updatedAtMs && updatedAtMs < staleThresholdMs);
+        return Boolean(updatedAtMs && updatedAtMs < refreshThresholdMs);
       })
       .sort((a, b) => (latestUpdatedAtByBeachMs.get(a.id) ?? 0) - (latestUpdatedAtByBeachMs.get(b.id) ?? 0));
 
-    let beachesToUpdate = [...missingBeaches, ...staleBeaches];
+    let beachesToUpdate = [...missingBeaches, ...dueForRefreshBeaches];
 
     // If everything is fresh, rotate oldest 5
     if (beachesToUpdate.length === 0) {
@@ -853,9 +857,10 @@ export class EnhancedForecastService {
     return {
       selected,
       eligible: eligibleBeaches,
+      refreshSelectionWindowHours,
       stats: {
         missing: missingBeaches.length,
-        stale: staleBeaches.length,
+        dueForRefresh: dueForRefreshBeaches.length,
         selectedMissing: selected.filter((b) => !latestUpdatedAtByBeachMs.has(b.id)).length,
       },
     };
@@ -883,8 +888,9 @@ export class EnhancedForecastService {
       }
 
       log.info(
-        `Starting CDIP-only update for ${beaches.selected.length}/${beaches.totalStale} CDIP-stale beaches ` +
-        `(stale>${config.freshnessWindowHours}h, max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
+        `Starting CDIP-only update for ${beaches.selected.length}/${beaches.totalDueForRefresh} CDIP beaches due for refresh ` +
+        `(due>${beaches.refreshSelectionWindowHours}h, target ${config.freshnessWindowHours}h, ` +
+        `max ${config.maxBeachesPerRun} per run, batch size: ${config.batchSize})`
       );
 
       // Fetch nowcast observation anchors once per CDIP cron invocation, mirroring
@@ -933,16 +939,19 @@ export class EnhancedForecastService {
   }
 
   /**
-   * Select CDIP beaches for update based on staleness
+   * Select CDIP beaches before their refresh target expires.
    *
    * FIXED: Previously this method only selected beaches that already had data_source='CDIP',
    * which meant beaches not initially seeded with CDIP data were never updated by the CDIP cron.
    * Now we use the cdip_eligible column to determine which beaches should receive CDIP updates,
    * regardless of their current data_source.
    */
-  private async selectCdipBeachesForUpdate(config: { freshnessWindowHours: number; maxBeachesPerRun: number }) {
+  private async selectCdipBeachesForUpdate(
+    config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours" | "maxBeachesPerRun">
+  ) {
     const supabase = await createSupabaseServiceRoleClient();
-    const staleThresholdMs = Date.now() - config.freshnessWindowHours * 60 * 60 * 1000;
+    const refreshSelectionWindowHours = getRefreshSelectionWindowHours(config);
+    const refreshThresholdMs = Date.now() - refreshSelectionWindowHours * 60 * 60 * 1000;
 
     // Load CDIP-eligible beaches from DB (not all beaches)
     const { data: cdipBeaches, error: beachError } = await supabase
@@ -969,15 +978,15 @@ export class EnhancedForecastService {
       latestByBeach.set(row.beach_id, { updated_at: row.updated_at, data_source: row.data_source ?? null });
     }
 
-    // Select stale OR missing beaches (DO NOT filter by data_source)
-    const cdipStale = cdipBeaches
+    // Select due OR missing beaches (DO NOT filter by data_source)
+    const cdipDueForRefresh = cdipBeaches
       .filter((b) => {
         const latest = latestByBeach.get(b.id);
         // FIXED: Missing forecast data = needs update (was incorrectly returning false)
         if (!latest) return true;
         // FIXED: Removed data_source check - we want to update based on eligibility, not current source
         const ts = new Date(latest.updated_at).getTime();
-        return Number.isFinite(ts) && ts < staleThresholdMs;
+        return Number.isFinite(ts) && ts < refreshThresholdMs;
       })
       .sort((a, b) => {
         // Sort missing first, then by oldest updated
@@ -990,8 +999,9 @@ export class EnhancedForecastService {
       });
 
     return {
-      selected: cdipStale.slice(0, config.maxBeachesPerRun),
-      totalStale: cdipStale.length,
+      selected: cdipDueForRefresh.slice(0, config.maxBeachesPerRun),
+      totalDueForRefresh: cdipDueForRefresh.length,
+      refreshSelectionWindowHours,
     };
   }
 

--- a/lib/services/forecast/batch-beach-processor.ts
+++ b/lib/services/forecast/batch-beach-processor.ts
@@ -53,6 +53,24 @@ export interface BatchProcessConfig {
   batchDelayMs: number;
   maxBeachesPerRun: number;
   freshnessWindowHours: number;
+  refreshLeadHours: number;
+}
+
+/**
+ * Start refresh work before the public freshness window expires so cron
+ * cadence and execution time cannot create a rotating stale queue.
+ */
+export function getRefreshSelectionWindowHours(
+  config: Pick<BatchProcessConfig, "freshnessWindowHours" | "refreshLeadHours">
+): number {
+  const freshnessWindowHours = Number.isFinite(config.freshnessWindowHours)
+    ? Math.max(0, config.freshnessWindowHours)
+    : 0;
+  const refreshLeadHours = Number.isFinite(config.refreshLeadHours)
+    ? Math.max(0, config.refreshLeadHours)
+    : 0;
+
+  return Math.max(0, freshnessWindowHours - refreshLeadHours);
 }
 
 /**
@@ -64,6 +82,7 @@ export function loadBatchConfig(overrides?: Partial<BatchProcessConfig>): BatchP
     batchDelayMs: Number(process.env.FORECAST_BATCH_DELAY_MS ?? 1000),
     maxBeachesPerRun: Number(process.env.FORECAST_MAX_BEACHES_PER_RUN ?? 45),
     freshnessWindowHours: Number(process.env.FORECAST_FRESHNESS_WINDOW_HOURS ?? 12),
+    refreshLeadHours: Number(process.env.FORECAST_REFRESH_LEAD_HOURS ?? 4),
     ...overrides,
   };
 }
@@ -81,6 +100,7 @@ export function loadCdipBatchConfig(): BatchProcessConfig {
         25
     ),
     freshnessWindowHours: Number(process.env.FORECAST_CDIP_FRESHNESS_WINDOW_HOURS ?? 2),
+    refreshLeadHours: Number(process.env.FORECAST_CDIP_REFRESH_LEAD_HOURS ?? 0.5),
   };
 }
 


### PR DESCRIPTION
## Production slice
- begin enhanced forecast refresh at 8h, before the 12h public stale threshold
- begin CDIP refresh at 1.5h, before its 2h target
- keep the authenticated Week Scout v1 endpoint enabled unless explicitly killed

## Scope
Only the two reviewed runtime commits and their focused tests are included. Main-only SEO benchmark tooling is intentionally excluded from this selective prod branch.

## Verification
- 60 focused production-slice tests passed
- production-slice TypeScript passed
- shared and live Preview Week Scout responses passed actual mobile 1.0.1 and 1.0.2 consumers
- mobile prod-readonly Maestro passed 4/4

## Monitoring
Check the stale inventory hourly for two hours; rerun the 346-beach gate after the second check or as soon as stale reaches zero.