### PR TITLE
feat(prod): publish forecast authority across all beaches

### DIFF
--- a/.planning/embed-freshness-fix-and-refactor-20260805.md
+++ b/.planning/embed-freshness-fix-and-refactor-20260805.md
@@ -1,0 +1,226 @@
+# Embed conditions blanking — fix and freshness refactor
+
+Date: 2026-08-05
+Status: **SPEC — not implemented**
+Trigger: `/embed/conditions/<slug>` intermittently renders "No conditions available" for beaches that
+have data. Found while verifying outreach links for plan 064 W3 (embed syndication to surf shops).
+
+## 1. What is happening
+
+Measured 2026-08-05, five consecutive fetches per beach:
+
+| Beach | Result |
+|---|---|
+| `huntington-beach-pier` | `. . . . .` (data) |
+| `la-jolla-shores` | `. . . . .` (data) |
+| `waikiki-beach` | `E E E E E` (blank) |
+| `cannon-beach-ecolaindian` | `E E E E E` (blank) |
+
+Consistent within a window, different across windows: seven beaches with data in the morning were
+blank the same afternoon, and `la-jolla-shores` was blank at midday and fine an hour later.
+
+**Mechanism.** `app/embed/conditions/[slug]/page.tsx:29` calls
+`getFreshForecastFromCache(beach.id, 2)` — a **2-hour** freshness window, against a pipeline that
+cannot meet it:
+
+| Input | Value | Source |
+|---|---|---|
+| Marine refresh cron | hourly, `maxBeaches=130` | `vercel.json` |
+| Beaches | 318 | `beaches-table-2026-06-19.json` |
+| → worst-case age of any beach | **~3 h** (`ceil(318/130)` × 1 h) | derived |
+| Embed freshness window | **2 h** | `app/embed/conditions/[slug]/page.tsx:29` |
+| `getFreshForecastFromCache` default | 48 h | `lib/utils/forecast-service-utils.ts:130` |
+
+The widget demands data fresher than the pipeline can produce, so beaches routinely fall outside the
+window and render an empty box.
+
+## 2. The fix is not "widen the window"
+
+The codebase already models this correctly. `ForecastCacheOptions`
+(`lib/utils/forecast-service-utils.ts:99`) documents the policy verbatim:
+
+```ts
+/**
+ * Return stale cached rows for display-only surfaces.
+ * Keep false for alerts, emails, pushes, and automation.
+ */
+allowStale?: boolean;
+/** Maximum cache age allowed when allowStale is true. Defaults to 24 hours. */
+```
+
+And it is honoured elsewhere — beach detail passes `{ allowStale: true, maxStaleHours: 24 }`
+(`app/api/forecasts/update-enhanced/route.ts:93`); the discovery batch fetcher and orchestrator both
+use it as a fallback.
+
+**The four embed widgets are the only display-only surfaces that do not opt in.** They are on the
+wrong side of a policy the codebase already defines. The fix is to move them to the right side, not to
+invent a new number.
+
+### Immediate change
+
+For `app/embed/{conditions,ticker,tides}/[slug]/page.tsx`:
+
+1. Pass `{ allowStale: true, maxStaleHours: 24 }`, matching beach detail.
+2. Use the returned `metadata` instead of discarding it. Render **three distinct states**:
+   - `cached && !stale` → conditions as today
+   - `stale` → the same conditions plus an "as of {lastUpdated}" line. A slightly old reading on a
+     shop's storefront is strictly better than an empty box.
+   - `missing` → an honest short message and a link to the beach page. Not a bare empty widget.
+3. Replace `catch { /* Render with empty data */ }` with a logged catch that distinguishes an
+   exception from absent data. This failure has been invisible because nothing recorded it.
+
+`surf-terminal` passes **288** (12 days) — the opposite failure, silently presenting nearly two-week-old
+data as current. Bring it under the same named policy.
+
+### Secondary bug in the same block
+
+The "closest forecast to now" sort builds
+``new Date(`${a.forecast_date}T${a.forecast_time || "00:00"}`)`` — no timezone, so it parses as
+**local** time, and it uses the **deprecated** `forecast_date` + `forecast_time` columns. Workspace
+`CLAUDE.md` says use `forecast_at` (timestamptz). Migrate the sort to `forecast_at` and compare
+instants. Wrong-by-hours row selection is possible today.
+
+## 3. The refactor
+
+The bug is a symptom. Two structural faults produced it.
+
+### Fault A — freshness policy is an unnamed integer, duplicated per call site
+
+Every consumer invents its own number, with no stated rationale and no shared meaning:
+
+| Call site | Window |
+|---|---|
+| `app/embed/conditions/[slug]/page.tsx` | 2 |
+| `app/embed/ticker/[slug]/page.tsx` | 2 |
+| `app/embed/tides/[slug]/page.tsx` | 2 |
+| `app/embed/surf-terminal/[slug]/page.tsx` | **288** |
+| `getFreshForecastFromCache` default | 48 |
+
+Two orders of magnitude apart, none explained. Nothing anywhere states what a *correct* value would be.
+
+**Move 1 — name the policy, don't repeat the number.** Introduce a single module owning forecast
+freshness policy, exporting named policies rather than integers:
+
+- `DISPLAY_SURFACE` — embeds, beach detail, anything a human reads. Allows stale, timestamps it.
+- `AUTOMATION` — alerts, emails, pushes. Never stale, per the existing comment.
+- `LONG_RANGE` — multi-day outlook surfaces such as surf-terminal.
+
+Call sites express intent (`FRESHNESS.DISPLAY_SURFACE`), never a literal. A reviewer can then see that a
+change is wrong; today `2` and `288` look equally plausible.
+
+**Move 2 — derive the window from the pipeline instead of guessing.** The safe display window is a
+function of the refresh cycle, not a hunch:
+
+```
+worstCaseAgeHours = ceil(beachCount / maxBeachesPerRun) * cronIntervalHours
+```
+
+Encode that, and add a test asserting `DISPLAY_SURFACE.windowHours > worstCaseAgeHours * safetyFactor`,
+reading `maxBeaches` from `vercel.json` and the beach count from the DB or a fixture. **That test is
+the one that would have caught this**, and it will catch it again the next time the beach count grows
+or the cron cap changes. Right now those numbers can drift apart forever in silence.
+
+### Fault B — the data layer computes rich state that every consumer throws away
+
+`getFreshForecastFromCache` already returns
+`{ cached, stale, missing, reason, dataSource, lastUpdated }`. The embed pages check
+`result?.forecasts?.length` and discard all of it. Four widgets independently re-implement
+"truthy check → blank", collapsing three distinct states into one indistinguishable failure.
+
+**Move 3 — one presenter, three states.** A shared helper mapping `ForecastCacheMetadata` to a
+`{ kind: "fresh" | "stale" | "unavailable", asOf?, reason? }` view model, consumed by all four embeds.
+Fixes the UI once instead of four times, and makes "stale" representable at all — today it is not.
+
+**Move 4 — make silence impossible.** Bare `catch {}` plus no metric is why this shipped and persisted.
+Log the catch with beach id and reason, and add an embed empty-render counter to the existing
+`/api/monitoring/forecast-health` cron (already scheduled `*/30 * * * *`). Alert if the empty rate for a
+beach with a live embed crosses a threshold. A widget on someone else's website failing silently is
+strictly worse than one failing on ours — we will not see it, and they will not tell us; they will just
+remove it.
+
+### Where the presenter gets reused — this is not an embed concern
+
+The same problem is solved four different ways across at least nine surfaces, and the staleness
+computation itself is implemented **twice**.
+
+**Two independent implementations of the same metadata.** Both query `v_enhanced_forecast_latest` for
+`updated_at, data_source`, call `getStalenessDetails()`, and build a
+`{ stale, missing, dataSource, lastUpdated, reason }` shape:
+- `lib/utils/forecast-service-utils.ts` (`getFreshForecastFromCache`)
+- `app/api/forecasts/current/route.ts` (local `freshness` helper)
+
+**Four different strategies for "data isn't fresh":**
+
+| Surface | Current behavior |
+|---|---|
+| `app/embed/{conditions,ticker,tides}` | Renders a blank box |
+| `app/embed/surf-terminal` | Accepts up to **288 h** silently |
+| `app/api/forecasts/current` | **Collapses `stale` into `unavailable`** (line ~155) |
+| `app/api/surf/utils.ts` | Falls back to a **nearby beach** with data |
+| `app/api/beaches/featured` | Silently omits the beach |
+| `app/api/cron/morning-forecast-bot` | Errors the region out |
+| Beach detail (`update-enhanced`) | `allowStale: true, maxStaleHours: 24` — the one doing it right |
+
+**It crosses into native.** `quiver-native/src/hooks/use-source-backed-current-conditions.ts` calls
+`/api/forecasts/current?refresh=if-stale`. Because that route folds `stale` into `unavailable`, native
+cannot distinguish "old reading" from "no reading" either — so
+`src/components/forecast-chart.tsx` ("No forecast data"),
+`src/components/beach-detail/looking-ahead-card.tsx` ("No forecast data yet for this beach."), and
+`beach-card` / `saved-spots-rail` (`conditions?.waveHeight ?? null`) all inherit the same flattening.
+
+**Therefore the presenter does not belong in the embed component. It belongs at the contract boundary.**
+
+- **One freshness model** in the domain layer — collapse the two implementations into one.
+- **The API returns three states**, not a boolean: `fresh` / `stale{asOf}` / `unavailable{reason}`.
+  Removing the `|| args.freshness.stale` collapse is the single highest-leverage line in this refactor —
+  it unblocks honest freshness rendering on **web and native simultaneously**.
+- **A shared view-model helper** both web and native map to their own UI from.
+
+`/api/forecasts/current` is a native-consumed route, so per `quiver/AGENTS.md` §Native ↔ web boundary it
+is a **versioned contract** — additive fields first, native reads them when it ships, only then retire
+the old shape. Do not change its meaning in place.
+
+Worth noting `/api/surf`'s nearby-beach fallback is a genuinely better degradation than blanking, and is
+a candidate for the `unavailable` branch on map and discovery surfaces — but not for embeds, where a
+shop expects *their* break, not a neighbouring one.
+
+### Sequencing
+
+1. **Immediate fix (§2)** — three embeds opt into `allowStale`, render three states. Unblocks plan 064
+   W3. Small, shippable on its own, no contract change.
+2. **Unify the two freshness implementations** into one domain-layer model.
+3. **Stop collapsing `stale` into `unavailable` in `/api/forecasts/current`** — additive fields, since
+   native consumes it. This is the line that unblocks honest freshness on web *and* native.
+4. **Shared view-model helper**, adopted by the four embeds and web beach detail.
+5. **Native adopts the new fields** — forecast-chart, looking-ahead-card, beach-card, saved-spots-rail
+   stop showing "No forecast data" for data that merely aged.
+6. **Named policy + derived window + regression test** — prevents recurrence.
+7. **Observability** — log the catch, embed empty-render counter on `forecast-health`.
+8. **`forecast_at` migration** — separate branch, one concern.
+
+Steps 1 and 2–5 are independently shippable; do not bundle them. Step 1 is the only one plan 064 waits
+on.
+
+## 4. Why this matters beyond the bug
+
+The embed widget is the deliverable of plan 064 W3. 37 verified surf shops and schools are queued
+(`Brand-Vault/marketing/growth-ops/reports/outreach-targets-research-2026-08-05.md`). Distributing a
+widget that blanks part of every refresh cycle is worse than not distributing: a shop that sees an empty
+box removes it and does not look again, and the backlink goes with it.
+
+**Do not send embed outreach until §2 ships.** Surf Diva already received a `la-jolla-shores` embed link
+on 2026-08-03; that beach was verified blank on 2026-08-05.
+
+## 5. Not in scope
+
+- Increasing `maxBeaches` or the cron cadence. That is a cost/ratelimit decision, and widening the
+  display window is the cheaper correct fix.
+- ~~Backfilling genuinely dataless beaches.~~ **Corrected 2026-08-05: there are none among the
+  observed set.** `south-padre-island-isla-blanca-park-…`, `deerfield-beach-pier-…`, and
+  `12th-street-jetty-sea-isle-city-nj` were each classified "dataless" from their rendered output; all
+  three in fact have data and were merely stale. Verified on the fix branch: `deerfield-beach-pier`
+  renders blank on prod and renders conditions + "as of Wed, Aug 5 at 10:30 AM" with the fix. **A beach
+  cannot be classified from the widget's output until this ships** — the widget is precisely what
+  conflates the two states.
+- `robots.txt` currently has `Disallow: /embed/`, which conflicts with embeds as a distribution
+  surface. Flagged in the target-research report; decide separately.

--- a/.planning/forecast-availability-contract-20260805.md
+++ b/.planning/forecast-availability-contract-20260805.md
@@ -1,0 +1,131 @@
+# Step 3 — `/api/forecasts/current`: stop collapsing stale into missing
+
+Date: 2026-08-05
+Status: **SPEC — not implemented**
+Parent: `quiver/.planning/embed-freshness-fix-and-refactor-20260805.md` (§3, step 3)
+Scope: web API contract change + native adoption. **Not** the embed fix (step 1, separate branch).
+
+## 1. The defect
+
+`app/api/forecasts/current/route.ts:156`:
+
+```ts
+const unavailable = args.current == null || args.freshness.missing || args.freshness.stale;
+return {
+  stale:   args.freshness.stale,   // correct
+  missing: unavailable,            // WRONG — folds `stale` into `missing`
+  ...
+};
+```
+
+A beach with a real but aging forecast returns `stale: true, missing: true` at the same time. `missing`
+therefore does not mean "there is no data" — it means "do not show data", and its name lies.
+
+**`CurrentMetadata` already has the two fields it needs.** Nothing new is required to model the states;
+one of them is simply being overwritten.
+
+## 2. Why it matters
+
+`/api/forecasts/current` is consumed by native:
+`quiver-native/src/hooks/use-source-backed-current-conditions.ts:59`
+(`?beachId=…&refresh=if-stale`).
+
+Blast radius is **one line** — `quiver-native/src/screens/beach-detail.tsx:738`:
+
+```ts
+const currentConditionsUnavailable =
+  Boolean(currentConditionsError) ||
+  currentConditionsMetadata?.missing === true ||
+  (!currentConditionsPending && currentForecastRow == null);
+```
+
+So aging-but-real conditions are **hidden entirely on native beach detail**. The user sees nothing
+rather than a slightly old reading — the same failure as the web embeds, reached through this contract.
+
+This is also why fixing `missing` **in place is not safe**: it would immediately start surfacing stale
+data on every already-installed native build, with no "as of" label, silently presenting old numbers as
+current. Correct data, dishonest presentation.
+
+Per `quiver/AGENTS.md` §Native ↔ web boundary, mobile-consumed routes are **versioned contracts**:
+additive first, native adopts, only then retire.
+
+## 3. The change
+
+Add one unambiguous field. Do not alter the meaning of any existing field in phase A.
+
+```ts
+type CurrentMetadata = {
+  // ... existing fields unchanged ...
+
+  /**
+   * Authoritative freshness state. Prefer this over `stale`/`missing`.
+   *
+   * fresh       — usable data, within the staleness threshold
+   * stale       — usable data, past the threshold. Render it WITH `lastUpdated`.
+   * unavailable — no usable data. Render an explicit empty state.
+   *
+   * `missing` is retained for pre-adoption native builds and currently also
+   * returns true for `stale`. It will be corrected once the minimum supported
+   * native version reads `availability` (see §4 phase C).
+   */
+  availability: "fresh" | "stale" | "unavailable";
+};
+```
+
+Derivation — the only branch that matters:
+
+```ts
+const availability =
+  args.current == null || args.freshness.missing ? "unavailable"
+  : args.freshness.stale                          ? "stale"
+  : "fresh";
+```
+
+`lastUpdated` already carries the timestamp and needs no change. `reason` stays populated for
+`unavailable`, and should also be populated for `stale` (it already computes
+`Data is Xh old (threshold: Yh)`).
+
+### Also fold in the duplicate implementation
+
+The route's local `readLatestMetadata` re-implements `getFreshForecastFromCache`'s staleness logic —
+both query `v_enhanced_forecast_latest` for `updated_at, data_source` and call `getStalenessDetails()`.
+Two implementations of one rule will drift. Collapse them onto one shared helper as part of this change,
+or explicitly defer it to step 2 and say so — but do not add a third.
+
+## 4. Rollout
+
+**Phase A — web, additive.** Add `availability`. Leave `stale` and `missing` byte-identical. Zero native
+impact by construction: no existing field changes value, so every installed build behaves exactly as it
+does today. Independently shippable.
+
+**Phase B — native adopts.** `beach-detail.tsx:738` switches from `metadata?.missing === true` to
+`metadata?.availability === 'unavailable'`, and renders the `stale` case as conditions **plus an
+"as of {lastUpdated}" line** — matching the treatment step 1 ships on web embeds, so the two platforms
+agree. JS-only, so it ships OTA. Also update `CurrentConditionsMetadata` in
+`use-source-backed-current-conditions.ts` and the `e2e` stub at line ~46 (add `availability: 'fresh'`).
+
+**Phase C — web, corrective.** Once the minimum supported native version reads `availability`, change
+`missing` to mean genuinely missing (`args.current == null || args.freshness.missing`) and mark the old
+semantics deprecated. **Gate C on evidence** that pre-adoption builds are drained — not on a date.
+
+Do not merge B into A. Phase A must be able to sit in production alone indefinitely.
+
+## 5. Verification
+
+- **Phase A:** unit coverage for all three `availability` values, plus an explicit regression test that
+  `stale` and `missing` still return their **current** values for a stale beach — that test is what
+  proves phase A is non-breaking, and it should be deleted in phase C.
+- **Phase B:** native unit test that `availability: 'stale'` renders conditions **and** the timestamp,
+  and that `'unavailable'` renders the empty state. Simulator check on a beach that is actually stale
+  (they rotate — pick one empirically at run time rather than hardcoding a slug).
+- Contract: if there is an API contract doc or generated type shared with native, update it in the same
+  change. Search before assuming there isn't one.
+
+## 6. Out of scope
+
+- The embed fix (step 1) — separate branch, already in flight.
+- `surf-terminal`'s 288-hour window, the named-policy module, and the derived-window regression test
+  (step 6).
+- `/api/surf`'s nearby-beach fallback. It is a better degradation for map/discovery and is worth
+  considering for `unavailable` there, but it is not part of this contract.
+- The `forecast_at` migration.

--- a/.vercelignore
+++ b/.vercelignore
@@ -2,6 +2,17 @@
 /e2e/
 __tests__/
 
+# Local dependency and build output; Vercel installs/builds these remotely.
+/node_modules/
+/.next/
+/reports/
+/.planning/
+/.git/
+/.claude/
+/.agents/
+/.superpowers/
+/.worktrees/
+
 # Documentation
 docs/
 

--- a/__tests__/app/generic-beach-detail-resolution.test.ts
+++ b/__tests__/app/generic-beach-detail-resolution.test.ts
@@ -6,6 +6,7 @@ import GenericBeachDetailPage, {
   generateMetadata,
 } from "@/app/[intent]/[city]/[beachSlug]/page";
 import { getBeachesBySlug } from "@/actions/beach/beach-query-actions";
+import { getSpotSurfReportPublic } from "@/actions/spot/spot-surf-report-actions";
 import { getNearbyBeaches } from "@/actions/beach/beach-location-actions";
 import { expectConsoleWarnings } from "@/__tests__/setup/test-utils";
 import type { Beach } from "@/types/database";
@@ -173,6 +174,23 @@ function makeBeach(overrides: BeachTestOverrides) {
   } as unknown as Beach;
 }
 
+function freshForecastResult() {
+  const now = Date.now();
+  return {
+    report: {
+      waveHeight: "2-3 ft",
+      updatedAt: new Date(now - 60 * 60 * 1000).toISOString(),
+    },
+    isTomorrow: false,
+    forecastContext: {
+      selectedRowTime: new Date(now + 60 * 60 * 1000).toISOString(),
+      waveHeight: "2-3 ft",
+      sourceDataUpdatedAt: new Date(now - 60 * 60 * 1000).toISOString(),
+      primaryDataSource: "NOAA_NWS",
+    },
+  };
+}
+
 describe("GenericBeachDetailPage slug resolution", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -317,6 +335,7 @@ describe("GenericBeachDetailPage slug resolution", () => {
         }],
       })],
     });
+    (getSpotSurfReportPublic as jest.Mock).mockResolvedValue(freshForecastResult());
 
     const metadata = await generateMetadata({
       params: Promise.resolve({ intent: "ca", city: "dana-point", beachSlug: "lower-trestles" }),
@@ -336,6 +355,7 @@ describe("GenericBeachDetailPage slug resolution", () => {
         wave_tips: "Watch the reef peak before paddling out.",
       })],
     });
+    (getSpotSurfReportPublic as jest.Mock).mockResolvedValue(freshForecastResult());
 
     const metadata = await generateMetadata({
       params: Promise.resolve({
@@ -353,7 +373,7 @@ describe("GenericBeachDetailPage slug resolution", () => {
     );
   });
 
-  it("keeps an explicitly rejected GSC-protected beach noindex", async () => {
+  it("does not let editorial rejection take a current forecast page down", async () => {
     (getBeachesBySlug as jest.Mock).mockResolvedValue({
       success: true,
       data: [makeBeach({
@@ -365,6 +385,7 @@ describe("GenericBeachDetailPage slug resolution", () => {
         editorial_reviewed_at: "2026-07-13T00:00:00.000Z",
       })],
     });
+    (getSpotSurfReportPublic as jest.Mock).mockResolvedValue(freshForecastResult());
 
     const metadata = await generateMetadata({
       params: Promise.resolve({
@@ -374,6 +395,6 @@ describe("GenericBeachDetailPage slug resolution", () => {
       }),
     });
 
-    expect((metadata.robots as { index?: boolean })?.index).toBe(false);
+    expect((metadata.robots as { index?: boolean } | undefined)?.index).not.toBe(false);
   });
 });

--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -26,6 +26,10 @@ import {
 } from "@/lib/data/blog-posts";
 import { learnArticles } from "@/lib/data/learn-articles";
 import { slugifyAscii } from "@/lib/utils/text-utils";
+import {
+  getForecastIndexabilityForBeaches,
+  type ForecastIndexabilitySnapshot,
+} from "@/lib/seo/forecast-indexability";
 
 // Mock the action modules
 jest.mock("@/actions/beach/beach-location-list-actions", () => ({
@@ -46,6 +50,11 @@ jest.mock("@/actions/city/best-time-actions", () => ({
 
 jest.mock("@/actions/city/city-editorial-actions", () => ({
   getReviewedCityEditorialContent: jest.fn(),
+}));
+
+jest.mock("@/lib/seo/forecast-indexability", () => ({
+  ...jest.requireActual("@/lib/seo/forecast-indexability"),
+  getForecastIndexabilityForBeaches: jest.fn(),
 }));
 
 function reviewedBeach() {
@@ -69,6 +78,23 @@ describe("Sitemap Generation", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    (getForecastIndexabilityForBeaches as jest.Mock).mockImplementation(
+      async (beaches: Array<string | { id: string }>) => {
+        const snapshot: ForecastIndexabilitySnapshot = {
+          forecastAvailable: true,
+          selectedStateComplete: true,
+          forecastFresh: true,
+          forecastValidAt: "2026-08-08T18:00:00.000Z",
+          sourceDataUpdatedAt: "2026-08-08T16:00:00.000Z",
+          primaryDataSource: "NOAA_NWS",
+          isStale: false,
+        };
+        return new Map(
+          beaches.map((beach) => [typeof beach === "string" ? beach : beach.id, snapshot]),
+        );
+      },
+    );
 
     // Default mocks
     (getAllBeachLocations as jest.Mock).mockResolvedValue({
@@ -726,7 +752,59 @@ describe("Sitemap Generation", () => {
   });
 
   describe("Beach Routes", () => {
-    it("omits unreviewed beaches from the sitemap", async () => {
+    it("uses forecast freshness for beach URLs instead of editorial approval", async () => {
+      (getBeaches as jest.Mock).mockResolvedValue({
+        success: true,
+        data: [
+          {
+            id: "beach-1",
+            slug: "forecast-authority",
+            city: "San Diego",
+            state: "CA",
+            country: "USA",
+            ...reviewedBeach(),
+            seo_indexable: false,
+          },
+        ],
+      });
+
+      const result = await sitemap();
+      expect(result.some((route) => route.url.endsWith("/ca/san-diego/forecast-authority"))).toBe(true);
+    });
+
+    it("omits a beach URL when its forecast coverage is stale", async () => {
+      (getBeaches as jest.Mock).mockResolvedValue({
+        success: true,
+        data: [
+          {
+            id: "beach-1",
+            slug: "stale-forecast",
+            city: "San Diego",
+            state: "CA",
+            country: "USA",
+            ...reviewedBeach(),
+          },
+        ],
+      });
+      (getForecastIndexabilityForBeaches as jest.Mock).mockResolvedValue(
+        new Map([
+          ["beach-1", {
+            forecastAvailable: true,
+            selectedStateComplete: true,
+            forecastFresh: false,
+            forecastValidAt: "2026-08-07T18:00:00.000Z",
+            sourceDataUpdatedAt: "2026-08-07T00:00:00.000Z",
+            primaryDataSource: "CDIP",
+            isStale: true,
+          } satisfies ForecastIndexabilitySnapshot],
+        ]),
+      );
+
+      const result = await sitemap();
+      expect(result.some((route) => route.url.endsWith("/ca/san-diego/stale-forecast"))).toBe(false);
+    });
+
+    it("includes unreviewed beaches when forecast coverage is fresh", async () => {
       (getBeaches as jest.Mock).mockResolvedValue({
         success: true,
         data: [{
@@ -742,10 +820,10 @@ describe("Sitemap Generation", () => {
 
       const result = await sitemap();
 
-      expect(result.find((r) => r.url.includes("unreviewed-break"))).toBeUndefined();
+      expect(result.find((r) => r.url.includes("unreviewed-break"))).not.toBeUndefined();
     });
 
-    it("includes only the protected subpages for a substantive unreviewed beach", async () => {
+    it("includes the canonical page and forecast subpages for a substantive unreviewed beach", async () => {
       (getBeaches as jest.Mock).mockResolvedValue({
         success: true,
         data: [{
@@ -763,7 +841,7 @@ describe("Sitemap Generation", () => {
 
       expect(
         result.find((route) => route.url === `${baseUrl}/ca/encinitas/swamis`),
-      ).toBeUndefined();
+      ).not.toBeUndefined();
       expect(
         result.find(
           (route) =>
@@ -778,7 +856,7 @@ describe("Sitemap Generation", () => {
       ).not.toBeUndefined();
     });
 
-    it("lets explicit rejection veto protected beach subpages", async () => {
+    it("does not let editorial rejection veto a current forecast page", async () => {
       (getBeaches as jest.Mock).mockResolvedValue({
         success: true,
         data: [{
@@ -796,7 +874,7 @@ describe("Sitemap Generation", () => {
 
       const result = await sitemap();
 
-      expect(result.some((route) => route.url.includes("/swamis"))).toBe(false);
+      expect(result.some((route) => route.url.includes("/swamis"))).toBe(true);
     });
 
     it("should use hierarchical URL for beaches with complete location data", async () => {

--- a/__tests__/components/beach-detail/public-forecast-answer.test.tsx
+++ b/__tests__/components/beach-detail/public-forecast-answer.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
+import type { Beach } from "@/types/database";
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+
+const beach = {
+  id: "beach-1",
+  name: "Oceanside Harbor",
+  city: "Oceanside",
+  state: "CA",
+  timezone: "America/Los_Angeles",
+} as Beach;
+
+const context: ForecastRecommendationContext = {
+  beachId: "beach-1",
+  localDate: "2026-08-09",
+  recommendationType: "best_window",
+  contextType: "best_window",
+  startTime: "2026-08-09T18:00:00.000Z",
+  endTime: "2026-08-09T20:00:00.000Z",
+  selectedWindowStart: "2026-08-09T18:00:00.000Z",
+  selectedWindowEnd: "2026-08-09T20:00:00.000Z",
+  displayWindowStart: "2026-08-09T18:00:00.000Z",
+  displayWindowEnd: "2026-08-09T20:00:00.000Z",
+  displayTimeLabel: "Best window: 11:00 AM-1:00 PM",
+  selectedRowTime: "2026-08-09T19:00:00.000Z",
+  waveHeight: "3 ft",
+  waveHeightFt: 3,
+  waveHeightRangeLabel: "2-3 ft",
+  swellPeriod: "12s",
+  periodSec: 12,
+  swellDirection: "SW",
+  primarySwellHeight: "2.5 ft",
+  secondarySwellHeight: "1 ft",
+  secondarySwellPeriod: "8s",
+  secondarySwellDirection: "W",
+  windSpeed: "5 mph",
+  windDirection: "E",
+  score: 78,
+  confidence: 82,
+  primaryDataSource: "NOAA_NWS",
+  sourceDataUpdatedAt: "2026-08-09T17:00:00.000Z",
+  contributingSources: ["NOAA_NWS", "NOAA_CO-OPS"],
+  resolverUsed: "surf-call",
+  source: "looking_ahead",
+  timezone: "America/Los_Angeles",
+};
+
+describe("PublicForecastAnswer", () => {
+  it("renders the selected tomorrow state and truthful provenance in server HTML", () => {
+    render(
+      <PublicForecastAnswer
+        beach={beach}
+        report={null}
+        context={context}
+        isTomorrow
+      />,
+    );
+
+    expect(screen.getByTestId("public-forecast-answer")).toBeInTheDocument();
+    expect(screen.getByText("Tomorrow's surf forecast")).toBeInTheDocument();
+    expect(screen.getByText(/Oceanside Harbor surf forecast for/)).toBeInTheDocument();
+    expect(screen.getByText("2-3 ft")).toBeInTheDocument();
+    expect(screen.getByText(/NOAA NWS, NOAA CO-OPS/)).toBeInTheDocument();
+  });
+
+  it("does not render without a selected forecast row", () => {
+    render(
+      <PublicForecastAnswer
+        beach={beach}
+        report={null}
+        context={null}
+        isTomorrow={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("public-forecast-answer")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/beach-detail/zine/today-surf-call.test.tsx
+++ b/__tests__/components/beach-detail/zine/today-surf-call.test.tsx
@@ -9,6 +9,25 @@ import { TodaySurfCall } from "@/components/beach-detail/zine/today-surf-call";
 import { createMockBeach } from "@/__tests__/setup/typed-mocks";
 
 describe("TodaySurfCall", () => {
+  it("labels the public call as tomorrow when the selected forecast rolls over", () => {
+    render(
+      <TodaySurfCall
+        beach={createMockBeach({ name: "Oceanside Harbor" })}
+        isTomorrow
+        surfCallReport={{
+          verdict: "MAYBE",
+          bestWindowStart: null,
+          bestWindowEnd: null,
+          whySentence: "Use the tomorrow window.",
+          updatedAt: "2026-05-21T18:32:00.000Z",
+        } as any}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: "Tomorrow's surf call" })).toBeInTheDocument();
+    expect(screen.getByText("Tomorrow's Surf Call")).toBeInTheDocument();
+  });
+
   it("uses the Go surf family for YES when no window exists", () => {
     render(
       <TodaySurfCall

--- a/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
+++ b/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
@@ -28,6 +28,38 @@ describe("ZineHero heading level", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("uses the beach coordinates to render a real static location map", () => {
+    const previousToken = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+    process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = "test-map-token";
+    const beach = createMockBeach({
+      name: "Tourmaline Beach",
+      city: "San Diego",
+      state: "CA",
+      lat: 32.805149,
+      lon: -117.262364,
+    });
+
+    try {
+      render(<ZineHero beach={beach} />);
+
+      const map = screen.getByRole("img", {
+        name: "Map showing Tourmaline Beach at its actual location",
+      });
+      const mapImage = map.querySelector("img");
+
+      expect(mapImage).toHaveAttribute(
+        "src",
+        expect.stringContaining("-117.262364,32.805149,15,0"),
+      );
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+      } else {
+        process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN = previousToken;
+      }
+    }
+  });
+
   it("renders a stored cam still in the hero when the live stream URL is unavailable", () => {
     const beach = createMockBeach({
       name: "Inches",

--- a/__tests__/components/beach-detail/zine/zine-tab.test.tsx
+++ b/__tests__/components/beach-detail/zine/zine-tab.test.tsx
@@ -76,6 +76,29 @@ describe("ZineTab", () => {
     expect(screen.getByText(/BEST SWELL:/)).toBeInTheDocument();
     // Footer / hero — location appears in multiple zine surfaces
     expect(screen.getAllByText(/Solana Beach, CA/i).length).toBeGreaterThan(0);
+    const mapRegion = screen.getByRole("img", {
+      name: "Map showing Seaside Reef at its actual location",
+    });
+    expect(mapRegion).toBeInTheDocument();
+    expect(mapRegion).toHaveAttribute(
+      "aria-label",
+      "Map showing Seaside Reef at its actual location",
+    );
+  });
+
+  it("renders the doodle map cue when coordinates are unavailable", () => {
+    const beach = createMockBeach({
+      name: "Seaside Reef",
+      city: "Solana Beach",
+      state: "CA",
+      break_type: "Reef",
+      features: ["Reef", "Stairway lineup"],
+      lat: undefined,
+      lon: undefined,
+    });
+
+    render(<ZineTab beach={beach} />);
+
     expect(screen.getByTestId("zine-map-cue-reef")).toBeInTheDocument();
   });
 

--- a/__tests__/components/forecast/conditions-overview/outlook-bar-chart.test.tsx
+++ b/__tests__/components/forecast/conditions-overview/outlook-bar-chart.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { OutlookBarChart } from "@/components/forecast/conditions-overview/outlook-bar-chart";
+import type { EnrichedDaySummary } from "@/lib/utils/enriched-day-summary";
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: ({
+    children,
+    minPointSize,
+  }: {
+    children: React.ReactNode;
+    minPointSize?: number;
+  }) => (
+    <div data-testid="score-bars" data-min-point-size={minPointSize}>
+      {children}
+    </div>
+  ),
+  Cell: ({ fill }: { fill?: string }) => (
+    <span data-testid="score-bar" data-fill={fill} />
+  ),
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  ReferenceLine: () => null,
+}));
+
+function createDay(overrides: Partial<EnrichedDaySummary>): EnrichedDaySummary {
+  return {
+    date: "Aug 4",
+    dayName: "Today",
+    minHeight: 1,
+    maxHeight: 2,
+    tier: "marginal",
+    score: 0,
+    fullDate: "2026-08-04",
+    isToday: false,
+    bestTime: "06:00",
+    period: 10,
+    windConditions: "light",
+    bestTimeSlot: "morning",
+    windSpeed: "3 mph",
+    ...overrides,
+  };
+}
+
+describe("OutlookBarChart", () => {
+  it("keeps zero-score days visible as minimum-height bars", () => {
+    const days = [
+      createDay({ score: 65, tier: "good", isToday: true }),
+      createDay({
+        date: "Aug 5",
+        dayName: "Wed",
+        fullDate: "2026-08-05",
+        score: 0,
+      }),
+    ];
+
+    render(<OutlookBarChart days={days} />);
+
+    expect(screen.getByTestId("score-bars")).toHaveAttribute(
+      "data-min-point-size",
+      "4",
+    );
+    const bars = screen.getAllByTestId("score-bar");
+    expect(bars).toHaveLength(2);
+    expect(bars[1]).toHaveAttribute("data-fill", "#7F96AD");
+  });
+});

--- a/__tests__/components/ui/wave-height-display.test.tsx
+++ b/__tests__/components/ui/wave-height-display.test.tsx
@@ -70,6 +70,8 @@ describe("WaveHeightDisplay", () => {
       const label = screen.getByTestId("wave-height-label");
       expect(label).toBeInTheDocument();
       expect(label).toHaveTextContent("Face height");
+      expect(label).toHaveClass("text-[#3F382E]");
+      expect(label).toHaveClass("font-medium");
       // 'Forecast height' must NOT be present
       expect(screen.queryByText("Forecast height")).toBeNull();
     });

--- a/__tests__/lib/config/forecast-staleness.test.ts
+++ b/__tests__/lib/config/forecast-staleness.test.ts
@@ -12,6 +12,7 @@ describe('Forecast Staleness Configuration', () => {
     it('should have correct thresholds for each source', () => {
       expect(STALENESS_THRESHOLDS.CDIP).toBe(4);
       expect(STALENESS_THRESHOLDS.NOAA_NWS).toBe(12);
+      expect(STALENESS_THRESHOLDS.OPEN_METEO).toBe(12);
       expect(STALENESS_THRESHOLDS.FALLBACK).toBe(12);
       expect(STALENESS_THRESHOLDS.DEFAULT).toBe(6);
     });
@@ -37,6 +38,11 @@ describe('Forecast Staleness Configuration', () => {
       expect(getStalenessThreshold('NOAA_NWS')).toBe(12);
       expect(getStalenessThreshold('noaa_nws')).toBe(12);
       expect(getStalenessThreshold('Noaa_Nws')).toBe(12);
+    });
+
+    it('should return the explicit threshold for OPEN_METEO', () => {
+      expect(getStalenessThreshold('OPEN_METEO')).toBe(12);
+      expect(getStalenessThreshold('open_meteo')).toBe(12);
     });
 
     it('should return correct threshold for FALLBACK', () => {

--- a/__tests__/lib/seo/editorial-integrity.test.ts
+++ b/__tests__/lib/seo/editorial-integrity.test.ts
@@ -1,0 +1,54 @@
+import type { Beach } from "@/types/database";
+import {
+  evaluateBeachEditorialIntegrity,
+  sanitizeBeachEditorialContent,
+} from "@/lib/seo/editorial-integrity";
+import { expectConsoleWarnings } from "@/__tests__/setup/test-utils";
+
+function beach(overrides: Record<string, unknown> = {}): Beach {
+  return {
+    id: "beach-1",
+    name: "Oceanside Harbor",
+    city: "Oceanside",
+    state: "CA",
+    description: "A local break near the Siuslaw River with shifting sandbars.",
+    wave_tips: "Look for the river mouth on a lower tide.",
+    crowd_tips: "Arrive early.",
+    best_conditions_prose: "Works best on a clean southwest swell.",
+    ...overrides,
+  } as Beach;
+}
+
+describe("editorial integrity", () => {
+  it("quarantines a location reference that conflicts with the beach state", () => {
+    expect(evaluateBeachEditorialIntegrity(beach())).toEqual({
+      quarantined: true,
+      reasons: ["location-reference:Siuslaw River"],
+    });
+  });
+
+  it("removes questionable editorial fields while preserving forecast identity", () => {
+    const sanitized = sanitizeBeachEditorialContent(beach());
+
+    expect(sanitized).toMatchObject({
+      id: "beach-1",
+      name: "Oceanside Harbor",
+      city: "Oceanside",
+      state: "CA",
+      description: null,
+      wave_tips: null,
+      crowd_tips: null,
+      best_conditions_prose: null,
+    });
+    expectConsoleWarnings([/Editorial content quarantined/]);
+  });
+
+  it("leaves compatible local copy untouched", () => {
+    const oregonBeach = beach({ city: "Florence", state: "OR" });
+    expect(evaluateBeachEditorialIntegrity(oregonBeach)).toEqual({
+      quarantined: false,
+      reasons: [],
+    });
+    expect(sanitizeBeachEditorialContent(oregonBeach)).toBe(oregonBeach);
+  });
+});

--- a/__tests__/lib/seo/forecast-authority-audit.test.ts
+++ b/__tests__/lib/seo/forecast-authority-audit.test.ts
@@ -1,0 +1,107 @@
+import {
+  buildForecastAuthorityAudit,
+  type ForecastAuthorityAuditBeach,
+} from "@/lib/seo/forecast-authority-audit";
+import type { ForecastIndexabilitySnapshot } from "@/lib/seo/forecast-indexability";
+
+function beach(
+  id: string,
+  overrides: Partial<ForecastAuthorityAuditBeach> = {},
+): ForecastAuthorityAuditBeach {
+  return {
+    id,
+    name: `Beach ${id}`,
+    slug: `beach-${id}`,
+    city: "Oceanside",
+    state: "CA",
+    country: "USA",
+    lat: 33.2,
+    lon: -117.3,
+    description: null,
+    wave_tips: null,
+    crowd_tips: null,
+    best_conditions_prose: null,
+    ...overrides,
+  };
+}
+
+function snapshot(
+  overrides: Partial<ForecastIndexabilitySnapshot> = {},
+): ForecastIndexabilitySnapshot {
+  return {
+    forecastAvailable: true,
+    selectedStateComplete: true,
+    forecastFresh: true,
+    forecastValidAt: "2026-08-08T12:00:00.000Z",
+    sourceDataUpdatedAt: "2026-08-08T10:00:00.000Z",
+    primaryDataSource: "noaa",
+    isStale: false,
+    ...overrides,
+  };
+}
+
+describe("buildForecastAuthorityAudit", () => {
+  it("reports whole-inventory eligibility and quality counts", () => {
+    const beaches = [
+      beach("approved"),
+      beach("missing", { slug: "missing-forecast" }),
+      beach("stale"),
+      beach("bad-location", { lat: null }),
+      beach("contaminated", {
+        description: "A Siuslaw River break outside Oregon.",
+      }),
+    ];
+    const snapshots = new Map<string, ForecastIndexabilitySnapshot>([
+      ["approved", snapshot()],
+      ["missing", snapshot({ forecastAvailable: false, selectedStateComplete: false })],
+      ["stale", snapshot({ forecastFresh: false, isStale: true })],
+      ["bad-location", snapshot()],
+      ["contaminated", snapshot()],
+    ]);
+
+    const report = buildForecastAuthorityAudit(beaches, snapshots, {
+      generatedAt: "2026-08-08T12:00:00.000Z",
+      sitemapPaths: ["/ca/oceanside/beach-approved"],
+    });
+
+    expect(report.summary).toMatchObject({
+      totalBeachRecords: 5,
+      totalCanonicalSpotPages: 4,
+      forecastEligible: 2,
+      forecastIneligible: 3,
+      missingForecast: 1,
+      staleForecast: 1,
+      badLocationIdentity: 1,
+      quarantinedEditorial: 1,
+      missingSitemapEntries: 1,
+    });
+    expect(report.reasonCounts["forecast-approved"]).toBe(2);
+    expect(report.failures).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "missing", indexabilityReason: "forecast-missing" }),
+        expect.objectContaining({ id: "stale", indexabilityReason: "forecast-stale" }),
+        expect.objectContaining({ id: "bad-location", indexabilityReason: "invalid-canonical" }),
+      ]),
+    );
+  });
+
+  it("detects duplicate canonical mappings", () => {
+    const duplicateA = beach("duplicate-a");
+    const duplicateB = beach("duplicate-b", { slug: duplicateA.slug });
+    const report = buildForecastAuthorityAudit(
+      [duplicateA, duplicateB],
+      new Map([
+        [duplicateA.id, snapshot()],
+        [duplicateB.id, snapshot()],
+      ]),
+    );
+
+    expect(report.summary.canonicalConflicts).toBe(2);
+    expect(report.canonicalConflicts).toEqual([
+      expect.objectContaining({
+        canonicalPath: "/ca/oceanside/beach-duplicate-a",
+        beachIds: ["duplicate-a", "duplicate-b"],
+      }),
+    ]);
+  });
+});

--- a/__tests__/lib/seo/forecast-authority-benchmark.test.ts
+++ b/__tests__/lib/seo/forecast-authority-benchmark.test.ts
@@ -1,7 +1,10 @@
 import {
   buildForecastBenchmarkQueries,
   classifyForecastBenchmarkRegion,
+  createUnmeasuredForecastRetrievalBenchmark,
   extractForecastAnswerContractFacts,
+  summarizeForecastCompetitiveBenchmark,
+  summarizeForecastRetrievalEvidence,
   type ForecastBenchmarkSpot,
 } from "@/lib/seo/forecast-authority-benchmark";
 
@@ -16,12 +19,14 @@ const spot = (overrides: Partial<ForecastBenchmarkSpot> = {}): ForecastBenchmark
 });
 
 describe("forecast authority benchmark", () => {
-  it("samples California, Hawaii, East Coast, Gulf, and international inventory", () => {
+  it("samples every domestic coast and international inventory", () => {
     const spots = [
       spot(),
       spot({ id: "hi", state: "HI", country: "USA" }),
       spot({ id: "east", state: "NC", country: "USA" }),
       spot({ id: "gulf", state: "TX", country: "USA" }),
+      spot({ id: "west", state: "OR", country: "USA" }),
+      spot({ id: "florida", state: "FL", country: "USA" }),
       spot({ id: "intl", state: "Jalisco", country: "Mexico" }),
     ];
 
@@ -30,9 +35,11 @@ describe("forecast authority benchmark", () => {
       "Hawaii",
       "East Coast",
       "Gulf Coast",
+      "West Coast",
+      "East Coast",
       "International",
     ]);
-    expect(buildForecastBenchmarkQueries(spots, 1)).toHaveLength(50);
+    expect(buildForecastBenchmarkQueries(spots, 1)).toHaveLength(60);
   });
 
   it("extracts the server-rendered answer contract from raw HTML", () => {
@@ -59,6 +66,151 @@ describe("forecast authority benchmark", () => {
       freshness: true,
       provenance: true,
       score: 1,
+    });
+  });
+
+  it("calculates Answer Share, citations, and canonical selection from query evidence", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query, index) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath === null
+        ? null
+        : index === 1
+          ? "https://www.surfline.com/surf-report/oceanside-harbor"
+          : index === 2
+            ? null
+            : "https://www.quiversurf.app/ca/oceanside/oceanside-harbor",
+      answerUrl: index === 1
+        ? "https://www.surfline.com/surf-report/oceanside-harbor"
+        : query.canonicalPath === null
+          ? null
+          : "https://www.quiversurf.app/ca/oceanside/oceanside-harbor",
+      citedUrl: index < 5
+        ? "https://www.quiversurf.app/ca/oceanside/oceanside-harbor"
+        : null,
+      answerComplete: index < 8,
+      current: index < 7,
+    }));
+
+    const benchmark = summarizeForecastRetrievalEvidence(
+      queries,
+      evidence,
+      "fixture-search",
+      "https://www.quiversurf.app",
+    );
+    const competitive = summarizeForecastCompetitiveBenchmark(queries, evidence, benchmark);
+
+    expect(benchmark).toMatchObject({
+      status: "measured",
+      provider: "fixture-search",
+      expectedQueries: 10,
+      measuredQueries: 10,
+      retrievedShare: 0.6,
+      answerShare: 0.7,
+      currentAnswerShare: 0.6,
+      citationShare: 0.5,
+      canonicalSelectionShare: 0.75,
+      missingQueryIds: [],
+      unexpectedQueryIds: [],
+      duplicateQueryIds: [],
+      reason: null,
+    });
+    expect(competitive).toMatchObject({
+      status: "measured",
+      competitors: [
+        {
+          name: "Surfline",
+          selectedShare: 0.1,
+          answerShare: 0.1,
+          citationShare: 0,
+        },
+        {
+          name: "Surf Captain",
+          selectedShare: 0,
+          answerShare: 0,
+          citationShare: 0,
+        },
+      ],
+    });
+  });
+
+  it("does not credit a competitor that uses the canonical Quiver path", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath === null
+        ? null
+        : `https://competitor.example${query.canonicalPath}`,
+      answerUrl: "https://competitor.example/answer",
+      citedUrl: "https://competitor.example/citation",
+      answerComplete: true,
+      current: true,
+    }));
+
+    const benchmark = summarizeForecastRetrievalEvidence(queries, evidence, "fixture-search");
+
+    expect(benchmark).toMatchObject({
+      retrievedShare: 0,
+      answerShare: 0,
+      currentAnswerShare: 0,
+      citationShare: 0,
+      canonicalSelectionShare: 0,
+    });
+  });
+
+  it("does not credit relative or malformed retrieval values as Quiver URLs", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const evidence = queries.map((query) => ({
+      queryId: query.queryId,
+      selectedUrl: query.canonicalPath,
+      answerUrl: "not a URL",
+      citedUrl: "/ca/oceanside/oceanside-harbor",
+      answerComplete: true,
+      current: true,
+    }));
+
+    expect(summarizeForecastRetrievalEvidence(queries, evidence, "fixture-search")).toMatchObject({
+      retrievedShare: 0,
+      answerShare: 0,
+      currentAnswerShare: 0,
+      citationShare: 0,
+      canonicalSelectionShare: 0,
+    });
+  });
+
+  it("rejects incomplete retrieval evidence instead of reporting partial coverage as measured", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const benchmark = summarizeForecastRetrievalEvidence(
+      queries,
+      queries.slice(0, -1).map((query) => ({
+        queryId: query.queryId,
+        selectedUrl: null,
+        answerUrl: null,
+        citedUrl: null,
+        answerComplete: false,
+        current: false,
+      })),
+      "fixture-search",
+    );
+
+    expect(benchmark.status).toBe("invalid");
+    expect(benchmark.missingQueryIds).toEqual([queries.at(-1)?.queryId]);
+    expect(benchmark.answerShare).toBeNull();
+  });
+
+  it("marks raw-HTML-only runs as unmeasured retrieval benchmarks", () => {
+    const queries = buildForecastBenchmarkQueries([spot()], 1);
+    const benchmark = createUnmeasuredForecastRetrievalBenchmark(
+      queries,
+      "provider not configured",
+    );
+
+    expect(benchmark).toMatchObject({
+      status: "not-run",
+      expectedQueries: 10,
+      measuredQueries: 0,
+      answerShare: null,
+      reason: "provider not configured",
     });
   });
 });

--- a/__tests__/lib/seo/forecast-authority-benchmark.test.ts
+++ b/__tests__/lib/seo/forecast-authority-benchmark.test.ts
@@ -1,0 +1,64 @@
+import {
+  buildForecastBenchmarkQueries,
+  classifyForecastBenchmarkRegion,
+  extractForecastAnswerContractFacts,
+  type ForecastBenchmarkSpot,
+} from "@/lib/seo/forecast-authority-benchmark";
+
+const spot = (overrides: Partial<ForecastBenchmarkSpot> = {}): ForecastBenchmarkSpot => ({
+  id: "spot-1",
+  name: "Oceanside Harbor",
+  city: "Oceanside",
+  state: "CA",
+  country: "USA",
+  canonicalPath: "/ca/oceanside/oceanside-harbor",
+  ...overrides,
+});
+
+describe("forecast authority benchmark", () => {
+  it("samples California, Hawaii, East Coast, Gulf, and international inventory", () => {
+    const spots = [
+      spot(),
+      spot({ id: "hi", state: "HI", country: "USA" }),
+      spot({ id: "east", state: "NC", country: "USA" }),
+      spot({ id: "gulf", state: "TX", country: "USA" }),
+      spot({ id: "intl", state: "Jalisco", country: "Mexico" }),
+    ];
+
+    expect(spots.map(classifyForecastBenchmarkRegion)).toEqual([
+      "California",
+      "Hawaii",
+      "East Coast",
+      "Gulf Coast",
+      "International",
+    ]);
+    expect(buildForecastBenchmarkQueries(spots, 1)).toHaveLength(50);
+  });
+
+  it("extracts the server-rendered answer contract from raw HTML", () => {
+    const facts = extractForecastAnswerContractFacts(`
+      <section data-testid="public-forecast-answer">
+        <h2>Today's surf forecast</h2>
+        <dt>Surf</dt><span>3-4 ft</span>
+        <p>Best window: 6:00–9:00 AM</p>
+        <p>Why: morning winds stay light.</p>
+        <p>Forecast valid at 2026-08-08T12:00Z</p>
+        <p>Source data updated 2026-08-08T10:00Z</p>
+        <p>Quiver computed 2026-08-08T10:05Z</p>
+        <p>Contributing sources: NOAA</p>
+        <p>Score 8/10 · Confidence high</p>
+      </section>
+    `);
+
+    expect(facts).toEqual({
+      answerLayer: true,
+      forecastDate: true,
+      surfFacts: true,
+      bestWindow: true,
+      reasoning: true,
+      freshness: true,
+      provenance: true,
+      score: 1,
+    });
+  });
+});

--- a/__tests__/lib/seo/forecast-indexability.test.ts
+++ b/__tests__/lib/seo/forecast-indexability.test.ts
@@ -1,0 +1,157 @@
+import {
+  buildForecastIndexabilitySnapshot,
+  type ForecastCoverageRow,
+} from "@/lib/seo/forecast-indexability";
+import { evaluateBeachForecastIndexability } from "@/lib/seo/indexability";
+
+function row(overrides: Partial<ForecastCoverageRow> = {}): ForecastCoverageRow {
+  return {
+    beach_id: "beach-1",
+    forecast_at: "2026-08-08T19:00:00.000Z",
+    wave_height: "3 ft",
+    updated_at: "2026-08-08T16:00:00.000Z",
+    data_source: "NOAA_NWS",
+    ...overrides,
+  };
+}
+
+describe("forecast indexability contract", () => {
+  it("approves a complete fresh forecast independently of editorial approval", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [row()],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      forecastAvailable: true,
+      selectedStateComplete: true,
+      forecastFresh: true,
+      primaryDataSource: "NOAA_NWS",
+    });
+    expect(
+      evaluateBeachForecastIndexability({
+        canonicalValid: true,
+        forecastAvailable: snapshot.forecastAvailable,
+        selectedStateComplete: snapshot.selectedStateComplete,
+        forecastFresh: snapshot.forecastFresh,
+      }),
+    ).toEqual({ indexable: true, reason: "forecast-approved" });
+  });
+
+  it("withholds missing, incomplete, and stale states with explicit reasons", () => {
+    expect(
+      evaluateBeachForecastIndexability({
+        canonicalValid: true,
+        forecastAvailable: false,
+        selectedStateComplete: false,
+        forecastFresh: false,
+      }),
+    ).toEqual({ indexable: false, reason: "forecast-missing" });
+
+    expect(
+      evaluateBeachForecastIndexability({
+        canonicalValid: true,
+        forecastAvailable: true,
+        selectedStateComplete: false,
+        forecastFresh: false,
+      }),
+    ).toEqual({ indexable: false, reason: "forecast-incomplete" });
+
+    expect(
+      evaluateBeachForecastIndexability({
+        canonicalValid: true,
+        forecastAvailable: true,
+        selectedStateComplete: true,
+        forecastFresh: false,
+      }),
+    ).toEqual({ indexable: false, reason: "forecast-stale" });
+  });
+
+  it("marks a complete but stale row as stale using its source threshold", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [row({ updated_at: "2026-08-07T00:00:00.000Z", data_source: "CDIP" })],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      forecastAvailable: true,
+      selectedStateComplete: true,
+      forecastFresh: false,
+      isStale: true,
+    });
+  });
+
+  it("evaluates the today row before an extended-horizon row", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [
+        row({ forecast_at: "2026-08-08T19:00:00.000Z" }),
+        row({
+          forecast_at: "2026-08-11T18:00:00.000Z",
+          updated_at: "2026-08-07T00:00:00.000Z",
+          data_source: "OPEN_METEO",
+        }),
+      ],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      forecastFresh: true,
+      forecastValidAt: "2026-08-08T19:00:00.000Z",
+      primaryDataSource: "NOAA_NWS",
+    });
+  });
+
+  it("skips an expired today row and selects the next current or tomorrow row", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [
+        row({ forecast_at: "2026-08-08T06:00:00.000Z" }),
+        row({ forecast_at: "2026-08-09T15:00:00.000Z" }),
+      ],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      selectedStateComplete: true,
+      forecastValidAt: "2026-08-09T15:00:00.000Z",
+    });
+  });
+
+  it("falls back to tomorrow when today has no complete row", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [
+        row({
+          forecast_at: "2026-08-09T18:00:00.000Z",
+          data_source: "OPEN_METEO",
+          updated_at: "2026-08-08T12:00:00.000Z",
+        }),
+        row({
+          forecast_at: "2026-08-11T18:00:00.000Z",
+          data_source: "OPEN_METEO",
+          updated_at: "2026-08-08T12:00:00.000Z",
+        }),
+      ],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      selectedStateComplete: true,
+      forecastFresh: true,
+      forecastValidAt: "2026-08-09T18:00:00.000Z",
+      primaryDataSource: "OPEN_METEO",
+    });
+  });
+
+  it("does not treat a complete row outside the near-term window as selected", () => {
+    const snapshot = buildForecastIndexabilitySnapshot(
+      [row({ forecast_at: "2026-08-11T18:00:00.000Z" })],
+      new Date("2026-08-08T18:30:00.000Z"),
+    );
+
+    expect(snapshot).toMatchObject({
+      forecastAvailable: true,
+      selectedStateComplete: false,
+      forecastFresh: false,
+      forecastValidAt: null,
+    });
+  });
+});

--- a/__tests__/lib/seo/indexnow-url-collectors.test.ts
+++ b/__tests__/lib/seo/indexnow-url-collectors.test.ts
@@ -8,6 +8,25 @@ jest.mock("@/lib/supabase/server", () => ({
   })),
 }));
 
+jest.mock("@/lib/seo/forecast-indexability", () => ({
+  getForecastIndexabilityForBeaches: jest.fn(async (beaches: Array<{ id: string }>) =>
+    new Map(
+      beaches.map((beach) => [
+        beach.id,
+        {
+          forecastAvailable: true,
+          selectedStateComplete: true,
+          forecastFresh: true,
+          forecastValidAt: "2026-08-08T18:00:00.000Z",
+          sourceDataUpdatedAt: "2026-08-08T16:00:00.000Z",
+          primaryDataSource: "NOAA_NWS",
+          isStale: false,
+        },
+      ]),
+    ),
+  ),
+}));
+
 import { SITE_URL } from "@/lib/constants/seo";
 import {
   collectIndexNowUrlGroups,
@@ -15,6 +34,7 @@ import {
   flattenIndexNowUrlGroups,
   type IndexNowUrlGroups,
 } from "@/lib/seo/indexnow-url-collectors";
+import { getForecastIndexabilityForBeaches } from "@/lib/seo/forecast-indexability";
 import { getIndexableSeoFunnelRoutes } from "@/lib/seo/funnel-pages";
 
 type MockQueryChain = {
@@ -138,12 +158,14 @@ describe("IndexNow URL collectors", () => {
     beachDetailChain.range.mockResolvedValue({
       data: [
         {
+          id: "beach-blacks",
           slug: "blacks",
           city: "San Diego",
           state: "CA",
           country: "USA",
         },
         {
+          id: "beach-alfonsos",
           slug: "alfonsos",
           city: "Rosarito",
           state: "Baja California",
@@ -201,5 +223,54 @@ describe("IndexNow URL collectors", () => {
     );
     expect(urls).toContain(`${SITE_URL}/features`);
     expect(urls).toEqual([...new Set(urls)]);
+  });
+
+  it("does not submit stale beach URLs to IndexNow", async () => {
+    mockRpc.mockResolvedValue({ data: [], error: null });
+
+    const beachDetailChain = createQueryChain();
+    beachDetailChain.range.mockResolvedValue({
+      data: [{
+        id: "beach-stale",
+        slug: "stale-break",
+        city: "San Diego",
+        state: "CA",
+        country: "USA",
+      }],
+      error: null,
+    });
+
+    const bestTimeChain = createQueryChain();
+    bestTimeChain.then.mockImplementation((resolve) =>
+      resolve({ data: [], error: null }),
+    );
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table !== "beaches") return createQueryChain();
+      const beachesCallIndex = mockFrom.mock.calls.filter(
+        ([calledTable]) => calledTable === "beaches",
+      ).length;
+      return beachesCallIndex === 1 ? beachDetailChain : bestTimeChain;
+    });
+
+    (getForecastIndexabilityForBeaches as jest.Mock).mockResolvedValue(
+      new Map([
+        ["beach-stale", {
+          forecastAvailable: true,
+          selectedStateComplete: true,
+          forecastFresh: false,
+          forecastValidAt: "2026-08-08T18:00:00.000Z",
+          sourceDataUpdatedAt: "2026-08-07T00:00:00.000Z",
+          primaryDataSource: "NOAA_NWS",
+          isStale: true,
+        }],
+      ]),
+    );
+
+    const groups = await collectIndexNowUrlGroups();
+
+    expect(groups.beachDetailUrls).not.toContain(
+      `${SITE_URL}/ca/san-diego/stale-break`,
+    );
   });
 });

--- a/__tests__/lib/services/noaa-coops-cache.test.ts
+++ b/__tests__/lib/services/noaa-coops-cache.test.ts
@@ -28,7 +28,8 @@ describe("NOAACOOPSService Tide Cache", () => {
     it("should use geographic fallback for unknown beaches", () => {
       // Unknown beach in San Diego area should use nearest station
       const station = service.getStationForLocation("Unknown Beach", 32.8, -117.25);
-      expect(station).toBeTruthy();
+      expect(typeof station).toBe("string");
+      expect(station.length).toBeGreaterThan(0);
     });
   });
 
@@ -85,6 +86,23 @@ describe("NOAACOOPSService Tide Cache", () => {
       // Should have made new fetch calls after cache clear
       expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(callsAfterFirst);
     });
+
+    it("should not cache an unavailable tide response", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Unavailable",
+        text: () => Promise.resolve("down"),
+      });
+
+      const firstResult = await service.fetchCOOPSData("9410230", 10);
+      const callsAfterFirst = (global.fetch as jest.Mock).mock.calls.length;
+      const secondResult = await service.fetchCOOPSData("9410230", 10);
+
+      expect(firstResult).toBeNull();
+      expect(secondResult).toBeNull();
+      expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    });
   });
 
   describe("fetchCurrentWaterLevel with range parameter", () => {
@@ -104,18 +122,14 @@ describe("NOAACOOPSService Tide Cache", () => {
       const waterLevelCall = calls.find((call: any[]) => 
         call[0]?.includes("water_level")
       );
-      
-      if (waterLevelCall) {
-        // Should use range parameter, not begin_date with time
-        expect(waterLevelCall[0]).toContain("range=1");
-        expect(waterLevelCall[0]).not.toMatch(/begin_date=\d{8}\s/);
-      }
+
+      expect(waterLevelCall?.[0]).toEqual(expect.stringContaining("range=1"));
+      expect(waterLevelCall?.[0]).not.toEqual(
+        expect.stringMatching(/begin_date=\d{8}\s/)
+      );
     });
   });
 });
-
-
-
 
 
 

--- a/__tests__/lib/services/noaa-coops/api-client.test.ts
+++ b/__tests__/lib/services/noaa-coops/api-client.test.ts
@@ -1,4 +1,7 @@
-import { fetchWaterTemperature } from "@/lib/services/noaa-coops/api-client";
+import {
+  fetchAllStationData,
+  fetchWaterTemperature,
+} from "@/lib/services/noaa-coops/api-client";
 
 // Mock global fetch
 const mockFetch = jest.fn();
@@ -96,5 +99,23 @@ describe("fetchWaterTemperature", () => {
     expect(calledUrl).toContain("units=metric");
     expect(calledUrl).toContain("time_zone=gmt");
     expect(calledUrl).toContain("range=24");
+  });
+});
+
+describe("fetchAllStationData", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns no tide data instead of fabricating synthetic predictions when NOAA fails", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: "Unavailable", text: async () => "down" })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ stations: [{ name: "Test Station" }] }) });
+
+    const result = await fetchAllStationData("9410230", 2);
+
+    expect(result.tideData).toEqual([]);
+    expect(result.stationInfo).toEqual({ name: "Test Station" });
   });
 });

--- a/__tests__/migrations/near-term-forecast-latest-view.test.ts
+++ b/__tests__/migrations/near-term-forecast-latest-view.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    "supabase",
+    "migrations",
+    "20260809050000_fix_near_term_forecast_latest_view.sql",
+  ),
+  "utf8",
+);
+
+describe("near-term enhanced forecast latest view migration", () => {
+  it("uses the answer horizon and requires complete forecast rows", () => {
+    expect(migration).toContain("ef.forecast_at >= now() - interval '24 hours'");
+    expect(migration).toContain("ef.forecast_at < now() + interval '72 hours'");
+    expect(migration).toContain("nullif(btrim(ef.wave_height), '') is not null");
+    expect(migration).toContain("nullif(btrim(ef.data_source), '') is not null");
+  });
+
+  it("prioritizes local today before tomorrow and creates the supporting index", () => {
+    expect(migration).toContain("coalesce(nullif(b.timezone, ''), 'America/Los_Angeles')");
+    expect(migration).toContain("then 0");
+    expect(migration).toContain("then 1");
+    expect(migration).toContain(
+      "idx_enhanced_forecasts_beach_forecast_at_updated_at",
+    );
+  });
+
+  it("has a follow-up migration that skips expired today slots", () => {
+    const followUpMigration = readFileSync(
+      join(
+        process.cwd(),
+        "supabase",
+        "migrations",
+        "20260809130000_skip_expired_today_forecast_latest.sql",
+      ),
+      "utf8",
+    );
+
+    expect(followUpMigration).toContain("ef.forecast_at >= now()");
+    expect(followUpMigration).toContain("ef.forecast_at < now() + interval '72 hours'");
+    expect(followUpMigration).not.toContain(
+      "ef.forecast_at >= now() - interval '24 hours'",
+    );
+  });
+});

--- a/__tests__/migrations/tourmaline-beach-coordinates.test.ts
+++ b/__tests__/migrations/tourmaline-beach-coordinates.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("Tourmaline beach coordinate correction migration", () => {
+  const migrationSQL = readFileSync(
+    join(
+      __dirname,
+      "../../supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql",
+    ),
+    "utf8",
+  );
+  const normalizedSQL = migrationSQL.replace(/\s+/g, " ").toLowerCase();
+
+  it("wraps the correction in a transaction", () => {
+    expect(migrationSQL).toMatch(/^\s*BEGIN;\s*$/m);
+    expect(migrationSQL).toMatch(/^\s*COMMIT;\s*$/m);
+  });
+
+  it("moves only the canonical Tourmaline row to the shoreline", () => {
+    expect(normalizedSQL).toContain("lat = 32.805149");
+    expect(normalizedSQL).toContain("lon = -117.262364");
+    expect(normalizedSQL).toContain(
+      "where id = '17628f35-9ed1-4257-aad6-070c4bd73bb8'::uuid",
+    );
+    expect(normalizedSQL).toContain("and slug = 'tourmaline'");
+    expect(normalizedSQL).toContain("and deleted_at is null");
+    expect(normalizedSQL).not.toContain("delete from");
+  });
+});

--- a/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
@@ -1,8 +1,10 @@
 import { BeachPageStructuredData } from "@/components/seo/structured-data";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
+import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
+import { WebPageSchema } from "@/components/seo/web-page-schema";
 import type { Metadata } from "next";
-import { buildPageMetadata, formatMetaDate } from "@/lib/seo/meta";
+import { buildDynamicBeachMetadata, buildPageMetadata } from "@/lib/seo/meta";
 import {
   buildBeachUrl,
   buildInternationalBeachUrl,
@@ -16,6 +18,10 @@ import { notFound } from "next/navigation";
 import type { Beach } from "@/types/database";
 import { getTimezoneFromCoords } from "@/lib/utils/timezone-utils.server";
 import { isFreeGrowthPhaseEnabled } from "@/lib/flags/free-growth-phase";
+import { getSpotSurfReportPublic } from "@/actions/spot/spot-surf-report-actions";
+import { evaluateBeachForecastIndexability, applyIndexabilityToMetadata } from "@/lib/seo/indexability";
+import { isDataStale } from "@/lib/utils/forecast-client-utils";
+import { sanitizeBeachEditorialContent } from "@/lib/seo/editorial-integrity";
 
 // The route only reads public beach data; cache on demand instead of rendering
 // every crawler request from scratch.
@@ -173,11 +179,16 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
         beach.city,
         beach.slug
       ) || buildBeachUrl(beach);
+    const surfReportResult = await getSpotSurfReportPublic(beach);
+    const publicBeach = sanitizeBeachEditorialContent(beach);
+    const surfCallReport = surfReportResult?.report ?? null;
+    const surfCallIsTomorrow = surfReportResult?.isTomorrow ?? false;
+    const forecastContext = surfReportResult?.forecastContext ?? null;
 
     return (
       <>
         <BeachPageStructuredData
-          beachName={beach.name}
+          beachName={publicBeach.name}
           description={`Surf conditions, tides, wind, swell and community intel for ${beach.name}.`}
           latitude={beach.lat || 0}
           longitude={beach.lon || 0}
@@ -200,10 +211,25 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
           ]}
         />
 
+        <WebPageSchema
+          name={`${beach.name} Surf Report & Forecast`}
+          url={`${baseUrl}${beachUrl}`}
+          dateModified={forecastContext?.sourceDataUpdatedAt ?? undefined}
+        />
+
+        <PublicForecastAnswer
+          beach={publicBeach}
+          report={surfCallReport}
+          context={forecastContext}
+          isTomorrow={surfCallIsTomorrow}
+        />
+
         <BeachDetailClient
-          beach={beach}
+          beach={publicBeach}
           slug={intlBeachSlug}
           beachTimezone={beachTimezone}
+          surfCallReport={surfCallReport}
+          surfCallIsTomorrow={surfCallIsTomorrow}
           freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
         />
       </>
@@ -256,10 +282,35 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
         beach.city,
         beach.slug
       );
+      const surfReportResult = await getSpotSurfReportPublic(beach);
+      const forecastContext = surfReportResult?.forecastContext ?? null;
+      const { title, description } = buildDynamicBeachMetadata({
+        beach: {
+          name: beach.name,
+          city: beach.city,
+          state: beach.state,
+          break_type: beach.break_type,
+          skill_level: beach.skill_level,
+          description_excerpt: beach.description
+            ? `${beach.description.split(/\.(\s|$)/)[0]}.`
+            : null,
+          wave_tips: beach.wave_tips,
+          crowd_level: beach.crowd_level,
+          average_rating: beach.average_rating,
+          review_count: beach.review_count,
+        },
+        forecast: forecastContext
+          ? {
+              wave_height:
+                forecastContext.waveHeightRangeLabel ?? forecastContext.waveHeight,
+              dayLabel: surfReportResult?.isTomorrow ? "tomorrow" : "today",
+            }
+          : null,
+      });
 
-      return buildPageMetadata({
-        title: `${beach.name} Surf Report & Forecast${locationContext}`,
-        description: `${beach.name} surf report for ${formatMetaDate()}. Tides, wind, swell, cams, and community intel${locationContext}.`,
+      const metadata = buildPageMetadata({
+        title: `${title}${locationContext}`,
+        description,
         path: path || `/beach/${intlBeachSlug}`,
         keywords: [
           beach.name,
@@ -276,6 +327,28 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
           "wind",
         ].filter(Boolean),
       });
+
+      return applyIndexabilityToMetadata(
+        metadata,
+        evaluateBeachForecastIndexability({
+          canonicalValid: Boolean(path && path !== "/" && !path.startsWith("/beach/")),
+          forecastAvailable: Boolean(surfReportResult),
+          selectedStateComplete: Boolean(
+            forecastContext?.selectedRowTime &&
+              forecastContext.waveHeight &&
+              forecastContext.sourceDataUpdatedAt &&
+              forecastContext.primaryDataSource,
+          ),
+          forecastFresh: Boolean(
+            forecastContext?.sourceDataUpdatedAt &&
+              forecastContext.primaryDataSource &&
+              !isDataStale(
+                forecastContext.sourceDataUpdatedAt,
+                forecastContext.primaryDataSource,
+              ),
+          ),
+        }),
+      );
     }
   } catch (error) {
     console.error("[InternationalBeachDetailPage] Error generating metadata:", {

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -2,6 +2,7 @@ import { cache, Suspense } from "react";
 import { BeachPageStructuredData } from "@/components/seo/structured-data";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
+import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
 import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spots";
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
@@ -11,7 +12,6 @@ import { isFreeGrowthPhaseEnabled } from "@/lib/flags/free-growth-phase";
 
 import type { Metadata } from "next";
 import { buildPageMetadata, buildDynamicBeachMetadata } from "@/lib/seo/meta";
-import { getBeachForecastPreview } from "@/actions/forecast-actions";
 import {
   buildBeachUrl,
   buildHiCityUrlForBeach,
@@ -40,10 +40,10 @@ import { LiveCamSchema } from "@/components/seo/live-cam-schema";
 import { getBeachCameraUrl } from "@/actions/beach/cam-actions";
 import {
   applyIndexabilityToMetadata,
-  evaluateBeachIndexability,
-  toBeachEditorialInput,
-  type BeachEditorialDatabaseRecord,
+  evaluateBeachForecastIndexability,
 } from "@/lib/seo/indexability";
+import { isDataStale } from "@/lib/utils/forecast-client-utils";
+import { sanitizeBeachEditorialContent } from "@/lib/seo/editorial-integrity";
 
 // Public beach data is cookie-free. Major-event hold transitions explicitly
 // revalidate affected paths, so hourly ISR remains safe between transitions.
@@ -173,6 +173,9 @@ export default async function GenericBeachDetailPage(props: PageProps) {
 
     const surfCallReport = surfReportResult?.report || null;
     const surfCallIsTomorrow = surfReportResult?.isTomorrow ?? false;
+    const forecastContext = surfReportResult?.forecastContext ?? null;
+    const publicBeach = sanitizeBeachEditorialContent(beach);
+    const reviews = reviewsResult.success ? (reviewsResult.data ?? []) : [];
 
     // Validate that the beach's state matches the URL state parameter
     const expectedStateSlug = stateToSlug(beach.state);
@@ -247,12 +250,20 @@ export default async function GenericBeachDetailPage(props: PageProps) {
         />
 
         {/* FAQ structured data for rich snippets */}
-        <FAQSchema items={generateBeachFAQ(beach)} />
+        <FAQSchema items={generateBeachFAQ(publicBeach)} />
 
         {/* WebPage structured data with dateModified for freshness signal */}
         <WebPageSchema
           name={`${beach.name} Surf Report & Forecast`}
           url={`${baseUrl}${buildBeachUrl(beach)}`}
+          dateModified={forecastContext?.sourceDataUpdatedAt ?? undefined}
+        />
+
+        <PublicForecastAnswer
+          beach={publicBeach}
+          report={surfCallReport}
+          context={forecastContext}
+          isTomorrow={surfCallIsTomorrow}
         />
 
         {/* VideoObject + BroadcastEvent for live cam — earns LIVE badge in SERPs */}
@@ -266,7 +277,7 @@ export default async function GenericBeachDetailPage(props: PageProps) {
 
         {/* Client detail component with auth tracking */}
         <BeachDetailClient
-          beach={beach}
+          beach={publicBeach}
           slug={beachSlug}
           beachTimezone={beachTimezone}
           surfCallReport={surfCallReport}
@@ -395,16 +406,17 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       path = `/beach/${beachSlug}`;
     }
 
-    // Fetch forecast data for dynamic SEO (lightweight preview endpoint)
-    let forecastData: { wave_height?: string | null } | null = null;
-    try {
-      const forecastResult = await getBeachForecastPreview(beach.id);
-      if (forecastResult.success && forecastResult.data) {
-        forecastData = { wave_height: forecastResult.data.wave_height };
-      }
-    } catch {
-      // Gracefully degrade to static metadata on forecast fetch failure
-    }
+    // Metadata and robots use the same selected state as the server-rendered
+    // answer layer, so a stale or incomplete forecast cannot earn indexability.
+    const surfReportResult = await getSpotSurfReportPublic(beach);
+    const forecastContext = surfReportResult?.forecastContext ?? null;
+    const forecastData = forecastContext
+      ? {
+          wave_height:
+            forecastContext.waveHeightRangeLabel ?? forecastContext.waveHeight,
+          dayLabel: surfReportResult?.isTomorrow ? "tomorrow" as const : "today" as const,
+        }
+      : null;
 
     // Extract first sentence of beach description for meta tags
     const descriptionExcerpt = beach.description
@@ -448,10 +460,24 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       ].filter(Boolean),
     });
 
-    const decision = evaluateBeachIndexability(
-      toBeachEditorialInput(beach as BeachEditorialDatabaseRecord),
-      path,
-    );
+    const decision = evaluateBeachForecastIndexability({
+      canonicalValid: path === buildBeachUrl(beach) && !path.startsWith("/beach/"),
+      forecastAvailable: Boolean(surfReportResult),
+      selectedStateComplete: Boolean(
+        forecastContext?.selectedRowTime &&
+          forecastContext.waveHeight &&
+          forecastContext.sourceDataUpdatedAt &&
+          forecastContext.primaryDataSource,
+      ),
+      forecastFresh: Boolean(
+        forecastContext?.sourceDataUpdatedAt &&
+          forecastContext.primaryDataSource &&
+          !isDataStale(
+            forecastContext.sourceDataUpdatedAt,
+            forecastContext.primaryDataSource,
+          ),
+      ),
+    });
     return applyIndexabilityToMetadata(metadata, decision);
   } catch (error) {
     console.error("[GenericBeachDetailPage] Error generating metadata:", {

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -175,7 +175,6 @@ export default async function GenericBeachDetailPage(props: PageProps) {
     const surfCallIsTomorrow = surfReportResult?.isTomorrow ?? false;
     const forecastContext = surfReportResult?.forecastContext ?? null;
     const publicBeach = sanitizeBeachEditorialContent(beach);
-    const reviews = reviewsResult.success ? (reviewsResult.data ?? []) : [];
 
     // Validate that the beach's state matches the URL state parameter
     const expectedStateSlug = stateToSlug(beach.state);

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -30,11 +30,16 @@ import {
   cityEditorialKey,
   evaluateBeachIndexability,
   evaluateCityEditorialIndexability,
+  evaluateBeachForecastIndexability,
   toBeachEditorialInput,
   toCityEditorialInput,
   type BeachEditorialDatabaseRecord,
   type CityEditorialDatabaseRecord,
 } from "@/lib/seo/indexability";
+import {
+  getForecastIndexabilityForBeaches,
+  type ForecastIndexabilitySnapshot,
+} from "@/lib/seo/forecast-indexability";
 
 const baseUrl = (
   process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
@@ -157,6 +162,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const beachesResponse = await getBeaches();
   const allBeaches =
     beachesResponse.success && beachesResponse.data ? beachesResponse.data : [];
+  const forecastIndexabilityByBeachId = await getForecastIndexabilityForBeaches(
+    allBeaches.map((beach) => ({ id: beach.id, timezone: beach.timezone })),
+  );
   const reviewedCityEditorial = await getReviewedCityEditorialContent();
   const cityEditorialRoutes = new Map<string, CityEditorialRoute>();
   const selectedCityEditorial = new Map<string, (typeof reviewedCityEditorial)[number]>();
@@ -224,7 +232,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     blogRoutes,
   ] = await Promise.all([
     Promise.resolve(getStaticRoutes()),
-    Promise.resolve(buildBeachRoutes(allBeaches)),
+    Promise.resolve(buildBeachRoutes(allBeaches, forecastIndexabilityByBeachId)),
     getLocationRoutes(validCitySlugs, cityEditorialRoutes),
     getIntentRoutes(cityEditorialRoutes),
     Promise.resolve(getGuideRoutes()),
@@ -315,7 +323,10 @@ function getStaticRoutes(): MetadataRoute.Sitemap {
  * Accepts pre-fetched beach data to avoid duplicate DB calls (the main
  * sitemap function shares this data with location route validation).
  */
-export function buildBeachRoutes(beaches: NonNullable<Awaited<ReturnType<typeof getBeaches>>["data"]>): MetadataRoute.Sitemap {
+export function buildBeachRoutes(
+  beaches: NonNullable<Awaited<ReturnType<typeof getBeaches>>["data"]>,
+  forecastIndexabilityByBeachId: ReadonlyMap<string, ForecastIndexabilitySnapshot>,
+): MetadataRoute.Sitemap {
   const subPageTypes = ["tides", "water-temp"] as const;
 
   return beaches
@@ -344,12 +355,14 @@ export function buildBeachRoutes(beaches: NonNullable<Awaited<ReturnType<typeof 
       const stateSlug = stateToSlug(beach.state);
       const isUsa = isUsaCountry(beach.country) && isValidStateSlug(stateSlug);
       const hasDedicatedSubPages = isUsa || countrySlug === "mexico";
+      const forecastSnapshot = forecastIndexabilityByBeachId.get(beach.id);
+      const forecastIndexable = isBeachForecastIndexableForSitemap(
+        forecastSnapshot,
+        beachPath,
+      );
 
       const candidateRoutes = [
-        ...(isBeachIndexableForSitemap(
-          beach as SitemapBeachEditorialFields,
-          beachPath,
-        )
+        ...(forecastIndexable
           ? [{
           url: beachUrl,
           lastModified: lastModifiedDate,
@@ -358,10 +371,7 @@ export function buildBeachRoutes(beaches: NonNullable<Awaited<ReturnType<typeof 
         ...(hasDedicatedSubPages
           ? subPageTypes.flatMap((subPage) => {
               const subPagePath = `${beachPath}/${subPage}`;
-              return isBeachIndexableForSitemap(
-                beach as SitemapBeachEditorialFields,
-                subPagePath,
-              )
+              return forecastIndexable
                 ? [{
                     url: `${baseUrl}${subPagePath}`,
                     lastModified: lastModifiedDate,
@@ -373,6 +383,20 @@ export function buildBeachRoutes(beaches: NonNullable<Awaited<ReturnType<typeof 
 
       return candidateRoutes;
     });
+}
+
+export function isBeachForecastIndexableForSitemap(
+  snapshot: ForecastIndexabilitySnapshot | undefined,
+  canonicalPath: string,
+): boolean {
+  if (!snapshot) return false;
+
+  return evaluateBeachForecastIndexability({
+    canonicalValid: !canonicalPath.startsWith("/beach/"),
+    forecastAvailable: snapshot.forecastAvailable,
+    selectedStateComplete: snapshot.selectedStateComplete,
+    forecastFresh: snapshot.forecastFresh,
+  }).indexable;
 }
 
 /**

--- a/components/beach-detail.tsx
+++ b/components/beach-detail.tsx
@@ -1030,6 +1030,7 @@ function BeachDetailContent({
                 waterQuality={waterQuality}
                 beachPhoto={beachPhoto}
                 surfCallReport={surfCallReport}
+                surfCallIsTomorrow={surfCallIsTomorrow}
                 beachTimezone={beachTimezone}
                 onWriteReview={() =>
                   handleWriteReview(REVIEW_TRACKING_SOURCES.OVERVIEW_CTA)

--- a/components/beach-detail/beach-prose-summary.tsx
+++ b/components/beach-detail/beach-prose-summary.tsx
@@ -1,6 +1,7 @@
 import type { Beach } from "@/types/database";
 import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
 import type { EditorialSource } from "@/lib/seo/indexability";
+import { sanitizeBeachEditorialContent } from "@/lib/seo/editorial-integrity";
 
 /**
  * Server-rendered prose summary for beach detail pages.
@@ -14,14 +15,17 @@ export function BeachProseSummary({
   beach,
   surfCallReport,
   editorialSources = [],
+  forecastSources = [],
 }: {
   beach: Beach;
   surfCallReport: SurfCallResult | null;
   editorialSources?: EditorialSource[];
+  forecastSources?: string[];
 }) {
-  const breakTypeLabel = formatBreakType(beach.break_type);
-  const skillLabel = formatSkillLevel(beach.skill_level);
-  const locationParts = [beach.city, beach.state].filter(Boolean).join(", ");
+  const publicBeach = sanitizeBeachEditorialContent(beach);
+  const breakTypeLabel = formatBreakType(publicBeach.break_type);
+  const skillLabel = formatSkillLevel(publicBeach.skill_level);
+  const locationParts = [publicBeach.city, publicBeach.state].filter(Boolean).join(", ");
 
   // Build prose sentences conditionally based on available data
   const sentences: string[] = [];
@@ -29,14 +33,14 @@ export function BeachProseSummary({
   // Opening: beach identity
   if (locationParts && breakTypeLabel) {
     sentences.push(
-      `${beach.name} in ${locationParts} is a ${breakTypeLabel} break${skillLabel ? `, ${skillLabel}` : ""}.`
+      `${publicBeach.name} in ${locationParts} is a ${breakTypeLabel} break${skillLabel ? `, ${skillLabel}` : ""}.`
     );
   } else if (locationParts) {
     sentences.push(
-      `${beach.name} in ${locationParts} is a surf break${skillLabel ? ` ${skillLabel}` : ""} along the ${beach.state || "US"} coast.`
+      `${publicBeach.name} in ${locationParts} is a surf break${skillLabel ? ` ${skillLabel}` : ""} along the ${publicBeach.state || "US"} coast.`
     );
   } else {
-    sentences.push(`${beach.name} is a surf break${skillLabel ? ` ${skillLabel}` : ""}.`);
+    sentences.push(`${publicBeach.name} is a surf break${skillLabel ? ` ${skillLabel}` : ""}.`);
   }
 
   // Current conditions from surf call
@@ -72,30 +76,29 @@ export function BeachProseSummary({
   }
 
   // Beach description (first sentence only)
-  if (beach.description) {
-    const firstSentence = beach.description.split(/\.(\s|$)/)[0];
+  if (publicBeach.description) {
+    const firstSentence = publicBeach.description.split(/\.(\s|$)/)[0];
     if (firstSentence && firstSentence.length > 20) {
       sentences.push(`${firstSentence}.`);
     }
   }
 
   // Wave tips
-  if (beach.wave_tips) {
-    sentences.push(beach.wave_tips);
+  if (publicBeach.wave_tips) {
+    sentences.push(publicBeach.wave_tips);
   }
 
-  if (beach.crowd_tips) {
-    sentences.push(beach.crowd_tips);
+  if (publicBeach.crowd_tips) {
+    sentences.push(publicBeach.crowd_tips);
   }
 
-  if (beach.best_conditions_prose) {
-    sentences.push(beach.best_conditions_prose);
+  if (publicBeach.best_conditions_prose) {
+    sentences.push(publicBeach.best_conditions_prose);
   }
 
-  // Data source attribution
-  sentences.push(
-    "Forecasts are updated every 3 hours using ML-corrected NOAA models with live buoy data from CDIP, NDBC, and IOOS stations."
-  );
+  if (forecastSources && forecastSources.length > 0) {
+    sentences.push(`Forecast data sources: ${forecastSources.join(", ")}.`);
+  }
 
   return (
     <section
@@ -107,7 +110,7 @@ export function BeachProseSummary({
           Surf report snapshot
         </p>
         <h2 className="mt-2 text-xl font-semibold text-foreground">
-          {beach.name} current conditions and local guidance
+          {publicBeach.name} current conditions and local guidance
         </h2>
         <p className="mt-3 text-sm leading-6 text-muted-foreground">
           {sentences.join(" ")}

--- a/components/beach-detail/public-forecast-answer.tsx
+++ b/components/beach-detail/public-forecast-answer.tsx
@@ -1,0 +1,172 @@
+import type { Beach } from "@/types/database";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import { formatBeachDateTime, formatTimeInTimezone } from "@/lib/utils/date-time";
+import { isDataStale } from "@/lib/utils/forecast-client-utils";
+
+interface PublicForecastAnswerProps {
+  beach: Beach;
+  report: SurfCallResult | null;
+  context: ForecastRecommendationContext | null;
+  isTomorrow: boolean;
+}
+
+function formatForecastDate(
+  localDate: string | null | undefined,
+  timezone: string,
+): string | null {
+  if (!localDate) return null;
+  const date = new Date(`${localDate}T12:00:00Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    timeZone: timezone,
+  }).format(date);
+}
+
+function formatRange(
+  start: string | null | undefined,
+  end: string | null | undefined,
+  timezone: string,
+): string | null {
+  if (!start || !end) return null;
+  const startLabel = formatTimeInTimezone(start, timezone);
+  const endLabel = formatTimeInTimezone(end, timezone);
+  if (!startLabel || !endLabel) return null;
+  return `${startLabel}–${endLabel}`;
+}
+
+function joinParts(parts: Array<string | null | undefined>): string | null {
+  const filtered = parts.filter((part): part is string => Boolean(part?.trim()));
+  return filtered.length > 0 ? filtered.join(" ") : null;
+}
+
+function buildSwell(
+  height: string | null | undefined,
+  period: string | null | undefined,
+  direction: string | null | undefined,
+): string | null {
+  if (!height && !period && !direction) return null;
+  const heightLabel = height ? `${height}` : null;
+  const periodLabel = period ? `@ ${period}` : null;
+  return joinParts([heightLabel, periodLabel, direction]);
+}
+
+function sourceLabel(source: string): string {
+  switch (source) {
+    case "NOAA_CO-OPS":
+      return "NOAA CO-OPS";
+    case "NOAA_NWS":
+      return "NOAA NWS";
+    case "OPEN_METEO":
+      return "Open-Meteo";
+    default:
+      return source.replaceAll("_", " ");
+  }
+}
+
+export function PublicForecastAnswer({
+  beach,
+  report,
+  context,
+  isTomorrow,
+}: PublicForecastAnswerProps) {
+  const timezone =
+    context?.timezone ??
+    (beach as { timezone?: string | null }).timezone ??
+    "UTC";
+  const forecastDate = formatForecastDate(context?.localDate, timezone);
+  const waveHeight = context?.waveHeightRangeLabel ?? context?.waveHeight ?? report?.waveHeight;
+  const bestWindow = formatRange(
+    context?.displayWindowStart ?? report?.bestWindowStart,
+    context?.displayWindowEnd ?? report?.bestWindowEnd,
+    timezone,
+  );
+  const primarySwell = buildSwell(
+    context?.primarySwellHeight,
+    context?.swellPeriod,
+    context?.swellDirection,
+  );
+  const secondarySwell = buildSwell(
+    context?.secondarySwellHeight,
+    context?.secondarySwellPeriod,
+    context?.secondarySwellDirection,
+  );
+  const wind = joinParts([
+    context?.windSpeed ?? report?.windSpeed,
+    context?.windDirection ?? report?.windCompass,
+    report?.windType,
+  ]);
+  const tide = joinParts([
+    report?.tideHeight,
+    report?.tidePhase,
+    report?.nextTideType ? `next ${report.nextTideType.toLowerCase()}` : null,
+  ]);
+  const sourceDataUpdatedAt = context?.sourceDataUpdatedAt ?? null;
+  const primaryDataSource = context?.primaryDataSource ?? null;
+  const isStale = sourceDataUpdatedAt
+    ? isDataStale(sourceDataUpdatedAt, primaryDataSource)
+    : false;
+  if (!context?.selectedRowTime || !context.waveHeight) return null;
+
+  const titleDate = forecastDate ? ` for ${forecastDate}` : "";
+  const validAt = context?.selectedRowTime
+    ? formatBeachDateTime(context.selectedRowTime, timezone, "EEE h:mm a")
+    : null;
+  const sourceUpdatedAt = sourceDataUpdatedAt
+    ? formatBeachDateTime(sourceDataUpdatedAt, timezone, "EEE h:mm a")
+    : null;
+  const computedAt = report?.updatedAt
+    ? formatBeachDateTime(report.updatedAt, timezone, "EEE h:mm a")
+    : null;
+
+  return (
+    <section
+      aria-labelledby="public-forecast-answer-heading"
+      data-testid="public-forecast-answer"
+      className="mx-auto max-w-5xl px-4 pt-6 sm:px-6 lg:px-8"
+    >
+      <div className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {isTomorrow ? "Tomorrow's surf forecast" : "Surf forecast"}
+        </p>
+        <h2 id="public-forecast-answer-heading" className="mt-2 text-xl font-semibold text-foreground">
+          {beach.name} surf forecast{titleDate}
+        </h2>
+
+        <dl className="mt-4 grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+          {waveHeight && <div><dt className="font-medium text-muted-foreground">Surf</dt><dd>{waveHeight}</dd></div>}
+          {bestWindow && <div><dt className="font-medium text-muted-foreground">Best window</dt><dd>{bestWindow}</dd></div>}
+          {report?.verdict && <div><dt className="font-medium text-muted-foreground">Verdict</dt><dd>{report.verdict}</dd></div>}
+          {report?.score != null && <div><dt className="font-medium text-muted-foreground">Score</dt><dd>{report.score}/100</dd></div>}
+          {report?.forecastConfidence != null && <div><dt className="font-medium text-muted-foreground">Confidence</dt><dd>{report.forecastConfidence}/100</dd></div>}
+          {primarySwell && <div><dt className="font-medium text-muted-foreground">Primary swell</dt><dd>{primarySwell}</dd></div>}
+          {secondarySwell && <div><dt className="font-medium text-muted-foreground">Secondary swell</dt><dd>{secondarySwell}</dd></div>}
+          {wind && <div><dt className="font-medium text-muted-foreground">Wind</dt><dd>{wind}</dd></div>}
+          {tide && <div><dt className="font-medium text-muted-foreground">Tide</dt><dd>{tide}</dd></div>}
+        </dl>
+
+        {report?.whySentence && (
+          <p className="mt-5 text-sm leading-6 text-foreground">
+            <strong>Why:</strong> {report.whySentence}
+          </p>
+        )}
+
+        <div className="mt-5 border-t border-border/60 pt-3 text-xs leading-5 text-muted-foreground">
+          <p>
+            Forecast valid at {validAt ?? "the selected forecast time"} ({timezone}).
+            {isStale ? " Source data is stale; conditions may have changed." : ""}
+          </p>
+          {sourceUpdatedAt && <p>Source data updated: {sourceUpdatedAt}.</p>}
+          {computedAt && <p>Quiver computed this answer: {computedAt}.</p>}
+          {context?.contributingSources && context.contributingSources.length > 0 && (
+            <p>Contributing sources: {context.contributingSources.map(sourceLabel).join(", ")}.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/beach-detail/tabs/overview-tab.tsx
+++ b/components/beach-detail/tabs/overview-tab.tsx
@@ -26,6 +26,7 @@ interface OverviewTabProps {
   beachPhoto?: ZineBeachPhoto | null;
   surfCallReport?: SurfCallResult | null;
   beachTimezone?: string | null;
+  surfCallIsTomorrow?: boolean;
   onWriteReview?: () => void;
 }
 
@@ -40,6 +41,7 @@ export function OverviewTab({
   beachPhoto,
   surfCallReport,
   beachTimezone,
+  surfCallIsTomorrow = false,
   onWriteReview,
 }: OverviewTabProps) {
   return (
@@ -50,6 +52,7 @@ export function OverviewTab({
       beachPhoto={beachPhoto}
       surfCallReport={surfCallReport}
       beachTimezone={beachTimezone}
+      surfCallIsTomorrow={surfCallIsTomorrow}
       onWriteReview={onWriteReview}
     />
   );

--- a/components/beach-detail/zine/atoms/index.tsx
+++ b/components/beach-detail/zine/atoms/index.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { getOptimizedImageUrl } from "@/lib/image-proxy";
+import { getStaticMapImageUrl } from "@/lib/map-utils";
 import { buildZineMapScene, type ZineMapCue } from "../map-doodle-scene";
 
 export function RoughEdgeFilter() {
@@ -332,42 +333,78 @@ export function MapDoodle({
   const approachStartX = scene.oceanSide === "left" ? 30 : 370;
   const approachEndX = scene.oceanSide === "left" ? markerX - 18 : markerX + 18;
   const locationFontSize = locationName.length > 18 ? 15 : locationName.length > 14 ? 17 : 20;
+  const mapUrl = lat != null && lon != null
+    ? getStaticMapImageUrl(lat, lon, {
+        width: 800,
+        height: 480,
+        zoom: 15,
+      })
+    : null;
+  const hasRealMap = mapUrl != null && !mapUrl.startsWith("data:image");
+
   return (
-    <div style={{ position: "relative", width: "100%", height, background: "#EBDFC2", overflow: "hidden" }} aria-hidden>
+    <div
+      style={{ position: "relative", width: "100%", height, background: "#EBDFC2", overflow: "hidden" }}
+      role="img"
+      aria-label={`Map showing ${beachName || locationName} at its actual location`}
+    >
+      {hasRealMap && (
+        // eslint-disable-next-line @next/next/no-img-element -- static map providers are already optimized and can fall back independently
+        <img
+          src={mapUrl}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          style={{ filter: "sepia(0.16) saturate(0.72) contrast(1.08)", opacity: 0.88 }}
+        />
+      )}
       <svg viewBox="0 0 400 240" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}>
         <pattern id={scene.patternId} x="0" y="0" width="6" height="6" patternUnits="userSpaceOnUse">
           <circle cx="3" cy="3" r="1.1" fill="#7FA7B8" opacity="0.55" />
         </pattern>
-        <path d={scene.oceanPath} fill="#C9D8DD" />
-        <path d={scene.oceanPath} fill={`url(#${scene.patternId})`} />
-        <path d={scene.landPath} fill="#EBDFC2" />
-        <path d={scene.coastPath} stroke="#11100D" strokeWidth="2" fill="none" filter="url(#zine-rough-edge)" />
-        <g stroke="#11100D" strokeWidth="0.6" opacity="0.55">
-          {scene.gridLines.map((path) => (
-            <path key={path} d={path} />
-          ))}
-        </g>
-        <g transform={scene.cueTransform} data-testid={`zine-map-cue-${scene.cue}`}>
-          <MapCue cue={scene.cue} />
-        </g>
-        <g transform={`translate(${markerX},${markerY})`}>
-          <circle r="14" fill="none" stroke="#11100D" strokeWidth="2" filter="url(#zine-rough-edge)" />
-          <path d="M-7,-7 L7,7 M-7,7 L7,-7" stroke="#11100D" strokeWidth="2.2" strokeLinecap="round" />
-        </g>
-        <g stroke="#0B3A75" strokeWidth="1.6" fill="none" strokeDasharray="3,3">
-          <path d={`M${approachStartX},${markerY - 30} C${approachStartX - 18},${markerY - 25} ${approachEndX},${markerY - 28} ${approachEndX},${markerY - 12}`} />
-          <path d={`M${approachStartX},${markerY + 30} C${approachStartX - 18},${markerY + 25} ${approachEndX},${markerY + 28} ${approachEndX},${markerY + 12}`} />
-        </g>
-        <path d={`M${approachEndX},${markerY - 17} L${markerX},${markerY - 12} L${approachEndX},${markerY - 7}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
-        <path d={`M${approachEndX},${markerY + 7} L${markerX},${markerY + 12} L${approachEndX},${markerY + 17}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+        {hasRealMap ? (
+          <>
+            <rect width="400" height="240" fill={`url(#${scene.patternId})`} opacity="0.18" />
+            <circle cx="200" cy="120" r="16" fill="none" stroke="#11100D" strokeWidth="2.5" filter="url(#zine-rough-edge)" />
+            <path d="M192,112 L208,128 M192,128 L208,112" stroke="#11100D" strokeWidth="2.4" strokeLinecap="round" />
+          </>
+        ) : (
+          <>
+            <path d={scene.oceanPath} fill="#C9D8DD" />
+            <path d={scene.oceanPath} fill={`url(#${scene.patternId})`} />
+            <path d={scene.landPath} fill="#EBDFC2" />
+            <path d={scene.coastPath} stroke="#11100D" strokeWidth="2" fill="none" filter="url(#zine-rough-edge)" />
+            <g stroke="#11100D" strokeWidth="0.6" opacity="0.55">
+              {scene.gridLines.map((path) => (
+                <path key={path} d={path} />
+              ))}
+            </g>
+            <g transform={scene.cueTransform} data-testid={`zine-map-cue-${scene.cue}`}>
+              <MapCue cue={scene.cue} />
+            </g>
+            <g transform={`translate(${markerX},${markerY})`}>
+              <circle r="14" fill="none" stroke="#11100D" strokeWidth="2" filter="url(#zine-rough-edge)" />
+              <path d="M-7,-7 L7,7 M-7,7 L7,-7" stroke="#11100D" strokeWidth="2.2" strokeLinecap="round" />
+            </g>
+            <g stroke="#0B3A75" strokeWidth="1.6" fill="none" strokeDasharray="3,3">
+              <path d={`M${approachStartX},${markerY - 30} C${approachStartX - 18},${markerY - 25} ${approachEndX},${markerY - 28} ${approachEndX},${markerY - 12}`} />
+              <path d={`M${approachStartX},${markerY + 30} C${approachStartX - 18},${markerY + 25} ${approachEndX},${markerY + 28} ${approachEndX},${markerY + 12}`} />
+            </g>
+            <path d={`M${approachEndX},${markerY - 17} L${markerX},${markerY - 12} L${approachEndX},${markerY - 7}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+            <path d={`M${approachEndX},${markerY + 7} L${markerX},${markerY + 12} L${approachEndX},${markerY + 17}`} stroke="#0B3A75" strokeWidth="1.6" fill="none" />
+          </>
+        )}
         <text
-          x={scene.label.x}
-          y={scene.label.y}
+          x={hasRealMap ? 302 : scene.label.x}
+          y={hasRealMap ? 214 : scene.label.y}
           fontFamily="var(--font-handwritten), cursive"
           fontSize={locationFontSize}
           fill="#11100D"
           fontWeight="700"
           textAnchor="middle"
+          paintOrder="stroke"
+          stroke="#F4EBD8"
+          strokeWidth={hasRealMap ? 4 : 0}
+          strokeLinejoin="round"
         >
           {locationName}
         </text>

--- a/components/beach-detail/zine/today-surf-call.tsx
+++ b/components/beach-detail/zine/today-surf-call.tsx
@@ -10,6 +10,7 @@ interface TodaySurfCallProps {
   beach: Beach;
   surfCallReport?: SurfCallResult | null;
   beachTimezone?: string | null;
+  isTomorrow?: boolean;
 }
 
 const ZINE_YES_DARK_TEAL_3_95_CONTRAST_ON_TAN = "#006B5F";
@@ -33,7 +34,12 @@ function selectDisplayTier(userTier: SkillLevel | null | undefined): TierKey {
   return "beginner";
 }
 
-export function TodaySurfCall({ beach, surfCallReport, beachTimezone }: TodaySurfCallProps) {
+export function TodaySurfCall({
+  beach,
+  surfCallReport,
+  beachTimezone,
+  isTomorrow = false,
+}: TodaySurfCallProps) {
   const tiers = surfCallReport?.tiers ?? null;
   const userTier = surfCallReport?.userTier ?? null;
   const displayTier: TierKey | null = tiers ? selectDisplayTier(userTier) : null;
@@ -65,7 +71,10 @@ export function TodaySurfCall({ beach, surfCallReport, beachTimezone }: TodaySur
     : null;
 
   return (
-    <section className="relative mt-8" aria-label="Today's surf call">
+    <section
+      className="relative mt-8"
+      aria-label={isTomorrow ? "Tomorrow's surf call" : "Today's surf call"}
+    >
       <TornDivider />
 
       <div
@@ -90,7 +99,7 @@ export function TodaySurfCall({ beach, surfCallReport, beachTimezone }: TodaySur
               lineHeight: 1,
             }}
           >
-            Today&apos;s Surf Call
+            {isTomorrow ? "Tomorrow's Surf Call" : "Today's Surf Call"}
           </h2>
         </div>
 

--- a/components/beach-detail/zine/zine-overview-body.tsx
+++ b/components/beach-detail/zine/zine-overview-body.tsx
@@ -18,6 +18,7 @@ interface ZineOverviewBodyProps {
   beachPhoto?: ZineBeachPhoto | null;
   surfCallReport?: SurfCallResult | null;
   beachTimezone?: string | null;
+  surfCallIsTomorrow?: boolean;
   onWriteReview?: () => void;
 }
 
@@ -36,6 +37,7 @@ export function ZineOverviewBody({
   beachPhoto,
   surfCallReport,
   beachTimezone,
+  surfCallIsTomorrow = false,
   onWriteReview,
 }: ZineOverviewBodyProps) {
   return (
@@ -44,6 +46,7 @@ export function ZineOverviewBody({
         beach={beach}
         surfCallReport={surfCallReport}
         beachTimezone={beachTimezone}
+        isTomorrow={surfCallIsTomorrow}
       />
       <ZineMainGrid beach={beach} beachPhoto={beachPhoto} />
       <ZineSpotSummary beach={beach} />

--- a/components/beach-detail/zine/zine-tab.tsx
+++ b/components/beach-detail/zine/zine-tab.tsx
@@ -17,6 +17,7 @@ interface ZineTabProps {
   beachPhoto?: ZineBeachPhoto | null;
   surfCallReport?: SurfCallResult | null;
   beachTimezone?: string | null;
+  surfCallIsTomorrow?: boolean;
   onWriteReview?: () => void;
 }
 
@@ -33,6 +34,7 @@ export function ZineTab({
   beachPhoto,
   surfCallReport,
   beachTimezone,
+  surfCallIsTomorrow = false,
   onWriteReview,
 }: ZineTabProps) {
   return (
@@ -61,6 +63,7 @@ export function ZineTab({
             beachPhoto={beachPhoto}
             surfCallReport={surfCallReport}
             beachTimezone={beachTimezone}
+            surfCallIsTomorrow={surfCallIsTomorrow}
             onWriteReview={onWriteReview}
           />
           <ZineFooter city={beach.city} state={beach.state} />

--- a/components/forecast/conditions-overview/outlook-bar-chart.tsx
+++ b/components/forecast/conditions-overview/outlook-bar-chart.tsx
@@ -105,7 +105,12 @@ export function OutlookBarChart({ days }: OutlookBarChartProps) {
           <ReferenceLine y={40} stroke="#0B3A75" strokeDasharray="3 3" />
           <ReferenceLine y={60} stroke="#0B3A75" strokeDasharray="3 3" />
           <ReferenceLine y={80} stroke="#0B3A75" strokeDasharray="3 3" />
-          <Bar dataKey="score" radius={[4, 4, 0, 0]} maxBarSize={40}>
+          <Bar
+            dataKey="score"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+            minPointSize={4}
+          >
             {days.map((day, i) => (
               <Cell
                 key={i}

--- a/components/seo/web-page-schema.tsx
+++ b/components/seo/web-page-schema.tsx
@@ -18,7 +18,7 @@ export function WebPageSchema({
     "@type": "WebPage",
     name,
     url,
-    dateModified: dateModified ?? new Date().toISOString(),
+    ...(dateModified ? { dateModified } : {}),
     ...(description ? { description } : {}),
     ...additionalData,
   };

--- a/components/ui/wave-height-display.tsx
+++ b/components/ui/wave-height-display.tsx
@@ -121,7 +121,7 @@ export function WaveHeightDisplay({
       ? null
       : (
           <span
-            className="text-[11px] leading-tight text-muted-foreground/80"
+            className="text-[11px] font-medium leading-tight text-[#3F382E]"
             data-testid="wave-height-label"
           >
             {isCalibrated ? "Face height" : "Forecast height"}

--- a/docs/FORECAST_HEALTH_RECOVERY.md
+++ b/docs/FORECAST_HEALTH_RECOVERY.md
@@ -34,7 +34,12 @@ The marine cron job (`/api/cron/forecasts/refresh?source=marine`) was not refres
 
 ### Database View Optimization
 
-**Migration**: `supabase/migrations/20260105161500_ensure_fast_v_enhanced_forecast_latest.sql`
+**Original optimization migration**: `supabase/migrations/20260105161500_ensure_fast_v_enhanced_forecast_latest.sql`
+
+The view now also prioritizes the local today/tomorrow forecast window. See
+`supabase/migrations/20260809050000_fix_near_term_forecast_latest_view.sql` and
+the follow-up `supabase/migrations/20260809130000_skip_expired_today_forecast_latest.sql`,
+which excludes already-passed forecast slots.
 
 Replaced `DISTINCT ON` with the `LATERAL + LIMIT 1` pattern:
 
@@ -43,17 +48,32 @@ CREATE OR REPLACE VIEW public.v_enhanced_forecast_latest
 WITH (security_invoker = true) AS
 SELECT
   b.id AS beach_id,
-  ef.updated_at,
-  ef.data_source
+  near_term.updated_at,
+  near_term.data_source
 FROM public.beaches b
 CROSS JOIN LATERAL (
-  SELECT updated_at, data_source
+  SELECT ef.updated_at, ef.data_source
   FROM public.enhanced_forecasts ef
   WHERE ef.beach_id = b.id
+    AND ef.forecast_at >= now()
+    AND ef.forecast_at < now() + interval '72 hours'
     AND ef.updated_at IS NOT NULL
-  ORDER BY ef.updated_at DESC
+    AND NULLIF(BTRIM(ef.wave_height), '') IS NOT NULL
+    AND NULLIF(BTRIM(ef.data_source), '') IS NOT NULL
+  ORDER BY
+    CASE
+      WHEN (ef.forecast_at AT TIME ZONE COALESCE(NULLIF(b.timezone, ''), 'America/Los_Angeles'))::date =
+        (now() AT TIME ZONE COALESCE(NULLIF(b.timezone, ''), 'America/Los_Angeles'))::date THEN 0
+      WHEN (ef.forecast_at AT TIME ZONE COALESCE(NULLIF(b.timezone, ''), 'America/Los_Angeles'))::date =
+        ((now() AT TIME ZONE COALESCE(NULLIF(b.timezone, ''), 'America/Los_Angeles'))::date + 1) THEN 1
+      ELSE 2
+    END,
+    -- Local today first, then tomorrow; future horizon rows cannot mask a
+    -- stale public-answer row.
+    ef.forecast_at ASC,
+    ef.updated_at DESC
   LIMIT 1
-) ef;
+) near_term;
 ```
 
 ### Why LATERAL is Faster

--- a/docs/architecture/DATABASE_SCHEMA.md
+++ b/docs/architecture/DATABASE_SCHEMA.md
@@ -591,16 +591,14 @@ XP transaction log.
 
 ### `v_enhanced_forecast_latest`
 
-Returns latest forecast row per beach for health monitoring.
+Returns the most recently written complete near-term forecast row per beach
+for health monitoring and refresh selection. It prioritizes the beach's local
+today, then tomorrow, so extended-horizon rows cannot mask stale public-answer
+data.
 
 ```sql
-SELECT DISTINCT ON (beach_id)
-  beach_id,
-  updated_at,
-  data_source
-FROM enhanced_forecasts
-WHERE updated_at IS NOT NULL
-ORDER BY beach_id, updated_at DESC;
+SELECT beach_id, updated_at, data_source
+FROM v_enhanced_forecast_latest;
 ```
 
 ---

--- a/e2e/guest-beach-ssr-content.spec.ts
+++ b/e2e/guest-beach-ssr-content.spec.ts
@@ -37,4 +37,14 @@ test.describe("Guest beach server-rendered content", () => {
       page.getByRole("navigation", { name: /related surf guides/i }),
     ).toHaveCount(0);
   });
+
+  test("renders the selected forecast answer in initial HTML @requires-data", async ({ page }) => {
+    const response = await page.request.get(reviewedBeachPath);
+    expect(response.status()).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain('data-testid="public-forecast-answer"');
+    expect(html).toMatch(/surf forecast/i);
+    expect(html).toMatch(/Forecast valid at/i);
+  });
 });

--- a/e2e/guest-forecast-authority.spec.ts
+++ b/e2e/guest-forecast-authority.spec.ts
@@ -1,0 +1,304 @@
+import { expect, test } from "@playwright/test";
+import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+
+interface PublicBeach {
+  id: string;
+  slug: string | null;
+  name: string | null;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+}
+
+interface BeachesResponse {
+  data?: {
+    beaches?: PublicBeach[];
+    count?: number;
+  };
+}
+
+interface ForecastResponse {
+  success?: boolean;
+  data?: {
+    days?: number;
+    forecasts?: Array<{
+      id?: string | null;
+      beach_id?: string | null;
+      forecast_at?: string | null;
+      wave_height?: string | number | null;
+      water_temp?: string | number | null;
+      confidence_score?: number | null;
+      data_source?: string | null;
+      created_at?: string | null;
+      updated_at?: string | null;
+    }>;
+    metadata?: {
+      missing?: boolean;
+      stale?: boolean;
+      lastUpdated?: string;
+    };
+  };
+}
+
+const EXPECTED_PUBLIC_BEACH_COUNT = 346;
+const REQUESTED_FORECAST_DAYS = 3;
+const HORIZON_TOLERANCE_HOURS = 6;
+const FORECAST_CADENCE_HOURS = 3;
+const FORECAST_CADENCE_TOLERANCE_HOURS = 1;
+const HOUR_MS = 60 * 60 * 1000;
+
+function decodeXml(value: string): string {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'");
+}
+
+function extractSitemapPaths(xml: string): Set<string> {
+  const paths = new Set<string>();
+
+  for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/g)) {
+    const url = new URL(decodeXml(match[1]));
+    paths.add(url.pathname);
+  }
+
+  return paths;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  let nextIndex = 0;
+  const results: R[] = new Array(items.length);
+
+  async function run(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, items.length) },
+      () => run(),
+    ),
+  );
+
+  return results;
+}
+
+function assertPublicBeachInventory(beaches: PublicBeach[]): void {
+  expect(beaches.length).toBe(EXPECTED_PUBLIC_BEACH_COUNT);
+  expect(new Set(beaches.map((beach) => beach.id)).size).toBe(beaches.length);
+  expect(beaches.every((beach) => beach.id && beach.name)).toBe(true);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidWaveHeight(value: unknown): boolean {
+  if (typeof value === 'number') return Number.isFinite(value) && value >= 0;
+  if (typeof value !== 'string') return false;
+  const match = /^(\d+(?:\.\d+)?)(?:\s*-\s*(\d+(?:\.\d+)?))?\s*(?:ft|feet)?$/i.exec(
+    value.trim(),
+  );
+  if (!match) return false;
+  const low = Number(match[1]);
+  const high = match[2] === undefined ? low : Number(match[2]);
+  return Number.isFinite(low) && Number.isFinite(high) && low >= 0 && high >= low;
+}
+
+function isValidTemperature(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string') return false;
+  return /^-?\d+(?:\.\d+)?\s*°?\s*[FC]?$/i.test(value.trim());
+}
+
+function validateForecastRows(
+  beach: PublicBeach,
+  payload: ForecastResponse,
+  status: number,
+  now: number,
+): string[] {
+  const label = beach.slug ?? beach.id;
+  const failures: string[] = [];
+  const forecasts = payload.data?.forecasts ?? [];
+  const forecastTimes = forecasts.map((forecast) => Date.parse(forecast.forecast_at ?? ''));
+  const lastUpdated = Date.parse(payload.data?.metadata?.lastUpdated ?? '');
+
+  if (status !== 200) failures.push(`${label}: HTTP ${status}`);
+  if (payload.success !== true) failures.push(`${label}: success was not true`);
+  if (payload.data?.days !== REQUESTED_FORECAST_DAYS) {
+    failures.push(`${label}: days was ${String(payload.data?.days)}`);
+  }
+  if (payload.data?.metadata?.missing !== false) failures.push(`${label}: forecast missing`);
+  if (payload.data?.metadata?.stale !== false) failures.push(`${label}: forecast stale`);
+  if (forecasts.length === 0) failures.push(`${label}: no forecast rows`);
+
+  const invalidTimestampCount = forecastTimes.filter((time) => !Number.isFinite(time)).length;
+  if (invalidTimestampCount > 0) {
+    failures.push(`${label}: ${invalidTimestampCount} invalid forecast timestamps`);
+  }
+  const outOfOrder = forecastTimes.some((time, index) => (
+    index > 0 && time < forecastTimes[index - 1]
+  ));
+  if (outOfOrder) failures.push(`${label}: forecast rows are not ordered`);
+  if (new Set(forecastTimes).size !== forecasts.length) {
+    failures.push(`${label}: duplicate forecast timestamps`);
+  }
+
+  const rowIds = forecasts.map((forecast) => forecast.id);
+  if (!rowIds.every(isNonEmptyString)) failures.push(`${label}: missing forecast row id`);
+  if (new Set(rowIds).size !== rowIds.length) failures.push(`${label}: duplicate forecast row ids`);
+
+  forecasts.forEach((forecast, index) => {
+    const rowLabel = `${label}: row ${index}`;
+    if (forecast.beach_id !== beach.id) {
+      failures.push(`${rowLabel} belongs to ${String(forecast.beach_id)}, expected ${beach.id}`);
+    }
+    for (const field of ['wave_height', 'water_temp', 'confidence_score'] as const) {
+      if (!Object.prototype.hasOwnProperty.call(forecast, field)) {
+        failures.push(`${rowLabel} missing ${field}`);
+      }
+    }
+    if (!isValidWaveHeight(forecast.wave_height)) {
+      failures.push(`${rowLabel} invalid wave_height`);
+    }
+    if (!isValidTemperature(forecast.water_temp)) {
+      failures.push(`${rowLabel} invalid water_temp`);
+    }
+    if (
+      typeof forecast.confidence_score !== 'number'
+      || !Number.isFinite(forecast.confidence_score)
+      || forecast.confidence_score < 0
+      || forecast.confidence_score > 100
+    ) {
+      failures.push(`${rowLabel} invalid confidence_score`);
+    }
+    if (!isNonEmptyString(forecast.data_source)) {
+      failures.push(`${rowLabel} missing data_source`);
+    }
+    if (!Number.isFinite(Date.parse(forecast.created_at ?? ''))) {
+      failures.push(`${rowLabel} invalid created_at`);
+    }
+    if (!Number.isFinite(Date.parse(forecast.updated_at ?? ''))) {
+      failures.push(`${rowLabel} invalid updated_at`);
+    }
+  });
+
+  const horizonStart = now - HORIZON_TOLERANCE_HOURS * HOUR_MS;
+  const horizonEnd = now + REQUESTED_FORECAST_DAYS * 24 * HOUR_MS;
+  const horizonTimes = forecastTimes.filter((time) => (
+    Number.isFinite(time) && time >= horizonStart && time <= horizonEnd
+  ));
+  const coverageBuckets = Array.from({ length: REQUESTED_FORECAST_DAYS }, (_, dayIndex) => {
+    const bucketStart = now + dayIndex * 24 * HOUR_MS;
+    const bucketEnd = now + (dayIndex + 1) * 24 * HOUR_MS;
+    return horizonTimes.filter((time) => time >= bucketStart && time < bucketEnd).length;
+  });
+  coverageBuckets.forEach((count, dayIndex) => {
+    if (count === 0) failures.push(`${label}: no forecast coverage in day ${dayIndex + 1}`);
+  });
+
+  const futureTimes = horizonTimes.filter((time) => time >= now).sort((a, b) => a - b);
+  const maxAllowedGap = (FORECAST_CADENCE_HOURS + FORECAST_CADENCE_TOLERANCE_HOURS) * HOUR_MS;
+  if (futureTimes.length > 0 && futureTimes[0] - now > maxAllowedGap) {
+    failures.push(`${label}: first forecast starts more than 4h from now`);
+  }
+  const sparseGap = futureTimes.findIndex((time, index) => (
+    index > 0 && time - futureTimes[index - 1] > maxAllowedGap
+  ));
+  if (sparseGap > 0) {
+    failures.push(
+      `${label}: forecast gap exceeds ${FORECAST_CADENCE_HOURS + FORECAST_CADENCE_TOLERANCE_HOURS}h`,
+    );
+  }
+  const maxFutureTime = futureTimes.at(-1) ?? Number.NaN;
+  if (maxFutureTime < now + (REQUESTED_FORECAST_DAYS * 24 - HORIZON_TOLERANCE_HOURS) * HOUR_MS) {
+    failures.push(`${label}: forecast horizon ends too early`);
+  }
+
+  if (!Number.isFinite(lastUpdated)) failures.push(`${label}: invalid metadata lastUpdated`);
+  if (lastUpdated > now + 5 * 60 * 1000) failures.push(`${label}: metadata lastUpdated is in the future`);
+
+  return failures;
+}
+
+test.describe("Forecast authority API contracts", () => {
+  test("serves a fresh three-day forecast for every public beach @requires-data", async ({
+    request,
+  }) => {
+    test.setTimeout(120_000);
+
+    const beachesResponse = await request.get("/api/beaches");
+    expect(beachesResponse.status()).toBe(200);
+    const beachesPayload = (await beachesResponse.json()) as BeachesResponse;
+    const beaches = beachesPayload.data?.beaches ?? [];
+    assertPublicBeachInventory(beaches);
+    expect(beachesPayload.data?.count).toBe(beaches.length);
+
+    const validationStart = Date.now();
+    const validationResults = await mapWithConcurrency(beaches, 8, async (beach) => {
+      try {
+        const forecastResponse = await request.get(
+          "/api/forecasts/update-enhanced",
+          { params: { beachId: beach.id, days: String(REQUESTED_FORECAST_DAYS) } },
+        );
+        const forecastPayload = (await forecastResponse.json()) as ForecastResponse;
+        return validateForecastRows(
+          beach,
+          forecastPayload,
+          forecastResponse.status(),
+          validationStart,
+        );
+      } catch (error) {
+        return [`${beach.slug ?? beach.id}: ${error instanceof Error ? error.message : String(error)}`];
+      }
+    });
+    const failures = validationResults.flat();
+
+    expect(validationResults).toHaveLength(EXPECTED_PUBLIC_BEACH_COUNT);
+    expect(failures).toEqual([]);
+
+    test.info().annotations.push({
+      type: "forecast-authority",
+      description: `Fresh three-day forecasts validated for ${beaches.length} public beaches`,
+    });
+  });
+
+  test("publishes every public beach with a canonical sitemap forecast page @requires-data", async ({
+    request,
+  }) => {
+    const beachesResponse = await request.get("/api/beaches");
+    expect(beachesResponse.status()).toBe(200);
+
+    const beachesPayload = (await beachesResponse.json()) as BeachesResponse;
+    const beaches = beachesPayload.data?.beaches ?? [];
+    assertPublicBeachInventory(beaches);
+    expect(beachesPayload.data?.count).toBe(beaches.length);
+
+    const canonicalPaths = beaches.map((beach) => buildBeachUrl(beach));
+    expect(canonicalPaths.every((path) => !path.startsWith("/beach/"))).toBe(true);
+    expect(new Set(canonicalPaths).size).toBe(EXPECTED_PUBLIC_BEACH_COUNT);
+
+    const sitemapResponse = await request.get("/sitemap.xml");
+    expect(sitemapResponse.status()).toBe(200);
+    const sitemapPaths = extractSitemapPaths(await sitemapResponse.text());
+    const missingPaths = canonicalPaths.filter((path) => !sitemapPaths.has(path));
+
+    test.info().annotations.push({
+      type: "forecast-authority",
+      description: `Public beaches: ${beaches.length}; canonical sitemap entries: ${sitemapPaths.size}; missing: ${missingPaths.length}`,
+    });
+
+    expect(missingPaths).toEqual([]);
+  });
+});

--- a/lib/config/forecast-staleness.ts
+++ b/lib/config/forecast-staleness.ts
@@ -13,6 +13,8 @@
  *   catching genuinely stale data.
  * - NOAA_NWS: Enhanced forecasts regenerate daily (6 AM), so 12-hour threshold prevents
  *   unnecessary regeneration attempts while providing buffer until next update
+ * - OPEN_METEO: Extended-horizon model rows are refreshed on the same batch cadence as
+ *   the forecast pipeline. Keep the 12-hour window aligned with that batch SLA.
  * - FALLBACK: Fallback data is less critical and can tolerate longer staleness
  * - NOWCAST_ANCHOR: Single-row buoy observation accepted as ground truth in the
  *   nowcast window. 6h matches CDIP-via-IOOS ingestion lag (2h sync cron +
@@ -23,6 +25,7 @@
 export const STALENESS_THRESHOLDS = {
   CDIP: 4,          // 4 hours (CDIP buoy cron doesn't reliably update every beach every hour)
   NOAA_NWS: 12,     // 12 hours (Enhanced forecasts regenerate daily, matches actual update cadence)
+  OPEN_METEO: 12,   // 12 hours (extended-horizon rows follow the forecast batch cadence)
   FALLBACK: 12,     // 12 hours (fallback data less critical)
   NOWCAST_ANCHOR: 6, // 6 hours (matches CDIP-via-IOOS ingestion lag; see forecast-builder shouldApplyNowcastAnchor)
   DEFAULT: 6        // Default for unknown sources

--- a/lib/constants/beach-coordinates.ts
+++ b/lib/constants/beach-coordinates.ts
@@ -37,7 +37,7 @@ export const beachCoordinates: Record<string, BeachCoordinates> = {
   "blacks beach": { lat: 32.9016, lon: -117.2524 },
   "windansea beach": { lat: 32.8217, lon: -117.2837 },
   "la jolla shores": { lat: 32.8507, lon: -117.2726 },
-  "tourmaline surf park": { lat: 32.8563, lon: -117.256 },
+  "tourmaline surf park": { lat: 32.805149, lon: -117.262364 },
   "crystal pier": { lat: 32.811, lon: -117.2544 },
   "pacific beach": { lat: 32.803, lon: -117.2405 },
   "mission beach": { lat: 32.7801, lon: -117.2549 },

--- a/lib/seo/editorial-integrity.ts
+++ b/lib/seo/editorial-integrity.ts
@@ -1,0 +1,110 @@
+import type { Beach } from "@/types/database";
+
+export interface EditorialIntegrityBeach {
+  id: string;
+  name: string | null;
+  city: string | null;
+  state: string | null;
+  description?: string | null;
+  wave_tips?: string | null;
+  crowd_tips?: string | null;
+  best_conditions_prose?: string | null;
+  parking_tips?: string | null;
+  access_tips?: string | null;
+  local_etiquette?: string | null;
+  hazards?: string[] | null;
+}
+
+export interface EditorialIntegrityResult {
+  quarantined: boolean;
+  reasons: string[];
+}
+
+interface LocationReferenceGuard {
+  label: string;
+  pattern: RegExp;
+  allowedStates: string[];
+  allowedCities?: string[];
+}
+
+const LOCATION_REFERENCE_GUARDS: LocationReferenceGuard[] = [
+  {
+    label: "Siuslaw River",
+    pattern: /\bsiuslaw\s+river\b/i,
+    allowedStates: ["OR", "Oregon"],
+    allowedCities: ["Florence", "Reedsport"],
+  },
+];
+
+function normalized(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function editorialText(beach: EditorialIntegrityBeach): string {
+  return [
+    beach.description,
+    beach.wave_tips,
+    beach.crowd_tips,
+    beach.best_conditions_prose,
+    beach.parking_tips,
+    beach.access_tips,
+    beach.local_etiquette,
+    ...(beach.hazards ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export function evaluateBeachEditorialIntegrity(
+  beach: EditorialIntegrityBeach,
+): EditorialIntegrityResult {
+  const state = normalized(beach.state);
+  const city = normalized(beach.city);
+  const text = editorialText(beach);
+  const reasons: string[] = [];
+
+  for (const guard of LOCATION_REFERENCE_GUARDS) {
+    if (!guard.pattern.test(text)) continue;
+
+    const stateAllowed = guard.allowedStates.some(
+      (allowedState) => normalized(allowedState) === state,
+    );
+    const cityAllowed = guard.allowedCities?.some(
+      (allowedCity) => normalized(allowedCity) === city,
+    );
+
+    if (!stateAllowed || (guard.allowedCities && !cityAllowed)) {
+      reasons.push(`location-reference:${guard.label}`);
+    }
+  }
+
+  return { quarantined: reasons.length > 0, reasons };
+}
+
+/**
+ * Remove only editorial fields from a contaminated record. Forecast, access
+ * coordinates, hazards metadata, and identity remain available to the page.
+ */
+export function sanitizeBeachEditorialContent<T extends Beach>(beach: T): T {
+  const integrity = evaluateBeachEditorialIntegrity(beach);
+  if (!integrity.quarantined) return beach;
+
+  const sanitized = {
+    ...beach,
+    description: null,
+    wave_tips: null,
+    crowd_tips: null,
+    best_conditions_prose: null,
+    parking_tips: null,
+    access_tips: null,
+    local_etiquette: null,
+    hazards: null,
+  } as T;
+
+  console.warn("[sanitizeBeachEditorialContent] Editorial content quarantined", {
+    beachId: beach.id,
+    beachName: beach.name,
+    reasons: integrity.reasons,
+  });
+  return sanitized;
+}

--- a/lib/seo/forecast-authority-audit.ts
+++ b/lib/seo/forecast-authority-audit.ts
@@ -1,0 +1,272 @@
+import {
+  evaluateBeachForecastIndexability,
+  type IndexabilityReason,
+} from "./indexability";
+import {
+  evaluateBeachEditorialIntegrity,
+  type EditorialIntegrityBeach,
+} from "./editorial-integrity";
+import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+import type { ForecastIndexabilitySnapshot } from "./forecast-indexability";
+
+export interface ForecastAuthorityAuditBeach extends EditorialIntegrityBeach {
+  slug: string | null;
+  country: string | null;
+  lat: number | null;
+  lon: number | null;
+  timezone?: string | null;
+}
+
+export interface ForecastAuthorityAuditFailure {
+  id: string;
+  name: string | null;
+  canonicalPath: string;
+  indexabilityReason: IndexabilityReason;
+  editorialQuarantined: boolean;
+  editorialReasons: string[];
+  metadataMissing: boolean;
+}
+
+export interface ForecastAuthorityAuditReport {
+  generatedAt: string;
+  forecastQuerySucceeded: boolean;
+  eligibleSpots: Array<{
+    id: string;
+    name: string | null;
+    city: string | null;
+    state: string | null;
+    country: string | null;
+    canonicalPath: string;
+  }>;
+  summary: {
+    totalBeachRecords: number;
+    totalCanonicalSpotPages: number;
+    forecastEligible: number;
+    forecastIneligible: number;
+    missingForecast: number;
+    incompleteForecast: number;
+    staleForecast: number;
+    badLocationIdentity: number;
+    quarantinedEditorial: number;
+    missingMetadata: number;
+    canonicalConflicts: number;
+    sitemapEntries: number | null;
+    missingSitemapEntries: number | null;
+  };
+  reasonCounts: Partial<Record<IndexabilityReason, number>>;
+  canonicalConflicts: Array<{
+    canonicalPath: string;
+    beachIds: string[];
+    beachNames: Array<string | null>;
+  }>;
+  missingSitemapEntries: Array<{
+    id: string;
+    name: string | null;
+    canonicalPath: string;
+  }>;
+  failures: ForecastAuthorityAuditFailure[];
+}
+
+const EMPTY_FORECAST_SNAPSHOT: ForecastIndexabilitySnapshot = {
+  forecastAvailable: false,
+  selectedStateComplete: false,
+  forecastFresh: false,
+  forecastValidAt: null,
+  sourceDataUpdatedAt: null,
+  primaryDataSource: null,
+  isStale: false,
+};
+
+function hasText(value: string | null | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function hasValidCoordinates(beach: ForecastAuthorityAuditBeach): boolean {
+  return Number.isFinite(beach.lat) && Number.isFinite(beach.lon);
+}
+
+export function buildAuditCanonicalPath(beach: ForecastAuthorityAuditBeach): string {
+  if (!beach.slug || !beach.city || !beach.state || !beach.country) {
+    return `/beach/${beach.slug || beach.id}`;
+  }
+
+  return buildBeachUrl(beach);
+}
+
+export function isAuditCanonicalIdentityValid(
+  beach: ForecastAuthorityAuditBeach,
+  canonicalPath = buildAuditCanonicalPath(beach),
+): boolean {
+  return Boolean(
+    hasText(beach.slug) &&
+      hasText(beach.city) &&
+      hasText(beach.state) &&
+      hasText(beach.country) &&
+      hasValidCoordinates(beach) &&
+      canonicalPath !== "/" &&
+      !canonicalPath.startsWith("/beach/"),
+  );
+}
+
+function isMetadataMissing(beach: ForecastAuthorityAuditBeach): boolean {
+  return !hasText(beach.name) || !hasText(beach.city) || !hasText(beach.state);
+}
+
+function incrementReason(
+  counts: Partial<Record<IndexabilityReason, number>>,
+  reason: IndexabilityReason,
+): void {
+  counts[reason] = (counts[reason] ?? 0) + 1;
+}
+
+export function buildForecastAuthorityAudit(
+  beaches: ForecastAuthorityAuditBeach[],
+  snapshots: ReadonlyMap<string, ForecastIndexabilitySnapshot>,
+  options: {
+    generatedAt?: string;
+    forecastQuerySucceeded?: boolean;
+    sitemapPaths?: Iterable<string>;
+  } = {},
+): ForecastAuthorityAuditReport {
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const forecastQuerySucceeded = options.forecastQuerySucceeded ?? true;
+  const reasonCounts: Partial<Record<IndexabilityReason, number>> = {};
+  const failures: ForecastAuthorityAuditFailure[] = [];
+  const canonicalGroups = new Map<string, ForecastAuthorityAuditBeach[]>();
+  const missingSitemapEntries: ForecastAuthorityAuditReport["missingSitemapEntries"] = [];
+  const sitemapPaths = options.sitemapPaths ? new Set(options.sitemapPaths) : null;
+
+  let totalCanonicalSpotPages = 0;
+  let forecastEligible = 0;
+  let quarantinedEditorial = 0;
+  let missingMetadata = 0;
+  const eligibleSpots: ForecastAuthorityAuditReport["eligibleSpots"] = [];
+
+  for (const beach of beaches) {
+    const canonicalPath = buildAuditCanonicalPath(beach);
+    const canonicalValid = isAuditCanonicalIdentityValid(beach, canonicalPath);
+    const snapshot = snapshots.get(beach.id) ?? EMPTY_FORECAST_SNAPSHOT;
+    const editorial = evaluateBeachEditorialIntegrity(beach);
+    const metadataMissing = isMetadataMissing(beach);
+
+    if (canonicalValid) totalCanonicalSpotPages += 1;
+    if (editorial.quarantined) quarantinedEditorial += 1;
+    if (metadataMissing) missingMetadata += 1;
+    incrementReason(
+      reasonCounts,
+      canonicalValid
+        ? evaluateBeachForecastIndexability({
+            canonicalValid: true,
+            forecastAvailable: snapshot.forecastAvailable,
+            selectedStateComplete: snapshot.selectedStateComplete,
+            forecastFresh: snapshot.forecastFresh,
+          }).reason
+        : "invalid-canonical",
+    );
+
+    const decision = evaluateBeachForecastIndexability({
+      canonicalValid,
+      forecastAvailable: snapshot.forecastAvailable,
+      selectedStateComplete: snapshot.selectedStateComplete,
+      forecastFresh: snapshot.forecastFresh,
+    });
+
+    if (decision.indexable) {
+      forecastEligible += 1;
+      eligibleSpots.push({
+        id: beach.id,
+        name: beach.name,
+        city: beach.city,
+        state: beach.state,
+        country: beach.country,
+        canonicalPath,
+      });
+      if (sitemapPaths && !sitemapPaths.has(canonicalPath)) {
+        missingSitemapEntries.push({ id: beach.id, name: beach.name, canonicalPath });
+      }
+    }
+
+    if (canonicalValid) {
+      const group = canonicalGroups.get(canonicalPath) ?? [];
+      group.push(beach);
+      canonicalGroups.set(canonicalPath, group);
+    }
+
+    if (
+      !decision.indexable ||
+      editorial.quarantined ||
+      metadataMissing
+    ) {
+      failures.push({
+        id: beach.id,
+        name: beach.name,
+        canonicalPath,
+        indexabilityReason: decision.reason,
+        editorialQuarantined: editorial.quarantined,
+        editorialReasons: editorial.reasons,
+        metadataMissing,
+      });
+    }
+  }
+
+  const canonicalConflicts = [...canonicalGroups.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([canonicalPath, group]) => ({
+      canonicalPath,
+      beachIds: group.map((beach) => beach.id),
+      beachNames: group.map((beach) => beach.name),
+    }));
+
+  for (const conflict of canonicalConflicts) {
+    for (const beachId of conflict.beachIds) {
+      const failure = failures.find((candidate) => candidate.id === beachId);
+      if (failure) continue;
+      const beach = beaches.find((candidate) => candidate.id === beachId);
+      if (!beach) continue;
+      const snapshot = snapshots.get(beach.id) ?? EMPTY_FORECAST_SNAPSHOT;
+      const decision = evaluateBeachForecastIndexability({
+        canonicalValid: true,
+        forecastAvailable: snapshot.forecastAvailable,
+        selectedStateComplete: snapshot.selectedStateComplete,
+        forecastFresh: snapshot.forecastFresh,
+      });
+      failures.push({
+        id: beach.id,
+        name: beach.name,
+        canonicalPath: conflict.canonicalPath,
+        indexabilityReason: decision.reason,
+        editorialQuarantined: false,
+        editorialReasons: [],
+        metadataMissing: false,
+      });
+    }
+  }
+
+  return {
+    generatedAt,
+    forecastQuerySucceeded,
+    eligibleSpots,
+    summary: {
+      totalBeachRecords: beaches.length,
+      totalCanonicalSpotPages,
+      forecastEligible,
+      forecastIneligible: beaches.length - forecastEligible,
+      missingForecast: reasonCounts["forecast-missing"] ?? 0,
+      incompleteForecast: reasonCounts["forecast-incomplete"] ?? 0,
+      staleForecast: reasonCounts["forecast-stale"] ?? 0,
+      badLocationIdentity: reasonCounts["invalid-canonical"] ?? 0,
+      quarantinedEditorial,
+      missingMetadata,
+      canonicalConflicts: canonicalConflicts.reduce(
+        (count, conflict) => count + conflict.beachIds.length,
+        0,
+      ),
+      sitemapEntries: sitemapPaths ? sitemapPaths.size : null,
+      missingSitemapEntries: sitemapPaths ? missingSitemapEntries.length : null,
+    },
+    reasonCounts,
+    canonicalConflicts,
+    missingSitemapEntries,
+    failures,
+  };
+}

--- a/lib/seo/forecast-authority-benchmark.ts
+++ b/lib/seo/forecast-authority-benchmark.ts
@@ -35,12 +35,65 @@ export interface ForecastBenchmarkSpot {
 }
 
 export interface ForecastBenchmarkQuery {
+  queryId: string;
   queryClass: ForecastBenchmarkQueryClass;
   query: string;
   spotId: string | null;
   region: string;
   canonicalPath: string | null;
 }
+
+export interface ForecastRetrievalEvidence {
+  queryId: string;
+  selectedUrl: string | null;
+  answerUrl: string | null;
+  citedUrl: string | null;
+  answerComplete: boolean;
+  current: boolean;
+}
+
+export interface ForecastBenchmarkCompetitor {
+  name: string;
+  domains: string[];
+}
+
+export interface ForecastCompetitiveSourceResult {
+  name: string;
+  domains: string[];
+  selectedShare: number | null;
+  answerShare: number | null;
+  citationShare: number | null;
+}
+
+export interface ForecastCompetitiveBenchmark {
+  status: ForecastRetrievalBenchmark["status"];
+  provider: string | null;
+  competitors: ForecastCompetitiveSourceResult[];
+  reason: string | null;
+}
+
+export interface ForecastRetrievalBenchmark {
+  status: "measured" | "not-run" | "invalid";
+  provider: string | null;
+  expectedQueries: number;
+  measuredQueries: number;
+  retrievedShare: number | null;
+  answerShare: number | null;
+  currentAnswerShare: number | null;
+  citationShare: number | null;
+  canonicalSelectionShare: number | null;
+  missingQueryIds: string[];
+  unexpectedQueryIds: string[];
+  duplicateQueryIds: string[];
+  reason: string | null;
+}
+
+export const DEFAULT_FORECAST_BENCHMARK_COMPETITORS: ForecastBenchmarkCompetitor[] = [
+  { name: "Surfline", domains: ["surfline.com"] },
+  { name: "Surf Captain", domains: ["surfcaptain.com"] },
+];
+
+export const DEFAULT_QUIVER_BENCHMARK_ORIGIN = "https://www.quiversurf.app";
 
 export interface ForecastAnswerContractFacts {
   answerLayer: boolean;
@@ -56,7 +109,8 @@ export interface ForecastAnswerContractFacts {
 const EAST_COAST_STATES = new Set([
   "ct", "de", "fl", "ga", "ma", "md", "me", "nc", "nh", "nj", "ny", "ri", "sc", "va",
 ]);
-const GULF_STATES = new Set(["al", "fl", "la", "ms", "tx"]);
+const GULF_STATES = new Set(["al", "la", "ms", "tx"]);
+const WEST_COAST_STATES = new Set(["or", "wa"]);
 
 function normalized(value: string | null | undefined): string {
   return value?.trim().toLowerCase() ?? "";
@@ -68,6 +122,7 @@ export function classifyForecastBenchmarkRegion(spot: ForecastBenchmarkSpot): st
   if (country === "usa" || country === "us" || country === "united states") {
     if (state === "ca" || state === "california") return "California";
     if (state === "hi" || state === "hawaii") return "Hawaii";
+    if (WEST_COAST_STATES.has(state)) return "West Coast";
     if (GULF_STATES.has(state)) return "Gulf Coast";
     if (EAST_COAST_STATES.has(state)) return "East Coast";
   }
@@ -91,6 +146,14 @@ function spotQuery(
   }
 }
 
+function queryId(
+  queryClass: ForecastBenchmarkQueryClass,
+  spotId: string | null,
+  region: string,
+): string {
+  return `${region}:${spotId ?? "region"}:${queryClass}`;
+}
+
 export function buildForecastBenchmarkQueries(
   spots: ForecastBenchmarkSpot[],
   spotsPerRegion = 5,
@@ -112,6 +175,7 @@ export function buildForecastBenchmarkQueries(
     for (const spot of sampledSpots) {
       for (const queryClass of SPOT_QUERY_CLASSES) {
         queries.push({
+          queryId: queryId(queryClass, spot.id, region),
           queryClass,
           query: spotQuery(spot, queryClass),
           spotId: spot.id,
@@ -126,18 +190,234 @@ export function buildForecastBenchmarkQueries(
       "where-should-i-surf-region-tomorrow",
     ] as const) {
       queries.push({
+        queryId: queryId(queryClass, null, region),
         queryClass,
         query: queryClass === "best-surf-region-tomorrow"
           ? `best surf ${region} tomorrow`
           : `where should I surf ${region} tomorrow`,
         spotId: null,
         region,
-        canonicalPath: sampledSpots[0]?.canonicalPath ?? null,
+        canonicalPath: null,
       });
     }
   }
 
   return queries;
+}
+
+function normalizedUrl(value: string | null): URL | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedPath(value: string): string {
+  return value.length > 1 ? value.replace(/\/$/, "") : value;
+}
+
+function normalizedHost(value: string): string {
+  return value.toLowerCase().replace(/^www\./, "");
+}
+
+function urlBelongsToDomains(url: URL | null, domains: string[]): boolean {
+  if (!url) return false;
+  const host = normalizedHost(url.hostname);
+  return domains.some((domain) => {
+    const normalizedDomain = normalizedHost(domain);
+    return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+  });
+}
+
+function isQuiverUrl(value: string | null, quiverOrigin: string): boolean {
+  const originUrl = normalizedUrl(quiverOrigin);
+  if (!originUrl) return false;
+  return urlBelongsToDomains(
+    normalizedUrl(value),
+    [originUrl.hostname],
+  );
+}
+
+function isCanonicalQuiverUrl(
+  value: string | null,
+  canonicalPath: string,
+  quiverOrigin: string,
+): boolean {
+  const url = normalizedUrl(value);
+  return (
+    isQuiverUrl(value, quiverOrigin)
+    && url !== null
+    && normalizedPath(url.pathname) === normalizedPath(canonicalPath)
+  );
+}
+
+function isRetrievalEvidence(value: unknown): value is ForecastRetrievalEvidence {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.queryId === "string"
+    && (record.selectedUrl === null || typeof record.selectedUrl === "string")
+    && (record.answerUrl === null || typeof record.answerUrl === "string")
+    && (record.citedUrl === null || typeof record.citedUrl === "string")
+    && typeof record.answerComplete === "boolean"
+    && typeof record.current === "boolean"
+  );
+}
+
+export function parseForecastRetrievalEvidence(value: unknown): ForecastRetrievalEvidence[] {
+  if (!Array.isArray(value) || !value.every(isRetrievalEvidence)) {
+    throw new Error(
+      "Retrieval evidence must be an array of { queryId, selectedUrl, answerUrl, citedUrl, answerComplete, current } objects.",
+    );
+  }
+
+  return value;
+}
+
+function share(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+export function createUnmeasuredForecastRetrievalBenchmark(
+  queries: ForecastBenchmarkQuery[],
+  reason: string,
+): ForecastRetrievalBenchmark {
+  return {
+    status: "not-run",
+    provider: null,
+    expectedQueries: queries.length,
+    measuredQueries: 0,
+    retrievedShare: null,
+    answerShare: null,
+    currentAnswerShare: null,
+    citationShare: null,
+    canonicalSelectionShare: null,
+    missingQueryIds: queries.map((query) => query.queryId),
+    unexpectedQueryIds: [],
+    duplicateQueryIds: [],
+    reason,
+  };
+}
+
+export function summarizeForecastRetrievalEvidence(
+  queries: ForecastBenchmarkQuery[],
+  evidence: ForecastRetrievalEvidence[],
+  provider: string,
+  quiverOrigin = DEFAULT_QUIVER_BENCHMARK_ORIGIN,
+): ForecastRetrievalBenchmark {
+  const expectedById = new Map(queries.map((query) => [query.queryId, query]));
+  const evidenceCounts = new Map<string, number>();
+  for (const result of evidence) {
+    evidenceCounts.set(result.queryId, (evidenceCounts.get(result.queryId) ?? 0) + 1);
+  }
+
+  const duplicateQueryIds = [...evidenceCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([queryId]) => queryId);
+  const unexpectedQueryIds = [...evidenceCounts.keys()]
+    .filter((queryId) => !expectedById.has(queryId));
+  const missingQueryIds = queries
+    .map((query) => query.queryId)
+    .filter((queryId) => !evidenceCounts.has(queryId));
+
+  if (duplicateQueryIds.length > 0 || unexpectedQueryIds.length > 0 || missingQueryIds.length > 0) {
+    return {
+      status: "invalid",
+      provider,
+      expectedQueries: queries.length,
+      measuredQueries: evidence.length,
+      retrievedShare: null,
+      answerShare: null,
+      currentAnswerShare: null,
+      citationShare: null,
+      canonicalSelectionShare: null,
+      missingQueryIds,
+      unexpectedQueryIds,
+      duplicateQueryIds,
+      reason: "Retrieval evidence must contain exactly one result for every generated query.",
+    };
+  }
+
+  const expectedCanonicalQueries = queries.filter((query) => query.canonicalPath !== null);
+  const measuredById = new Map(evidence.map((result) => [result.queryId, result]));
+  const retrieved = evidence.filter((result) => isQuiverUrl(result.selectedUrl, quiverOrigin)).length;
+  const answered = evidence.filter((result) => (
+    result.answerComplete && isQuiverUrl(result.answerUrl, quiverOrigin)
+  )).length;
+  const currentAnswers = evidence.filter((result) => (
+    result.answerComplete
+    && result.current
+    && isQuiverUrl(result.answerUrl, quiverOrigin)
+  )).length;
+  const cited = evidence.filter((result) => isQuiverUrl(result.citedUrl, quiverOrigin)).length;
+  const canonicalSelections = expectedCanonicalQueries.filter((query) => {
+    const result = measuredById.get(query.queryId);
+    return isCanonicalQuiverUrl(
+      result?.selectedUrl ?? null,
+      query.canonicalPath!,
+      quiverOrigin,
+    );
+  }).length;
+
+  return {
+    status: "measured",
+    provider,
+    expectedQueries: queries.length,
+    measuredQueries: evidence.length,
+    retrievedShare: share(retrieved, queries.length),
+    answerShare: share(answered, queries.length),
+    currentAnswerShare: share(currentAnswers, queries.length),
+    citationShare: share(cited, queries.length),
+    canonicalSelectionShare: share(canonicalSelections, expectedCanonicalQueries.length),
+    missingQueryIds: [],
+    unexpectedQueryIds: [],
+    duplicateQueryIds: [],
+    reason: null,
+  };
+}
+
+export function summarizeForecastCompetitiveBenchmark(
+  queries: ForecastBenchmarkQuery[],
+  evidence: ForecastRetrievalEvidence[],
+  retrieval: ForecastRetrievalBenchmark,
+  competitors: ForecastBenchmarkCompetitor[] = DEFAULT_FORECAST_BENCHMARK_COMPETITORS,
+): ForecastCompetitiveBenchmark {
+  const sourceResults = competitors.map((competitor): ForecastCompetitiveSourceResult => {
+    const selected = evidence.filter((result) => urlBelongsToDomains(
+      normalizedUrl(result.selectedUrl),
+      competitor.domains,
+    )).length;
+    const answered = evidence.filter((result) => (
+      result.answerComplete
+      && urlBelongsToDomains(
+        normalizedUrl(result.answerUrl),
+        competitor.domains,
+      )
+    )).length;
+    const cited = evidence.filter((result) => urlBelongsToDomains(
+      normalizedUrl(result.citedUrl),
+      competitor.domains,
+    )).length;
+
+    return {
+      name: competitor.name,
+      domains: competitor.domains,
+      selectedShare: retrieval.status === "measured" ? share(selected, queries.length) : null,
+      answerShare: retrieval.status === "measured" ? share(answered, queries.length) : null,
+      citationShare: retrieval.status === "measured" ? share(cited, queries.length) : null,
+    };
+  });
+
+  return {
+    status: retrieval.status,
+    provider: retrieval.provider,
+    competitors: sourceResults,
+    reason: retrieval.reason,
+  };
 }
 
 function hasAny(html: string, patterns: RegExp[]): boolean {

--- a/lib/seo/forecast-authority-benchmark.ts
+++ b/lib/seo/forecast-authority-benchmark.ts
@@ -1,0 +1,163 @@
+export const FORECAST_BENCHMARK_QUERY_CLASSES = [
+  "spot-surf-forecast",
+  "spot-surf-report",
+  "spot-tomorrow",
+  "best-time-to-surf-spot",
+  "when-should-i-surf-spot",
+  "spot-swell-tomorrow",
+  "spot-wind-tomorrow",
+  "spot-tide-tomorrow",
+  "best-surf-region-tomorrow",
+  "where-should-i-surf-region-tomorrow",
+] as const;
+
+export type ForecastBenchmarkQueryClass =
+  (typeof FORECAST_BENCHMARK_QUERY_CLASSES)[number];
+
+const SPOT_QUERY_CLASSES = [
+  "spot-surf-forecast",
+  "spot-surf-report",
+  "spot-tomorrow",
+  "best-time-to-surf-spot",
+  "when-should-i-surf-spot",
+  "spot-swell-tomorrow",
+  "spot-wind-tomorrow",
+  "spot-tide-tomorrow",
+] as const;
+
+export interface ForecastBenchmarkSpot {
+  id: string;
+  name: string;
+  city: string | null;
+  state: string | null;
+  country: string | null;
+  canonicalPath: string;
+}
+
+export interface ForecastBenchmarkQuery {
+  queryClass: ForecastBenchmarkQueryClass;
+  query: string;
+  spotId: string | null;
+  region: string;
+  canonicalPath: string | null;
+}
+
+export interface ForecastAnswerContractFacts {
+  answerLayer: boolean;
+  forecastDate: boolean;
+  surfFacts: boolean;
+  bestWindow: boolean;
+  reasoning: boolean;
+  freshness: boolean;
+  provenance: boolean;
+  score: number;
+}
+
+const EAST_COAST_STATES = new Set([
+  "ct", "de", "fl", "ga", "ma", "md", "me", "nc", "nh", "nj", "ny", "ri", "sc", "va",
+]);
+const GULF_STATES = new Set(["al", "fl", "la", "ms", "tx"]);
+
+function normalized(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function classifyForecastBenchmarkRegion(spot: ForecastBenchmarkSpot): string {
+  const country = normalized(spot.country);
+  const state = normalized(spot.state);
+  if (country === "usa" || country === "us" || country === "united states") {
+    if (state === "ca" || state === "california") return "California";
+    if (state === "hi" || state === "hawaii") return "Hawaii";
+    if (GULF_STATES.has(state)) return "Gulf Coast";
+    if (EAST_COAST_STATES.has(state)) return "East Coast";
+  }
+  return "International";
+}
+
+function spotQuery(
+  spot: ForecastBenchmarkSpot,
+  queryClass: Exclude<ForecastBenchmarkQueryClass, "best-surf-region-tomorrow" | "where-should-i-surf-region-tomorrow">,
+): string {
+  const name = spot.name;
+  switch (queryClass) {
+    case "spot-surf-forecast": return `${name} surf forecast`;
+    case "spot-surf-report": return `${name} surf report`;
+    case "spot-tomorrow": return `${name} tomorrow`;
+    case "best-time-to-surf-spot": return `best time to surf ${name}`;
+    case "when-should-i-surf-spot": return `when should I surf ${name}`;
+    case "spot-swell-tomorrow": return `${name} swell tomorrow`;
+    case "spot-wind-tomorrow": return `${name} wind tomorrow`;
+    case "spot-tide-tomorrow": return `${name} tide tomorrow`;
+  }
+}
+
+export function buildForecastBenchmarkQueries(
+  spots: ForecastBenchmarkSpot[],
+  spotsPerRegion = 5,
+): ForecastBenchmarkQuery[] {
+  const spotsByRegion = new Map<string, ForecastBenchmarkSpot[]>();
+  for (const spot of spots) {
+    const region = classifyForecastBenchmarkRegion(spot);
+    const regionSpots = spotsByRegion.get(region) ?? [];
+    regionSpots.push(spot);
+    spotsByRegion.set(region, regionSpots);
+  }
+
+  const queries: ForecastBenchmarkQuery[] = [];
+  for (const [region, regionSpots] of spotsByRegion) {
+    const sampledSpots = [...regionSpots]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .slice(0, spotsPerRegion);
+
+    for (const spot of sampledSpots) {
+      for (const queryClass of SPOT_QUERY_CLASSES) {
+        queries.push({
+          queryClass,
+          query: spotQuery(spot, queryClass),
+          spotId: spot.id,
+          region,
+          canonicalPath: spot.canonicalPath,
+        });
+      }
+    }
+
+    for (const queryClass of [
+      "best-surf-region-tomorrow",
+      "where-should-i-surf-region-tomorrow",
+    ] as const) {
+      queries.push({
+        queryClass,
+        query: queryClass === "best-surf-region-tomorrow"
+          ? `best surf ${region} tomorrow`
+          : `where should I surf ${region} tomorrow`,
+        spotId: null,
+        region,
+        canonicalPath: sampledSpots[0]?.canonicalPath ?? null,
+      });
+    }
+  }
+
+  return queries;
+}
+
+function hasAny(html: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(html));
+}
+
+export function extractForecastAnswerContractFacts(
+  html: string,
+): ForecastAnswerContractFacts {
+  const facts = {
+    answerLayer: /data-testid=["']public-forecast-answer["']/.test(html),
+    forecastDate: /Forecast valid at|surf forecast/i.test(html),
+    surfFacts: /<dt[^>]*>Surf<\/dt>|Surf<\/h[1-6]>|Surf forecast/i.test(html),
+    bestWindow: /Best window/i.test(html),
+    reasoning: /Why:/i.test(html),
+    freshness: /Source data updated|Quiver computed/i.test(html),
+    provenance: /Contributing sources|Source data updated/i.test(html),
+    score: hasAny(html, [/Score/i, /Confidence/i]) ? 1 : 0,
+  };
+
+  const passed = Object.values(facts).filter((value) => value === true || value === 1).length;
+  return { ...facts, score: passed / Object.keys(facts).length };
+}

--- a/lib/seo/forecast-indexability.ts
+++ b/lib/seo/forecast-indexability.ts
@@ -1,0 +1,212 @@
+import { createSupabaseServiceRoleClient } from "@/lib/supabase/server";
+import { getStalenessThreshold } from "@/lib/config/forecast-staleness";
+import {
+  getLocalDateString,
+  resolveBeachTimezone,
+} from "@/lib/utils/timezone-utils";
+
+export interface ForecastCoverageRow {
+  beach_id: string | null;
+  forecast_at: string | null;
+  wave_height: string | number | null;
+  updated_at: string | null;
+  data_source: string | null;
+}
+
+export interface ForecastIndexabilitySnapshot {
+  forecastAvailable: boolean;
+  selectedStateComplete: boolean;
+  forecastFresh: boolean;
+  forecastValidAt: string | null;
+  sourceDataUpdatedAt: string | null;
+  primaryDataSource: string | null;
+  isStale: boolean;
+}
+
+export interface ForecastIndexabilityBeach {
+  id: string;
+  timezone?: string | null;
+}
+
+const FORECAST_COVERAGE_SELECT =
+  "beach_id, forecast_at, wave_height, updated_at, data_source";
+const BEACH_ID_BATCH_SIZE = 20;
+
+function hasValue(value: string | number | null | undefined): boolean {
+  return value !== null && value !== undefined && String(value).trim().length > 0;
+}
+
+function isComplete(row: ForecastCoverageRow): boolean {
+  if (!hasValue(row.beach_id) || !hasValue(row.wave_height) || !hasValue(row.data_source)) {
+    return false;
+  }
+
+  return Boolean(
+    row.forecast_at && !Number.isNaN(Date.parse(row.forecast_at)) &&
+      row.updated_at && !Number.isNaN(Date.parse(row.updated_at)),
+  );
+}
+
+function isFresh(row: ForecastCoverageRow, nowMs: number): boolean {
+  if (!row.updated_at || !row.data_source) return false;
+  const updatedMs = Date.parse(row.updated_at);
+  if (Number.isNaN(updatedMs)) return false;
+
+  const thresholdHours = getStalenessThreshold(row.data_source);
+  return nowMs - updatedMs <= thresholdHours * 60 * 60 * 1000;
+}
+
+function sortByForecastTime(rows: ForecastCoverageRow[]): ForecastCoverageRow[] {
+  return [...rows].sort(
+    (left, right) => Date.parse(left.forecast_at ?? "") - Date.parse(right.forecast_at ?? ""),
+  );
+}
+
+function selectNearTermForecast(
+  completeRows: ForecastCoverageRow[],
+  now: Date,
+  timezone?: string | null,
+): ForecastCoverageRow | null {
+  const resolvedTimezone = resolveBeachTimezone(timezone);
+  const today = getLocalDateString(now, resolvedTimezone);
+  const tomorrow = getLocalDateString(
+    new Date(now.getTime() + 24 * 60 * 60 * 1000),
+    resolvedTimezone,
+  );
+  const upcomingRows = completeRows.filter(
+    (row) => Date.parse(row.forecast_at!) >= now.getTime(),
+  );
+
+  return (
+    upcomingRows.find(
+      (row) => getLocalDateString(new Date(row.forecast_at!), resolvedTimezone) === today,
+    ) ??
+    upcomingRows.find(
+      (row) => getLocalDateString(new Date(row.forecast_at!), resolvedTimezone) === tomorrow,
+    ) ??
+    null
+  );
+}
+
+export function buildForecastIndexabilitySnapshot(
+  rows: ForecastCoverageRow[],
+  now = new Date(),
+  timezone?: string | null,
+): ForecastIndexabilitySnapshot {
+  const completeRows = sortByForecastTime(rows.filter(isComplete));
+  // The public answer is today-first and tomorrow-second. Do not let a stale
+  // extended-horizon row determine indexability when the near-term answer is fresh.
+  const selected = selectNearTermForecast(completeRows, now, timezone);
+  const selectedFresh = selected ? isFresh(selected, now.getTime()) : false;
+
+  return {
+    forecastAvailable: rows.length > 0,
+    selectedStateComplete: Boolean(selected),
+    forecastFresh: selectedFresh,
+    forecastValidAt: selected?.forecast_at ?? null,
+    sourceDataUpdatedAt: selected?.updated_at ?? null,
+    primaryDataSource: selected?.data_source ?? null,
+    isStale: Boolean(selected && !selectedFresh),
+  };
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+/**
+ * Fetch the small forecast-coverage envelope needed by the sitemap. Keeping
+ * this separate from the page report avoids one full forecast query per URL.
+ */
+export async function getForecastIndexabilityForBeaches(
+  beaches: ReadonlyArray<string | ForecastIndexabilityBeach>,
+): Promise<Map<string, ForecastIndexabilitySnapshot>> {
+  const timezoneByBeachId = new Map<string, string | null | undefined>();
+  const ids = [
+    ...new Set(
+      beaches.flatMap((beach) => {
+        const beachId = typeof beach === "string" ? beach : beach.id;
+        if (!beachId) return [];
+        if (typeof beach !== "string") {
+          timezoneByBeachId.set(beachId, beach.timezone);
+        }
+        return [beachId];
+      }),
+    ),
+  ];
+  if (ids.length === 0) return new Map();
+
+  const now = new Date();
+  const start = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const end = new Date(now.getTime() + 72 * 60 * 60 * 1000).toISOString();
+  let supabase: Awaited<ReturnType<typeof createSupabaseServiceRoleClient>>;
+  try {
+    supabase = await createSupabaseServiceRoleClient();
+  } catch (error) {
+    console.error("[getForecastIndexabilityForBeaches] Client creation failed", {
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    return new Map();
+  }
+
+  let responses: Array<{
+    data: ForecastCoverageRow[];
+    error: { message: string } | null;
+  }>;
+  try {
+    responses = await Promise.all(
+      chunk(ids, BEACH_ID_BATCH_SIZE).map(async (batch) => {
+        const result = await supabase
+          .from("enhanced_forecasts")
+          .select(FORECAST_COVERAGE_SELECT)
+          .in("beach_id", batch)
+          .gte("forecast_at", start)
+          .lt("forecast_at", end)
+          .order("forecast_at", { ascending: true })
+          .limit(1000);
+
+        return {
+          data: (result.data ?? []) as ForecastCoverageRow[],
+          error: result.error,
+        };
+      }),
+    );
+  } catch (error) {
+    console.error("[getForecastIndexabilityForBeaches] Coverage query failed", {
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    return new Map();
+  }
+
+  if (responses.some(({ error }) => error)) {
+    console.error("[getForecastIndexabilityForBeaches] Coverage query failed", {
+      errors: responses
+        .map(({ error }) => error?.message)
+        .filter(Boolean),
+    });
+    return new Map();
+  }
+
+  const rowsByBeach = new Map<string, ForecastCoverageRow[]>();
+  for (const row of responses.flatMap(({ data }) => data)) {
+    if (!row.beach_id) continue;
+    const rows = rowsByBeach.get(row.beach_id) ?? [];
+    rows.push(row);
+    rowsByBeach.set(row.beach_id, rows);
+  }
+
+  return new Map(
+    ids.map((beachId) => [
+      beachId,
+      buildForecastIndexabilitySnapshot(
+        rowsByBeach.get(beachId) ?? [],
+        now,
+        timezoneByBeachId.get(beachId),
+      ),
+    ]),
+  );
+}

--- a/lib/seo/indexability.ts
+++ b/lib/seo/indexability.ts
@@ -65,7 +65,13 @@ export type IndexabilityReason =
   | "gsc-protected"
   | "editorial-rejected"
   | "insufficient-data"
-  | "unproven";
+  | "unproven"
+  | "forecast-approved"
+  | "forecast-missing"
+  | "forecast-incomplete"
+  | "forecast-stale"
+  | "invalid-canonical"
+  | "forecast-integrity-quarantined";
 
 export interface EditorialQualityResult {
   approved: boolean;
@@ -84,6 +90,14 @@ export interface IndexabilityContext {
 export interface IndexabilityDecision {
   indexable: boolean;
   reason: IndexabilityReason;
+}
+
+export interface ForecastIndexabilityInput {
+  canonicalValid: boolean;
+  forecastAvailable: boolean;
+  selectedStateComplete: boolean;
+  forecastFresh: boolean;
+  integrityQuarantined?: boolean;
 }
 
 function hasText(value: string | null | undefined): boolean {
@@ -274,6 +288,37 @@ export function evaluateBeachIndexability(
     dataRich: hasBeachSubstantiveContent(input),
     performanceProtected: isGscPerformanceProtected(canonicalPath),
   });
+}
+
+/**
+ * Forecast pages earn indexability from the live forecast contract, not from
+ * the editorial review queue. Editorial quality is enforced separately so a
+ * bad paragraph cannot take a useful, current forecast out of the catalog.
+ */
+export function evaluateBeachForecastIndexability(
+  input: ForecastIndexabilityInput,
+): IndexabilityDecision {
+  if (!input.canonicalValid) {
+    return { indexable: false, reason: "invalid-canonical" };
+  }
+
+  if (input.integrityQuarantined) {
+    return { indexable: false, reason: "forecast-integrity-quarantined" };
+  }
+
+  if (!input.forecastAvailable) {
+    return { indexable: false, reason: "forecast-missing" };
+  }
+
+  if (!input.selectedStateComplete) {
+    return { indexable: false, reason: "forecast-incomplete" };
+  }
+
+  if (!input.forecastFresh) {
+    return { indexable: false, reason: "forecast-stale" };
+  }
+
+  return { indexable: true, reason: "forecast-approved" };
 }
 
 export function evaluateCityEditorialIndexability(

--- a/lib/seo/indexnow-url-collectors.ts
+++ b/lib/seo/indexnow-url-collectors.ts
@@ -6,6 +6,8 @@ import { createPublicReadClient } from "@/lib/supabase/server";
 import { COLLISION_CITY_MAP } from "@/lib/seo/city-collision-list";
 import { buildCitySlug } from "@/lib/seo/city-slug-utils";
 import { getIndexableSeoFunnelRoutes } from "@/lib/seo/funnel-pages";
+import { evaluateBeachForecastIndexability } from "@/lib/seo/indexability";
+import { getForecastIndexabilityForBeaches } from "@/lib/seo/forecast-indexability";
 import {
   buildBeachUrl,
   isValidCountrySlug,
@@ -275,11 +277,15 @@ async function collectBeachDetailUrls(): Promise<string[]> {
   let from = 0;
 
   type BeachRow = {
+    id: string;
     slug: string | null;
     city: string | null;
     state: string | null;
     country?: string | null;
+    timezone?: string | null;
   };
+
+  const beaches: BeachRow[] = [];
 
   try {
     const supabase = createPublicReadClient();
@@ -287,7 +293,7 @@ async function collectBeachDetailUrls(): Promise<string[]> {
     while (true) {
       const { data, error } = await supabase
         .from("beaches")
-        .select("slug, city, state, country")
+        .select("id, slug, city, state, country, timezone")
         .not("slug", "is", null)
         .not("city", "is", null)
         .not("state", "is", null)
@@ -299,19 +305,34 @@ async function collectBeachDetailUrls(): Promise<string[]> {
       }
 
       const rows = data as BeachRow[];
-      for (const beach of rows) {
-        const beachPath = buildBeachUrl(beach);
-        urls.push(`${SITE_URL}${beachPath}`);
-
-        const stateSlug = stateToSlug(beach.state);
-        if (isValidStateSlug(stateSlug)) {
-          urls.push(`${SITE_URL}${beachPath}/tides`);
-          urls.push(`${SITE_URL}${beachPath}/water-temp`);
-        }
-      }
+      beaches.push(...rows);
 
       if (rows.length < pageSize) break;
       from += pageSize;
+    }
+
+    const forecastIndexabilityByBeachId = await getForecastIndexabilityForBeaches(
+      beaches.map((beach) => ({ id: beach.id, timezone: beach.timezone })),
+    );
+
+    for (const beach of beaches) {
+      const beachPath = buildBeachUrl(beach);
+      const snapshot = forecastIndexabilityByBeachId.get(beach.id);
+      const forecastIndexable = evaluateBeachForecastIndexability({
+        canonicalValid: !beachPath.startsWith("/beach/"),
+        forecastAvailable: snapshot?.forecastAvailable ?? false,
+        selectedStateComplete: snapshot?.selectedStateComplete ?? false,
+        forecastFresh: snapshot?.forecastFresh ?? false,
+      }).indexable;
+      if (!forecastIndexable) continue;
+
+      urls.push(`${SITE_URL}${beachPath}`);
+
+      const stateSlug = stateToSlug(beach.state);
+      if (isValidStateSlug(stateSlug)) {
+        urls.push(`${SITE_URL}${beachPath}/tides`);
+        urls.push(`${SITE_URL}${beachPath}/water-temp`);
+      }
     }
   } catch (error) {
     console.error("IndexNow: Error collecting beach detail URLs", error);

--- a/lib/seo/meta.ts
+++ b/lib/seo/meta.ts
@@ -357,7 +357,10 @@ export function buildDynamicBeachMetadata({
     average_rating?: number | null;
     review_count?: number | null;
   };
-  forecast: { wave_height?: string | null } | null;
+  forecast: {
+    wave_height?: string | null;
+    dayLabel?: "today" | "tomorrow" | null;
+  } | null;
 }): { title: string; description: string } {
   const expandedState = beach.state ? expandStateForMeta(beach.state) : "";
   const locationText =
@@ -368,16 +371,23 @@ export function buildDynamicBeachMetadata({
   const shortBeachName = shortenBeachNameForSerpTitle(beach.name);
 
   if (forecast?.wave_height) {
+    const dayLabel = forecast.dayLabel;
     const title = fitDynamicBeachTitle(
       `${shortBeachName}: ${forecast.wave_height} Surf Report & Forecast`,
       beach.city,
       beach.state,
     );
-    const description = pickMetaDescription([
-      `Current ${forecast.wave_height} wave height at ${beach.name}. See today's surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
-      `Current ${forecast.wave_height} wave height at ${shortBeachName}. See today's surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
-      `${forecast.wave_height} surf report & forecast for ${shortBeachName}: wave height, wind, tide, crowd intel, and 7-day forecast.`,
-    ]);
+    const description = dayLabel
+      ? pickMetaDescription([
+          `${dayLabel === "tomorrow" ? "Tomorrow's" : "Current"} ${forecast.wave_height} wave height at ${beach.name}. See the ${dayLabel} surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
+          `${dayLabel === "tomorrow" ? "Tomorrow's" : "Current"} ${forecast.wave_height} wave height at ${shortBeachName}. See the ${dayLabel} surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
+          `${forecast.wave_height} surf report & forecast for ${shortBeachName}: wave height, wind, tide, crowd intel, and 7-day forecast.`,
+        ])
+      : pickMetaDescription([
+          `Current ${forecast.wave_height} wave height at ${beach.name}. See today's surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
+          `Current ${forecast.wave_height} wave height at ${shortBeachName}. See today's surf report & forecast, wind, tide, crowd intel, and 7-day forecast.`,
+          `${forecast.wave_height} surf report & forecast for ${shortBeachName}: wave height, wind, tide, crowd intel, and 7-day forecast.`,
+        ]);
 
     return { title, description };
   }

--- a/lib/services/beach-query-service.ts
+++ b/lib/services/beach-query-service.ts
@@ -23,7 +23,7 @@ import type { Beach } from "@/types/database";
 // Selective field query for beach list - only fetch commonly needed fields
 // Updated after 20251025 migrations: location->city, latitude->lat, longitude->lon, region->state
 const BEACH_LIST_FIELDS =
-  "id, name, slug, city, lat, lon, state, country, created_at, is_private, break_type, skill_level, average_rating, review_count, description, crowd_tips, wave_tips, best_conditions_prose, seo_indexable, editorial_reviewed_at, editorial_sources";
+  "id, name, slug, city, lat, lon, state, country, timezone, created_at, is_private, break_type, skill_level, average_rating, review_count, description, crowd_tips, wave_tips, best_conditions_prose, seo_indexable, editorial_reviewed_at, editorial_sources";
 
 // Full beach detail fields for single beach queries
 const BEACH_DETAIL_FIELDS = "*";

--- a/lib/services/forecast-recommendation-context.ts
+++ b/lib/services/forecast-recommendation-context.ts
@@ -41,10 +41,17 @@ export interface ForecastRecommendationContext {
   swellPeriod: string | null;
   periodSec: number | null;
   swellDirection: string | null;
+  primarySwellHeight?: string | null;
+  secondarySwellHeight?: string | null;
+  secondarySwellPeriod?: string | null;
+  secondarySwellDirection?: string | null;
   windSpeed: string | null;
   windDirection: string | null;
   score: number | null;
   confidence: number | null;
+  primaryDataSource?: string | null;
+  sourceDataUpdatedAt?: string | null;
+  contributingSources?: string[];
   resolverUsed: "surf-call";
   source: ForecastDisplayContextSource;
   timezone?: string | null;
@@ -332,6 +339,46 @@ function buildConditionDrivers({
   };
 }
 
+function forecastProvenance(row: EnhancedForecastEntity | null): {
+  primaryDataSource: string | null;
+  sourceDataUpdatedAt: string | null;
+  contributingSources: string[];
+} {
+  if (!row) {
+    return {
+      primaryDataSource: null,
+      sourceDataUpdatedAt: null,
+      contributingSources: [],
+    };
+  }
+
+  const sources = [
+    ...(row.raw_forecast?.data_sources ?? []),
+    row.data_source,
+    row.coops_station_id ? "NOAA_CO-OPS" : null,
+  ].filter((source): source is string => Boolean(source?.trim()));
+
+  return {
+    primaryDataSource: row.data_source ?? null,
+    sourceDataUpdatedAt: row.updated_at ?? null,
+    contributingSources: [...new Set(sources)],
+  };
+}
+
+function swellFields(row: EnhancedForecastEntity | null): {
+  primarySwellHeight: string | null;
+  secondarySwellHeight: string | null;
+  secondarySwellPeriod: string | null;
+  secondarySwellDirection: string | null;
+} {
+  return {
+    primarySwellHeight: row?.swell_1_height ?? null,
+    secondarySwellHeight: row?.swell_2_height ?? null,
+    secondarySwellPeriod: normalizePeriod(row?.swell_2_period ?? null),
+    secondarySwellDirection: row?.swell_2_direction ?? null,
+  };
+}
+
 function pickCurrentRow(
   forecasts: EnhancedForecastEntity[],
   nowMs: number,
@@ -393,6 +440,8 @@ function contextFromRow(args: {
   const startTime = toIso(rowTime);
   const waveHeightFt = parseAverageNumber(args.row.wave_height);
   const periodSec = parseAverageNumber(pickSwellPeriod(args.row, null, args.beach));
+  const provenance = forecastProvenance(args.row);
+  const swell = swellFields(args.row);
   return {
     beachId: String(args.beach.id),
     localDate: getLocalDateString(rowTime, args.timezone),
@@ -410,10 +459,12 @@ function contextFromRow(args: {
     swellPeriod: pickSwellPeriod(args.row, null, args.beach),
     periodSec,
     swellDirection: pickSwellDirection(args.row, args.beach),
+    ...swell,
     windSpeed: args.row.wind_speed ?? null,
     windDirection: args.row.wind_direction ?? null,
     score: args.score,
     confidence: args.row.confidence_score ?? null,
+    ...provenance,
     resolverUsed: "surf-call",
     source: args.source,
     timezone: args.timezone,
@@ -461,6 +512,8 @@ export function buildForecastRecommendationContext({
     const periodSec = parseAverageNumber(swellPeriod);
     const waveHeightRangeLabel = formatForecastDisplayWaveHeightRange(waveHeightFt);
     const swellDirection = pickSwellDirection(selectedForecast, beach);
+    const provenance = forecastProvenance(selectedForecast);
+    const swell = swellFields(selectedForecast);
     return {
       beachId: String(beach.id),
       localDate: getLocalDateString(start, resolvedTimezone),
@@ -482,10 +535,12 @@ export function buildForecastRecommendationContext({
       swellPeriod,
       periodSec,
       swellDirection,
+      ...swell,
       windSpeed: selectedForecast?.wind_speed ?? sourceForecast?.wind_speed ?? null,
       windDirection: selectedForecast?.wind_direction ?? sourceForecast?.wind_direction ?? null,
       score: window.score ?? null,
       confidence: window.confidence ?? selectedForecast?.confidence_score ?? sourceForecast?.confidence_score ?? null,
+      ...provenance,
       resolverUsed: "surf-call",
       source: "looking_ahead",
       timezone: resolvedTimezone,

--- a/lib/services/noaa-coops/api-client.ts
+++ b/lib/services/noaa-coops/api-client.ts
@@ -7,7 +7,6 @@
 
 import type { TideData, TideExtreme, StationInfo } from "./types";
 import { parseCOOPSTimestampToUnixSecondsUTC } from "./tide-analysis";
-import { generateFallbackTideData } from "./fallback-generator";
 
 /** NOAA CO-OPS API base URL */
 const COOPS_BASE_URL =
@@ -123,7 +122,7 @@ function createTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
  * @param beginDate - Start date (YYYYMMDD)
  * @param endDate - End date (YYYYMMDD)
  * @param options - Optional logging configuration
- * @returns Array of tide data or fallback data on error
+ * @returns Array of tide data, or an empty array when NOAA is unavailable
  */
 async function fetchTidePredictions(
   stationId: string,
@@ -160,8 +159,8 @@ async function fetchTidePredictions(
     }
 
     if (!data.predictions) {
-      options?.logger?.warn("No tide predictions data returned, using fallback");
-      return generateFallbackTideData();
+      options?.logger?.warn("No tide predictions data returned");
+      return [];
     }
 
     const tideData = data.predictions.map((prediction: TideExtreme) => ({
@@ -182,10 +181,7 @@ async function fetchTidePredictions(
     return tideData;
   } catch (error) {
     options?.logger?.error("Error fetching tide predictions:", error);
-    if (options?.verbose && options?.logger) {
-      options.logger.debug("Using fallback tide data");
-    }
-    return generateFallbackTideData();
+    return [];
   }
 }
 
@@ -351,11 +347,11 @@ export async function fetchAllStationData(
       fetchStationInfo(stationId),
     ]);
 
-  // Extract results, using fallbacks for failed optional calls
+  // Do not fabricate tide observations when NOAA fails.
   const tideData =
     tideResult.status === "fulfilled"
       ? tideResult.value
-      : generateFallbackTideData();
+      : [];
 
   const waterLevel =
     waterLevelResult.status === "fulfilled" ? waterLevelResult.value : null;
@@ -366,7 +362,7 @@ export async function fetchAllStationData(
   // Log any failures for debugging (but don't block)
   if (tideResult.status === "rejected") {
     options?.logger?.warn(
-      `Tide predictions failed for station ${stationId}, using fallback`
+      `Tide predictions failed for station ${stationId}`
     );
   }
   if (waterLevelResult.status === "rejected") {

--- a/lib/services/noaa-coops/noaa-coops-service.ts
+++ b/lib/services/noaa-coops/noaa-coops-service.ts
@@ -115,6 +115,11 @@ export class NOAACOOPSService {
         this.getLoggerOptions()
       );
 
+      if (tideData.length === 0) {
+        log.warn(`No tide predictions available for station ${stationId}`);
+        return null;
+      }
+
       const result: COOPSForecast = {
         station_id: stationId,
         station_name: stationInfo?.name || `Station ${stationId}`,

--- a/lib/utils/horizon-strip-utils.ts
+++ b/lib/utils/horizon-strip-utils.ts
@@ -102,7 +102,7 @@ export const TIER_COLOR_HEX: Record<ConditionTier, string> = {
   great: "#f59e0b",
   good: "#10b981",
   fair: "#60a5fa",
-  marginal: "#e2e8f0",
+  marginal: "#7F96AD",
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "seo:gsc-refresh": "node --import tsx scripts/seo/gsc-refresh.ts",
     "seo:technical-audit": "node --import tsx scripts/seo/technical-audit.ts",
     "seo:metadata-audit": "node --import tsx scripts/seo/metadata-audit.ts",
+    "seo:forecast-authority-audit": "node --import tsx scripts/seo/forecast-authority-audit.ts",
+    "seo:forecast-authority-benchmark": "node --import tsx scripts/seo/forecast-authority-benchmark.ts",
     "seo:enrich": "node --import tsx scripts/seo/enrich.ts",
     "seo:export:vercel": "node --import tsx scripts/seo/export-vercel.ts",
     "seo:export:posthog": "node --import tsx scripts/seo/export-posthog.ts",

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-followup-migration.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-followup-migration.json
@@ -1,0 +1,2823 @@
+{
+  "generatedAt": "2026-08-09T13:01:25.533Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/204s"
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "city": "Bodega Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/cardiff-reef"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "city": "Monterey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca"
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "city": "Isla Vista",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny"
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "city": "Marina",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "city": "Moss Landing",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca"
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "city": "Grover Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-pier"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "city": "Palos Verdes",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes"
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "city": "Pismo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/salt-creek"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach"
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "city": "Manzanita",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/strands"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "city": "Charleston",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "city": "Torrance",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca"
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/trails"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/upper-trestles"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 331,
+    "forecastIneligible": 15,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 15,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 993,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 15,
+    "forecast-approved": 331
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "canonicalPath": "/hi/kapolei/tracks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "canonicalPath": "/hi/ewa-beach/white-plains",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-0-rerun.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-0-rerun.json
@@ -1,0 +1,2894 @@
+{
+  "generatedAt": "2026-08-09T12:46:53.025Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 260,
+    "forecastIneligible": 86,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 86,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 780,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 86,
+    "forecast-approved": 260
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "canonicalPath": "/ca/encinitas/cardiff-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "canonicalPath": "/ca/dana-point/doheny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "canonicalPath": "/pr/isabela/jobos",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "canonicalPath": "/pr/san-juan/la-ocho",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "canonicalPath": "/pr/luquillo/la-pared",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "canonicalPath": "/pr/rincon/marias",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "canonicalPath": "/ca/san-diego/mission-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "canonicalPath": "/ca/oceanside/oceanside-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "canonicalPath": "/ca/dana-point/salt-creek",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "canonicalPath": "/ca/dana-point/strands",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "canonicalPath": "/hi/kapolei/tracks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "canonicalPath": "/ca/san-onofre/trails",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "canonicalPath": "/ca/san-onofre/upper-trestles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "canonicalPath": "/hi/ewa-beach/white-plains",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-0.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-0.json
@@ -1,0 +1,2894 @@
+{
+  "generatedAt": "2026-08-09T12:45:43.608Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 260,
+    "forecastIneligible": 86,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 86,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 780,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 86,
+    "forecast-approved": 260
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "canonicalPath": "/ca/encinitas/cardiff-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "canonicalPath": "/ca/dana-point/doheny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "canonicalPath": "/pr/isabela/jobos",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "canonicalPath": "/pr/san-juan/la-ocho",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "canonicalPath": "/pr/luquillo/la-pared",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "canonicalPath": "/pr/rincon/marias",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "canonicalPath": "/ca/san-diego/mission-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "canonicalPath": "/ca/oceanside/oceanside-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "canonicalPath": "/ca/dana-point/salt-creek",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "canonicalPath": "/ca/dana-point/strands",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "canonicalPath": "/hi/kapolei/tracks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "canonicalPath": "/ca/san-onofre/trails",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "canonicalPath": "/ca/san-onofre/upper-trestles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "canonicalPath": "/hi/ewa-beach/white-plains",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-1.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-1.json
@@ -1,0 +1,2824 @@
+{
+  "generatedAt": "2026-08-09T13:01:55.638Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/204s"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "city": "Bodega Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/cardiff-reef"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "city": "Monterey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca"
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "city": "Isla Vista",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny"
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "city": "Marina",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "city": "Morro Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca"
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "city": "Moss Landing",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca"
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "city": "Orleans",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "city": "Grover Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-pier"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "city": "Palos Verdes",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes"
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "city": "Pismo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "city": "Ponce Inlet",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/salt-creek"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach"
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "city": "Manzanita",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/strands"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "city": "Charleston",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "city": "Torrance",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca"
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "city": "Kapolei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapolei/tracks"
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/trails"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/upper-trestles"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "city": "Ewa Beach",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/ewa-beach/white-plains"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 330,
+    "forecastIneligible": 16,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 16,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 990,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 16,
+    "forecast-approved": 330
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "canonicalPath": "/hi/pupukea/rocky-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-2.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-2.json
@@ -1,0 +1,2818 @@
+{
+  "generatedAt": "2026-08-09T13:02:16.811Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/204s"
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "city": "Bodega Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/cardiff-reef"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "city": "Monterey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca"
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "city": "Isla Vista",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny"
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "city": "Marina",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "city": "Morro Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca"
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "city": "Moss Landing",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca"
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "city": "Orleans",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "city": "Grover Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-pier"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "city": "Palos Verdes",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes"
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "city": "Pismo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "city": "Ponce Inlet",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/salt-creek"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach"
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "city": "Manzanita",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/strands"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "city": "Charleston",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "city": "Torrance",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca"
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "city": "Kapolei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapolei/tracks"
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/trails"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/upper-trestles"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "city": "Ewa Beach",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/ewa-beach/white-plains"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 336,
+    "forecastIneligible": 10,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 10,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 1008,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 10,
+    "forecast-approved": 336
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-3.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-after-shard-3.json
@@ -1,0 +1,2807 @@
+{
+  "generatedAt": "2026-08-09T13:02:43.780Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj"
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/204s"
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "city": "Bodega Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "city": "Boynton Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/cardiff-reef"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "city": "Monterey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca"
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "city": "Isla Vista",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny"
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach"
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/domes"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "city": "Port Orford",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "city": "Marina",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "city": "Morro Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca"
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "city": "Moss Landing",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca"
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "city": "Orleans",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "city": "Grover Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-pier"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "city": "Palos Verdes",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes"
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "city": "Pismo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "city": "Ponce Inlet",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/salt-creek"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/sandy-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach"
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "city": "Manzanita",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/strands"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "city": "Charleston",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "city": "Torrance",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca"
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "city": "Kapolei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapolei/tracks"
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/trails"
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/tres-palmas"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/upper-trestles"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "city": "Ewa Beach",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/ewa-beach/white-plains"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 346,
+    "forecastIneligible": 0,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 0,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 1038,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-approved": 346
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-final.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-final.json
@@ -1,0 +1,2807 @@
+{
+  "generatedAt": "2026-08-09T13:03:18.831Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj"
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/204s"
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "city": "Bodega Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "city": "Boynton Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/cardiff-reef"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "city": "Monterey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca"
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "city": "Isla Vista",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca"
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny"
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach"
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/domes"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "city": "Port Orford",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "city": "Pacific Grove",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "city": "Marina",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "city": "Morro Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca"
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "city": "Moss Landing",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca"
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "city": "Orleans",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "city": "Grover Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-pier"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "city": "Palos Verdes",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes"
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "city": "Pismo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "city": "Ponce Inlet",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/salt-creek"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/sandy-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach"
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "city": "Manzanita",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "city": "Dana Point",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/dana-point/strands"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "city": "Charleston",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "city": "Torrance",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca"
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "city": "Kapolei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapolei/tracks"
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/trails"
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/tres-palmas"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/upper-trestles"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "city": "Ewa Beach",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/ewa-beach/white-plains"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 346,
+    "forecastIneligible": 0,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 0,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 1038,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-approved": 346
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-local.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-local.json
@@ -1,0 +1,3064 @@
+{
+  "generatedAt": "2026-08-09T04:52:43.602Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj"
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj"
+    },
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "city": "Asbury Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj"
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "city": "Boynton Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl"
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "city": "Eastham",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "city": "Corolla",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "city": "Deerfield Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/domes"
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr"
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "city": "Flagler Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "city": "Hampton",
+      "state": "NH",
+      "country": "USA",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "city": "Patillas",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/jobos"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "city": "Kure Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc"
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "city": "San Juan",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/san-juan/la-ocho"
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-pared"
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "city": "Yabucoa",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj"
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj"
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "city": "Manasquan",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj"
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/marias"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "city": "Orleans",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma"
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "city": "Navarre",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "city": "Ogunquit",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "city": "Pensacola Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri"
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "city": "Ponce Inlet",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "city": "Miami Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/tres-palmas"
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj"
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "city": "Ocean City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 81,
+    "forecastIneligible": 265,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 265,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 243,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-approved": 81,
+    "forecast-stale": 265
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "canonicalPath": "/or/newport/agate-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "canonicalPath": "/ca/laguna-beach/agate-street",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "canonicalPath": "/hi/anahola/anahola",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "canonicalPath": "/ca/ocean-beach/avalanche",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "canonicalPath": "/or/bandon/bandon",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "canonicalPath": "/ca/encinitas/beacons",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "canonicalPath": "/ca/san-diego/big-jetty",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "canonicalPath": "/ca/la-jolla/birdrock",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "canonicalPath": "/ca/newport-beach/blackies",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "canonicalPath": "/ca/san-diego/blacks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "canonicalPath": "/or/brookings/brookings-harris-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "canonicalPath": "/ca/laguna-beach/brooks-street",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "canonicalPath": "/ca/encinitas/cardiff-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "canonicalPath": "/hi/haleiwa/chuns-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "canonicalPath": "/ca/san-clemente/church",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "canonicalPath": "/ca/san-clemente/cottons",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "canonicalPath": "/ca/newport-coast/crystal-cove",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "canonicalPath": "/ca/san-diego/crystal-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "canonicalPath": "/ca/del-mar/del-mar",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "canonicalPath": "/ca/dana-point/doheny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "canonicalPath": "/ca/encinitas/d-street",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "canonicalPath": "/or/florence/florence-south-jetty",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "canonicalPath": "/ca/huntington-beach/goldenwest",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "canonicalPath": "/ca/encinitas/grandview",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "canonicalPath": "/hi/haleiwa/haleiwa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "canonicalPath": "/hi/kapalua/honolua-bay",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "canonicalPath": "/hi/paia/hookipa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "canonicalPath": "/ca/la-jolla/horseshoe",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "canonicalPath": "/ca/huntington-beach/huntington-st",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "canonicalPath": "/hi/honolulu/kaisers",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "canonicalPath": "/hi/lihue/kalapaki-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "canonicalPath": "/hi/waimea/pakala-infinities",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "canonicalPath": "/hi/honolulu/kewalo-basin",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "canonicalPath": "/hi/haleiwa/laniakea",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "canonicalPath": "/wa/la-push/la-push-first-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "canonicalPath": "/pr/luquillo/la-selva",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "canonicalPath": "/ca/san-onofre/lower-trestles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "canonicalPath": "/hi/waianae/makaha",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "canonicalPath": "/hi/waimanalo/makapuu",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "canonicalPath": "/ca/san-diego/marine-street-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "canonicalPath": "/ca/san-onofre/middles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "canonicalPath": "/ca/san-diego/mission-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "canonicalPath": "/ca/san-diego/mission-beach-central",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "canonicalPath": "/ca/san-diego/new-break-nubes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "canonicalPath": "/ca/newport-beach/newport-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "canonicalPath": "/ca/san-diego/ocean-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "canonicalPath": "/ca/oceanside/oceanside-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "canonicalPath": "/hi/pupukea/off-the-wall",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "canonicalPath": "/ca/san-diego/osprey-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "canonicalPath": "/ca/san-diego/pacific-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "canonicalPath": "/ca/san-diego/pb-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "canonicalPath": "/hi/haleiwa/pipeline",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "canonicalPath": "/ca/san-clemente/poche-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "canonicalPath": "/ca/carlsbad/ponto",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "canonicalPath": "/hi/honolulu/pops",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "canonicalPath": "/hi/haleiwa/puaena-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "canonicalPath": "/hi/honolulu/publics",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "canonicalPath": "/ca/newport-beach/river-jetties",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "canonicalPath": "/ca/san-clemente/riviera",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "canonicalPath": "/ca/laguna-beach/rockpile",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "canonicalPath": "/hi/pupukea/rocky-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "canonicalPath": "/ca/dana-point/salt-creek",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "canonicalPath": "/ca/la-jolla/scripps",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "canonicalPath": "/or/seaside/seaside-cove",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "canonicalPath": "/ca/solana-beach/seaside-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "canonicalPath": "/ca/solana-beach/solana-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "canonicalPath": "/ca/dana-point/strands",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "canonicalPath": "/hi/pupukea/sunset-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "canonicalPath": "/ca/encinitas/swamis",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "canonicalPath": "/ca/carlsbad/tamarack",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "canonicalPath": "/ca/carlsbad/terramar-point",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "canonicalPath": "/ca/laguna-beach/thalia-street",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "canonicalPath": "/ca/newport-beach/the-wedge",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "canonicalPath": "/hi/honolulu/threes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "canonicalPath": "/ca/san-diego/tourmaline",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "canonicalPath": "/hi/kapolei/tracks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "canonicalPath": "/ca/san-onofre/trails",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "canonicalPath": "/ca/san-clemente/t-street",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "canonicalPath": "/ca/san-onofre/upper-trestles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "canonicalPath": "/hi/kahuku/velzyland",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "canonicalPath": "/hi/honolulu/waikiki-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "canonicalPath": "/hi/honolulu/waikiki-queens",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "canonicalPath": "/hi/pupukea/waimea-bay",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "canonicalPath": "/wa/westport/westport-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "canonicalPath": "/hi/ewa-beach/white-plains",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "canonicalPath": "/ca/la-jolla/windansea",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-AUDIT-post-migration.json
+++ b/reports/seo/FORECAST-AUTHORITY-AUDIT-post-migration.json
@@ -1,0 +1,2897 @@
+{
+  "generatedAt": "2026-08-09T12:44:09.917Z",
+  "forecastQuerySucceeded": true,
+  "eligibleSpots": [
+    {
+      "id": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "name": "36th-42nd Street",
+      "city": "Sea Isle City",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj"
+    },
+    {
+      "id": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "name": "38th Avenue (Santa Cruz)",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca"
+    },
+    {
+      "id": "84564bea-a736-474e-a822-efa55be830ee",
+      "name": "3rd Avenue Beach",
+      "city": "Bradley Beach",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bradley-beach/3rd-avenue-beach-bradley-beach-nj"
+    },
+    {
+      "id": "3a0a42c0-85e0-47ef-938b-fc9c29fd030f",
+      "name": "3rd Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/3rd-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "name": "52nd Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca"
+    },
+    {
+      "id": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "name": "54th Street",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca"
+    },
+    {
+      "id": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "name": "72nd Place",
+      "city": "Long Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca"
+    },
+    {
+      "id": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "name": "8th Avenue Jetty",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj"
+    },
+    {
+      "id": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "name": "Agate Beach",
+      "city": "Newport",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/newport/agate-beach"
+    },
+    {
+      "id": "0f0dcd5a-be9d-4c0d-a7ba-d6f932f9b769",
+      "name": "Agate Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/agate-street"
+    },
+    {
+      "id": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "name": "Alfonsos",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos"
+    },
+    {
+      "id": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "name": "Anahola",
+      "city": "Anahola",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/anahola/anahola"
+    },
+    {
+      "id": "3b2d3a98-7c91-4d8a-81a4-6e0d5d2b9a04",
+      "name": "Andrew Molera State Beach (river mouth)",
+      "city": "Big Sur",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/big-sur/andrew-molera-river-mouth-big-sur-ca"
+    },
+    {
+      "id": "63af8c07-1aed-44bd-b03b-9b20abdff56c",
+      "name": "Avalanche",
+      "city": "Ocean Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ocean-beach/avalanche"
+    },
+    {
+      "id": "a797dcac-2507-4b2b-9d37-1f92dfd6af89",
+      "name": "Avalon Pier",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/avalon-pier-kill-devil-hills-nc"
+    },
+    {
+      "id": "0e7a0a9f-3a0b-44a2-b81c-43a6f7b2a203",
+      "name": "Avila Beach",
+      "city": "Avila Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/avila-beach/avila-beach-avila-beach-ca"
+    },
+    {
+      "id": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "name": "Backyards",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/backyards"
+    },
+    {
+      "id": "3c8f272b-473a-4303-83b7-3081579a042b",
+      "name": "Bandon",
+      "city": "Bandon",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/bandon/bandon"
+    },
+    {
+      "id": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "name": "Banyans",
+      "city": "Kailua-Kona",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kailua-kona/banyans"
+    },
+    {
+      "id": "615ff20a-922f-4487-88d8-fa7d830ebacf",
+      "name": "Bastendorff Beach",
+      "city": "Coos Bay",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/coos-bay/bastendorff-beach-coos-bay-or"
+    },
+    {
+      "id": "b9627a2a-493e-467f-9521-9081b47512cc",
+      "name": "Bay Head Beach",
+      "city": "Bay Head",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/bay-head/bay-head-beach-bay-head-nj"
+    },
+    {
+      "id": "6c4b160d-8aba-4078-aca7-9bde1bf81738",
+      "name": "Bay Street",
+      "city": "Santa Monica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-monica/bay-street-santa-monica-ca"
+    },
+    {
+      "id": "22536002-c7d2-48ab-a676-9b489fd79874",
+      "name": "Beacons",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/beacons"
+    },
+    {
+      "id": "fb0ee60f-a269-47ed-b244-e8dc64fff891",
+      "name": "Belmar Beach",
+      "city": "Belmar",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/belmar/belmar-belmar-nj"
+    },
+    {
+      "id": "ec73bb77-4be5-4126-8986-348929c1e7e9",
+      "name": "Big Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/big-jetty"
+    },
+    {
+      "id": "dbbafa09-3143-4f73-82e8-90a69a4121f5",
+      "name": "Big Rock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/big-rock-la-jolla-ca"
+    },
+    {
+      "id": "ca2b1d6f-2428-4273-ab02-7555eeec4323",
+      "name": "Birdrock",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/birdrock"
+    },
+    {
+      "id": "66d06e54-10bd-458c-a57b-1966a957b825",
+      "name": "Blackies",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/blackies"
+    },
+    {
+      "id": "01330afc-00d3-461b-88f3-b173774766f4",
+      "name": "Blacks Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/blacks"
+    },
+    {
+      "id": "04940f92-f611-448d-acd3-a6456ca8b6de",
+      "name": "Bob Hall Pier",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/bob-hall-pier-corpus-christi-tx"
+    },
+    {
+      "id": "5c0969f9-8496-4291-830e-8caea021d7cc",
+      "name": "Bolinas",
+      "city": "Bolinas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/bolinas/bolinas-bolinas-ca"
+    },
+    {
+      "id": "ef5d9f02-6dfa-4513-92c2-c158dc8c17b5",
+      "name": "Broadway Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/broadway-beach-cape-may-nj"
+    },
+    {
+      "id": "c62b7ad4-8deb-4275-889d-b0eb8ec7c5f0",
+      "name": "Brookings (Harris Beach)",
+      "city": "Brookings",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/brookings/brookings-harris-beach"
+    },
+    {
+      "id": "1f8660f2-891d-4f79-8f16-cad8ebd59c79",
+      "name": "Brooks Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/brooks-street"
+    },
+    {
+      "id": "8de2c2cf-2b8d-4a4e-8d5e-3e7b5d5c7d07",
+      "name": "Campus Point (UCSB)",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/campus-point-ucsb-goleta-ca"
+    },
+    {
+      "id": "b2286d82-0f40-45db-b4d1-3774950f6632",
+      "name": "Cannon Beach (Ecola/Indian)",
+      "city": "Cannon Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/cannon-beach/cannon-beach-ecolaindian"
+    },
+    {
+      "id": "d264fbf8-0525-4d31-adb5-9a0742eaeb7e",
+      "name": "Cape Hatteras Lighthouse",
+      "city": "Buxton",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/buxton/cape-hatteras-lighthouse-buxton-nc"
+    },
+    {
+      "id": "dca521c3-ab32-46c6-8045-8aa7477f59a8",
+      "name": "Capitola Beach",
+      "city": "Capitola",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/capitola/capitola-capitola-ca"
+    },
+    {
+      "id": "c0977bcd-5475-4745-b4b8-0ca1e16a7faf",
+      "name": "Carlsbad State Beach",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/carlsbad-state-beach"
+    },
+    {
+      "id": "d7ed5c84-df3b-4837-85b8-d73c5a7bff3e",
+      "name": "Carmel Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-beach-carmel-ca"
+    },
+    {
+      "id": "a1a7c2e8-2b3f-4b0d-9a6a-3b9d3b6b6c06",
+      "name": "Carmel River State Beach",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/carmel-river-state-beach-carmel-ca"
+    },
+    {
+      "id": "23554d2f-cf2b-487c-8e38-45d19ec785b5",
+      "name": "Carolina Beach",
+      "city": "Carolina Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/carolina-beach/carolina-beach-carolina-beach-nc"
+    },
+    {
+      "id": "1bd1a1f5-5c8a-4607-8d7b-0b8f0d2c9b02",
+      "name": "Cayucos Pier (south side)",
+      "city": "Cayucos",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cayucos/cayucos-pier-south-cayucos-ca"
+    },
+    {
+      "id": "e12b9c1b-c500-47e0-a31c-3765736fe270",
+      "name": "Chun’s Reef",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/chuns-reef"
+    },
+    {
+      "id": "a0332432-4877-48c5-855d-b30fd097ba38",
+      "name": "Church",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/church"
+    },
+    {
+      "id": "99e50d6b-a1cf-458b-8fff-c199cd55b23c",
+      "name": "Cocoa Beach Pier",
+      "city": "Cocoa Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/cocoa-beach/cocoa-beach-pier-cocoa-beach-fl"
+    },
+    {
+      "id": "12e0096c-9826-443f-9131-53aaa646f789",
+      "name": "Corona del Mar",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/corona-del-mar"
+    },
+    {
+      "id": "b29821f9-c91a-486f-981b-7085c6d86b68",
+      "name": "Coronado North Jetty",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/coronado-north-jetty"
+    },
+    {
+      "id": "2c1d7948-72c1-4787-93e8-f33ac9567db0",
+      "name": "Cottons",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/cottons"
+    },
+    {
+      "id": "71bdbe5a-67f6-429c-b1e4-80ec390ec4a3",
+      "name": "County Line",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/county-line-malibu-ca"
+    },
+    {
+      "id": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "name": "Crash Boat",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/crash-boat"
+    },
+    {
+      "id": "a3f9b33e-6b29-4b41-8024-3f7cf1eb66c8",
+      "name": "Crystal Beach",
+      "city": "Crystal Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/crystal-beach/crystal-beach-crystal-beach-tx"
+    },
+    {
+      "id": "0e557ec4-355a-4176-8352-6ea50e379c13",
+      "name": "Crystal Cove",
+      "city": "Newport Coast",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-coast/crystal-cove"
+    },
+    {
+      "id": "cc7c0837-257c-42c3-9d98-634911e73a6a",
+      "name": "Crystal Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/crystal-pier"
+    },
+    {
+      "id": "486dc095-4b21-4edb-838c-97f68b40d1df",
+      "name": "C Street / Ventura Point",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/c-street-ventura-ca"
+    },
+    {
+      "id": "5e72b79d-a12d-4cd3-8da4-b7b92069efbf",
+      "name": "Del Mar",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar"
+    },
+    {
+      "id": "7fc84dd8-abcc-4d7c-9ade-3d1500c1c24c",
+      "name": "Del Mar Rivermouth",
+      "city": "Del Mar",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/del-mar/del-mar-rivermouth"
+    },
+    {
+      "id": "632e0e1c-a256-4d1f-8c6a-c1cbbc6ff2b6",
+      "name": "Ditch Plains",
+      "city": "Montauk",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/montauk/ditch-plains-montauk-ny"
+    },
+    {
+      "id": "1376c3e3-d7b2-408d-b1d4-e6e004cbe063",
+      "name": "Dockweiler State Beach",
+      "city": "Playa Del Rey",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/playa-del-rey/dockweiler-state-beach-playa-del-rey-ca"
+    },
+    {
+      "id": "902a215b-2a3d-40af-9391-16b0afed7dee",
+      "name": "D Street",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/d-street"
+    },
+    {
+      "id": "4194e543-a87e-46ee-b317-56c5820c5567",
+      "name": "El Capitan",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/el-capitan-santa-barbara-ca"
+    },
+    {
+      "id": "6cbb1b4f-d25e-40a3-a78a-b138ebdf9e96",
+      "name": "El Morro Point (K37.5)",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/el-morro-point-k375"
+    },
+    {
+      "id": "52879e4f-fc7f-4c02-a5e3-ea40b992ea80",
+      "name": "El Porto (Manhattan)",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/el-porto-manhattan"
+    },
+    {
+      "id": "be03bc6f-878a-4806-bff2-9cf870a9f241",
+      "name": "El Segundo Beach Jetty",
+      "city": "El Segundo",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/el-segundo/el-segundo-beach-jetty-el-segundo-ca"
+    },
+    {
+      "id": "2b401051-cdbf-41a9-ac30-e636c33a42ef",
+      "name": "Florence South Jetty",
+      "city": "Florence",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/florence/florence-south-jetty"
+    },
+    {
+      "id": "76057acb-e6b4-46c0-ae0e-4110cd7a19d1",
+      "name": "Folly Beach",
+      "city": "Folly Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/folly-beach/folly-beach-folly-beach-sc"
+    },
+    {
+      "id": "e5fee219-672c-4113-a0bb-a86a5d97700f",
+      "name": "Forster St. Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/forster-st-oceanside"
+    },
+    {
+      "id": "208cd792-7e94-419f-802c-09c9634ec6a9",
+      "name": "Fort Point (San Francisco)",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/fort-point-san-francisco-ca"
+    },
+    {
+      "id": "cc0b9ee8-0efc-4f78-9049-48a99e0d2c52",
+      "name": "Galveston – Pleasure Pier",
+      "city": "Galveston",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/galveston/galveston-pleasure-pier-galveston-tx"
+    },
+    {
+      "id": "f0d0c0d9-6c1a-4d2b-9f4e-9f7bb7b8c205",
+      "name": "Garrapata State Beach (southern coves)",
+      "city": "Carmel-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel-by-the-sea/garrapata-southern-coves-carmel-ca"
+    },
+    {
+      "id": "f1899def-896d-48ea-adf3-f7de468966eb",
+      "name": "Ghost Tree",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/ghost-tree-pebble-beach-ca"
+    },
+    {
+      "id": "8d4afe79-ac68-4508-84d5-9175282a3f2c",
+      "name": "Gold Beach (South Jetty)",
+      "city": "Gold Beach",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/gold-beach/gold-beach-south-jetty"
+    },
+    {
+      "id": "66ef3c08-a8a2-4cf1-9361-273489bac45b",
+      "name": "Goldenwest",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/goldenwest"
+    },
+    {
+      "id": "f29ddb0a-6d46-4589-a4a4-da406ddd3d5c",
+      "name": "Grandview Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/grandview"
+    },
+    {
+      "id": "43cfaf0d-0376-45cb-a8bd-78087ba4ee15",
+      "name": "Haleʻiwa Aliʻi Beach",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/haleiwa"
+    },
+    {
+      "id": "b4202dc4-e308-4dc2-9844-665413a75cb1",
+      "name": "Hanalei Bay (Kauai)",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-bay-kauai"
+    },
+    {
+      "id": "71fa4843-1235-4f11-9184-fe1c87e8fbc5",
+      "name": "Hanalei (Wainiha) — Colony Resort",
+      "city": "Hanalei",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/hanalei/hanalei-wainiha-colony-resort"
+    },
+    {
+      "id": "d60dd5c8-d147-4042-a531-c2ec55c620af",
+      "name": "HB Cliffs",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/hb-cliffs"
+    },
+    {
+      "id": "326941d7-6c39-4e82-b045-941b156f7897",
+      "name": "Hermosa Beach Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-pier-hermosa-beach-ca"
+    },
+    {
+      "id": "37ffa92a-d811-4791-afbb-b90a86dcdf49",
+      "name": "Hermosa Pier",
+      "city": "Hermosa Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-pier"
+    },
+    {
+      "id": "adcd7128-424e-46d3-b8d1-f3aad6dd5edb",
+      "name": "Higgins Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/higgins-beach-scarborough-me"
+    },
+    {
+      "id": "44c9add8-cbd4-4e2f-8554-58a32b9b3c08",
+      "name": "Hobuck Beach (Neah Bay)",
+      "city": "Neah Bay",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/neah-bay/hobuck-beach-neah-bay-wa"
+    },
+    {
+      "id": "4dd216b1-edc3-46b6-aabb-66beb467bcaf",
+      "name": "Honolua Bay",
+      "city": "Kapalua",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kapalua/honolua-bay"
+    },
+    {
+      "id": "e6cec9c8-ab43-4ff8-9d79-cb297422b529",
+      "name": "Ho'okipa",
+      "city": "Paia",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/paia/hookipa"
+    },
+    {
+      "id": "30e68b00-c27d-4d22-ba57-2d92156964c6",
+      "name": "Horseshoe",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/horseshoe"
+    },
+    {
+      "id": "84d3468b-c1ec-46ad-8621-d8507e5f167a",
+      "name": "Hotel Del Coronado",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/hotel-del-coronado"
+    },
+    {
+      "id": "071db1df-b5ee-4af6-a022-ea8a09667cbe",
+      "name": "Huntington Beach Pier",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier"
+    },
+    {
+      "id": "72726bcb-bed0-4b76-8336-f90d7fb57159",
+      "name": "Huntington Beach Pier Northside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-northside"
+    },
+    {
+      "id": "025cfc18-8357-49d6-994e-e0abf0a16f6d",
+      "name": "Huntington Beach Pier Southside",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-beach-pier-southside"
+    },
+    {
+      "id": "b57b32b9-0057-46f6-9fa9-cd35d5bd5319",
+      "name": "Huntington St.",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-st"
+    },
+    {
+      "id": "502bd50f-21c8-4cdc-ae96-1d53fcbc34de",
+      "name": "Huntington State Beach",
+      "city": "Huntington Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/huntington-beach/huntington-state-beach"
+    },
+    {
+      "id": "9e94759c-d531-4e5c-9bc2-d022acea9dcd",
+      "name": "Imperial Beach",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach"
+    },
+    {
+      "id": "d9f93c82-7f4b-440a-865a-55cdbb821f74",
+      "name": "Imperial Beach Pier",
+      "city": "Imperial Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/imperial-beach/imperial-beach-pier"
+    },
+    {
+      "id": "f298d080-177b-4407-9e3a-be51bae58605",
+      "name": "Indicators",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/indicators"
+    },
+    {
+      "id": "d15efc29-c4cb-407c-99b8-be92914473f4",
+      "name": "Isle of Palms",
+      "city": "Isle of Palms",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/isle-of-palms/isle-of-palms-isle-of-palms-sc"
+    },
+    {
+      "id": "a4472f56-626e-4905-b909-5f1dc27174a9",
+      "name": "Jacksonville Beach Pier",
+      "city": "Jacksonville Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/jacksonville-beach/jacksonville-beach-pier-jacksonville-beach-fl"
+    },
+    {
+      "id": "1ec3682e-d993-4c60-a650-f630e1ea3b06",
+      "name": "Jalama Beach",
+      "city": "Jalama",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/jalama/jalama-beach-jalama-ca"
+    },
+    {
+      "id": "77d286c5-87e9-4678-82d3-81d0125285fa",
+      "name": "K-38",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/k-38"
+    },
+    {
+      "id": "de6575ce-4ee1-4c6b-a2cf-7009ba171c3b",
+      "name": "K-40 (Puerto Nuevo)",
+      "city": "Puerto Nuevo",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/puerto-nuevo/k-40-puerto-nuevo"
+    },
+    {
+      "id": "67996143-6e0e-4391-a810-9dec48e19963",
+      "name": "Kahalu'u",
+      "city": "Kahaluu-Keauhou",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahaluu-keauhou/kahaluu"
+    },
+    {
+      "id": "785980ea-6213-48bf-8571-55f3267bd2da",
+      "name": "Kaisers",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kaisers"
+    },
+    {
+      "id": "b2b469ea-3d00-44df-88e8-621934c6926f",
+      "name": "Kalapaki Beach",
+      "city": "Lihue",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lihue/kalapaki-beach"
+    },
+    {
+      "id": "34e6e6d4-b640-4412-934f-4343b7dd8dfc",
+      "name": "Kekaha / Pakala (Infinities)",
+      "city": "Waimea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimea/pakala-infinities"
+    },
+    {
+      "id": "8809c326-c194-4b6a-aba0-dd25102294a5",
+      "name": "Kewalo Basin",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/kewalo-basin"
+    },
+    {
+      "id": "fea10ecf-6b55-4cc9-b29b-f215f923759d",
+      "name": "Kill Devil Hills",
+      "city": "Kill Devil Hills",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/kill-devil-hills/kill-devil-hills-kill-devil-hills-nc"
+    },
+    {
+      "id": "a3344c6e-847a-4d85-84f4-6c8de7f7256f",
+      "name": "Kook Bay (Spring Lake)",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/kook-bay-spring-lake-nj"
+    },
+    {
+      "id": "2c622571-c1fa-4c46-afd1-c0769c184570",
+      "name": "Lahaina Harbor (Breakwall)",
+      "city": "Lahaina",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/lahaina/lahaina-harbor-breakwall"
+    },
+    {
+      "id": "d291411d-d331-4bf1-ad1a-302da3c69de0",
+      "name": "La Jolla Shores",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/la-jolla-shores"
+    },
+    {
+      "id": "11fc4aab-e5d2-4439-a726-fd4bd31b6acd",
+      "name": "Laniakea",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/laniakea"
+    },
+    {
+      "id": "058c415c-39da-41bb-aee9-c4942d79e95d",
+      "name": "La Push — First Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-first-beach"
+    },
+    {
+      "id": "281b7eef-bcc3-4ecd-998f-1faa190ed956",
+      "name": "La Push – Second Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-second-beach-la-push-wa"
+    },
+    {
+      "id": "c03fc6d7-913e-4c99-b1f4-610d036b3cbf",
+      "name": "La Push – Third Beach",
+      "city": "La Push",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/la-push/la-push-third-beach-la-push-wa"
+    },
+    {
+      "id": "7db87d82-4e66-4a48-9c8b-d5f95a282a4c",
+      "name": "La Selva",
+      "city": "Luquillo",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/luquillo/la-selva"
+    },
+    {
+      "id": "965196e2-81c3-4c1a-8c2f-e5c9c0f8e3fd",
+      "name": "Las Gaviotas",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/las-gaviotas"
+    },
+    {
+      "id": "ca9f0f1b-f4f5-4601-91c5-5e972c5f1a41",
+      "name": "Latigo Point",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/latigo-point-malibu-ca"
+    },
+    {
+      "id": "e0dd3e3a-1a9e-4b7d-8c55-2d3b6f9b7f09",
+      "name": "Leadbetter",
+      "city": "Santa Barbara",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-barbara/leadbetter-santa-barbara-ca"
+    },
+    {
+      "id": "a13f108b-ad2a-43fa-8ea7-40577ebce66c",
+      "name": "Leo Carrillo State Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/leo-carrillo-state-beach-malibu-ca"
+    },
+    {
+      "id": "03dc4aef-c5e3-48a6-9563-39e0fe08c9b5",
+      "name": "Long Beach",
+      "city": "Long Beach",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/long-beach/long-beach-long-beach-ny"
+    },
+    {
+      "id": "839bab65-0ae4-443e-94a5-0d5bb4b4a5a8",
+      "name": "Long Beach (Boardwalk)",
+      "city": "Long Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/long-beach/long-beach-boardwalk"
+    },
+    {
+      "id": "193a3f9a-66d0-4362-bf55-d25bb831dae4",
+      "name": "Lower Trestles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/lower-trestles"
+    },
+    {
+      "id": "bb286d50-ad8d-4315-b966-5dbc31605a26",
+      "name": "Makaha",
+      "city": "Waianae",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waianae/makaha"
+    },
+    {
+      "id": "86710207-89d0-4d3d-a44b-36648d0e9588",
+      "name": "Makapuʻu",
+      "city": "Waimanalo",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waimanalo/makapuu"
+    },
+    {
+      "id": "9841bdd0-e70f-4c10-bc54-135575006298",
+      "name": "Malibu First Point (Surfrider)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-first-point-surfrider"
+    },
+    {
+      "id": "afbd3aaf-099f-4147-b845-443590f0e148",
+      "name": "Malibu Surfrider (First Point)",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/malibu-surfrider-first-point-malibu-ca"
+    },
+    {
+      "id": "7a093b7e-2230-4bf1-abeb-9b31faa794d5",
+      "name": "Manhattan Beach Pier",
+      "city": "Manhattan Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manhattan-beach/manhattan-beach-pier-manhattan-beach-ca"
+    },
+    {
+      "id": "9b292a48-7a88-4d79-926f-16601515d7a0",
+      "name": "Marine Street Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/marine-street-beach"
+    },
+    {
+      "id": "d2d0b946-da8b-40ea-86ee-5ca2075d7851",
+      "name": "Matagorda",
+      "city": "Matagorda",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/matagorda/matagorda-matagorda-tx"
+    },
+    {
+      "id": "da7dc3e8-51c7-46a7-86f6-c3a90f4da036",
+      "name": "Matunuck",
+      "city": "South Kingstown",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/south-kingstown/matunuck-south-kingstown-ri"
+    },
+    {
+      "id": "033b5518-ee98-4014-9d81-114b936778af",
+      "name": "Mavericks",
+      "city": "Half Moon Bay",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/half-moon-bay/mavericks-half-moon-bay-ca"
+    },
+    {
+      "id": "b5bcd27f-3399-4a0a-b5d5-da8147e43b9a",
+      "name": "Middles",
+      "city": "San Onofre",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-onofre/middles"
+    },
+    {
+      "id": "77903282-042b-4294-b6b2-2e3815489513",
+      "name": "Middles Isabela",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/middles-isabela"
+    },
+    {
+      "id": "cdcf733b-a704-45ef-affc-d8152ffde1e4",
+      "name": "Mission Beach (Central)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/mission-beach-central"
+    },
+    {
+      "id": "abb56ca0-7dad-4026-960f-23412fa5cc8b",
+      "name": "Mitchell's Cove",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/mitchells-cove-santa-cruz-ca"
+    },
+    {
+      "id": "ca0f960e-e859-4b33-8e88-6b2980e48e6a",
+      "name": "Monastery Beach / San Jose Creek Beach",
+      "city": "Carmel",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carmel/monastery-beach-san-jose-creek-beach-carmel-ca"
+    },
+    {
+      "id": "9a64d63a-0c0c-40b7-bc97-d3d931204bba",
+      "name": "Mondos Beach",
+      "city": "Ventura",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/ventura/mondos-beach-ventura-ca"
+    },
+    {
+      "id": "deea2ae1-849d-47a1-9c27-b7bd505dbc07",
+      "name": "Moonlight State Beach",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/moonlight-state-beach"
+    },
+    {
+      "id": "872fdb8c-6e6b-459e-813c-e8fc6a9561bd",
+      "name": "Nags Head Beach",
+      "city": "Nags Head",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/nags-head/nags-head-nags-head-nc"
+    },
+    {
+      "id": "6693188e-80a0-4877-a618-d733ab4809b2",
+      "name": "Nantasket Beach",
+      "city": "Hull",
+      "state": "MA",
+      "country": "USA",
+      "canonicalPath": "/ma/hull/nantasket-beach-hull-ma"
+    },
+    {
+      "id": "662cc0f6-4488-48dc-a820-47768a2e285b",
+      "name": "Narragansett Town Beach",
+      "city": "Narragansett",
+      "state": "RI",
+      "country": "USA",
+      "canonicalPath": "/ri/narragansett/narragansett-town-beach-narragansett-ri"
+    },
+    {
+      "id": "998e264e-3ad7-4875-bb19-04c25d1b173e",
+      "name": "Nelscott Reef",
+      "city": "Lincoln City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/lincoln-city/nelscott-reef-lincoln-city-or"
+    },
+    {
+      "id": "d920e1b9-9e23-4ba8-9f8e-776571435f6f",
+      "name": "New Break (Nubes)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/new-break-nubes"
+    },
+    {
+      "id": "53cc78d5-a759-4153-8a2e-b13cf1bb6b4e",
+      "name": "Newport 56th St",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-56th-st"
+    },
+    {
+      "id": "bbe7f4eb-9807-4e65-8e69-e2cee28d6b24",
+      "name": "Newport Lower Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-lower-jetties"
+    },
+    {
+      "id": "11662c67-a1bb-43a0-b0f7-0e4071b1c3f2",
+      "name": "Newport Point",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-point"
+    },
+    {
+      "id": "e64001e6-e2bd-4596-8f24-d8064e7f5186",
+      "name": "Newport Upper Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/newport-upper-jetties"
+    },
+    {
+      "id": "f5eec6e8-844a-41be-b3bf-4c47e0615545",
+      "name": "New Smyrna Beach (NSB) Inlet",
+      "city": "New Smyrna Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/new-smyrna-beach/new-smyrna-beach-nsb-inlet-new-smyrna-beach-fl"
+    },
+    {
+      "id": "15c7337e-5258-4339-9dc3-c435c666926b",
+      "name": "Ocean Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach"
+    },
+    {
+      "id": "65d177de-e75a-4ad8-aa0d-48a67c0851b0",
+      "name": "Ocean Beach Pier",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/ocean-beach-pier"
+    },
+    {
+      "id": "eca7e91a-0e5e-40d5-acb4-59c6ff50d861",
+      "name": "Ocean Beach SF – North",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-north-san-francisco-ca"
+    },
+    {
+      "id": "d9524c9d-8315-4686-9d35-24ceb6db2a82",
+      "name": "Ocean Beach SF – Sloat",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-sloat-san-francisco-ca"
+    },
+    {
+      "id": "04ab6e6a-477f-49ab-b435-6b201134bcbf",
+      "name": "Ocean Shores",
+      "city": "Ocean Shores",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores"
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor"
+    },
+    {
+      "id": "32c84ce9-ba42-464c-afad-58e4c8664d1e",
+      "name": "Off the Wall",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/off-the-wall"
+    },
+    {
+      "id": "f7d5b137-3950-43ce-891a-0c6ef8917dfd",
+      "name": "Ortley Beach",
+      "city": "Toms River",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/toms-river/ortley-beach-toms-river-nj"
+    },
+    {
+      "id": "c3b42f85-e650-445f-89b1-1debe661652e",
+      "name": "Osprey Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/osprey-point"
+    },
+    {
+      "id": "1fbbe6cc-783f-4b74-9664-a1996ca2649a",
+      "name": "Otter Rock",
+      "city": "Otter Rock",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/otter-rock/otter-rock-otter-rock-or"
+    },
+    {
+      "id": "f2cc331f-6569-40d9-a98b-9f50fb3da67f",
+      "name": "Pacifica / Linda Mar",
+      "city": "Pacifica",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pacifica/linda-mar-pacifica-ca"
+    },
+    {
+      "id": "65809772-20bc-4009-b9b2-89c8ef3c4127",
+      "name": "Pacific Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pacific-beach"
+    },
+    {
+      "id": "cf59e55d-f146-4a72-8daf-5781a0693d13",
+      "name": "Pacific City (Cape Kiwanda)",
+      "city": "Pacific City",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/pacific-city/pacific-city-cape-kiwanda"
+    },
+    {
+      "id": "55c7c5dd-1979-410a-bf39-ce3c52e29166",
+      "name": "Packery Channel Jetties",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/packery-channel-jetties-corpus-christi-tx"
+    },
+    {
+      "id": "14907560-8c92-4d2e-997b-9661e97b0751",
+      "name": "Padre Island National Seashore – South Beach",
+      "city": "Corpus Christi",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/corpus-christi/padre-island-national-seashore-south-beach-corpus-christi-tx"
+    },
+    {
+      "id": "ee7239d5-8e40-4385-b60c-288aff0d4706",
+      "name": "Pawleys Island Pier",
+      "city": "Pawleys Island",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/pawleys-island/pawleys-island-pier-pawleys-island-sc"
+    },
+    {
+      "id": "13ef0aa1-c857-4d82-a40d-a83612110943",
+      "name": "PB Point",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/pb-point"
+    },
+    {
+      "id": "55c54357-fdc9-402e-9c31-1bb17978bb03",
+      "name": "Pine Grove",
+      "city": "Carolina",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/carolina/pine-grove"
+    },
+    {
+      "id": "6a0674ac-3e6d-49f3-9fd4-a4f1857c408a",
+      "name": "Pipeline",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/pipeline"
+    },
+    {
+      "id": "cdfb7e59-ce4e-4112-acc5-15fe56a8b6a3",
+      "name": "Pleasure Point",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/pleasure-point-santa-cruz-ca"
+    },
+    {
+      "id": "b9c4a949-4562-47db-ae7d-b2131e20d7a7",
+      "name": "Poche Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/poche-beach"
+    },
+    {
+      "id": "c778cc0a-2094-4649-84cd-4c38ce864f23",
+      "name": "Point Arena / Manchester Beach",
+      "city": "Manchester",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/manchester/point-arena-manchester-beach-ca"
+    },
+    {
+      "id": "231d8635-6ae1-40e5-9112-88c26b0918ac",
+      "name": "Poipu Beach (Kauai)",
+      "city": "Koloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/koloa/poipu-beach-kauai"
+    },
+    {
+      "id": "badd7986-4609-421a-ab3d-81fcd8409a5b",
+      "name": "Ponto",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/ponto"
+    },
+    {
+      "id": "b8e6da01-3696-4d18-b00f-e71081e7a8dc",
+      "name": "Pops",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/pops"
+    },
+    {
+      "id": "13febd14-22c1-41a8-a78d-09c436194c9f",
+      "name": "Port Aransas – Horace Caldwell Pier",
+      "city": "Port Aransas",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/port-aransas/port-aransas-horace-caldwell-pier-port-aransas-tx"
+    },
+    {
+      "id": "1073228d-4ca4-4d67-a5bd-2ff372f1a749",
+      "name": "Poverty Beach",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/poverty-beach-cape-may-nj"
+    },
+    {
+      "id": "3bee4922-90ff-442c-b173-05c5ffa0e127",
+      "name": "Puaʻena Point",
+      "city": "Haleiwa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/haleiwa/puaena-point"
+    },
+    {
+      "id": "99c6a506-e4b7-42e4-be2d-c3afb303c22e",
+      "name": "Publics",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/publics"
+    },
+    {
+      "id": "13a91b0d-3e80-4140-b11e-2c1b12e00687",
+      "name": "Redondo Breakwall",
+      "city": "Redondo Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/redondo-beach/redondo-breakwall-redondo-beach-ca"
+    },
+    {
+      "id": "a17f4c57-324d-4157-a641-fa935464302e",
+      "name": "Refugio State Beach",
+      "city": "Goleta",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/goleta/refugio-state-beach-goleta-ca"
+    },
+    {
+      "id": "294712f3-3c06-44bd-9bc6-17275675fe9a",
+      "name": "Renes",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/renes"
+    },
+    {
+      "id": "bec2d595-ed20-4c2b-93c7-4b880406332f",
+      "name": "Rincon",
+      "city": "Carpinteria",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carpinteria/rincon-carpinteria-ca"
+    },
+    {
+      "id": "a0e764f1-d0bb-4341-b397-7b21823cb93b",
+      "name": "River Jetties",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/river-jetties"
+    },
+    {
+      "id": "1a854513-1c65-458e-abb6-384ba4090b0b",
+      "name": "Riviera",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/riviera"
+    },
+    {
+      "id": "22696f11-3897-4fa6-b266-2f52dae4d5ac",
+      "name": "Robert Moses State Park",
+      "city": "Babylon",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/babylon/robert-moses-state-park-babylon-ny"
+    },
+    {
+      "id": "7e7b38b1-767f-4213-9314-538f51ab5084",
+      "name": "Rockaway Beach – 90th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-90th-st-queens-ny"
+    },
+    {
+      "id": "1a7ac53d-f3ac-4f78-a89a-8befb2fa69b7",
+      "name": "Rockaway Beach – 98th St",
+      "city": "Queens",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/queens/rockaway-beach-98th-st-queens-ny"
+    },
+    {
+      "id": "79e8be90-df33-4b80-9d92-e79e26a67a69",
+      "name": "Rockpile",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/rockpile"
+    },
+    {
+      "id": "943e369c-2180-4152-b457-26dbbbb9c23e",
+      "name": "Rocky Point",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/rocky-point"
+    },
+    {
+      "id": "f0ddfc6a-7392-40c5-9211-836c05e449f1",
+      "name": "Rosarito Beach",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/rosarito-beach"
+    },
+    {
+      "id": "e99552bf-45bd-46a8-a716-4cdfff2061f2",
+      "name": "San Clemente Pier, Northside",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-pier-northside"
+    },
+    {
+      "id": "02dfc45e-f7f8-4fdc-8008-6ce14e2839f5",
+      "name": "San Clemente State Beach",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/san-clemente-state-beach"
+    },
+    {
+      "id": "f11ccd59-b778-4ea1-a8ff-88bffb447cd8",
+      "name": "Sandy Beach Rincón",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/sandy-beach-rincon"
+    },
+    {
+      "id": "0e550715-3367-4829-8671-8f38bd5be34f",
+      "name": "Sandy Hook",
+      "city": "Sandy Hook",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/sandy-hook/sandy-hook-sandy-hook-nj"
+    },
+    {
+      "id": "09affcd2-1eca-4f7d-852e-413972ea4154",
+      "name": "San Elijo State Beach",
+      "city": "Cardiff-by-the-Sea",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/cardiff-by-the-sea/san-elijo-state-beach"
+    },
+    {
+      "id": "307d7cb3-f235-4b32-9b42-8a375ac9f54f",
+      "name": "Satellite Beach",
+      "city": "Satellite Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/satellite-beach/satellite-beach-satellite-beach-fl"
+    },
+    {
+      "id": "a1566585-0143-4a1d-983f-c7fd195c5e55",
+      "name": "Scarborough Beach",
+      "city": "Scarborough",
+      "state": "ME",
+      "country": "USA",
+      "canonicalPath": "/me/scarborough/scarborough-beach-scarborough-me"
+    },
+    {
+      "id": "4b0cf129-c706-4e24-8210-2219defc5ea7",
+      "name": "Scripps",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/scripps"
+    },
+    {
+      "id": "5079a9ab-8d43-433e-99ea-20d3667dd0a8",
+      "name": "Seabrook (Pacific Beach area)",
+      "city": "Pacific Beach",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/pacific-beach/seabrook-pacific-beach-area"
+    },
+    {
+      "id": "e6602d4e-7b5a-456d-b675-230ca5501cde",
+      "name": "Seal Beach Pier",
+      "city": "Seal Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/seal-beach/seal-beach-pier-seal-beach-ca"
+    },
+    {
+      "id": "4055099a-2e07-4a84-b17a-47a401ff749c",
+      "name": "Seaside Cove",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove"
+    },
+    {
+      "id": "6f683baf-fd73-4a77-95b2-46f04050b136",
+      "name": "Seaside Cove (Oregon)",
+      "city": "Seaside",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/seaside/seaside-cove-oregon-seaside-or"
+    },
+    {
+      "id": "ce47aad5-8a2d-490c-8d42-5ebafc9e9105",
+      "name": "Seaside Park",
+      "city": "Seaside Park",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/seaside-park/seaside-park-seaside-park-nj"
+    },
+    {
+      "id": "5a34b2ac-01b9-4b83-8c05-c47b1b55d923",
+      "name": "Seaside Reef",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/seaside-reef"
+    },
+    {
+      "id": "d0f77b47-ec94-4188-8dde-d52a10b7be49",
+      "name": "Sebastian Inlet",
+      "city": "Melbourne Beach",
+      "state": "FL",
+      "country": "USA",
+      "canonicalPath": "/fl/melbourne-beach/sebastian-inlet-melbourne-beach-fl"
+    },
+    {
+      "id": "81dac2f3-8646-4f01-b8e3-a863c421ba2a",
+      "name": "Seven Presidents Oceanfront Park",
+      "city": "Long Branch",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/long-branch/seven-presidents-long-branch-nj"
+    },
+    {
+      "id": "a240ccfc-d047-4471-a406-6ae5e92b0816",
+      "name": "Shacks",
+      "city": "Isabela",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/isabela/shacks"
+    },
+    {
+      "id": "5e8d07ff-786c-4b7e-ab19-53d2b3774e23",
+      "name": "Shipwrecks",
+      "city": "Coronado",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/coronado/shipwrecks-coronado-ca"
+    },
+    {
+      "id": "2c2dea98-280b-488c-9d46-ffed8226447b",
+      "name": "Short Sands (Oswald West)",
+      "city": "Arch Cape",
+      "state": "OR",
+      "country": "USA",
+      "canonicalPath": "/or/arch-cape/short-sands-oswald-west"
+    },
+    {
+      "id": "94f1010b-c71f-4025-bda1-c26ed9467c85",
+      "name": "Silver Strand State Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/silver-strand-state-beach"
+    },
+    {
+      "id": "144b902f-4766-4bfa-a0ed-db41ade6a704",
+      "name": "Smith Point County Park",
+      "city": "Shirley",
+      "state": "NY",
+      "country": "USA",
+      "canonicalPath": "/ny/shirley/smith-point-county-park-shirley-ny"
+    },
+    {
+      "id": "65d3a4de-1f4b-4a1d-8ce0-b5b67288ee08",
+      "name": "Solana Beach",
+      "city": "Solana Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/solana-beach/solana-beach"
+    },
+    {
+      "id": "eb18d122-5d15-4239-9eb5-eca0392b4c4b",
+      "name": "South End Jetty",
+      "city": "Spring Lake",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/spring-lake/south-end-jetty-spring-lake-nj"
+    },
+    {
+      "id": "19313c94-11c9-431e-9f0b-9cc9e89628aa",
+      "name": "South Litchfield",
+      "city": "Litchfield Beach",
+      "state": "SC",
+      "country": "USA",
+      "canonicalPath": "/sc/litchfield-beach/south-litchfield-litchfield-beach-sc"
+    },
+    {
+      "id": "fa19107a-a276-4257-872d-c5331264d01b",
+      "name": "South Padre Island – Isla Blanca Park",
+      "city": "South Padre Island",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/south-padre-island/south-padre-island-isla-blanca-park-south-padre-island-tx"
+    },
+    {
+      "id": "b1adcf43-2b85-4247-b840-6b1230e886b4",
+      "name": "Spanish Bay / South Moss Beach",
+      "city": "Pebble Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/pebble-beach/spanish-bay-south-moss-beach-pebble-beach-ca"
+    },
+    {
+      "id": "2609a9ff-d247-4e0b-888f-a793ff7177a5",
+      "name": "Steamer Lane",
+      "city": "Santa Cruz",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/santa-cruz/steamer-lane-santa-cruz-ca"
+    },
+    {
+      "id": "5a5dc7b8-4d30-44af-9715-3dbb4dbc9859",
+      "name": "Stinson Beach",
+      "city": "Stinson Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/stinson-beach/stinson-beach-stinson-beach-ca"
+    },
+    {
+      "id": "4c29c993-e769-414b-8539-7867c7e04772",
+      "name": "S‑Turns",
+      "city": "Rodanthe",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/rodanthe/s-turns-rodanthe-nc"
+    },
+    {
+      "id": "f52f2c49-342a-4694-b04a-d66503446736",
+      "name": "Sunset Beach",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/sunset-beach"
+    },
+    {
+      "id": "b939f928-2653-494a-831d-6394cb548190",
+      "name": "Sunset Cliffs – Garbage",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage-san-diego-ca"
+    },
+    {
+      "id": "34af0af5-b61c-4b86-9d9d-bf328f538a12",
+      "name": "Sunset Cliffs – Luscombs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-luscombs-san-diego-ca"
+    },
+    {
+      "id": "d305ba0d-47cd-4494-b790-f924dac7bf1f",
+      "name": "Sunset Cliffs North (Garbage)",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/sunset-cliffs-garbage"
+    },
+    {
+      "id": "fd6522df-caf5-4d78-bb35-8b53ce603db2",
+      "name": "Surf City",
+      "city": "Surf City",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/surf-city/surf-city-surf-city-nc"
+    },
+    {
+      "id": "4a0aac5b-86e5-433d-8a54-64c8e15197f9",
+      "name": "Surfer's Beach",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/surfers-beach"
+    },
+    {
+      "id": "466b9671-93c6-402c-9de6-627367d9de6c",
+      "name": "Surfside Beach",
+      "city": "Surfside Beach",
+      "state": "TX",
+      "country": "USA",
+      "canonicalPath": "/tx/surfside-beach/surfside-beach-surfside-beach-tx"
+    },
+    {
+      "id": "b24c6fa9-9f82-4a1e-afcd-0d1fb0ce69d0",
+      "name": "Swami's",
+      "city": "Encinitas",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/encinitas/swamis"
+    },
+    {
+      "id": "b1b49703-2376-407d-b1fb-9df06130ac1d",
+      "name": "Tamarack",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/tamarack"
+    },
+    {
+      "id": "ec7b1ab4-5f43-4af3-b45f-325d29b8d5e6",
+      "name": "Teresa's",
+      "city": "Rosarito",
+      "state": "Baja California",
+      "country": "Mexico",
+      "canonicalPath": "/mexico/baja-california/rosarito/teresas"
+    },
+    {
+      "id": "1fe4bf73-c425-48a5-899d-a7e8ee2d67e3",
+      "name": "Terramar Point",
+      "city": "Carlsbad",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/carlsbad/terramar-point"
+    },
+    {
+      "id": "2a2195ef-27d1-4b35-a006-b7177b34dad2",
+      "name": "Thalia Street",
+      "city": "Laguna Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/laguna-beach/thalia-street"
+    },
+    {
+      "id": "d56a19ac-a0ee-4f99-b041-a10d70c26860",
+      "name": "The Cove (Cape May)",
+      "city": "Cape May",
+      "state": "NJ",
+      "country": "USA",
+      "canonicalPath": "/nj/cape-may/the-cove-cape-may-nj"
+    },
+    {
+      "id": "bfd3e168-f268-4692-901c-4b80b9b58dcb",
+      "name": "The Point at Sandy",
+      "city": "Rincón",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/rincon/the-point-at-sandy"
+    },
+    {
+      "id": "762fcfa2-8fd8-40ea-8955-b9cc6945a422",
+      "name": "The Rock, Oceanside",
+      "city": "Oceanside",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/oceanside/the-rock-oceanside"
+    },
+    {
+      "id": "c2c7cc01-4920-4fd9-941c-68df6b46ced0",
+      "name": "The Wedge",
+      "city": "Newport Beach",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/newport-beach/the-wedge"
+    },
+    {
+      "id": "b97ebd24-dcf6-49ce-a503-f678b4de0019",
+      "name": "Threes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/threes"
+    },
+    {
+      "id": "929caa5e-c79f-4b60-8fe0-bec75c2df2d6",
+      "name": "Tijuana Sloughs",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tijuana-sloughs"
+    },
+    {
+      "id": "101bd2f7-e1dc-4940-b4e3-3a820d5940dd",
+      "name": "Topanga",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/topanga-malibu-ca"
+    },
+    {
+      "id": "17628f35-9ed1-4257-aad6-070c4bd73bb8",
+      "name": "Tourmaline Beach",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline"
+    },
+    {
+      "id": "91df193c-f2c8-4e6c-984e-b859bd741061",
+      "name": "Tourmaline Surf Park",
+      "city": "San Diego",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-diego/tourmaline-surf-park"
+    },
+    {
+      "id": "dfeecc16-6395-4600-89e6-baf8456e3d69",
+      "name": "T-Street",
+      "city": "San Clemente",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/san-clemente/t-street"
+    },
+    {
+      "id": "d3740aa5-3c96-4575-a60c-d8200023affe",
+      "name": "Tybee Island",
+      "city": "Tybee Island",
+      "state": "GA",
+      "country": "USA",
+      "canonicalPath": "/ga/tybee-island/tybee-island-tybee-island-ga"
+    },
+    {
+      "id": "dc3e8490-9560-4713-8b87-dcc1a6a89c53",
+      "name": "Velzyland",
+      "city": "Kahuku",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/kahuku/velzyland"
+    },
+    {
+      "id": "96fd7011-b894-4776-a68d-ff16fb1985d8",
+      "name": "Venice Breakwater",
+      "city": "Venice",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/venice/venice-breakwater-los-angeles-ca"
+    },
+    {
+      "id": "1913d8a0-38f9-468f-bb4c-18789e92731d",
+      "name": "Waddell Creek",
+      "city": "Davenport",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/davenport/waddell-creek-davenport-ca"
+    },
+    {
+      "id": "880748ee-5423-4b2e-a5c3-b2faab5c4a7a",
+      "name": "Waikiki (Aquarium)",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-aquarium"
+    },
+    {
+      "id": "846ccff8-0e26-41f3-8496-5c5221109c6c",
+      "name": "Waikiki Beach",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-beach"
+    },
+    {
+      "id": "2ac8b200-fdf2-4822-bcb1-3ec336b83d05",
+      "name": "Waikiki – Canoes",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-canoes"
+    },
+    {
+      "id": "ae2e2eee-897c-4198-80fa-04b2d47128d7",
+      "name": "Waikiki – Queens",
+      "city": "Honolulu",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/honolulu/waikiki-queens"
+    },
+    {
+      "id": "22d65140-1c40-4bbe-8790-5068fa6e5f22",
+      "name": "Waikoloa Village Lagoon",
+      "city": "Waikoloa",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/waikoloa/waikoloa-village-lagoon"
+    },
+    {
+      "id": "12431285-b73c-48e4-99b3-731594f6f98c",
+      "name": "Waimea Bay",
+      "city": "Pupukea",
+      "state": "HI",
+      "country": "USA",
+      "canonicalPath": "/hi/pupukea/waimea-bay"
+    },
+    {
+      "id": "260868de-b952-470b-a764-b95b3e7f6655",
+      "name": "Westport Beach",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-beach"
+    },
+    {
+      "id": "51180cd3-b83b-4cf8-99b2-8705c68b87ef",
+      "name": "Westport – Half Moon Bay (The Cove)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-half-moon-bay-westport-wa"
+    },
+    {
+      "id": "a83def7f-6b68-402f-a0ef-f78a5bcfbf81",
+      "name": "Westport (Marina/Groins/Jetty)",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-marinagroinsjetty"
+    },
+    {
+      "id": "4ec455fa-dab5-4cfa-884f-1f1d29154c74",
+      "name": "Westport – The Groins",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-groins-westport-wa"
+    },
+    {
+      "id": "cb75834d-79cb-4b65-859b-d0a370bfc75e",
+      "name": "Westport – The Jetty",
+      "city": "Westport",
+      "state": "WA",
+      "country": "USA",
+      "canonicalPath": "/wa/westport/westport-jetty-westport-wa"
+    },
+    {
+      "id": "2795319c-e680-45d0-a8af-f4c55631986e",
+      "name": "Wilderness",
+      "city": "Aguadilla",
+      "state": "PR",
+      "country": "USA",
+      "canonicalPath": "/pr/aguadilla/wilderness"
+    },
+    {
+      "id": "6f42d47d-215b-47cb-ac14-b83bf8c2a797",
+      "name": "Windansea",
+      "city": "La Jolla",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/la-jolla/windansea"
+    },
+    {
+      "id": "4b88f10a-c794-4144-b17a-133af9fee9f9",
+      "name": "Wrightsville Beach",
+      "city": "Wrightsville Beach",
+      "state": "NC",
+      "country": "USA",
+      "canonicalPath": "/nc/wrightsville-beach/wrightsville-beach-wrightsville-beach-nc"
+    },
+    {
+      "id": "836f218a-9471-46c9-b201-24da1dfe0f3a",
+      "name": "Zuma Beach",
+      "city": "Malibu",
+      "state": "CA",
+      "country": "USA",
+      "canonicalPath": "/ca/malibu/zuma-beach-malibu-ca"
+    }
+  ],
+  "summary": {
+    "totalBeachRecords": 346,
+    "totalCanonicalSpotPages": 346,
+    "forecastEligible": 257,
+    "forecastIneligible": 89,
+    "missingForecast": 0,
+    "incompleteForecast": 0,
+    "staleForecast": 89,
+    "badLocationIdentity": 0,
+    "quarantinedEditorial": 1,
+    "missingMetadata": 0,
+    "canonicalConflicts": 0,
+    "sitemapEntries": 771,
+    "missingSitemapEntries": 0
+  },
+  "reasonCounts": {
+    "forecast-stale": 89,
+    "forecast-approved": 257
+  },
+  "canonicalConflicts": [],
+  "missingSitemapEntries": [],
+  "failures": [
+    {
+      "id": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "name": "12th Street Jetty",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "name": "1st Street Jetty",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "name": "204s",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "336e967d-86a6-40db-9404-e398b057fefe",
+      "name": "7th Street Beach",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "name": "Ala Moana Bowls",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1279cf64-8ef0-4bb9-b786-6dd77fc2c201",
+      "name": "Asbury Park",
+      "canonicalPath": "/nj/asbury-park/asbury-park-asbury-park-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "b1d6dd7c-cfd7-47ba-83ad-6fe09e67cfe4",
+      "name": "Asilomar State Beach",
+      "canonicalPath": "/ca/pacific-grove/asilomar-state-beach-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e28bbce6-2ad8-478c-9271-3dc82461975d",
+      "name": "Belmar Fishing Pier",
+      "canonicalPath": "/nj/belmar/belmar-fishing-pier-belmar-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "92e18cf0-97c3-4c68-9cdf-800eb9ac4313",
+      "name": "Bodega Bay / Doran Beach",
+      "canonicalPath": "/ca/bodega-bay/doran-beach-bodega-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "name": "Boynton Inlet",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4d6c17f9-5fd9-40d6-b9c3-cd0e25ce5bcb",
+      "name": "Brinley Avenue",
+      "canonicalPath": "/nj/bradley-beach/brinley-avenue-bradley-beach-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80efa1c0-37a2-4879-819b-647ae3c3d749",
+      "name": "Cardiff Reef",
+      "canonicalPath": "/ca/encinitas/cardiff-reef",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7c9ac9f8-a836-4ee4-b5bb-5fe5936d54b4",
+      "name": "Coast Guard Beach",
+      "canonicalPath": "/ma/eastham/coast-guard-beach-eastham-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885440f6-10c2-4c70-aa40-b7b71044cda3",
+      "name": "Corolla",
+      "canonicalPath": "/nc/corolla/corolla-corolla-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "name": "Deerfield Beach Pier",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3d480de-3743-4dd7-8092-fb52772a0fb2",
+      "name": "Del Monte Beach",
+      "canonicalPath": "/ca/monterey/del-monte-beach-monterey-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f7fbc2c4-7c4e-4c2c-8f8a-5e3bd1ee8e08",
+      "name": "Devereux / Sands (Coal Oil Point)",
+      "canonicalPath": "/ca/isla-vista/devereux-sands-isla-vista-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "name": "Diamond Head (Cliffs)",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a57ae4c8-7a27-4d3f-91d5-6229350fb888",
+      "name": "Doheny Beach",
+      "canonicalPath": "/ca/dana-point/doheny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a4575b12-2bc3-44d4-ba53-4415707f3851",
+      "name": "Doheny State Beach",
+      "canonicalPath": "/ca/dana-point/doheny-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "name": "Domes",
+      "canonicalPath": "/pr/rincon/domes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "name": "El Cocal",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "21eae8b9-387c-438c-b144-55796bab5caa",
+      "name": "Emma Wood",
+      "canonicalPath": "/ca/ventura/emma-wood-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "name": "Flagler Beach",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "name": "Galveston – 61st Street Pier",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "7dca6429-25ee-4161-a2c2-800555ed8a6a",
+      "name": "George's",
+      "canonicalPath": "/ca/cardiff-by-the-sea/georges",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8160745c-6322-45b0-8bad-81319574008b",
+      "name": "Hampton Beach",
+      "canonicalPath": "/nh/hampton/hampton-beach-hampton-nh",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "1ac4f5f1-94a1-4347-b4ca-6c9d62aee5d3",
+      "name": "Hapuna Beach (Kohala)",
+      "canonicalPath": "/hi/waimea/hapuna-beach-kohala",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "110a87b2-cb2c-4bb7-8e83-b895fb2f4940",
+      "name": "Hermosa Beach South",
+      "canonicalPath": "/ca/hermosa-beach/hermosa-beach-south-hermosa-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "387c8c1c-d6e3-494e-96d9-e5b025aa995b",
+      "name": "Humbug Mountain (Port Orford)",
+      "canonicalPath": "/or/port-orford/humbug-mountain-port-orford",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4b9682e4-87f9-4058-81aa-ea0630e7be47",
+      "name": "Inches",
+      "canonicalPath": "/pr/patillas/inches-patillas-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "388bb737-5889-46d0-a182-d26567bf23f6",
+      "name": "Jobos",
+      "canonicalPath": "/pr/isabela/jobos",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49edc438-1e29-47e4-a66f-d8d68cd4e7fe",
+      "name": "Kure Beach",
+      "canonicalPath": "/nc/kure-beach/kure-beach-kure-beach-nc",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bfcdd918-de0f-4b0f-b771-caca7a9c8baa",
+      "name": "La Ocho",
+      "canonicalPath": "/pr/san-juan/la-ocho",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6c111c72-1773-490b-ae9e-fe6d81827989",
+      "name": "La Pared",
+      "canonicalPath": "/pr/luquillo/la-pared",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d43d6f41-1458-4141-b11e-837760e8b14c",
+      "name": "La Pozita",
+      "canonicalPath": "/pr/yabucoa/la-pozita-yabucoa-pr",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f84767c3-4c79-42ed-9e77-2351ab80d20e",
+      "name": "Long Branch Beach",
+      "canonicalPath": "/nj/long-branch/long-branch-long-branch-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5251554-03ce-49c3-b8e8-bc7a40ecd44e",
+      "name": "Lovers Point",
+      "canonicalPath": "/ca/pacific-grove/lovers-point-pacific-grove-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "005b0ba6-a2d9-4069-adbb-6571baffa698",
+      "name": "Malibu Second Point",
+      "canonicalPath": "/ca/malibu/malibu-second-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "abd3b0fa-6de6-480a-a6cc-c5c83143a707",
+      "name": "Malibu Third Point",
+      "canonicalPath": "/ca/malibu/malibu-third-point-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee905024-1532-4540-9edb-e371c2dde4da",
+      "name": "Mambo Beach",
+      "canonicalPath": "/nj/spring-lake/mambo-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fb4fa0e0-328c-442b-b17a-82f95fbb6af5",
+      "name": "Manasquan Inlet",
+      "canonicalPath": "/nj/manasquan/manasquan-inlet-manasquan-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c879b55-26e6-4755-92f3-0291f4634f24",
+      "name": "María's",
+      "canonicalPath": "/pr/rincon/marias",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c0f23f4b-fcc4-4849-88f4-cb6da7206d80",
+      "name": "Marina State Beach",
+      "canonicalPath": "/ca/marina/marina-state-beach-marina-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "0f0a1339-f7d0-4b1a-ae95-61939998b4ef",
+      "name": "Mesa Lane",
+      "canonicalPath": "/ca/santa-barbara/mesa-lane-santa-barbara-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c02b4ede-69d9-440e-b8de-22ea4bde10ef",
+      "name": "Mission Beach",
+      "canonicalPath": "/ca/san-diego/mission-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "5c7c2a2e-3c7f-4a8c-8e8a-5cf2e9a0b101",
+      "name": "Morro Rock / Sandspit (inside bend)",
+      "canonicalPath": "/ca/morro-bay/morro-rock-sandspit-inside-bend-morro-bay-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "885ad595-67cb-4408-b4cc-9ecf2ce3a848",
+      "name": "Moss Landing",
+      "canonicalPath": "/ca/moss-landing/moss-landing-moss-landing-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "name": "Mustang Island State Park",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9eeb258d-2fb7-4e72-a6a4-4451882dedb6",
+      "name": "Nauset Beach",
+      "canonicalPath": "/ma/orleans/nauset-beach-orleans-ma",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3b948da8-26a0-43f6-8ad3-e99e9cc5174b",
+      "name": "Navarre Beach Pier",
+      "canonicalPath": "/fl/navarre/navarre-beach-pier-navarre-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e8a921b7-c2b5-4259-9e5c-bd06765f7ae4",
+      "name": "Ocean Beach SF – Middle",
+      "canonicalPath": "/ca/san-francisco/ocean-beach-middle-san-francisco-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "124c7751-a232-4c92-be53-3a750a315256",
+      "name": "Oceano / Grover Beach",
+      "canonicalPath": "/ca/grover-beach/oceano-grover-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "60b6bb17-dc08-4f18-8241-33729bcbc742",
+      "name": "Ocean Shores / North Beaches",
+      "canonicalPath": "/wa/ocean-shores/ocean-shores-north-beaches",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a30b9870-aace-48ef-a3e6-e275ad9c28c1",
+      "name": "Oceanside Harbor",
+      "canonicalPath": "/ca/oceanside/oceanside-harbor",
+      "indexabilityReason": "forecast-approved",
+      "editorialQuarantined": true,
+      "editorialReasons": [
+        "location-reference:Siuslaw River"
+      ],
+      "metadataMissing": false
+    },
+    {
+      "id": "cceecad1-7668-4ad8-88ff-ade893c605cd",
+      "name": "Oceanside Pier",
+      "canonicalPath": "/ca/oceanside/oceanside-pier",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4836065b-e9a9-4568-912d-41ca148ddce0",
+      "name": "Ogunquit Beach",
+      "canonicalPath": "/me/ogunquit/ogunquit-beach-ogunquit-me",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a956de46-b204-448e-a541-db427be7e85f",
+      "name": "Old Man's (SanO)",
+      "canonicalPath": "/ca/san-clemente/old-mans-sano",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9a3da3b5-e25b-45a4-b9dd-3ba6bc75a9fa",
+      "name": "Palos Verdes Cove",
+      "canonicalPath": "/ca/palos-verdes/palos-verdes-cove-palos-verdes-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3433ea8e-6528-4c18-8b16-c830bf642568",
+      "name": "Pensacola Pier",
+      "canonicalPath": "/fl/pensacola-beach/pensacola-pier-pensacola-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fbe805b3-b9f5-40e0-afbb-3c5a8d45f67b",
+      "name": "Pine Trees (Kohanaiki)",
+      "canonicalPath": "/hi/kailua-kona/pine-trees-kohanaiki",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2380adaa-a07c-44f4-9444-656ef51fa998",
+      "name": "Pipes",
+      "canonicalPath": "/ca/cardiff-by-the-sea/pipes",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "ee2aad76-966d-4aa3-86a2-499fde59b271",
+      "name": "Pismo Pier",
+      "canonicalPath": "/ca/pismo-beach/pismo-pier-pismo-beach-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bba95994-b2a3-4505-8e6f-1f85ccfbb0dc",
+      "name": "Point Dume",
+      "canonicalPath": "/ca/malibu/point-dume-malibu-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "64cb1fb1-e5aa-4306-a6eb-87b9afd14e99",
+      "name": "Point Judith",
+      "canonicalPath": "/ri/narragansett/point-judith-narragansett-ri",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "9c6bdc37-68c3-4101-9c2f-d188384528b6",
+      "name": "Ponce Inlet",
+      "canonicalPath": "/fl/ponce-inlet/ponce-inlet-ponce-inlet-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "49739de1-95fb-4e26-b890-56fafd8d2622",
+      "name": "Rockaway Beach (Pacifica)",
+      "canonicalPath": "/ca/pacifica/rockaway-beach-pacifica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "73bb4a48-3d53-42ba-bbd0-d89a7cf95711",
+      "name": "Salt Creek",
+      "canonicalPath": "/ca/dana-point/salt-creek",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "d663a525-f59d-4873-b67a-50898ca1c72c",
+      "name": "Sandy Beach",
+      "canonicalPath": "/hi/honolulu/sandy-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "8a47b323-0874-45d9-aa17-ced468f70f2d",
+      "name": "San Onofre State Beach",
+      "canonicalPath": "/ca/san-clemente/san-onofre-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "29fefd13-7472-4ce8-9c3c-be3dabcbb233",
+      "name": "Santa Monica Beach",
+      "canonicalPath": "/ca/santa-monica/santa-monica-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "6d3a734b-b051-490d-87e4-df83c3f49c42",
+      "name": "Short Sands",
+      "canonicalPath": "/or/manzanita/short-sands-manzanita-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "411b3825-c047-4628-997d-08712117ad56",
+      "name": "Solimar Reef",
+      "canonicalPath": "/ca/ventura/solimar-reef-ventura-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "55cc5dfa-6963-4e17-abfd-d2022a2dcd36",
+      "name": "South Beach",
+      "canonicalPath": "/fl/miami-beach/south-beach-miami-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "53e8654a-a2bb-46a9-8153-83661af98fb1",
+      "name": "Spanish House",
+      "canonicalPath": "/fl/melbourne-beach/spanish-house-melbourne-beach-fl",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "80e4aada-7d4a-4df1-b11b-841a97603979",
+      "name": "Strands",
+      "canonicalPath": "/ca/dana-point/strands",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "bd7a7984-d69a-4969-85b1-b97ea78d8fb7",
+      "name": "Sunset Bay State Park",
+      "canonicalPath": "/or/charleston/sunset-bay-charleston-or",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f3e1216f-2a17-47be-8c2e-67d8588ab065",
+      "name": "The Hook",
+      "canonicalPath": "/ca/santa-cruz/the-hook-santa-cruz-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "a3e9d10c-92e9-4302-b808-a3de0c2eca22",
+      "name": "Torrance Beach (RAT Beach)",
+      "canonicalPath": "/ca/torrance/torrance-beach-rat-beach-torrance-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "4bdbff9e-2c1f-4918-84a6-aed42fb6e42c",
+      "name": "Torrey Pines State Beach",
+      "canonicalPath": "/ca/san-diego/torrey-pines-state-beach",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "24dd2e18-f3a6-466e-b082-cd974df852c4",
+      "name": "Tracks",
+      "canonicalPath": "/hi/kapolei/tracks",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "2f3e2136-b094-49d7-b90f-948160cbb854",
+      "name": "Trails",
+      "canonicalPath": "/ca/san-onofre/trails",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "88424465-0b1d-4f93-aa17-93dd1c4d03f3",
+      "name": "Tres Palmas",
+      "canonicalPath": "/pr/rincon/tres-palmas",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "fad234b3-4c14-4c02-a0fe-db1ba6e67bbe",
+      "name": "Turtle Cove",
+      "canonicalPath": "/ny/montauk/turtle-cove-montauk-ny",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "f924aa96-395f-41e0-b966-502b37def7ac",
+      "name": "Upper Trestles",
+      "canonicalPath": "/ca/san-onofre/upper-trestles",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "11467f21-5a69-430d-9eb9-05a46cd39990",
+      "name": "Venice Beach",
+      "canonicalPath": "/ca/venice/venice-beach-venice-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "83572ce5-aa5d-4631-925c-9e4a19967a7c",
+      "name": "Washington Beach",
+      "canonicalPath": "/nj/spring-lake/washington-beach-spring-lake-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "e5f995d2-4d8c-4765-ad7e-3113430d0881",
+      "name": "Waverly Beach",
+      "canonicalPath": "/nj/ocean-city/waverly-beach-ocean-city-nj",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "c18f586b-85fb-47d2-8e0a-7786cd1eb341",
+      "name": "White Plains",
+      "canonicalPath": "/hi/ewa-beach/white-plains",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    },
+    {
+      "id": "3f1eeb72-41c1-4f58-9621-fd13df129c1a",
+      "name": "Will Rogers State Beach",
+      "canonicalPath": "/ca/santa-monica/will-rogers-state-beach-santa-monica-ca",
+      "indexabilityReason": "forecast-stale",
+      "editorialQuarantined": false,
+      "editorialReasons": [],
+      "metadataMissing": false
+    }
+  ]
+}

--- a/reports/seo/FORECAST-AUTHORITY-BENCHMARK-local.json
+++ b/reports/seo/FORECAST-AUTHORITY-BENCHMARK-local.json
@@ -1,0 +1,2303 @@
+{
+  "generatedAt": "2026-08-09T03:10:46.643Z",
+  "auditGeneratedAt": "2026-08-09T03:10:38.521Z",
+  "baseUrl": "http://127.0.0.1:3000",
+  "queryClasses": [
+    "spot-surf-forecast",
+    "spot-surf-report",
+    "spot-tomorrow",
+    "best-time-to-surf-spot",
+    "when-should-i-surf-spot",
+    "spot-swell-tomorrow",
+    "spot-wind-tomorrow",
+    "spot-tide-tomorrow",
+    "best-surf-region-tomorrow",
+    "where-should-i-surf-region-tomorrow"
+  ],
+  "regions": [
+    "East Coast",
+    "California",
+    "International",
+    "Hawaii",
+    "Gulf Coast"
+  ],
+  "sampledSpots": 25,
+  "queryCount": 210,
+  "rawHtml": {
+    "pagesChecked": 25,
+    "answeredPages": 0,
+    "averageContractScore": 0,
+    "pages": [
+      {
+        "path": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/ca/san-clemente/204s",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/ca/newport-beach/52nd-street-newport-beach-ca",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/ca/newport-beach/54th-street-newport-beach-ca",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/ca/long-beach/72nd-place-long-beach-ca",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/or/newport/agate-beach",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/mexico/baja-california/rosarito/alfonsos",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/pr/aguadilla/crash-boat",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/pr/rincon/domes",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/pr/yabucoa/el-cocal-yabucoa-pr",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/hi/honolulu/ala-moana-bowls",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/hi/anahola/anahola",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/hi/kahuku/backyards",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/hi/kailua-kona/banyans",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/hi/honolulu/diamond-head-cliffs",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      },
+      {
+        "path": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+        "status": null,
+        "facts": null,
+        "error": "fetch failed"
+      }
+    ]
+  },
+  "queries": [
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "12th Street Jetty surf forecast",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "12th Street Jetty surf report",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "12th Street Jetty tomorrow",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 12th Street Jetty",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 12th Street Jetty",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "12th Street Jetty swell tomorrow",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "12th Street Jetty wind tomorrow",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "12th Street Jetty tide tomorrow",
+      "spotId": "86f9f0cd-e095-4416-af44-b2dd1cfecbe6",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "1st Street Jetty surf forecast",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "1st Street Jetty surf report",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "1st Street Jetty tomorrow",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 1st Street Jetty",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 1st Street Jetty",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "1st Street Jetty swell tomorrow",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "1st Street Jetty wind tomorrow",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "1st Street Jetty tide tomorrow",
+      "spotId": "f7ebea96-dc6c-4a32-b881-9969cce2f986",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/1st-street-jetty-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "36th-42nd Street surf forecast",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "36th-42nd Street surf report",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "36th-42nd Street tomorrow",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 36th-42nd Street",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 36th-42nd Street",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "36th-42nd Street swell tomorrow",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "36th-42nd Street wind tomorrow",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "36th-42nd Street tide tomorrow",
+      "spotId": "08c3baad-9404-43d3-ab42-d4230dfdfbf4",
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/36th-42nd-street-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "7th Street Beach surf forecast",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "7th Street Beach surf report",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "7th Street Beach tomorrow",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 7th Street Beach",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 7th Street Beach",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "7th Street Beach swell tomorrow",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "7th Street Beach wind tomorrow",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "7th Street Beach tide tomorrow",
+      "spotId": "336e967d-86a6-40db-9404-e398b057fefe",
+      "region": "East Coast",
+      "canonicalPath": "/nj/ocean-city/7th-street-beach-ocean-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "8th Avenue Jetty surf forecast",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "8th Avenue Jetty surf report",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "8th Avenue Jetty tomorrow",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 8th Avenue Jetty",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 8th Avenue Jetty",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "8th Avenue Jetty swell tomorrow",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "8th Avenue Jetty wind tomorrow",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "8th Avenue Jetty tide tomorrow",
+      "spotId": "03e143a9-d7c1-4988-bbcd-5cb7732d4b99",
+      "region": "East Coast",
+      "canonicalPath": "/nj/belmar/8th-avenue-jetty-belmar-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-surf-region-tomorrow",
+      "query": "best surf East Coast tomorrow",
+      "spotId": null,
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "where-should-i-surf-region-tomorrow",
+      "query": "where should I surf East Coast tomorrow",
+      "spotId": null,
+      "region": "East Coast",
+      "canonicalPath": "/nj/sea-isle-city/12th-street-jetty-sea-isle-city-nj",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "204s surf forecast",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "204s surf report",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "204s tomorrow",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 204s",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 204s",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "204s swell tomorrow",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "204s wind tomorrow",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "204s tide tomorrow",
+      "spotId": "047e61b4-b4a8-4042-a290-f2189b5a70ca",
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "38th Avenue (Santa Cruz) surf forecast",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "38th Avenue (Santa Cruz) surf report",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "38th Avenue (Santa Cruz) tomorrow",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 38th Avenue (Santa Cruz)",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 38th Avenue (Santa Cruz)",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "38th Avenue (Santa Cruz) swell tomorrow",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "38th Avenue (Santa Cruz) wind tomorrow",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "38th Avenue (Santa Cruz) tide tomorrow",
+      "spotId": "36a2d39e-64f1-4c7e-9618-ac8cc695af62",
+      "region": "California",
+      "canonicalPath": "/ca/santa-cruz/38th-avenue-santa-cruz-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "52nd Street surf forecast",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "52nd Street surf report",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "52nd Street tomorrow",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 52nd Street",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 52nd Street",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "52nd Street swell tomorrow",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "52nd Street wind tomorrow",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "52nd Street tide tomorrow",
+      "spotId": "1207215c-f61d-4fe1-bbaa-a3db7d4e7d53",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/52nd-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "54th Street surf forecast",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "54th Street surf report",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "54th Street tomorrow",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 54th Street",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 54th Street",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "54th Street swell tomorrow",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "54th Street wind tomorrow",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "54th Street tide tomorrow",
+      "spotId": "da8ad733-8e6b-4781-8b3f-0fe4ee492c3f",
+      "region": "California",
+      "canonicalPath": "/ca/newport-beach/54th-street-newport-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "72nd Place surf forecast",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "72nd Place surf report",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "72nd Place tomorrow",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf 72nd Place",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf 72nd Place",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "72nd Place swell tomorrow",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "72nd Place wind tomorrow",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "72nd Place tide tomorrow",
+      "spotId": "6932c9a6-bc1f-46b7-9493-51c587bf7eb0",
+      "region": "California",
+      "canonicalPath": "/ca/long-beach/72nd-place-long-beach-ca",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-surf-region-tomorrow",
+      "query": "best surf California tomorrow",
+      "spotId": null,
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "where-should-i-surf-region-tomorrow",
+      "query": "where should I surf California tomorrow",
+      "spotId": null,
+      "region": "California",
+      "canonicalPath": "/ca/san-clemente/204s",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Agate Beach surf forecast",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Agate Beach surf report",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Agate Beach tomorrow",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Agate Beach",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Agate Beach",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Agate Beach swell tomorrow",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Agate Beach wind tomorrow",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Agate Beach tide tomorrow",
+      "spotId": "ffc0dcae-83d7-4b90-ade3-03c14e789088",
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Alfonsos surf forecast",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Alfonsos surf report",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Alfonsos tomorrow",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Alfonsos",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Alfonsos",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Alfonsos swell tomorrow",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Alfonsos wind tomorrow",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Alfonsos tide tomorrow",
+      "spotId": "6e083f22-4c11-46c5-9110-ac7500f6cba5",
+      "region": "International",
+      "canonicalPath": "/mexico/baja-california/rosarito/alfonsos",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Crash Boat surf forecast",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Crash Boat surf report",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Crash Boat tomorrow",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Crash Boat",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Crash Boat",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Crash Boat swell tomorrow",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Crash Boat wind tomorrow",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Crash Boat tide tomorrow",
+      "spotId": "acfad2b2-7d0c-4c42-9fba-e78fa73e4ae3",
+      "region": "International",
+      "canonicalPath": "/pr/aguadilla/crash-boat",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Domes surf forecast",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Domes surf report",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Domes tomorrow",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Domes",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Domes",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Domes swell tomorrow",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Domes wind tomorrow",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Domes tide tomorrow",
+      "spotId": "8a2b0951-38b4-4d7e-b5d5-6e076b58a5f0",
+      "region": "International",
+      "canonicalPath": "/pr/rincon/domes",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "El Cocal surf forecast",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "El Cocal surf report",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "El Cocal tomorrow",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf El Cocal",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf El Cocal",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "El Cocal swell tomorrow",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "El Cocal wind tomorrow",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "El Cocal tide tomorrow",
+      "spotId": "bf11355b-3072-49ce-9682-783349d5a17d",
+      "region": "International",
+      "canonicalPath": "/pr/yabucoa/el-cocal-yabucoa-pr",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-surf-region-tomorrow",
+      "query": "best surf International tomorrow",
+      "spotId": null,
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "where-should-i-surf-region-tomorrow",
+      "query": "where should I surf International tomorrow",
+      "spotId": null,
+      "region": "International",
+      "canonicalPath": "/or/newport/agate-beach",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Ala Moana Bowls surf forecast",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Ala Moana Bowls surf report",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Ala Moana Bowls tomorrow",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Ala Moana Bowls",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Ala Moana Bowls",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Ala Moana Bowls swell tomorrow",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Ala Moana Bowls wind tomorrow",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Ala Moana Bowls tide tomorrow",
+      "spotId": "80fc2c1b-2d3f-4a94-bcc2-c8ea0e9b8fc5",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Anahola surf forecast",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Anahola surf report",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Anahola tomorrow",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Anahola",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Anahola",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Anahola swell tomorrow",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Anahola wind tomorrow",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Anahola tide tomorrow",
+      "spotId": "c9659503-c562-4379-9177-fff60acdfb7f",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/anahola/anahola",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Backyards surf forecast",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Backyards surf report",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Backyards tomorrow",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Backyards",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Backyards",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Backyards swell tomorrow",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Backyards wind tomorrow",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Backyards tide tomorrow",
+      "spotId": "486929f4-c8f8-4ae8-9b10-5ba1b7be7bcf",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kahuku/backyards",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Banyans surf forecast",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Banyans surf report",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Banyans tomorrow",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Banyans",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Banyans",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Banyans swell tomorrow",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Banyans wind tomorrow",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Banyans tide tomorrow",
+      "spotId": "eadd2bf6-759a-46e4-a8af-8df1feb635cb",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/kailua-kona/banyans",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Diamond Head (Cliffs) surf forecast",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Diamond Head (Cliffs) surf report",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Diamond Head (Cliffs) tomorrow",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Diamond Head (Cliffs)",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Diamond Head (Cliffs)",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Diamond Head (Cliffs) swell tomorrow",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Diamond Head (Cliffs) wind tomorrow",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Diamond Head (Cliffs) tide tomorrow",
+      "spotId": "8ee452f0-4043-4fe0-a049-207afbd95523",
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/diamond-head-cliffs",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-surf-region-tomorrow",
+      "query": "best surf Hawaii tomorrow",
+      "spotId": null,
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "where-should-i-surf-region-tomorrow",
+      "query": "where should I surf Hawaii tomorrow",
+      "spotId": null,
+      "region": "Hawaii",
+      "canonicalPath": "/hi/honolulu/ala-moana-bowls",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Boynton Inlet surf forecast",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Boynton Inlet surf report",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Boynton Inlet tomorrow",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Boynton Inlet",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Boynton Inlet",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Boynton Inlet swell tomorrow",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Boynton Inlet wind tomorrow",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Boynton Inlet tide tomorrow",
+      "spotId": "c06c6bd7-dbce-4df7-8479-73c44c1cb905",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Deerfield Beach Pier surf forecast",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Deerfield Beach Pier surf report",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Deerfield Beach Pier tomorrow",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Deerfield Beach Pier",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Deerfield Beach Pier",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Deerfield Beach Pier swell tomorrow",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Deerfield Beach Pier wind tomorrow",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Deerfield Beach Pier tide tomorrow",
+      "spotId": "1bd4ef4d-eb8e-4833-8679-8a13095a97d6",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/deerfield-beach/deerfield-beach-pier-deerfield-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Flagler Beach surf forecast",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Flagler Beach surf report",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Flagler Beach tomorrow",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Flagler Beach",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Flagler Beach",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Flagler Beach swell tomorrow",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Flagler Beach wind tomorrow",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Flagler Beach tide tomorrow",
+      "spotId": "9ca1fa2f-2b90-4aa3-8784-48721e5463bb",
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/flagler-beach/flagler-beach-flagler-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Galveston – 61st Street Pier surf forecast",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Galveston – 61st Street Pier surf report",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Galveston – 61st Street Pier tomorrow",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Galveston – 61st Street Pier",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Galveston – 61st Street Pier",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Galveston – 61st Street Pier swell tomorrow",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Galveston – 61st Street Pier wind tomorrow",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Galveston – 61st Street Pier tide tomorrow",
+      "spotId": "13ba376d-efd5-4e4e-af12-85bfeb2c17bc",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/galveston/galveston-61st-street-pier-galveston-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-forecast",
+      "query": "Mustang Island State Park surf forecast",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-surf-report",
+      "query": "Mustang Island State Park surf report",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tomorrow",
+      "query": "Mustang Island State Park tomorrow",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-time-to-surf-spot",
+      "query": "best time to surf Mustang Island State Park",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "when-should-i-surf-spot",
+      "query": "when should I surf Mustang Island State Park",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-swell-tomorrow",
+      "query": "Mustang Island State Park swell tomorrow",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-wind-tomorrow",
+      "query": "Mustang Island State Park wind tomorrow",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "spot-tide-tomorrow",
+      "query": "Mustang Island State Park tide tomorrow",
+      "spotId": "d85492b8-31ed-4dd8-af53-4284e9456be9",
+      "region": "Gulf Coast",
+      "canonicalPath": "/tx/corpus-christi/mustang-island-state-park-corpus-christi-tx",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "best-surf-region-tomorrow",
+      "query": "best surf Gulf Coast tomorrow",
+      "spotId": null,
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    },
+    {
+      "queryClass": "where-should-i-surf-region-tomorrow",
+      "query": "where should I surf Gulf Coast tomorrow",
+      "spotId": null,
+      "region": "Gulf Coast",
+      "canonicalPath": "/fl/boynton-beach/boynton-inlet-boynton-beach-fl",
+      "status": null,
+      "facts": null,
+      "error": "fetch failed"
+    }
+  ],
+  "competitiveBenchmark": {
+    "competitors": [
+      "Surfline",
+      "Surf Captain"
+    ],
+    "criteria": [
+      "search discoverability",
+      "canonical-page selection",
+      "raw HTML completeness",
+      "surf facts available",
+      "freshness transparency",
+      "forecast reasoning",
+      "provenance",
+      "citation suitability"
+    ],
+    "status": "manual-evidence-required",
+    "note": "Provide a dated SERP capture or page fixture before recording competitor claims."
+  }
+}

--- a/scripts/seo/forecast-authority-audit.ts
+++ b/scripts/seo/forecast-authority-audit.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { buildBeachRoutes } from "../../app/sitemap";
+import {
+  buildForecastAuthorityAudit,
+  type ForecastAuthorityAuditBeach,
+} from "../../lib/seo/forecast-authority-audit";
+import {
+  buildForecastIndexabilitySnapshot,
+  type ForecastCoverageRow,
+  type ForecastIndexabilitySnapshot,
+} from "../../lib/seo/forecast-indexability";
+import { loadSeoEnv } from "./load-env";
+
+loadSeoEnv();
+
+const generatedAt = getFlag("--generated-at") ?? new Date().toISOString();
+const outputPath = getFlag("--output") ?? path.join(
+  process.cwd(),
+  "reports",
+  "seo",
+  `FORECAST-AUTHORITY-AUDIT-${generatedAt.slice(0, 10)}.json`,
+);
+
+interface AuditBeachRow extends ForecastAuthorityAuditBeach {
+  created_at: string | null;
+}
+
+void main();
+
+async function main(): Promise<void> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Missing Supabase URL or SUPABASE_SERVICE_ROLE_KEY. This is a read-only inventory audit.",
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+  const beaches = await fetchBeaches(supabase);
+  const { snapshots, querySucceeded } = await fetchForecastSnapshots(
+    supabase,
+    beaches,
+  );
+  const sitemapPaths = await fetchObservedSitemapPaths(beaches, snapshots);
+  const audit = buildForecastAuthorityAudit(beaches, snapshots, {
+    generatedAt,
+    forecastQuerySucceeded: querySucceeded,
+    sitemapPaths,
+  });
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(audit, null, 2)}\n`);
+  console.log(JSON.stringify({ outputPath, ...audit.summary }, null, 2));
+}
+
+async function fetchBeaches(supabase: SupabaseClient): Promise<AuditBeachRow[]> {
+  const result = await supabase
+    .from("beaches")
+    .select(
+      "id,name,slug,city,state,country,lat,lon,timezone,description,wave_tips,crowd_tips,best_conditions_prose,parking_tips,access_tips,local_etiquette,hazards,created_at",
+    )
+    .or("is_private.is.null,is_private.eq.false")
+    .is("deleted_at", null)
+    .order("name")
+    .limit(10000);
+
+  if (result.error) throw new Error(`Beach inventory query failed: ${result.error.message}`);
+  return (result.data ?? []) as AuditBeachRow[];
+}
+
+async function fetchForecastSnapshots(
+  supabase: SupabaseClient,
+  beaches: AuditBeachRow[],
+): Promise<{
+  snapshots: Map<string, ForecastIndexabilitySnapshot>;
+  querySucceeded: boolean;
+}> {
+  const now = new Date();
+  const start = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const end = new Date(now.getTime() + 72 * 60 * 60 * 1000).toISOString();
+  const snapshots = new Map<string, ForecastIndexabilitySnapshot>();
+  let querySucceeded = true;
+
+  for (let index = 0; index < beaches.length; index += 20) {
+    const batch = beaches.slice(index, index + 20);
+    const beachIds = batch.map((beach) => beach.id);
+    const result = await supabase
+      .from("enhanced_forecasts")
+      .select("beach_id,forecast_at,wave_height,updated_at,data_source")
+      .in("beach_id", beachIds)
+      .gte("forecast_at", start)
+      .lt("forecast_at", end)
+      .order("forecast_at", { ascending: true })
+      .limit(1000);
+
+    if (result.error) {
+      querySucceeded = false;
+      continue;
+    }
+
+    const rowsByBeach = new Map<string, ForecastCoverageRow[]>();
+    for (const row of (result.data ?? []) as ForecastCoverageRow[]) {
+      if (!row.beach_id) continue;
+      const rows = rowsByBeach.get(row.beach_id) ?? [];
+      rows.push(row);
+      rowsByBeach.set(row.beach_id, rows);
+    }
+
+    for (const beach of batch) {
+      snapshots.set(
+        beach.id,
+        buildForecastIndexabilitySnapshot(
+          rowsByBeach.get(beach.id) ?? [],
+          now,
+          beach.timezone,
+        ),
+      );
+    }
+  }
+
+  if (!querySucceeded) {
+    return { snapshots: new Map(), querySucceeded: false };
+  }
+
+  return { snapshots, querySucceeded };
+}
+
+async function fetchObservedSitemapPaths(
+  beaches: AuditBeachRow[],
+  snapshots: ReadonlyMap<string, ForecastIndexabilitySnapshot>,
+): Promise<Set<string>> {
+  const sitemapBeaches = beaches as Parameters<typeof buildBeachRoutes>[0];
+  const routes = buildBeachRoutes(sitemapBeaches, snapshots);
+  return new Set(routes.map((route) => new URL(route.url).pathname));
+}
+
+function getFlag(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1] ?? null;
+}

--- a/scripts/seo/forecast-authority-benchmark.ts
+++ b/scripts/seo/forecast-authority-benchmark.ts
@@ -3,8 +3,15 @@ import path from "node:path";
 
 import {
   buildForecastBenchmarkQueries,
+  createUnmeasuredForecastRetrievalBenchmark,
+  DEFAULT_QUIVER_BENCHMARK_ORIGIN,
   extractForecastAnswerContractFacts,
+  parseForecastRetrievalEvidence,
+  summarizeForecastCompetitiveBenchmark,
+  summarizeForecastRetrievalEvidence,
   type ForecastBenchmarkSpot,
+  type ForecastRetrievalBenchmark,
+  type ForecastRetrievalEvidence,
 } from "../../lib/seo/forecast-authority-benchmark";
 import { loadSeoEnv } from "./load-env";
 
@@ -25,10 +32,18 @@ const outputPath = getFlag("--output") ?? path.join(
 const baseUrl = (
   getFlag("--base-url") ?? process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
 ).replace(/\/$/, "");
+const quiverOrigin = (
+  getFlag("--quiver-origin") ?? DEFAULT_QUIVER_BENCHMARK_ORIGIN
+).replace(/\/$/, "");
 
 interface AuditInput {
   generatedAt: string;
   eligibleSpots: Array<Omit<ForecastBenchmarkSpot, "name"> & { name: string | null }>;
+}
+
+interface LoadedRetrievalBenchmark {
+  benchmark: ForecastRetrievalBenchmark;
+  evidence: ForecastRetrievalEvidence[];
 }
 
 void main();
@@ -43,18 +58,33 @@ async function main(): Promise<void> {
     spot.name ? [{ ...spot, name: spot.name }] : []
   );
   const queries = buildForecastBenchmarkQueries(benchmarkSpots);
+  const retrieval = await loadRetrievalBenchmark(queries);
+  if (retrieval.benchmark.status === "invalid") {
+    throw new Error(retrieval.benchmark.reason ?? "Retrieval evidence is invalid.");
+  }
+  if (hasFlag("--require-retrieval") && retrieval.benchmark.status !== "measured") {
+    throw new Error(
+      retrieval.benchmark.reason ?? "A measured retrieval benchmark is required.",
+    );
+  }
   const uniquePaths = [...new Set(
     queries.flatMap((query) => query.canonicalPath ? [query.canonicalPath] : []),
   )];
   const pageResults = await Promise.all(uniquePaths.map(fetchPage));
   const pagesByPath = new Map(pageResults.map((result) => [result.path, result]));
+  const retrievalByQueryId = new Map(
+    retrieval.evidence.map((result) => [result.queryId, result]),
+  );
   const queryResults = queries.map((query) => {
     const page = query.canonicalPath ? pagesByPath.get(query.canonicalPath) : undefined;
     return {
       ...query,
-      status: page?.status ?? null,
-      facts: page?.facts ?? null,
-      error: page?.error ?? null,
+      rawHtml: {
+        status: page?.status ?? null,
+        facts: page?.facts ?? null,
+        error: page?.error ?? null,
+      },
+      retrieval: retrievalByQueryId.get(query.queryId) ?? null,
     };
   });
 
@@ -66,6 +96,7 @@ async function main(): Promise<void> {
     generatedAt: new Date().toISOString(),
     auditGeneratedAt: audit.generatedAt,
     baseUrl,
+    quiverOrigin,
     queryClasses: [...new Set(queries.map((query) => query.queryClass))],
     regions: [...new Set(queries.map((query) => query.region))],
     sampledSpots: [...new Set(queries.map((query) => query.spotId).filter(Boolean))].length,
@@ -76,22 +107,13 @@ async function main(): Promise<void> {
       averageContractScore,
       pages: pageResults,
     },
+    retrievalBenchmark: retrieval.benchmark,
     queries: queryResults,
-    competitiveBenchmark: {
-      competitors: ["Surfline", "Surf Captain"],
-      criteria: [
-        "search discoverability",
-        "canonical-page selection",
-        "raw HTML completeness",
-        "surf facts available",
-        "freshness transparency",
-        "forecast reasoning",
-        "provenance",
-        "citation suitability",
-      ],
-      status: "manual-evidence-required",
-      note: "Provide a dated SERP capture or page fixture before recording competitor claims.",
-    },
+    competitiveBenchmark: summarizeForecastCompetitiveBenchmark(
+      queries,
+      retrieval.evidence,
+      retrieval.benchmark,
+    ),
   };
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
@@ -102,8 +124,95 @@ async function main(): Promise<void> {
     pagesChecked: report.rawHtml.pagesChecked,
     answeredPages: report.rawHtml.answeredPages,
     averageContractScore: report.rawHtml.averageContractScore,
-    competitiveBenchmark: report.competitiveBenchmark.status,
+    retrievalStatus: report.retrievalBenchmark.status,
+    retrievalProvider: report.retrievalBenchmark.provider,
+    answerShare: report.retrievalBenchmark.answerShare,
+    citationShare: report.retrievalBenchmark.citationShare,
+    canonicalSelectionShare: report.retrievalBenchmark.canonicalSelectionShare,
+    competitiveBenchmarkStatus: report.competitiveBenchmark.status,
   }, null, 2));
+}
+
+async function loadRetrievalBenchmark(
+  queries: ReturnType<typeof buildForecastBenchmarkQueries>,
+): Promise<LoadedRetrievalBenchmark> {
+  const retrievalUrl = getFlag("--retrieval-url");
+  const retrievalEvidencePath = getFlag("--retrieval-evidence");
+
+  if (retrievalUrl && retrievalEvidencePath) {
+    throw new Error("Use only one of --retrieval-url or --retrieval-evidence.");
+  }
+
+  if (!retrievalUrl && !retrievalEvidencePath) {
+    return {
+      benchmark: createUnmeasuredForecastRetrievalBenchmark(
+        queries,
+        "No retrieval provider or evidence supplied. Raw HTML is not Answer Share evidence.",
+      ),
+      evidence: [],
+    };
+  }
+
+  const payload = retrievalUrl
+    ? await fetchRetrievalProvider(retrievalUrl, queries)
+    : JSON.parse(fs.readFileSync(retrievalEvidencePath!, "utf8")) as unknown;
+  const parsed = parseRetrievalPayload(
+    payload,
+    retrievalUrl ? "retrieval-provider" : "evidence-file",
+  );
+
+  return {
+    benchmark: summarizeForecastRetrievalEvidence(
+      queries,
+      parsed.results,
+      parsed.provider,
+      quiverOrigin,
+    ),
+    evidence: parsed.results,
+  };
+}
+
+async function fetchRetrievalProvider(
+  retrievalUrl: string,
+  queries: ReturnType<typeof buildForecastBenchmarkQueries>,
+): Promise<unknown> {
+  const response = await fetch(retrievalUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ queries }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Retrieval provider returned HTTP ${response.status}.`);
+  }
+
+  return response.json() as Promise<unknown>;
+}
+
+function parseRetrievalPayload(
+  value: unknown,
+  fallbackProvider: string,
+): { provider: string; results: ForecastRetrievalEvidence[] } {
+  if (Array.isArray(value)) {
+    return {
+      provider: fallbackProvider,
+      results: parseForecastRetrievalEvidence(value),
+    };
+  }
+
+  if (typeof value !== "object" || value === null) {
+    throw new Error("Retrieval provider response must be an array or an object with results.");
+  }
+
+  const record = value as Record<string, unknown>;
+  const provider = typeof record.provider === "string" && record.provider.trim().length > 0
+    ? record.provider
+    : fallbackProvider;
+
+  return {
+    provider,
+    results: parseForecastRetrievalEvidence(record.results),
+  };
 }
 
 async function fetchPage(pagePath: string): Promise<{
@@ -134,4 +243,8 @@ async function fetchPage(pagePath: string): Promise<{
 function getFlag(name: string): string | null {
   const index = process.argv.indexOf(name);
   return index === -1 ? null : process.argv[index + 1] ?? null;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(name);
 }

--- a/scripts/seo/forecast-authority-benchmark.ts
+++ b/scripts/seo/forecast-authority-benchmark.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  buildForecastBenchmarkQueries,
+  extractForecastAnswerContractFacts,
+  type ForecastBenchmarkSpot,
+} from "../../lib/seo/forecast-authority-benchmark";
+import { loadSeoEnv } from "./load-env";
+
+loadSeoEnv();
+
+const inputPath = getFlag("--input") ?? path.join(
+  process.cwd(),
+  "reports",
+  "seo",
+  `FORECAST-AUTHORITY-AUDIT-${new Date().toISOString().slice(0, 10)}.json`,
+);
+const outputPath = getFlag("--output") ?? path.join(
+  process.cwd(),
+  "reports",
+  "seo",
+  `FORECAST-AUTHORITY-BENCHMARK-${new Date().toISOString().slice(0, 10)}.json`,
+);
+const baseUrl = (
+  getFlag("--base-url") ?? process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+).replace(/\/$/, "");
+
+interface AuditInput {
+  generatedAt: string;
+  eligibleSpots: Array<Omit<ForecastBenchmarkSpot, "name"> & { name: string | null }>;
+}
+
+void main();
+
+async function main(): Promise<void> {
+  if (!fs.existsSync(inputPath)) {
+    throw new Error(`Audit input not found: ${inputPath}`);
+  }
+
+  const audit = JSON.parse(fs.readFileSync(inputPath, "utf8")) as AuditInput;
+  const benchmarkSpots: ForecastBenchmarkSpot[] = audit.eligibleSpots.flatMap((spot) =>
+    spot.name ? [{ ...spot, name: spot.name }] : []
+  );
+  const queries = buildForecastBenchmarkQueries(benchmarkSpots);
+  const uniquePaths = [...new Set(
+    queries.flatMap((query) => query.canonicalPath ? [query.canonicalPath] : []),
+  )];
+  const pageResults = await Promise.all(uniquePaths.map(fetchPage));
+  const pagesByPath = new Map(pageResults.map((result) => [result.path, result]));
+  const queryResults = queries.map((query) => {
+    const page = query.canonicalPath ? pagesByPath.get(query.canonicalPath) : undefined;
+    return {
+      ...query,
+      status: page?.status ?? null,
+      facts: page?.facts ?? null,
+      error: page?.error ?? null,
+    };
+  });
+
+  const answeredPages = pageResults.filter((page) => page.facts?.answerLayer).length;
+  const averageContractScore = pageResults.length === 0
+    ? 0
+    : pageResults.reduce((sum, page) => sum + (page.facts?.score ?? 0), 0) / pageResults.length;
+  const report = {
+    generatedAt: new Date().toISOString(),
+    auditGeneratedAt: audit.generatedAt,
+    baseUrl,
+    queryClasses: [...new Set(queries.map((query) => query.queryClass))],
+    regions: [...new Set(queries.map((query) => query.region))],
+    sampledSpots: [...new Set(queries.map((query) => query.spotId).filter(Boolean))].length,
+    queryCount: queries.length,
+    rawHtml: {
+      pagesChecked: pageResults.length,
+      answeredPages,
+      averageContractScore,
+      pages: pageResults,
+    },
+    queries: queryResults,
+    competitiveBenchmark: {
+      competitors: ["Surfline", "Surf Captain"],
+      criteria: [
+        "search discoverability",
+        "canonical-page selection",
+        "raw HTML completeness",
+        "surf facts available",
+        "freshness transparency",
+        "forecast reasoning",
+        "provenance",
+        "citation suitability",
+      ],
+      status: "manual-evidence-required",
+      note: "Provide a dated SERP capture or page fixture before recording competitor claims.",
+    },
+  };
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(JSON.stringify({
+    outputPath,
+    queryCount: report.queryCount,
+    pagesChecked: report.rawHtml.pagesChecked,
+    answeredPages: report.rawHtml.answeredPages,
+    averageContractScore: report.rawHtml.averageContractScore,
+    competitiveBenchmark: report.competitiveBenchmark.status,
+  }, null, 2));
+}
+
+async function fetchPage(pagePath: string): Promise<{
+  path: string;
+  status: number | null;
+  facts: ReturnType<typeof extractForecastAnswerContractFacts> | null;
+  error: string | null;
+}> {
+  try {
+    const response = await fetch(`${baseUrl}${pagePath}`);
+    const html = await response.text();
+    return {
+      path: pagePath,
+      status: response.status,
+      facts: extractForecastAnswerContractFacts(html),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      path: pagePath,
+      status: null,
+      facts: null,
+      error: error instanceof Error ? error.message : "Unknown fetch error",
+    };
+  }
+}
+
+function getFlag(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1] ?? null;
+}

--- a/supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql
+++ b/supabase/migrations/20260804230000_correct_tourmaline_beach_coordinates.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- California DFG site 6-3-SD-133-D places Tourmaline Surfing Park at the
+-- shoreline. The previous point was roughly 300 m inland in Pacific Beach.
+UPDATE public.beaches
+SET
+  lat = 32.805149,
+  lon = -117.262364
+WHERE id = '17628f35-9ed1-4257-aad6-070c4bd73bb8'::uuid
+  AND slug = 'tourmaline'
+  AND deleted_at IS NULL
+  AND (
+    lat IS DISTINCT FROM 32.805149
+    OR lon IS DISTINCT FROM -117.262364
+  );
+
+COMMIT;

--- a/supabase/migrations/20260809050000_fix_near_term_forecast_latest_view.sql
+++ b/supabase/migrations/20260809050000_fix_near_term_forecast_latest_view.sql
@@ -1,0 +1,45 @@
+begin;
+
+-- The refresh selector and cache freshness checks must use the rows that can
+-- power today's public answer. The old view selected the newest write across
+-- the entire 12-day horizon, so an extended-horizon Open-Meteo row could make
+-- a beach look fresh while today's NOAA/CDIP rows were stale.
+create index if not exists idx_enhanced_forecasts_beach_forecast_at_updated_at
+  on public.enhanced_forecasts (beach_id, forecast_at, updated_at desc);
+
+create or replace view public.v_enhanced_forecast_latest
+with (security_invoker = true) as
+select
+  b.id as beach_id,
+  near_term.updated_at,
+  near_term.data_source
+from public.beaches b
+cross join lateral (
+  select
+    ef.updated_at,
+    ef.data_source
+  from public.enhanced_forecasts ef
+  where ef.beach_id = b.id
+    and ef.forecast_at >= now() - interval '24 hours'
+    and ef.forecast_at < now() + interval '72 hours'
+    and ef.updated_at is not null
+    and nullif(btrim(ef.wave_height), '') is not null
+    and nullif(btrim(ef.data_source), '') is not null
+  order by
+    case
+      when (ef.forecast_at at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date =
+        (now() at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date
+        then 0
+      when (ef.forecast_at at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date =
+        ((now() at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date + 1)
+        then 1
+      else 2
+    end,
+    ef.forecast_at asc,
+    ef.updated_at desc
+  limit 1
+) near_term;
+
+grant select on public.v_enhanced_forecast_latest to service_role;
+
+commit;

--- a/supabase/migrations/20260809130000_skip_expired_today_forecast_latest.sql
+++ b/supabase/migrations/20260809130000_skip_expired_today_forecast_latest.sql
@@ -1,0 +1,42 @@
+begin;
+
+-- The first near-term selector could still choose a passed forecast slot from
+-- local today. Once that slot expired, refreshes kept selecting the same old
+-- row and the stale queue never drained. Only current/future slots can power
+-- the public answer or freshness selector.
+create or replace view public.v_enhanced_forecast_latest
+with (security_invoker = true) as
+select
+  b.id as beach_id,
+  near_term.updated_at,
+  near_term.data_source
+from public.beaches b
+cross join lateral (
+  select
+    ef.updated_at,
+    ef.data_source
+  from public.enhanced_forecasts ef
+  where ef.beach_id = b.id
+    and ef.forecast_at >= now()
+    and ef.forecast_at < now() + interval '72 hours'
+    and ef.updated_at is not null
+    and nullif(btrim(ef.wave_height), '') is not null
+    and nullif(btrim(ef.data_source), '') is not null
+  order by
+    case
+      when (ef.forecast_at at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date =
+        (now() at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date
+        then 0
+      when (ef.forecast_at at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date =
+        ((now() at time zone coalesce(nullif(b.timezone, ''), 'America/Los_Angeles'))::date + 1)
+        then 1
+      else 2
+    end,
+    ef.forecast_at asc,
+    ef.updated_at desc
+  limit 1
+) near_term;
+
+grant select on public.v_enhanced_forecast_latest to service_role;
+
+commit;


### PR DESCRIPTION
## Production prerequisite
The immediate 346-beach baseline after PR #525 showed production still lacked the previously reviewed public forecast authority foundation: 315 canonical beach paths were absent from the sitemap.

This selective production slice adds that existing main commit, then applies the strengthened retrieval/all-beach validation. The already-applied database migrations remain represented in git.

## Conflict resolution
Preserved prod's newer removal of beach review fetching/schema output while retaining the public forecast answer and sanitized editorial contract.

## Verification
- production-slice TypeScript passed
- 163 focused sitemap, beach-page, forecast-authority, Week Scout, and proactive-refresh tests passed
- diff check passed

## Monitoring
Continue the already scheduled hourly freshness checks for two hours after the final production deployment becomes Ready.