### PR TITLE
fix(alerts): restore forecast alert delivery (P0, dead since 2026-07-26)

### DIFF
--- a/__tests__/api/cron/condition-alert-evaluate.test.ts
+++ b/__tests__/api/cron/condition-alert-evaluate.test.ts
@@ -239,6 +239,7 @@ function mockFrom(table: string) {
 
 const mockSupabase = { from: jest.fn(mockFrom) };
 let consoleLogSpy: jest.SpyInstance;
+let consoleWarnSpy: jest.SpyInstance;
 
 jest.mock("@/lib/supabase/server", () => ({
   createSupabaseServiceRoleClient: jest.fn(() => Promise.resolve(mockSupabase)),
@@ -342,6 +343,7 @@ beforeEach(() => {
   jest.useFakeTimers().setSystemTime(TEST_NOW);
   jest.clearAllMocks();
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   // mockReset drains any `mockReturnValueOnce` queue left over from a prior
   // test (jest.clearAllMocks does NOT clear that queue, only call records).
   mockFindMatchingWindows.mockReset();
@@ -407,6 +409,7 @@ beforeEach(() => {
 
 afterEach(() => {
   consoleLogSpy.mockRestore();
+  consoleWarnSpy.mockRestore();
   jest.useRealTimers();
 });
 
@@ -434,6 +437,11 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
     expect(body.evaluated).toBe(1);
     expect(body.matched).toBe(1);
     expect(body.queued).toBeGreaterThanOrEqual(1);
+    expect(body.status).toBe("ok");
+    expect(body.skipped_by_reason).toEqual({
+      hold_state_unavailable: 0,
+      major_event_hold: 0,
+    });
     expect(body.errors).toBe(0);
 
     expect(store.queueUpserts).toHaveLength(1);
@@ -473,7 +481,7 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
     });
   });
 
-  it("suppresses held or unresolved positive windows before alert_queue persistence", async () => {
+  it("reports unavailable hold state by reason and degrades when every match is suppressed", async () => {
     seedRule();
     seedProfile();
     seedBeach();
@@ -487,8 +495,54 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
     });
 
     const res = await GET(makeRequest());
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({ queued: 0, skipped: 1 });
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      status: "degraded",
+      matched: 1,
+      queued: 0,
+      skipped: 1,
+      skipped_by_reason: {
+        hold_state_unavailable: 1,
+        major_event_hold: 0,
+      },
+    });
+    expect(store.queueUpserts).toHaveLength(0);
+    expect(store.ruleUpdates).toHaveLength(0);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Suppressed matched alert window"),
+      expect.objectContaining({ reason_code: "hold_state_unavailable" }),
+    );
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Matched alert windows but queued none"),
+      expect.objectContaining({ matched: 1, queued: 0 }),
+    );
+  });
+
+  it("preserves active major-event hold suppression and records its distinct reason", async () => {
+    seedRule();
+    seedProfile();
+    seedBeach();
+    seedForecast();
+    seedMatchingWindow();
+    mockResolveNotificationMajorEventHold.mockResolvedValueOnce({
+      status: "suppressed",
+      reasonCode: "major_event_hold",
+      auditCode: "major_event_hold",
+      candidate: null,
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toMatchObject({
+      status: "degraded",
+      matched: 1,
+      queued: 0,
+      skipped: 1,
+      skipped_by_reason: {
+        hold_state_unavailable: 0,
+        major_event_hold: 1,
+      },
+    });
     expect(store.queueUpserts).toHaveLength(0);
     expect(store.ruleUpdates).toHaveLength(0);
   });

--- a/__tests__/api/cron/condition-alert-evaluate.test.ts
+++ b/__tests__/api/cron/condition-alert-evaluate.test.ts
@@ -513,12 +513,12 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
       expect.objectContaining({ reason_code: "hold_state_unavailable" }),
     );
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Matched alert windows but queued none"),
+      expect.stringContaining("Matched alert windows dropped without a safety hold"),
       expect.objectContaining({ matched: 1, queued: 0 }),
     );
   });
 
-  it("preserves active major-event hold suppression and records its distinct reason", async () => {
+  it("preserves active major-event hold suppression without degrading the run", async () => {
     seedRule();
     seedProfile();
     seedBeach();
@@ -531,10 +531,12 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
       candidate: null,
     });
 
+    // A real safety hold suppressing every match is the hold system working as
+    // designed — it must NOT page as a failure, or big-swell days alarm falsely.
     const res = await GET(makeRequest());
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({
-      status: "degraded",
+      status: "ok",
       matched: 1,
       queued: 0,
       skipped: 1,
@@ -545,6 +547,10 @@ describe("condition-alert-evaluate — A4.2 flat queries", () => {
     });
     expect(store.queueUpserts).toHaveLength(0);
     expect(store.ruleUpdates).toHaveLength(0);
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Matched alert windows dropped without a safety hold"),
+      expect.anything(),
+    );
   });
 
   it("2. empty rules: 0 enabled rules => no DB writes after rules query, message returned", async () => {

--- a/__tests__/lib/cron/observability.test.ts
+++ b/__tests__/lib/cron/observability.test.ts
@@ -94,6 +94,31 @@ describe("withCronObservability", () => {
     );
   });
 
+  it("records an error status while retaining a degraded result summary", async () => {
+    const { createSupabaseServiceRoleClient } = require("@/lib/supabase/server");
+    const client = mockChain();
+    createSupabaseServiceRoleClient.mockResolvedValue(client);
+    const summary = { status: "degraded" as const, matched: 4, queued: 0 };
+
+    const result = await withCronObservability(
+      "/api/cron/test",
+      async () => summary,
+      {
+        statusForResult: (value) => value.status === "degraded" ? "error" : "ok",
+        errorMessageForResult: () => "Matched alert windows but queued none",
+      },
+    );
+
+    expect(result).toEqual(summary);
+    expect(client._updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        summary,
+        error_message: "Matched alert windows but queued none",
+      }),
+    );
+  });
+
   it("records error and rethrows", async () => {
     const { createSupabaseServiceRoleClient } = require("@/lib/supabase/server");
     const client = mockChain();

--- a/__tests__/lib/recommendations/major-event-hold/notification.test.ts
+++ b/__tests__/lib/recommendations/major-event-hold/notification.test.ts
@@ -184,6 +184,69 @@ describe("notification major-event hold adapter", () => {
     expect(evaluateCandidates).not.toHaveBeenCalled();
   });
 
+  it("allows a user-configured forecast alert without a canonical session decision when hold state is clear", async () => {
+    const evaluateCandidates = evaluatorReturning("allowed");
+
+    const result = await resolveNotificationMajorEventHold(
+      {
+        eventId: "event-forecast-alert-clear",
+        type: "forecast_alert",
+        payload: {
+          beach_id: BEACH_ID,
+          forecast_at: STARTS_AT,
+          policy_context: {
+            kind: "positive_session_recommendation",
+            beach_id: BEACH_ID,
+            starts_at: STARTS_AT,
+            ends_at: ENDS_AT,
+          },
+        },
+        profileExperience: "beginner",
+        mode: "enforce",
+        asOf: new Date("2026-07-17T07:00:00.000Z"),
+      },
+      { evaluateCandidates },
+    );
+
+    expect(result).toMatchObject({ status: "allowed" });
+    expect(evaluateCandidates).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(MODE_EXPECTATIONS)(
+    "%s mode returns %s for a user-configured forecast alert under an active hold",
+    async (mode, expectedStatus) => {
+      const evaluateCandidates = evaluatorReturning("blocked");
+
+      const result = await resolveNotificationMajorEventHold(
+        {
+          eventId: `event-forecast-alert-held-${mode}`,
+          type: "forecast_alert",
+          payload: {
+            beach_id: BEACH_ID,
+            forecast_at: STARTS_AT,
+            policy_context: {
+              kind: "positive_session_recommendation",
+              beach_id: BEACH_ID,
+              starts_at: STARTS_AT,
+              ends_at: ENDS_AT,
+            },
+          },
+          profileExperience: "beginner",
+          mode,
+          asOf: new Date("2026-07-17T07:00:00.000Z"),
+        },
+        { evaluateCandidates },
+      );
+
+      expect(result).toMatchObject(
+        expectedStatus === "suppressed"
+          ? { status: "suppressed", reasonCode: "major_event_hold" }
+          : { status: "allowed" },
+      );
+      expect(evaluateCandidates).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("requires every positive surf notification to carry the exact fresh canonical decision", async () => {
     const evaluateCandidates = evaluatorReturning("allowed");
     const weekendPayload = homeMorningPayload(
@@ -225,7 +288,7 @@ describe("notification major-event hold adapter", () => {
     });
   });
 
-  it("suppresses a positive alert when its canonical selection does not match the outbound window", async () => {
+  it("suppresses a similarity alert when its canonical selection does not match the outbound window", async () => {
     const evaluateCandidates = evaluatorReturning("allowed");
     const payload = homeMorningPayload("2026-07-17T07:10:00.000Z");
     delete payload.verdict;
@@ -233,8 +296,8 @@ describe("notification major-event hold adapter", () => {
 
     const result = await resolveNotificationMajorEventHold(
       {
-        eventId: "event-forecast-mismatch",
-        type: "forecast_alert",
+        eventId: "event-similarity-mismatch",
+        type: "similarity_match",
         payload,
         profileExperience: "beginner",
         mode: "enforce",

--- a/app/api/cron/condition-alert-evaluate/route.ts
+++ b/app/api/cron/condition-alert-evaluate/route.ts
@@ -15,6 +15,7 @@ import { getMinRideable, MINIMUM_VIABLE_WINDOW_MINUTES } from "@/lib/utils/surf-
 import type { Beach } from "@/types/database";
 import { parseSkillLevel } from "@/lib/domains/user-preferences/skill-level";
 import { resolveNotificationMajorEventHold } from "@/lib/recommendations/major-event-hold/adapters/notification";
+import type { RecommendationHoldReasonCode } from "@/lib/recommendations/major-event-hold/types";
 
 export const revalidate = 0;
 export const runtime = "nodejs";
@@ -42,6 +43,17 @@ type AlertQueueInsertWithBestScore =
     best_score: number;
   };
 
+interface ConditionAlertEvaluationSummary {
+  status: "ok" | "degraded";
+  evaluated: number;
+  matched: number;
+  queued: number;
+  skipped: number;
+  skipped_unsurfable: number;
+  skipped_by_reason: Record<RecommendationHoldReasonCode, number>;
+  errors: number;
+}
+
 export async function GET(request: Request) {
   if (!validateCronRequest(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -53,7 +65,19 @@ export async function GET(request: Request) {
     const summary = await withCronObservability(
       "/api/cron/condition-alert-evaluate",
       async () => {
-        const result = { evaluated: 0, matched: 0, queued: 0, skipped: 0, skipped_unsurfable: 0, errors: 0 };
+        const result: ConditionAlertEvaluationSummary = {
+          status: "ok",
+          evaluated: 0,
+          matched: 0,
+          queued: 0,
+          skipped: 0,
+          skipped_unsurfable: 0,
+          skipped_by_reason: {
+            hold_state_unavailable: 0,
+            major_event_hold: 0,
+          },
+          errors: 0,
+        };
 
         // 1. Fetch all enabled rules — flat select, no embeds.
         //    Previously this used profiles!inner(...) which requires PostgREST to
@@ -316,6 +340,13 @@ export async function GET(request: Request) {
                 });
                 if (holdResolution.status === "suppressed") {
                   result.skipped++;
+                  result.skipped_by_reason[holdResolution.reasonCode]++;
+                  console.warn(`${CONTEXT_TAG} Suppressed matched alert window`, {
+                    rule_id: rule.id,
+                    user_id: userId,
+                    beach_id: rule.beach_id,
+                    reason_code: holdResolution.reasonCode,
+                  });
                   holdSuppressed = true;
                   continue;
                 }
@@ -366,11 +397,30 @@ export async function GET(request: Request) {
           }
         }
 
+        if (result.matched > 0 && result.queued === 0) {
+          result.status = "degraded";
+          console.warn(`${CONTEXT_TAG} Matched alert windows but queued none`, {
+            matched: result.matched,
+            queued: result.queued,
+            skipped_by_reason: result.skipped_by_reason,
+            errors: result.errors,
+          });
+        }
+
         console.log(`${CONTEXT_TAG} Summary:`, result);
         return result;
-      }
+      },
+      {
+        statusForResult: (result) => result.status === "degraded" ? "error" : "ok",
+        errorMessageForResult: (result) =>
+          result.status === "degraded"
+            ? "Matched alert windows but queued none"
+            : null,
+      },
     );
-    return NextResponse.json(summary);
+    return NextResponse.json(summary, {
+      status: summary.status === "degraded" ? 503 : 200,
+    });
   } catch (err) {
     console.error(`${CONTEXT_TAG} Fatal error:`, err);
     return NextResponse.json({ error: "Internal error" }, { status: 500 });

--- a/app/api/cron/condition-alert-evaluate/route.ts
+++ b/app/api/cron/condition-alert-evaluate/route.ts
@@ -397,9 +397,15 @@ export async function GET(request: Request) {
           }
         }
 
-        if (result.matched > 0 && result.queued === 0) {
+        // A matched window that never reaches the queue is only expected when a
+        // real safety hold suppressed it (`major_event_hold`) — that is the hold
+        // system working, and must stay `ok` or every big-swell day alarms falsely.
+        // `hold_state_unavailable` is the opposite: the hold could not be resolved
+        // at all, so the alert was dropped by a failure. That is the state which
+        // silently killed every forecast alert from 2026-07-26 onward.
+        if (result.skipped_by_reason.hold_state_unavailable > 0) {
           result.status = "degraded";
-          console.warn(`${CONTEXT_TAG} Matched alert windows but queued none`, {
+          console.warn(`${CONTEXT_TAG} Matched alert windows dropped without a safety hold`, {
             matched: result.matched,
             queued: result.queued,
             skipped_by_reason: result.skipped_by_reason,
@@ -414,7 +420,7 @@ export async function GET(request: Request) {
         statusForResult: (result) => result.status === "degraded" ? "error" : "ok",
         errorMessageForResult: (result) =>
           result.status === "degraded"
-            ? "Matched alert windows but queued none"
+            ? "Matched alert windows dropped without a safety hold"
             : null,
       },
     );

--- a/lib/cron/observability.ts
+++ b/lib/cron/observability.ts
@@ -22,6 +22,11 @@ type CronRunsTable = {
   };
 };
 
+interface CronObservabilityOptions<T> {
+  statusForResult: (result: T) => "ok" | "error";
+  errorMessageForResult?: (result: T) => string | null;
+}
+
 function extractErrorMessage(summary: unknown, statusCode: number): string {
   const fallback = `HTTP ${statusCode}`;
   if (!summary || typeof summary !== "object") return fallback;
@@ -195,7 +200,8 @@ export function withObservedCron<H extends (request: Request) => Promise<Respons
 
 export async function withCronObservability<T>(
   route: string,
-  handler: () => Promise<T>
+  handler: () => Promise<T>,
+  options?: CronObservabilityOptions<T>,
 ): Promise<T> {
   const supabase = await createSupabaseServiceRoleClient();
   const start = Date.now();
@@ -221,13 +227,18 @@ export async function withCronObservability<T>(
   try {
     const result = await handler();
     if (runId) {
+      const status = options?.statusForResult(result) ?? "ok";
       await db
         .from("cron_runs")
         .update({
-          status: "ok",
+          status,
           finished_at: new Date().toISOString(),
           duration_ms: Date.now() - start,
           summary: result as object,
+          error_message:
+            status === "error"
+              ? options?.errorMessageForResult?.(result) ?? "Cron reported a degraded result"
+              : null,
         })
         .eq("id", runId);
     }

--- a/lib/recommendations/major-event-hold/adapters/notification.ts
+++ b/lib/recommendations/major-event-hold/adapters/notification.ts
@@ -380,6 +380,7 @@ export async function resolveNotificationMajorEventHold(
   if (
     mode === "enforce"
     && POSITIVE_NOTIFICATION_TYPES.has(input.type)
+    && input.type !== "forecast_alert"
     && !hasFreshCanonicalPositiveDecision({
       type: input.type,
       payload: input.payload,


### PR DESCRIPTION
## Why

Forecast alerts have delivered **nothing to any user since 2026-07-25**. Verified against prod:

| date | evaluated | matched | queued |
|---|---:|---:|---:|
| 2026-07-25 | 110 | 20 | **20** |
| 2026-07-26 | 112 | 40 | **0** |
| 2026-08-10 | 144 | 31 | **0** |

`alert_deliveries` last row `2026-07-25 19:00 UTC`. Every run since reported `status: ok, errors: 0` — nothing logged, nothing paged. 36 new alert rules were created during the outage; 97 of 230 real users have one.

## Root cause

`resolveNotificationMajorEventHold` returns `suppressed("hold_state_unavailable")` in `enforce` mode unless a fresh canonical positive decision already exists matching beach + window + `forecast_at`. For `forecast_alert` that is circular — delivery builds that decision downstream. Every match was dropped.

All rows in `regional_recommendation_holds` have been `cancelled` since 2026-07-22, so no genuine safety hold was involved.

## Changes

1. **`notification.ts`** — exempt `forecast_alert` from the canonical-decision precondition only. Real hold evaluation is untouched: an active hold still returns `major_event_hold` and suppresses. All other notification types unchanged.
2. **`condition-alert-evaluate/route.ts`** — add `skipped_by_reason` counters (both keys always present), log each suppression with its reason, and mark the run `degraded` (503 + `cron_runs.status='error'`) when `hold_state_unavailable > 0`.
3. **`observability.ts`** — `statusForResult` / `errorMessageForResult` hooks so a degraded run is recorded rather than stored as a success.

The degraded signal deliberately does **not** fire on `major_event_hold` suppression — that is the hold system working, and alarming on it would page on exactly the big-swell days it exists for.

## Verification (run locally — Actions are disabled on this repo)

- `yarn typecheck` — pass
- `npx jest __tests__/lib/recommendations/major-event-hold __tests__/api/cron __tests__/lib/cron` — **616 passed / 24 suites**
- `yarn build` — pass
- Scoped `eslint --max-warnings=0` — pass
- Cherry-picked onto `origin/prod` with **0 conflicts**. No new routes, no UI links, no migrations.

## Rollback

Revert the merge. No flag gates this.

## After merge

Watch the next `09:00 UTC` `condition-alert-evaluate` run:
- `queued > 0` → fixed.
- `queued == 0` with `hold_state_unavailable > 0` → a second suppression path exists (the null-candidate branch in the same resolver) and this is not the whole fix. The new instrumentation surfaces that within one run instead of 16 days.

**No backfill.** ~480 dropped alerts reference stale windows; replaying them would blast users with obsolete surf calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)