### PR TITLE
fix(alerts): hash oversized hold candidates + shadow forecast delivery (SENDS NOTHING)

### DIFF
--- a/__tests__/api/cron/condition-alert-deliver.test.ts
+++ b/__tests__/api/cron/condition-alert-deliver.test.ts
@@ -17,9 +17,9 @@ if (typeof (globalThis as any).Response?.json !== "function") {
  * Unit tests for condition-alert-deliver cron worker hardening (Task 4).
  *
  * Verifies:
- * - ALERTS_DELIVERY_ENABLED=false short-circuits providers and writes one
+ * - FORECAST_ALERT_DELIVERY_ENABLED=false reaches the send boundary and writes one
  *   alert_delivery_attempts row per (queue_id, channel) with status
- *   "skipped_disabled" — but still marks queue rows sent.
+ *   "shadow_withheld" — but still marks queue rows sent.
  * - ALERTS_DELIVERY_USER_ALLOWLIST set + user not in list writes
  *   "skipped_allowlist" attempt rows and skips providers.
  * - Healthy state with empty allowlist + ENABLED=true writes a "sent"
@@ -322,7 +322,12 @@ function seedQueueRow(overrides: Partial<any> = {}) {
     best_score: 0.8,
     conditions_snapshot: { wave_height: 3 },
     sent: false,
-    alert_rules: { name: "Test rule", notify_email: true, notify_push: true },
+    alert_rules: {
+      name: "Test rule",
+      preset_type: "mellow_session",
+      notify_email: true,
+      notify_push: true,
+    },
     beaches: {
       name: "Test Beach",
       timezone: "America/Los_Angeles",
@@ -362,6 +367,7 @@ function expectQueueReasonTotals(body: {
       "non_canonical",
       "major_event_hold",
       "canonical_safety_rejected",
+      "shadow_withheld",
       "delivery_disabled",
       "allowlist_excluded",
       "cooldown",
@@ -416,6 +422,7 @@ beforeEach(() => {
     candidate: null,
   });
   delete process.env.ALERTS_DELIVERY_ENABLED;
+  process.env.FORECAST_ALERT_DELIVERY_ENABLED = "true";
   delete process.env.ALERTS_DELIVERY_USER_ALLOWLIST;
 });
 
@@ -442,10 +449,16 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(routeSource).toContain("async function markQueueItemsConsumed");
   });
 
-  it("ALERTS_DELIVERY_ENABLED=false writes skipped_disabled per channel and still marks queue sent", async () => {
-    process.env.ALERTS_DELIVERY_ENABLED = "false";
+  it("default-off forecast delivery records a canonical shadow outcome and consumes the row once without sending", async () => {
+    delete process.env.FORECAST_ALERT_DELIVERY_ENABLED;
     seedQueueRow({
-      alert_rules: { name: "Test rule", notify_email: true, notify_push: true },
+      best_score: 95,
+      alert_rules: {
+        name: "Test rule",
+        preset_type: "mellow_session",
+        notify_email: true,
+        notify_push: true,
+      },
     });
     seedProfile({ notif_email_enabled: true, notif_push_enabled: true });
     store.deviceRows.push({ user_id: USER_A, device_token: "ExpoPushToken[abc]" });
@@ -455,19 +468,45 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
 
     expect(mockEmailsSend).not.toHaveBeenCalled();
     expect(mockSendPushNotifications).not.toHaveBeenCalled();
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+    expect(mockLogDelivery).not.toHaveBeenCalled();
+    expect(mockConsolidatedAlertEmail).not.toHaveBeenCalled();
     expect(store.deliveryInserts).toHaveLength(0);
+    expect(mockResolveNotificationMajorEventHold).toHaveBeenCalledTimes(3);
 
     expect(store.attemptInserts).toHaveLength(2);
     const channels = store.attemptInserts.map((a) => a.channel).sort();
     expect(channels).toEqual(["email", "push"]);
     for (const a of store.attemptInserts) {
-      expect(a.status).toBe("skipped_disabled");
+      expect(a.status).toBe("shadow_withheld");
       expect(a.queue_id).toBe(QUEUE_1);
       expect(a.user_id).toBe(USER_A);
       expect(a.rule_id).toBe(RULE_1);
     }
 
+    const shadowUpdate = store.queueRefreshUpdates.find(
+      (update) => update.values.delivery_shadow_outcome,
+    );
+    expect(shadowUpdate).toEqual({
+      id: QUEUE_1,
+      values: {
+        delivery_shadow_outcome: {
+          status: "shadow_withheld",
+          verdict: "go",
+          reason_code: "selected_go",
+          preset_type: "mellow_session",
+          would_use_channels: ["email", "push"],
+        },
+      },
+    });
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      status: "ok",
+      queueMarked: 1,
+      queue_marked_by_reason: { shadow_withheld: 1 },
+    });
+    expectQueueReasonTotals(body);
   });
 
   it("Allowlist set, user not in list, ENABLED=true writes skipped_allowlist", async () => {
@@ -499,7 +538,8 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
   });
 
-  it("Empty allowlist, ENABLED=true, healthy email path writes one sent attempt + delivery row", async () => {
+  it("FORECAST_ALERT_DELIVERY_ENABLED=true restores email delivery", async () => {
+    process.env.FORECAST_ALERT_DELIVERY_ENABLED = "true";
     process.env.ALERTS_DELIVERY_ENABLED = "true";
     process.env.ALERTS_DELIVERY_USER_ALLOWLIST = "";
     seedQueueRow({
@@ -1206,6 +1246,44 @@ describe("condition-alert-deliver — email quiet-hours guard", () => {
     return n === 24 ? 0 : n;
   }
 
+  it("shadow mode consumes a quiet-hours row without degrading the run", async () => {
+    delete process.env.FORECAST_ALERT_DELIVERY_ENABLED;
+    const start = ptHourNow();
+    const end = (start + 1) % 24;
+    seedQueueRow({
+      alert_rules: {
+        name: "Test rule",
+        preset_type: "mellow_session",
+        notify_email: true,
+        notify_push: false,
+        conditions: { quiet_hours_start: start, quiet_hours_end: end },
+      },
+    });
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      status: "ok",
+      queueMarked: 1,
+      queue_marked_by_reason: { shadow_withheld: 1 },
+    });
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
+    expect(store.queueRefreshUpdates).toContainEqual({
+      id: QUEUE_1,
+      values: {
+        delivery_shadow_outcome: expect.objectContaining({
+          preset_type: "mellow_session",
+          would_use_channels: [],
+        }),
+      },
+    });
+    expectQueueReasonTotals(body);
+  });
+
   it("recipient inside quiet hours: email deferred, NOT sent/deduped/marked-sent", async () => {
     process.env.ALERTS_DELIVERY_ENABLED = "true";
     process.env.ALERTS_DELIVERY_USER_ALLOWLIST = "";
@@ -1647,7 +1725,12 @@ function seedSimilarityQueueRow(overrides: Partial<any> = {}) {
     sent: false,
     // notify_push/notify_email do NOT gate similarity — registry pref does.
     // We default false here to confirm the route bypasses the legacy flags.
-    alert_rules: { name: "Similarity match", notify_email: false, notify_push: false },
+    alert_rules: {
+      name: "Similarity match",
+      preset_type: "similarity_match",
+      notify_email: false,
+      notify_push: false,
+    },
     beaches: {
       name: "Ocean Beach SF",
       timezone: "America/Los_Angeles",
@@ -1769,6 +1852,43 @@ describe("condition-alert-deliver — similarity_match partition + enqueue", () 
       }),
     ]);
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_SIM], sent: true }]);
+  });
+
+  it("forecast delivery shadow mode withholds similarity enqueue and records its canonical outcome", async () => {
+    delete process.env.FORECAST_ALERT_DELIVERY_ENABLED;
+    process.env.ALERTS_DELIVERY_ENABLED = "true";
+    seedSimilarityQueueRow();
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: true });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(store.deliveryInserts).toHaveLength(0);
+    expect(store.attemptInserts).toEqual([
+      expect.objectContaining({
+        queue_id: QUEUE_SIM,
+        channel: "push",
+        status: "shadow_withheld",
+      }),
+    ]);
+    expect(store.queueRefreshUpdates).toContainEqual({
+      id: QUEUE_SIM,
+      values: {
+        delivery_shadow_outcome: {
+          status: "shadow_withheld",
+          verdict: "go",
+          reason_code: "selected_go",
+          preset_type: "similarity_match",
+          would_use_channels: ["push"],
+        },
+      },
+    });
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_SIM], sent: true }]);
+    expect(body.queue_marked_by_reason.shadow_withheld).toBe(1);
+    expectQueueReasonTotals(body);
   });
 
   it("kill switch: ALERTS_DELIVERY_ENABLED=false records skipped_disabled and marks similarity queue sent without enqueueing", async () => {

--- a/__tests__/lib/recommendations/major-event-hold/notification.test.ts
+++ b/__tests__/lib/recommendations/major-event-hold/notification.test.ts
@@ -212,6 +212,55 @@ describe("notification major-event hold adapter", () => {
     expect(evaluateCandidates).toHaveBeenCalledTimes(1);
   });
 
+  it("allows an over-length event id with a deterministic bounded candidate id", async () => {
+    const eventId = "condition-alert-deliver:push:" + "x".repeat(147);
+    const candidates: string[] = [];
+    const evaluateCandidates: NotificationMajorEventHoldEvaluator = jest.fn(
+      async ({ candidates: evaluatedCandidates }) => {
+        const candidate = evaluatedCandidates[0] as MajorEventHoldCandidate;
+        candidates.push(candidate.candidateId);
+        return [decisionFor(candidate, "allowed")];
+      },
+    );
+    const input = {
+      eventId,
+      type: "forecast_alert",
+      payload: {
+        beach_id: BEACH_ID,
+        forecast_at: STARTS_AT,
+        policy_context: {
+          kind: "positive_session_recommendation",
+          beach_id: BEACH_ID,
+          starts_at: STARTS_AT,
+          ends_at: ENDS_AT,
+        },
+      },
+      profileExperience: "beginner",
+      mode: "enforce" as const,
+      asOf: new Date("2026-07-17T07:00:00.000Z"),
+    };
+
+    await expect(
+      resolveNotificationMajorEventHold(input, { evaluateCandidates }),
+    ).resolves.toMatchObject({ status: "allowed" });
+    await expect(
+      resolveNotificationMajorEventHold(input, { evaluateCandidates }),
+    ).resolves.toMatchObject({ status: "allowed" });
+    await expect(
+      resolveNotificationMajorEventHold(
+        { ...input, eventId: `${eventId}y` },
+        { evaluateCandidates },
+      ),
+    ).resolves.toMatchObject({ status: "allowed" });
+
+    expect(eventId).toHaveLength(176);
+    expect(candidates).toHaveLength(3);
+    expect(candidates[0]).toMatch(/^notification:sha256:[a-f0-9]{64}$/);
+    expect(candidates[0]).toHaveLength(84);
+    expect(candidates[1]).toBe(candidates[0]);
+    expect(candidates[2]).not.toBe(candidates[0]);
+  });
+
   it.each(MODE_EXPECTATIONS)(
     "%s mode returns %s for a user-configured forecast alert under an active hold",
     async (mode, expectedStatus) => {

--- a/app/api/cron/condition-alert-deliver/route.ts
+++ b/app/api/cron/condition-alert-deliver/route.ts
@@ -2,20 +2,19 @@
 //
 // Delivery cron — runs hourly (`0 * * * *`).
 // Reads due items from alert_queue, consolidates per user, sends email + push.
-// Cadence relaxed from `*/15 * * * *` on 2026-05-02 alongside the
-// ALERTS_DELIVERY_ENABLED=true flip — initial-rollout latency budget is
+// Cadence relaxed from `*/15 * * * *` on 2026-05-02 — initial-rollout latency budget is
 // 60 min from evaluator → delivery, acceptable for surf condition alerts.
 // Re-tighten if user-volume or feedback warrants it.
 //
 // Hardened (Task 4) with:
-//   - ALERTS_DELIVERY_ENABLED kill switch (env var, default off)
+//   - FORECAST_ALERT_DELIVERY_ENABLED forecast send switch (default off)
+//   - ALERTS_DELIVERY_ENABLED legacy similarity-alert send switch
 //   - ALERTS_DELIVERY_USER_ALLOWLIST (comma-separated user_ids; empty = all)
 //   - Per-(queue_id, channel) row in `alert_delivery_attempts` for every
 //     decision (sent, skipped_*, failed_*).
 //
-// The kill-switch path STILL marks queue rows sent so the queue can't grow
-// unboundedly while delivery is paused. Throttle (cooldown + cap) lands in
-// Task 5.
+// Forecast shadow mode runs hold, canonical, and channel checks, records the
+// outcome, and consumes queue rows without calling an outbound provider.
 
 import { NextResponse } from "next/server";
 import { validateCronRequest } from "@/lib/middleware/api-wrappers";
@@ -52,6 +51,7 @@ import {
 } from "@/lib/alerts/revalidate-alert-window";
 import type { AlertConditions } from "@/lib/alerts/types";
 import type { MatchingWindow } from "@/lib/alerts/types";
+import { isForecastAlertDeliveryEnabled } from "@/lib/flags/forecast-alert-delivery";
 import { formatWaveHeightRange } from "@/lib/formatters/surf-data";
 import { parseSkillLevel } from "@/lib/domains/user-preferences/skill-level";
 import {
@@ -80,6 +80,7 @@ const QUEUE_MARK_REASONS = [
   "non_canonical",
   "major_event_hold",
   "canonical_safety_rejected",
+  "shadow_withheld",
   "delivery_disabled",
   "allowlist_excluded",
   "cooldown",
@@ -104,6 +105,14 @@ type RecordedAttempt = {
   skipReason: string | null;
 };
 
+type ForecastAlertShadowOutcome = {
+  status: "shadow_withheld";
+  verdict: CanonicalSessionDecision["verdict"];
+  reason_code: CanonicalSessionDecision["reasonCode"];
+  preset_type: string | null;
+  would_use_channels: Channel[];
+};
+
 function createQueueMarkedByReason(): Record<QueueMarkReason, number> {
   return Object.fromEntries(
     QUEUE_MARK_REASONS.map((reason) => [reason, 0]),
@@ -126,6 +135,7 @@ type SuppressedNotificationHold = Extract<
 
 type RuleEmbed = {
   name: string;
+  preset_type: string | null;
   notify_email: boolean;
   notify_push: boolean;
   conditions?: AlertConditions | null;
@@ -384,7 +394,9 @@ export async function GET(request: Request): Promise<NextResponse> {
   const supabase = await createSupabaseServiceRoleClient();
 
   // Env-driven gates. Default OFF for safety; staged rollout via allowlist.
-  const deliveryEnabled = process.env.ALERTS_DELIVERY_ENABLED === "true";
+  const forecastDeliveryEnabled = isForecastAlertDeliveryEnabled();
+  const similarityDeliveryEnabled =
+    process.env.ALERTS_DELIVERY_ENABLED === "true";
   const allowlistRaw = process.env.ALERTS_DELIVERY_USER_ALLOWLIST ?? "";
   const allowlist = new Set(
     allowlistRaw
@@ -395,6 +407,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   const recordedAttemptsByQueue = new Map<string, RecordedAttempt[]>();
   const deliveryAcceptedQueueIds = new Set<string>();
   const previousUnresolvedHoldRunsByQueue = new Map<string, number>();
+  const shadowOutcomesByQueue = new Map<string, ForecastAlertShadowOutcome>();
 
   async function recordAttempt(args: {
     queueId: string;
@@ -423,6 +436,35 @@ export async function GET(request: Request): Promise<NextResponse> {
       skipReason: args.skipReason ?? null,
     });
     recordedAttemptsByQueue.set(args.queueId, attempts);
+  }
+
+  async function persistShadowOutcome(
+    item: QueueItemWithMeta,
+  ): Promise<void> {
+    const outcome = shadowOutcomesByQueue.get(item.id);
+    if (!outcome) {
+      throw new Error(`missing shadow outcome for queue row ${item.id}`);
+    }
+
+    const { error } = await (supabase.from("alert_queue") as any)
+      .update({ delivery_shadow_outcome: outcome })
+      .eq("id", item.id);
+    if (error) {
+      throw new Error(
+        `failed to persist shadow outcome for alert_queue row ${item.id}: ${error.message}`,
+      );
+    }
+  }
+
+  function addShadowChannel(
+    items: QueueItemWithMeta[],
+    channel: Channel,
+  ): void {
+    for (const item of items) {
+      const outcome = shadowOutcomesByQueue.get(item.id);
+      if (!outcome || outcome.would_use_channels.includes(channel)) continue;
+      outcome.would_use_channels.push(channel);
+    }
   }
 
   async function refreshQueueItemFromLatestForecasts(
@@ -598,9 +640,13 @@ export async function GET(request: Request): Promise<NextResponse> {
         ): QueueMarkReason | null {
           if (deliveryAcceptedQueueIds.has(item.id)) return "delivered";
           if (enabledChannels(item).length === 0) return "no_enabled_channels";
+          if (shadowOutcomesByQueue.has(item.id)) return "shadow_withheld";
 
           const attempts = recordedAttemptsByQueue.get(item.id) ?? [];
           if (attempts.length === 0) return "unrecorded_consumption";
+          if (attempts.some((attempt) => attempt.status === "shadow_withheld")) {
+            return "shadow_withheld";
+          }
           if (attempts.some((attempt) => attempt.status === "sent")) {
             return "delivered";
           }
@@ -674,7 +720,7 @@ export async function GET(request: Request): Promise<NextResponse> {
           .select(`
             id, user_id, rule_id, beach_id, alert_date, send_at,
             window_start, window_end, best_hour, best_score, conditions_snapshot, sent,
-            alert_rules!inner(name, notify_email, notify_push, conditions),
+            alert_rules!inner(name, preset_type, notify_email, notify_push, conditions),
             beaches!inner(
               id, name, slug, timezone, lat, lon,
               wind_offshore_deg, wind_offshore_tol_deg, aspect_deg,
@@ -744,6 +790,7 @@ export async function GET(request: Request): Promise<NextResponse> {
             conditions_snapshot: (row.conditions_snapshot ?? {}) as Record<string, unknown>,
             sent: row.sent,
             rule_name: rule.name,
+            preset_type: rule.preset_type,
             beach_name: beach.name,
             beach_slug: beach.slug ?? null,
             beach_skill_level: beach.skill_level ?? null,
@@ -894,6 +941,25 @@ export async function GET(request: Request): Promise<NextResponse> {
             matches: allowedMatches,
             profileExperience: profile.experience_level,
           });
+          if (!forecastDeliveryEnabled) {
+            for (const item of userItems) {
+              const holdReason = holdReasonByCandidate.get(
+                canonicalAlertCandidateId(item),
+              );
+              const reasonCode = holdReason?.endsWith(":major_event_hold")
+                ? "major_event_hold"
+                : holdReason?.endsWith(":hold_state_unavailable")
+                  ? "hold_state_unavailable"
+                  : decision.reasonCode;
+              shadowOutcomesByQueue.set(item.id, {
+                status: "shadow_withheld",
+                verdict: holdReason ? "no" : decision.verdict,
+                reason_code: reasonCode,
+                preset_type: item.preset_type ?? null,
+                would_use_channels: [],
+              });
+            }
+          }
           const selectedMatch = selectedAlertMatch(allowedMatches, decision);
           const selectedItem = selectedMatch
             ? userItems.find(
@@ -940,6 +1006,11 @@ export async function GET(request: Request): Promise<NextResponse> {
               reason = "canonical_safety_rejected";
             }
             if (reason) addItemReason(suppressedItemsByReason, reason, item);
+          }
+          if (!forecastDeliveryEnabled) {
+            for (const item of suppressedItems) {
+              await persistShadowOutcome(item);
+            }
           }
           await markQueueItemsByReason(suppressedItemsByReason);
         }
@@ -1095,19 +1166,7 @@ export async function GET(request: Request): Promise<NextResponse> {
           try {
             // ---- Email branch ----
             if (emailItems.length > 0) {
-              // Gate: kill switch
-              if (!deliveryEnabled) {
-                for (const item of emailItems) {
-                  await recordAttempt({
-                    queueId: item.id,
-                    ruleId: item.rule_id,
-                    userId: payload.user_id,
-                    channel: "email",
-                    status: "skipped_disabled",
-                    skipReason: "ALERTS_DELIVERY_ENABLED=false",
-                  });
-                }
-              } else if (allowlist.size > 0 && !allowlist.has(payload.user_id)) {
+              if (allowlist.size > 0 && !allowlist.has(payload.user_id)) {
                 for (const item of emailItems) {
                   await recordAttempt({
                     queueId: item.id,
@@ -1126,11 +1185,17 @@ export async function GET(request: Request): Promise<NextResponse> {
                 // below so a later hourly run sends once they're out of quiet
                 // hours and send_at has passed.
                 for (const item of emailItems) {
-                  quietDeferredEmailQueueIds.add(item.id);
+                  if (forecastDeliveryEnabled) {
+                    quietDeferredEmailQueueIds.add(item.id);
+                  }
                 }
-                result.emailQuietHoursSkipped += emailItems.length;
+                if (forecastDeliveryEnabled) {
+                  result.emailQuietHoursSkipped += emailItems.length;
+                }
                 console.log(
-                  `${CONTEXT_TAG} Email deferred for user ${payload.user_id} (quiet hours; ${emailItems.length} item(s) left due)`
+                  forecastDeliveryEnabled
+                    ? `${CONTEXT_TAG} Email deferred for user ${payload.user_id} (quiet hours; ${emailItems.length} item(s) left due)`
+                    : `${CONTEXT_TAG} Email shadow-blocked for user ${payload.user_id} (quiet hours)`,
                 );
               } else {
                 // Throttle (cooldown per-rule, weekly cap per-user). Items that
@@ -1209,7 +1274,9 @@ export async function GET(request: Request): Promise<NextResponse> {
                       alertDate
                     );
 
-                    await rateLimiter.throttle();
+                    if (forecastDeliveryEnabled) {
+                      await rateLimiter.throttle();
+                    }
 
                     const emailHold = await resolveHoldForForecastMatches({
                       eventIdPrefix: `condition-alert-deliver:email:${payload.user_id}`,
@@ -1239,7 +1306,11 @@ export async function GET(request: Request): Promise<NextResponse> {
                       emailMatches.length > 0
                         ? buildConsolidatedSubject(emailMatches, alertDate)
                         : candidateEmailSubject;
-                    const sendResult = emailHold || !emailDecision || !selectedEmailMatch
+                    const sendResult =
+                      emailHold ||
+                      !emailDecision ||
+                      !selectedEmailMatch ||
+                      !forecastDeliveryEnabled
                       ? { data: null, error: null }
                       : await sendEmail({
                           from: MAIL_FROM,
@@ -1271,6 +1342,8 @@ export async function GET(request: Request): Promise<NextResponse> {
                             : `canonical_decision:${emailDecision?.reasonCode ?? "unavailable"}`,
                         });
                       }
+                    } else if (!forecastDeliveryEnabled) {
+                      addShadowChannel(emailSurvivors, "email");
                     } else if (sendError) {
                       console.error(`${CONTEXT_TAG} Email send failed for user ${payload.user_id}:`, sendError);
                       result.errors++;
@@ -1352,18 +1425,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 
             // ---- Push branch ----
             if (pushItems.length > 0) {
-              if (!deliveryEnabled) {
-                for (const item of pushItems) {
-                  await recordAttempt({
-                    queueId: item.id,
-                    ruleId: item.rule_id,
-                    userId: payload.user_id,
-                    channel: "push",
-                    status: "skipped_disabled",
-                    skipReason: "ALERTS_DELIVERY_ENABLED=false",
-                  });
-                }
-              } else if (allowlist.size > 0 && !allowlist.has(payload.user_id)) {
+              if (allowlist.size > 0 && !allowlist.has(payload.user_id)) {
                 for (const item of pushItems) {
                   await recordAttempt({
                     queueId: item.id,
@@ -1517,6 +1579,11 @@ export async function GET(request: Request): Promise<NextResponse> {
                             pushDecision?.reasonCode ??
                             "hold_state_unavailable",
                         }
+                      : !forecastDeliveryEnabled
+                        ? {
+                            enqueued: false as const,
+                            reason: "shadow_withheld" as const,
+                          }
                       : await enqueueNotification({
                           type: "forecast_alert",
                           recipientUserId: payload.user_id,
@@ -1529,7 +1596,12 @@ export async function GET(request: Request): Promise<NextResponse> {
                           return { enqueued: false as const, reason: "internal_error" as const };
                         });
 
-                    if (enqueueResult.enqueued) {
+                    if (
+                      !enqueueResult.enqueued &&
+                      enqueueResult.reason === "shadow_withheld"
+                    ) {
+                      addShadowChannel(pushSurvivors, "push");
+                    } else if (enqueueResult.enqueued) {
                       for (const item of pushSurvivors) {
                         deliveryAcceptedQueueIds.add(item.id);
                       }
@@ -1618,8 +1690,24 @@ export async function GET(request: Request): Promise<NextResponse> {
               }
             }
 
-            // 6. Mark queue items as sent (always — even when delivery is disabled —
-            //    so the queue cannot accumulate forever during a pause). EXCEPT
+            if (!forecastDeliveryEnabled) {
+              for (const item of contributingItems) {
+                await persistShadowOutcome(item);
+                const outcome = shadowOutcomesByQueue.get(item.id)!;
+                for (const channel of outcome.would_use_channels) {
+                  await recordAttempt({
+                    queueId: item.id,
+                    ruleId: item.rule_id,
+                    userId: payload.user_id,
+                    channel,
+                    status: "shadow_withheld",
+                    skipReason: JSON.stringify(outcome),
+                  });
+                }
+              }
+            }
+
+            // 6. Mark queue items as sent. EXCEPT
             //    rows whose email item was quiet-hours-deferred this run: those
             //    stay due+unsent so a later hourly tick re-evaluates and sends.
             //    (Push on the same row is dedup-protected by the push
@@ -1676,7 +1764,7 @@ export async function GET(request: Request): Promise<NextResponse> {
             // Kill switch — same semantics as the forecast branch: skip the
             // provider call but mark the queue row sent so the queue can't
             // grow unbounded during a pause.
-            if (!deliveryEnabled) {
+            if (forecastDeliveryEnabled && !similarityDeliveryEnabled) {
               await recordAttempt({
                 queueId: item.id,
                 ruleId: item.rule_id,
@@ -1838,6 +1926,22 @@ export async function GET(request: Request): Promise<NextResponse> {
               storedDecisionMatchesWindow && storedSimilarityDecision
                 ? storedSimilarityDecision
                 : similarityDecision;
+            if (!forecastDeliveryEnabled) {
+              const reasonCode =
+                similarityHold.status === "suppressed"
+                  ? similarityHold.reasonCode
+                  : notificationDecision?.reasonCode ?? "no_candidates";
+              shadowOutcomesByQueue.set(item.id, {
+                status: "shadow_withheld",
+                verdict:
+                  similarityHold.status === "suppressed"
+                    ? "no"
+                    : notificationDecision?.verdict ?? "no",
+                reason_code: reasonCode,
+                preset_type: item.preset_type ?? null,
+                would_use_channels: [],
+              });
+            }
             if (
               similarityHold.status !== "allowed" ||
               !similarityDecision ||
@@ -1855,6 +1959,9 @@ export async function GET(request: Request): Promise<NextResponse> {
                     ? `${similarityHold.auditCode}:${similarityHold.reasonCode}`
                     : `canonical_decision:${similarityDecision?.reasonCode ?? "unavailable"}`,
               });
+              if (!forecastDeliveryEnabled) {
+                await persistShadowOutcome(item);
+              }
               const similaritySuppressionReason =
                 similarityHold.status === "suppressed"
                   ? similarityHold.reasonCode
@@ -1870,6 +1977,22 @@ export async function GET(request: Request): Promise<NextResponse> {
                   "canonical_safety_rejected",
                 );
               }
+              continue;
+            }
+
+            if (!forecastDeliveryEnabled) {
+              addShadowChannel([item], "push");
+              await persistShadowOutcome(item);
+              const outcome = shadowOutcomesByQueue.get(item.id)!;
+              await recordAttempt({
+                queueId: item.id,
+                ruleId: item.rule_id,
+                userId: item.user_id,
+                channel: "push",
+                status: "shadow_withheld",
+                skipReason: JSON.stringify(outcome),
+              });
+              await markQueueItemsConsumed([item], "shadow_withheld");
               continue;
             }
 

--- a/lib/alerts/payload-builder.ts
+++ b/lib/alerts/payload-builder.ts
@@ -23,6 +23,7 @@ export interface QueueItemWithMeta {
   conditions_snapshot: Record<string, unknown>;
   sent: boolean;
   rule_name: string;
+  preset_type?: string | null;
   beach_name: string;
   beach_slug?: string | null;
   beach_skill_level?: string | null;

--- a/lib/alerts/throttle.ts
+++ b/lib/alerts/throttle.ts
@@ -1,5 +1,6 @@
 export type AttemptStatus =
   | "sent"
+  | "shadow_withheld"
   | "skipped_disabled"
   | "skipped_allowlist"
   | "skipped_cooldown"

--- a/lib/flags/__tests__/forecast-alert-delivery.test.ts
+++ b/lib/flags/__tests__/forecast-alert-delivery.test.ts
@@ -1,0 +1,27 @@
+import {
+  FORECAST_ALERT_DELIVERY_ENABLED_FLAG,
+  isForecastAlertDeliveryEnabled,
+} from "@/lib/flags/forecast-alert-delivery";
+
+describe("forecast alert delivery flag", () => {
+  const originalValue = process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG];
+      return;
+    }
+    process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG] = originalValue;
+  });
+
+  it("defaults off and enables only for exact true", () => {
+    delete process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG];
+    expect(isForecastAlertDeliveryEnabled()).toBe(false);
+
+    process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG] = "TRUE";
+    expect(isForecastAlertDeliveryEnabled()).toBe(false);
+
+    process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG] = "true";
+    expect(isForecastAlertDeliveryEnabled()).toBe(true);
+  });
+});

--- a/lib/flags/forecast-alert-delivery.ts
+++ b/lib/flags/forecast-alert-delivery.ts
@@ -1,0 +1,6 @@
+export const FORECAST_ALERT_DELIVERY_ENABLED_FLAG =
+  "FORECAST_ALERT_DELIVERY_ENABLED";
+
+export function isForecastAlertDeliveryEnabled(): boolean {
+  return process.env[FORECAST_ALERT_DELIVERY_ENABLED_FLAG] === "true";
+}

--- a/lib/recommendations/major-event-hold/adapters/notification.ts
+++ b/lib/recommendations/major-event-hold/adapters/notification.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { MAJOR_EVENT_HOLD_MODE } from "../config";
 import { parseMajorEventHoldCandidate } from "../evaluator";
 import { evaluateMajorEventHoldCandidates } from "../service";
@@ -20,6 +22,9 @@ const POSITIVE_NOTIFICATION_TYPES = new Set([
 ]);
 const FORECAST_SLOT_DURATION_MS = 60 * 60 * 1000;
 const AUDIT_CODE = "major_event_hold" as const;
+const MAX_CANDIDATE_ID_LENGTH = 160;
+const HASHED_CANDIDATE_PREFIX = "notification:sha256:";
+const HASH_DOMAIN = "quiver:notification-candidate:v1\0";
 
 export interface PositiveRecommendationPolicyContext {
   kind: "positive_session_recommendation";
@@ -91,10 +96,24 @@ function isPositiveNotification(type: string, payload: unknown): boolean {
   );
 }
 
+function hashedCandidateId(value: string): string {
+  const digest = createHash("sha256")
+    .update(HASH_DOMAIN)
+    .update(value)
+    .digest("hex");
+  return `${HASHED_CANDIDATE_PREFIX}${digest}`;
+}
+
+function boundedCandidateId(value: string): string {
+  return value.length <= MAX_CANDIDATE_ID_LENGTH &&
+    !value.startsWith(HASHED_CANDIDATE_PREFIX)
+    ? value
+    : hashedCandidateId(value);
+}
+
 function candidateIdFor(eventId: unknown): string | null {
   if (typeof eventId !== "string" || eventId.trim().length === 0) return null;
-  const candidateId = `notification:${eventId}`;
-  return candidateId.length <= 160 ? candidateId : null;
+  return boundedCandidateId(`notification:${eventId}`);
 }
 
 function candidateFromPolicyContext(
@@ -196,8 +215,9 @@ function candidatesFromForecastMatches(
       return null;
     }
     const matchCandidateId =
-      index === 0 ? candidateId : `${candidateId}:match:${index}`;
-    if (matchCandidateId.length > 160) return null;
+      index === 0
+        ? candidateId
+        : boundedCandidateId(`${candidateId}:match:${index}`);
 
     return parseMajorEventHoldCandidate({
       candidateId: matchCandidateId,

--- a/supabase/migrations/20260810120000_add_forecast_alert_shadow_outcomes.sql
+++ b/supabase/migrations/20260810120000_add_forecast_alert_shadow_outcomes.sql
@@ -1,0 +1,34 @@
+-- Retain one queryable shadow-delivery outcome on each consumed alert queue row.
+-- `shadow_withheld` is reserved for channels that reached the send boundary
+-- while FORECAST_ALERT_DELIVERY_ENABLED was off.
+
+BEGIN;
+
+ALTER TABLE public.alert_queue
+  ADD COLUMN IF NOT EXISTS delivery_shadow_outcome jsonb;
+
+ALTER TABLE public.alert_delivery_attempts
+  DROP CONSTRAINT IF EXISTS alert_delivery_attempts_status_check;
+
+ALTER TABLE public.alert_delivery_attempts
+  ADD CONSTRAINT alert_delivery_attempts_status_check
+  CHECK (status IN (
+    'sent',
+    'shadow_withheld',
+    'skipped_disabled',
+    'skipped_allowlist',
+    'skipped_cooldown',
+    'skipped_user_cap',
+    'skipped_no_device',
+    'skipped_no_email',
+    'skipped_channel_disabled',
+    'skipped_dedup_collision',
+    'skipped_stale_forecast',
+    'failed_provider',
+    'failed_internal'
+  ));
+
+COMMENT ON COLUMN public.alert_queue.delivery_shadow_outcome IS
+  'Snapshot recorded when forecast alert delivery is shadowed: status, canonical verdict/reason, preset type, and channels that reached the send boundary.';
+
+COMMIT;


### PR DESCRIPTION
Third and final mechanism fix, after #529 (evaluator) and #530 (deliver accounting). **This sends nothing to users.**

## ⚠️ MIGRATION MUST BE APPLIED BEFORE MERGING

`supabase/migrations/20260810120000_add_forecast_alert_shadow_outcomes.sql` — **not yet applied**. Shadow mode writes `shadow_withheld` the moment the code runs, so deploying first means every write violates the existing CHECK constraint.

Verified against the live DB before proposing:

| check | result |
|---|---|
| Constraint name matches | ✅ `alert_delivery_attempts_status_check` — `DROP IF EXISTS` really drops (a name mismatch would leave the old constraint rejecting every write) |
| Additive only | ✅ 12 → 13 values, none removed |
| All in-use statuses preserved | ✅ all 9 (729 `sent`, 389 `skipped_cooldown`, 351 `skipped_stale_forecast`, …) |
| New column | ✅ `alert_queue.delivery_shadow_outcome jsonb`, nullable, `IF NOT EXISTS` |
| Version ordering | ✅ `20260810120000` > latest applied `20260809130000` |
| Wrapped in `BEGIN;…COMMIT;` | ✅ |

Prod and dev share one Supabase instance, so applying it is a production change.

## Root cause

`candidateIdFor()` returns `null` when `notification:${eventId}` exceeds **160 chars**. The deliver route builds a 176-char event id → 189-char candidate → `suppressed / hold_state_unavailable`, before either channel.

Reproduced 7/7 against production; shortened (83) and sha256-hashed (84) candidates both return `allowed`; one row proven end-to-end to the Expo send boundary. Independently verified: `candidateId` is **never persisted** and **no 160-char column exists** in the database, so no stored identity changes.

## Changes

1. **Central overflow hashing** — candidates over 160 chars become stable `notification:sha256:<64 hex>`. Fixes the whole class; any caller with a long event id had this same silent failure, and it has already surfaced through two different doors.
2. **`FORECAST_ALERT_DELIVERY_ENABLED`** — enabled only on exact `"true"`, **default off**. Merging changes nothing user-visible.
3. **Shadow mode** — runs hold, canonical, throttle, preferences, quiet hours, destination, dedupe and channel checks, recording `verdict`, `reason_code`, `preset_type` and `would_use_channels` per row, without sending. Rows consumed exactly once; shadow withholding does not mark the run degraded.

## Why delivery stays off

A forward-horizon measurement (141 rules / 94 users / 279 windows / 11.75 days) found the decision layer rejects nearly everything — `mellow_session` 7.3% `go`, `clean_groundswell` 1.2%, `weekend_warrior` **0%** — and three separate causes are still open: a `>1.0` score scaling inversion, a `go` bar of 70 against scores averaging 41, and `beginner-intermediate` beaches requiring `intermediate` (84 beaches). Turning delivery on now would send ~153 mostly-`maybe`/`no` alerts.

Shadow mode converts those modelled numbers into measured production data so the gating policy can be decided from facts.

## Verification

- `yarn typecheck` — pass (deps reinstalled against prod's lockfile)
- `npx jest __tests__/lib/recommendations/major-event-hold __tests__/api/cron __tests__/lib/cron lib/flags` — **29 suites / 638 tests** pass
- Cherry-picked onto `origin/prod` with **0 conflicts**
- Send-path proof with flag off: `sendEmail` unreachable, `enqueueNotification` bypassed, no `alert_deliveries`/email log/notification event/in-app/provider write. A real `major_event_hold` still suppresses.

## Rollback

Revert the merge. The migration is additive and can stay — no code depends on the column existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)