### PR TITLE
fix(alerts): honour the user's rule, and stop alerting after dark

### DIFF
--- a/__tests__/alerts/sunrise.test.ts
+++ b/__tests__/alerts/sunrise.test.ts
@@ -35,6 +35,22 @@ describe("filterToDaylight", () => {
     ]);
   });
 
+  it("drops the last daylight hour when it runs past sunset", () => {
+    // Waddell Creek, 2026-08-10: sunset 20:08:42 local (2026-08-11T03:08:42Z).
+    // The 20:00 row starts 8 minutes before sunset but covers 20:00-21:00, so
+    // 52 of its 60 minutes are dark. The 19:00 row ends at 20:00 and is fine.
+    const WADDELL_LAT = 37.0925;
+    const WADDELL_LON = -122.2767;
+    const rows = [
+      { forecast_at: "2026-08-11T02:00:00.000Z" }, // 19:00 local, ends 20:00
+      { forecast_at: "2026-08-11T03:00:00.000Z" }, // 20:00 local, ends 21:00
+    ];
+
+    const result = filterToDaylight(rows, WADDELL_LAT, WADDELL_LON);
+
+    expect(result).toEqual([{ forecast_at: "2026-08-11T02:00:00.000Z" }]);
+  });
+
   it("keeps daytime rows on the second and third days of a 72-hour forecast", () => {
     const rows = makeRows("2026-07-15T06:00:00.000Z", 24);
 

--- a/__tests__/api/cron/condition-alert-deliver.test.ts
+++ b/__tests__/api/cron/condition-alert-deliver.test.ts
@@ -364,7 +364,6 @@ function expectQueueReasonTotals(body: {
     [
       "delivered",
       "stale",
-      "non_canonical",
       "major_event_hold",
       "canonical_safety_rejected",
       "shadow_withheld",
@@ -472,7 +471,7 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(mockLogDelivery).not.toHaveBeenCalled();
     expect(mockConsolidatedAlertEmail).not.toHaveBeenCalled();
     expect(store.deliveryInserts).toHaveLength(0);
-    expect(mockResolveNotificationMajorEventHold).toHaveBeenCalledTimes(3);
+    expect(mockResolveNotificationMajorEventHold).toHaveBeenCalledTimes(1);
 
     expect(store.attemptInserts).toHaveLength(2);
     const channels = store.attemptInserts.map((a) => a.channel).sort();
@@ -598,99 +597,94 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(body.queue_marked_by_reason).toMatchObject({
       delivered: 1,
       stale: 0,
-      non_canonical: 0,
     });
     expectQueueReasonTotals(body);
   });
 
-  it("retains unresolved-hold rows for bounded retry and degrades the run", async () => {
-    process.env.ALERTS_DELIVERY_ENABLED = "true";
-    process.env.ALERTS_DELIVERY_USER_ALLOWLIST = "";
+  it("sends a beginner user's forecast alert for an expert beach", async () => {
     seedQueueRow({
-      alert_rules: { name: "Test rule", notify_email: true, notify_push: true },
+      best_score: 95,
+      alert_rules: {
+        name: "Expert beach rule",
+        notify_email: true,
+        notify_push: true,
+      },
+      beaches: {
+        name: "Expert Beach",
+        timezone: "America/Los_Angeles",
+        skill_level: "expert",
+      },
     });
-    seedProfile();
-    mockResolveNotificationMajorEventHold.mockResolvedValue({
-      status: "suppressed",
-      reasonCode: "hold_state_unavailable",
-      auditCode: "major_event_hold",
-      candidate: null,
+    seedProfile({
+      experience_level: "beginner",
+      notif_email_enabled: true,
+      notif_push_enabled: true,
     });
 
     const res = await GET(makeRequest());
-    expect(res.status).toBe(503);
-    const body = await res.json();
 
-    expect(mockEmailsSend).not.toHaveBeenCalled();
-    expect(mockEnqueueNotification).not.toHaveBeenCalled();
-    expect(mockResolveNotificationMajorEventHold).toHaveBeenCalledTimes(1);
-    for (const call of mockResolveNotificationMajorEventHold.mock.calls) {
-      expect(call[0]).toMatchObject({
-        type: "forecast_alert",
-        payload: {
-          beach_id: BEACH_1,
-          policy_context: {
-            kind: "positive_session_recommendation",
-            beach_id: BEACH_1,
-            starts_at: "2026-04-26T13:00:00Z",
-            ends_at: "2026-04-26T15:00:00Z",
-          },
-        },
-        profileExperience: "beginner",
-      });
-    }
-    expect(store.attemptInserts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          queue_id: QUEUE_1,
-          channel: "email",
-          status: "skipped_disabled",
-          skip_reason: "major_event_hold:hold_state_unavailable",
-        }),
-        expect.objectContaining({
-          queue_id: QUEUE_1,
-          channel: "push",
-          status: "skipped_disabled",
-          skip_reason: "major_event_hold:hold_state_unavailable",
-        }),
-      ])
+    expect(res.status).toBe(200);
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueNotification).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueNotification.mock.calls[0][0].payload.session_decision).toMatchObject({
+      verdict: "no",
+      reasonCode: "beach_skill_exceeds_user",
+      skillEligibility: {
+        skill: "beginner",
+        state: "ineligible",
+        reasonCodes: expect.arrayContaining(["beach_skill_exceeds_user"]),
+      },
+    });
+    expect(store.attemptInserts).toContainEqual(
+      expect.objectContaining({
+        queue_id: QUEUE_1,
+        channel: "email",
+        status: "sent",
+      }),
     );
-    expect(store.queueUpdates).toEqual([]);
-    expect(body).toMatchObject({
-      status: "degraded",
-      holdStateUnavailableDeferred: 1,
-      queueMarked: 0,
-      queue_marked_by_reason: {
-        hold_state_unavailable_retry_exhausted: 0,
-      },
-    });
-    expectQueueReasonTotals(body);
-    expectConsoleWarnings([
-      /queue-retained-for-unresolved-hold/,
-      /degraded queue consumption/,
-    ]);
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
   });
 
-  it("consumes an unresolved-hold row after the third attempt so it cannot loop forever", async () => {
-    process.env.ALERTS_DELIVERY_ENABLED = "true";
-    process.env.ALERTS_DELIVERY_USER_ALLOWLIST = "";
+  it.each([
+    { verdict: "no", bestScore: 20 },
+    { verdict: "maybe", bestScore: 50 },
+  ])("sends when the canonical verdict is $verdict", async ({ verdict, bestScore }) => {
     seedQueueRow({
-      alert_rules: { name: "Test rule", notify_email: true, notify_push: true },
+      best_score: bestScore,
+      alert_rules: {
+        name: "Matched user rule",
+        notify_email: true,
+        notify_push: true,
+      },
     });
-    seedProfile();
-    for (const channel of ["email", "push"]) {
-      for (let attempt = 1; attempt <= 2; attempt++) {
-        store.seededAttempts.push({
-          queue_id: QUEUE_1,
-          rule_id: RULE_1,
-          user_id: USER_A,
-          channel,
-          status: "skipped_disabled",
-          skip_reason: "major_event_hold:hold_state_unavailable",
-          attempted_at: `2026-04-26T${14 + attempt}:00:00Z`,
-        });
-      }
-    }
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: true });
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueNotification).toHaveBeenCalledTimes(1);
+    expect(
+      mockEnqueueNotification.mock.calls[0][0].payload.session_decision.verdict,
+    ).toBe(verdict);
+    expect(store.attemptInserts).toContainEqual(
+      expect.objectContaining({
+        queue_id: QUEUE_1,
+        channel: "email",
+        status: "sent",
+      }),
+    );
+  });
+
+  it("sends when major-event hold state is unavailable", async () => {
+    seedQueueRow({
+      alert_rules: {
+        name: "Matched user rule",
+        notify_email: true,
+        notify_push: false,
+      },
+    });
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
     mockResolveNotificationMajorEventHold.mockResolvedValue({
       status: "suppressed",
       reasonCode: "hold_state_unavailable",
@@ -699,20 +693,17 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     });
 
     const res = await GET(makeRequest());
-    const body = await res.json();
 
-    expect(res.status).toBe(503);
-    expect(body).toMatchObject({
-      status: "degraded",
-      holdStateUnavailableDeferred: 0,
-      queueMarked: 1,
-      queue_marked_by_reason: {
-        hold_state_unavailable_retry_exhausted: 1,
-      },
-    });
+    expect(res.status).toBe(200);
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    expect(store.attemptInserts).toContainEqual(
+      expect.objectContaining({
+        queue_id: QUEUE_1,
+        channel: "email",
+        status: "sent",
+      }),
+    );
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
-    expectQueueReasonTotals(body);
-    expectConsoleWarnings([/degraded queue consumption/]);
   });
 
   it("consumes a real major-event hold as an explainable skip without degrading", async () => {
@@ -738,6 +729,24 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
       queueMarked: 1,
       queue_marked_by_reason: { major_event_hold: 1 },
     });
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+    expect(store.attemptInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          queue_id: QUEUE_1,
+          channel: "email",
+          status: "skipped_disabled",
+          skip_reason: "major_event_hold:major_event_hold",
+        }),
+        expect.objectContaining({
+          queue_id: QUEUE_1,
+          channel: "push",
+          status: "skipped_disabled",
+          skip_reason: "major_event_hold:major_event_hold",
+        }),
+      ]),
+    );
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
     expectQueueReasonTotals(body);
   });
@@ -807,7 +816,7 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
   });
 
-  it("sends only the canonical highest-ranked beach when multiple alerts qualify", async () => {
+  it("sends every matching forecast alert instead of selecting one canonical beach", async () => {
     process.env.ALERTS_DELIVERY_ENABLED = "true";
     process.env.ALERTS_DELIVERY_USER_ALLOWLIST = "";
     seedQueueRow({
@@ -840,25 +849,21 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(res.status).toBe(200);
     const body = await res.json();
 
-    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    expect(mockEmailsSend).toHaveBeenCalledTimes(2);
     expect(store.alertQueueSelects[0]).toContain("best_score");
-    expect(mockConsolidatedAlertEmail).toHaveBeenCalledTimes(1);
+    expect(mockConsolidatedAlertEmail).toHaveBeenCalledTimes(2);
     expect(
-      mockConsolidatedAlertEmail.mock.calls[0][0].matches[0].beach_name,
-    ).toBe("Higher Score Beach");
+      mockConsolidatedAlertEmail.mock.calls.map(
+        ([props]) => props.matches[0].beach_name,
+      ),
+    ).toEqual(["Lower Score Beach", "Higher Score Beach"]);
     expect(body.queue_marked_by_reason).toMatchObject({
-      delivered: 1,
-      non_canonical: 1,
+      delivered: 2,
     });
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      expect.stringContaining("queue-consumed"),
-      {
-        reason: "non_canonical",
-        queue_id: "00000000-0000-0000-0000-0000000000c2",
-        rule_id: "00000000-0000-0000-0000-0000000000a2",
-        user_id: USER_A,
-      },
-    );
+    expect(store.queueUpdates.flatMap((update) => update.ids)).toEqual([
+      "00000000-0000-0000-0000-0000000000c2",
+      "00000000-0000-0000-0000-0000000000c3",
+    ]);
     expectQueueReasonTotals(body);
   });
 
@@ -891,6 +896,50 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
       status: "skipped_no_email",
     });
 
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
+  });
+
+  it("existing delivery dedupes a matched forecast alert", async () => {
+    seedQueueRow({
+      alert_rules: { name: "Test rule", notify_email: true, notify_push: false },
+    });
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
+    store.existingDeliveries.push({
+      user_id: USER_A,
+      alert_date: "2026-04-26",
+      channel: "email",
+      payload: {},
+    });
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(store.deliveryInserts).toHaveLength(0);
+    expect(store.attemptInserts).toEqual([
+      expect.objectContaining({
+        queue_id: QUEUE_1,
+        channel: "email",
+        status: "skipped_dedup_collision",
+      }),
+    ]);
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
+  });
+
+  it("a rule with no enabled channels does not deliver", async () => {
+    seedQueueRow({
+      alert_rules: { name: "Test rule", notify_email: false, notify_push: false },
+    });
+    seedProfile();
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+    expect(store.attemptInserts).toHaveLength(0);
+    expect(body.queue_marked_by_reason.no_enabled_channels).toBe(1);
     expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
   });
 
@@ -946,7 +995,6 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     expect(body.queue_marked_by_reason).toMatchObject({
       stale: 1,
       delivered: 0,
-      non_canonical: 0,
     });
     expect(mockEmailsSend).not.toHaveBeenCalled();
     expect(store.deliveryInserts).toHaveLength(0);

--- a/__tests__/notifications/worker.test.ts
+++ b/__tests__/notifications/worker.test.ts
@@ -831,6 +831,43 @@ describe("processPendingEvents — happy path", () => {
     });
   });
 
+  it("forecast_alert: no device skips push and reconciles alert_delivery_attempts", async () => {
+    const state = emptyState();
+    state.events.push(
+      buildEvent({
+        id: "evt-forecast-no-device",
+        actor_user_id: null,
+        type: "forecast_alert",
+        entity_type: "beach",
+        entity_id: "beach-1",
+        payload: {
+          alert_date: "2026-05-10",
+          title: "Conditions lining up today",
+          body: "La Jolla Shores 7am-9am",
+          beach_id: "beach-1",
+          forecast_at: "2026-05-10T14:30:00.000Z",
+          queue_items: [{ queue_id: "queue-forecast-1", rule_id: "rule-forecast-1" }],
+        },
+      }),
+    );
+    state.profiles.set("user-recipient", buildProfile());
+
+    const summary = await processPendingEvents(
+      buildMockSupabase(state) as never,
+      { now: NOON_PT, fcm: { sendEach: jest.fn() } as never },
+    );
+
+    expect(summary.by_status.skipped_no_device).toBe(1);
+    expect(state.alertAttempts).toContainEqual({
+      queue_id: "queue-forecast-1",
+      rule_id: "rule-forecast-1",
+      user_id: "user-recipient",
+      channel: "push",
+      status: "skipped_no_device",
+      skip_reason: "skipped_no_device",
+    });
+  });
+
   it("similarity_match: worker push success reconciles alert_delivery_attempts", async () => {
     const state = emptyState();
     state.events.push(
@@ -1250,6 +1287,56 @@ describe("processPendingEvents — terminal skips", () => {
       );
     },
   );
+
+  it("delivers a forecast alert when hold state is unavailable", async () => {
+    const state = emptyState();
+    state.events.push(
+      buildEvent({
+        id: "evt-unavailable-forecast",
+        actor_user_id: null,
+        type: "forecast_alert",
+        entity_type: "beach",
+        entity_id: "11111111-1111-4111-8111-111111111111",
+        payload: {
+          alert_date: "2026-04-29",
+          title: "Conditions lining up today",
+          body: "Clean morning window",
+          beach_id: "11111111-1111-4111-8111-111111111111",
+          forecast_at: "2026-04-29T19:00:00.000Z",
+          queue_items: [{ queue_id: "queue-unavailable", rule_id: "rule-unavailable" }],
+        },
+      }),
+    );
+    state.profiles.set("user-recipient", buildProfile());
+    state.devices.set("user-recipient", ["device-token-A"]);
+    const fakeFcm = {
+      sendEach: jest.fn(async () => ({
+        successCount: 1,
+        failureCount: 0,
+        responses: [{ success: true }],
+      })),
+    };
+    const resolveMajorEventHold = jest.fn(async () => ({
+      status: "suppressed" as const,
+      reasonCode: "hold_state_unavailable" as const,
+      auditCode: "major_event_hold" as const,
+      candidate: null,
+    }));
+
+    const summary = await processPendingEvents(
+      buildMockSupabase(state) as never,
+      { now: NOON_PT, fcm: fakeFcm as never, resolveMajorEventHold },
+    );
+
+    expect(fakeFcm.sendEach).toHaveBeenCalledTimes(1);
+    expect(summary.by_status.sent).toBe(2);
+    expect(state.alertAttempts).toContainEqual(
+      expect.objectContaining({
+        queue_id: "queue-unavailable",
+        status: "sent",
+      }),
+    );
+  });
 
   it("suppresses a positive alert queued before hold activation immediately before delivery", async () => {
     const state = emptyState();

--- a/app/api/cron/condition-alert-deliver/route.ts
+++ b/app/api/cron/condition-alert-deliver/route.ts
@@ -56,7 +56,6 @@ import { formatWaveHeightRange } from "@/lib/formatters/surf-data";
 import { parseSkillLevel } from "@/lib/domains/user-preferences/skill-level";
 import {
   resolveNotificationMajorEventHold,
-  type NotificationMajorEventHoldResult,
   type PositiveRecommendationPolicyContext,
 } from "@/lib/recommendations/major-event-hold/adapters/notification";
 import {
@@ -77,7 +76,6 @@ const HOLD_STATE_UNAVAILABLE_MAX_ATTEMPTS = 3;
 const QUEUE_MARK_REASONS = [
   "delivered",
   "stale",
-  "non_canonical",
   "major_event_hold",
   "canonical_safety_rejected",
   "shadow_withheld",
@@ -128,10 +126,6 @@ const DEGRADED_QUEUE_MARK_REASONS = new Set<QueueMarkReason>([
 ]);
 
 type Channel = "email" | "push";
-type SuppressedNotificationHold = Extract<
-  NotificationMajorEventHoldResult,
-  { status: "suppressed" }
->;
 
 type RuleEmbed = {
   name: string;
@@ -355,35 +349,6 @@ function policyContextForMatch(
     starts_at: match.window_start,
     ends_at: match.window_end,
   };
-}
-
-async function resolveHoldForForecastMatches(args: {
-  eventIdPrefix: string;
-  payload: Record<string, unknown>;
-  matches: MatchingWindow[];
-  profileExperience: unknown;
-}): Promise<SuppressedNotificationHold | null> {
-  const basePayload = { ...args.payload };
-  delete basePayload.policy_context;
-  delete basePayload.matches;
-
-  for (const match of args.matches) {
-    const policyContext = policyContextForMatch(match);
-    const resolution = await resolveNotificationMajorEventHold({
-      eventId: `${args.eventIdPrefix}:${match.rule_id}:${match.window_start}`,
-      type: "forecast_alert",
-      payload: {
-        ...basePayload,
-        beach_id: match.beach_id,
-        forecast_at: match.best_hour || match.window_start,
-        ...(policyContext ? { policy_context: policyContext } : {}),
-      },
-      profileExperience: args.profileExperience,
-    });
-    if (resolution.status === "suppressed") return resolution;
-  }
-
-  return null;
 }
 
 export async function GET(request: Request): Promise<NextResponse> {
@@ -695,11 +660,6 @@ export async function GET(request: Request): Promise<NextResponse> {
               attempt.skipReason === "major_event_hold:major_event_hold"
             ) {
               deliberateReasons.add("major_event_hold");
-            } else if (
-              attempt.status === "skipped_disabled" &&
-              attempt.skipReason?.startsWith("canonical_decision:")
-            ) {
-              deliberateReasons.add("canonical_safety_rejected");
             }
           }
 
@@ -893,10 +853,10 @@ export async function GET(request: Request): Promise<NextResponse> {
           attempted_at: new Date(r.attempted_at),
         }));
 
-        // 4. Resolve one authoritative alert session per user across every
-        // beach/rule candidate. Candidates must first pass the P0-A boundary;
-        // only the exact canonical selection can reach email or push.
-        const canonicalItems: QueueItemWithMeta[] = [];
+        // 4. Resolve active operator holds and record the canonical decision
+        // for shadow observability. The user's matched rules remain the
+        // delivery candidates regardless of verdict or skill eligibility.
+        const deliverableItems: QueueItemWithMeta[] = [];
         const itemsByUser = new Map<string, QueueItemWithMeta[]>();
         for (const item of items) {
           const userItems = itemsByUser.get(item.user_id) ?? [];
@@ -907,14 +867,13 @@ export async function GET(request: Request): Promise<NextResponse> {
         for (const [userId, userItems] of itemsByUser) {
           const profile = profilesByUser.get(userId);
           if (!profile) {
-            canonicalItems.push(...userItems);
+            deliverableItems.push(...userItems);
             continue;
           }
           const userMatches = consolidateQueueItems(userItems).flatMap(
             (candidatePayload) => candidatePayload.matches,
           );
-          const allowedMatches: MatchingWindow[] = [];
-          const holdReasonByCandidate = new Map<string, string>();
+          const heldCandidateIds = new Set<string>();
           for (const match of userMatches) {
             const policyContext = policyContextForMatch(match);
             const resolution = await resolveNotificationMajorEventHold({
@@ -927,63 +886,39 @@ export async function GET(request: Request): Promise<NextResponse> {
               },
               profileExperience: profile.experience_level,
             });
-            if (resolution.status === "allowed") {
-              allowedMatches.push(match);
-            } else if (resolution.status === "suppressed") {
-              holdReasonByCandidate.set(
-                canonicalAlertCandidateId(match),
-                `${resolution.auditCode}:${resolution.reasonCode}`,
-              );
+            if (
+              resolution.status === "suppressed" &&
+              resolution.reasonCode === "major_event_hold"
+            ) {
+              heldCandidateIds.add(canonicalAlertCandidateId(match));
             }
           }
 
           const decision = buildAlertSessionDecision({
-            matches: allowedMatches,
+            matches: userMatches,
             profileExperience: profile.experience_level,
           });
           if (!forecastDeliveryEnabled) {
             for (const item of userItems) {
-              const holdReason = holdReasonByCandidate.get(
-                canonicalAlertCandidateId(item),
-              );
-              const reasonCode = holdReason?.endsWith(":major_event_hold")
-                ? "major_event_hold"
-                : holdReason?.endsWith(":hold_state_unavailable")
-                  ? "hold_state_unavailable"
-                  : decision.reasonCode;
+              const held = heldCandidateIds.has(canonicalAlertCandidateId(item));
               shadowOutcomesByQueue.set(item.id, {
                 status: "shadow_withheld",
-                verdict: holdReason ? "no" : decision.verdict,
-                reason_code: reasonCode,
+                verdict: held ? "no" : decision.verdict,
+                reason_code: held ? "major_event_hold" : decision.reasonCode,
                 preset_type: item.preset_type ?? null,
                 would_use_channels: [],
               });
             }
           }
-          const selectedMatch = selectedAlertMatch(allowedMatches, decision);
-          const selectedItem = selectedMatch
-            ? userItems.find(
-                (item) =>
-                  item.rule_id === selectedMatch.rule_id &&
-                  item.beach_id === selectedMatch.beach_id &&
-                  item.window_start === selectedMatch.window_start,
-              ) ?? null
-            : null;
-          if (selectedItem) {
-            canonicalItems.push(selectedItem);
-          }
-
-          const suppressedItems = userItems.filter(
-            (item) => item.id !== selectedItem?.id,
+          const heldItems = userItems.filter((item) =>
+            heldCandidateIds.has(canonicalAlertCandidateId(item)),
           );
-          const suppressedItemsByReason = new Map<
-            QueueMarkReason,
-            QueueItemWithMeta[]
-          >();
-          for (const item of suppressedItems) {
-            const holdReason = holdReasonByCandidate.get(
-              canonicalAlertCandidateId(item),
-            );
+          const unheldItems = userItems.filter(
+            (item) => !heldCandidateIds.has(canonicalAlertCandidateId(item)),
+          );
+          deliverableItems.push(...unheldItems);
+
+          for (const item of heldItems) {
             for (const channel of enabledChannels(item)) {
               await recordAttempt({
                 queueId: item.id,
@@ -991,31 +926,19 @@ export async function GET(request: Request): Promise<NextResponse> {
                 userId,
                 channel,
                 status: "skipped_disabled",
-                skipReason: holdReason ?? `canonical_decision:${decision.reasonCode}`,
+                skipReason: "major_event_hold:major_event_hold",
               });
             }
-
-            let reason: QueueMarkReason | null;
-            if (holdReason === "major_event_hold:hold_state_unavailable") {
-              reason = unresolvedHoldDisposition(item);
-            } else if (holdReason === "major_event_hold:major_event_hold") {
-              reason = "major_event_hold";
-            } else if (selectedItem) {
-              reason = "non_canonical";
-            } else {
-              reason = "canonical_safety_rejected";
-            }
-            if (reason) addItemReason(suppressedItemsByReason, reason, item);
           }
           if (!forecastDeliveryEnabled) {
-            for (const item of suppressedItems) {
+            for (const item of heldItems) {
               await persistShadowOutcome(item);
             }
           }
-          await markQueueItemsByReason(suppressedItemsByReason);
+          await markQueueItemsConsumed(heldItems, "major_event_hold");
         }
 
-        const payloads = consolidateQueueItems(canonicalItems);
+        const payloads = consolidateQueueItems(deliverableItems);
         const baseUrl = getBaseUrl();
         const rateLimiter = createResendRateLimiter();
         const emailLogger = createEmailLogger(supabase, CONTEXT_TAG);
@@ -1023,7 +946,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         for (const payload of payloads) {
           const payloadBeachId = payload.matches[0]?.beach_id ?? null;
           result.processed++;
-          const contributingItems = canonicalItems.filter(
+          const contributingItems = deliverableItems.filter(
             (item) =>
               item.user_id === payload.user_id && item.beach_id === payloadBeachId,
           );
@@ -1269,47 +1192,22 @@ export async function GET(request: Request): Promise<NextResponse> {
                       month: "long",
                       day: "numeric",
                     });
-                    const candidateEmailSubject = buildConsolidatedSubject(
-                      candidateEmailMatches,
-                      alertDate
-                    );
-
                     if (forecastDeliveryEnabled) {
                       await rateLimiter.throttle();
                     }
 
-                    const emailHold = await resolveHoldForForecastMatches({
-                      eventIdPrefix: `condition-alert-deliver:email:${payload.user_id}`,
-                      payload: {
-                        alert_date: payload.alert_date,
-                        title: candidateEmailSubject,
-                        body: candidateEmailMatches.map((match) => match.rule_name).join(", "),
-                      },
+                    const emailDecision = buildAlertSessionDecision({
                       matches: candidateEmailMatches,
                       profileExperience,
                     });
-                    const emailDecision = emailHold
-                      ? null
-                      : buildAlertSessionDecision({
-                          matches: candidateEmailMatches,
-                          profileExperience,
-                        });
-                    const selectedEmailMatch = emailDecision
-                      ? selectedAlertMatch(candidateEmailMatches, emailDecision)
-                      : null;
-                    const emailMatches = selectedEmailMatch
-                      ? [selectedEmailMatch]
-                      : [];
+                    const emailMatches = candidateEmailMatches;
                     const renderedEmailMatches =
                       buildRenderedMatchDetails(emailMatches);
-                    const emailSubject =
-                      emailMatches.length > 0
-                        ? buildConsolidatedSubject(emailMatches, alertDate)
-                        : candidateEmailSubject;
+                    const emailSubject = buildConsolidatedSubject(
+                      emailMatches,
+                      alertDate,
+                    );
                     const sendResult =
-                      emailHold ||
-                      !emailDecision ||
-                      !selectedEmailMatch ||
                       !forecastDeliveryEnabled
                       ? { data: null, error: null }
                       : await sendEmail({
@@ -1329,20 +1227,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                         });
                     const { data: sendData, error: sendError } = sendResult;
 
-                    if (emailHold || !emailDecision || !selectedEmailMatch) {
-                      for (const item of emailSurvivors) {
-                        await recordAttempt({
-                          queueId: item.id,
-                          ruleId: item.rule_id,
-                          userId: payload.user_id,
-                          channel: "email",
-                          status: "skipped_disabled",
-                          skipReason: emailHold
-                            ? `${emailHold.auditCode}:${emailHold.reasonCode}`
-                            : `canonical_decision:${emailDecision?.reasonCode ?? "unavailable"}`,
-                        });
-                      }
-                    } else if (!forecastDeliveryEnabled) {
+                    if (!forecastDeliveryEnabled) {
                       addShadowChannel(emailSurvivors, "email");
                     } else if (sendError) {
                       console.error(`${CONTEXT_TAG} Email send failed for user ${payload.user_id}:`, sendError);
@@ -1483,58 +1368,15 @@ export async function GET(request: Request): Promise<NextResponse> {
                     const candidatePushMatches = payload.matches.filter(
                       (m) => m.notify_push && survivorRuleIdsPush.has(m.rule_id)
                     );
-                    const candidateTopMatch = candidatePushMatches[0];
-                    const holdProbePayload = {
-                      alert_date: payload.alert_date,
-                      title: "Forecast alert",
-                      body: "A surf window matched your alert.",
-                      beach_id: candidateTopMatch?.beach_id ?? null,
-                      forecast_at:
-                        candidateTopMatch?.best_hour ??
-                        candidateTopMatch?.window_start ??
-                        null,
-                      matches: candidatePushMatches.map((m) => ({
-                        beach_id: m.beach_id,
-                        window_start: m.window_start,
-                        window_end: m.window_end,
-                        best_hour: m.best_hour,
-                      })),
-                    };
-                    const pushHold = await resolveHoldForForecastMatches({
-                      eventIdPrefix: `condition-alert-deliver:push:${payload.user_id}`,
-                      payload: holdProbePayload,
+                    const pushDecision = buildAlertSessionDecision({
                       matches: candidatePushMatches,
                       profileExperience,
                     });
-                    const pushDecision = pushHold
-                      ? null
-                      : buildAlertSessionDecision({
-                          matches: candidatePushMatches,
-                          profileExperience,
-                        });
-                    const selectedPushMatch = pushDecision
-                      ? selectedAlertMatch(candidatePushMatches, pushDecision)
-                      : null;
-                    const pushMatches = selectedPushMatch
-                      ? [selectedPushMatch]
-                      : [];
+                    const pushMatches = candidatePushMatches;
                     const renderedPushMatches =
                       buildRenderedMatchDetails(pushMatches);
-                    const {
-                      title,
-                      body,
-                      data: pushData,
-                    } = selectedPushMatch
-                      ? formatPushNotification(pushMatches)
-                      : {
-                          title: "Forecast alert",
-                          body: "No approved surf window.",
-                          data: {
-                            type: "forecast_alert",
-                            beach_id: null,
-                            forecast_at: null,
-                          },
-                        };
+                    const { title, body, data: pushData } =
+                      formatPushNotification(pushMatches);
                     const topMatch = pushMatches[0];
                     const quietHoursOverride =
                       resolveQuietHoursOverride(pushSurvivors);
@@ -1561,25 +1403,14 @@ export async function GET(request: Request): Promise<NextResponse> {
                       ...(topPolicyContext
                         ? { policy_context: topPolicyContext }
                         : {}),
-                      ...(pushDecision
-                        ? { session_decision: pushDecision }
-                        : {}),
+                      session_decision: pushDecision,
                       queue_items: pushSurvivors.map((s) => ({
                         queue_id: s.id,
                         rule_id: s.rule_id,
                       })),
                     };
                     const enqueueResult =
-                      pushHold || !pushDecision || !selectedPushMatch
-                      ? {
-                          enqueued: false as const,
-                          reason: "major_event_hold" as const,
-                          holdReason:
-                            pushHold?.reasonCode ??
-                            pushDecision?.reasonCode ??
-                            "hold_state_unavailable",
-                        }
-                      : !forecastDeliveryEnabled
+                      !forecastDeliveryEnabled
                         ? {
                             enqueued: false as const,
                             reason: "shadow_withheld" as const,
@@ -1621,7 +1452,7 @@ export async function GET(request: Request): Promise<NextResponse> {
                           notification_event_id: enqueueResult.eventId,
                           method: "enqueued_via_pipeline",
                           matches: renderedPushMatches,
-                          session_decision_id: pushDecision!.decisionId,
+                          session_decision_id: pushDecision.decisionId,
                         } as import("@/types/database.generated").Json,
                       });
 
@@ -1644,17 +1475,6 @@ export async function GET(request: Request): Promise<NextResponse> {
                       // (sent / skipped_no_device / skipped_channel_disabled /
                       // failed_provider / etc.), so cooldown reads on
                       // status='sent' reflect actual delivery.
-                    } else if (enqueueResult.reason === "major_event_hold") {
-                      for (const item of pushSurvivors) {
-                        await recordAttempt({
-                          queueId: item.id,
-                          ruleId: item.rule_id,
-                          userId: payload.user_id,
-                          channel: "push",
-                          status: "skipped_disabled",
-                          skipReason: `major_event_hold:${enqueueResult.holdReason}`,
-                        });
-                      }
                     } else if (enqueueResult.reason === "duplicate") {
                       // Worker-level dedup caught it (a prior tick already
                       // enqueued the same forecast_alert for today).

--- a/lib/alerts/sunrise.ts
+++ b/lib/alerts/sunrise.ts
@@ -10,6 +10,9 @@ export function getDaylightWindow(lat: number, lon: number, date: Date): Dayligh
   return { sunrise: times.sunrise, sunset: times.sunset };
 }
 
+/** Forecast rows are hourly, so each row represents the hour that follows it. */
+const FORECAST_ROW_DURATION_MS = 60 * 60 * 1000;
+
 export function filterToDaylight<T extends { forecast_at: string }>(
   forecasts: T[],
   lat: number,
@@ -19,6 +22,11 @@ export function filterToDaylight<T extends { forecast_at: string }>(
   return forecasts.filter((f) => {
     const t = new Date(f.forecast_at);
     const { sunrise, sunset } = getDaylightWindow(lat, lon, t);
-    return t >= sunrise && t <= sunset;
+    // The row's whole hour must fit inside daylight, not just its first instant.
+    // A 20:00 row against a 20:08 sunset is 8 minutes of light and 52 of dark —
+    // 14% of every alert window ever queued ended after sunset because of this.
+    // ponytail: assumes hourly rows; revisit if the forecast resolution changes.
+    const rowEnd = new Date(t.getTime() + FORECAST_ROW_DURATION_MS);
+    return t >= sunrise && rowEnd <= sunset;
   });
 }

--- a/lib/notifications/worker.ts
+++ b/lib/notifications/worker.ts
@@ -1014,7 +1014,11 @@ async function resolveHoldSuppression(
       candidate: null,
     };
   }
-  if (holdDecision.status === "suppressed") {
+  if (
+    holdDecision.status === "suppressed" &&
+    (event.type !== "forecast_alert" ||
+      holdDecision.reasonCode === "major_event_hold")
+  ) {
     return channelDecision("skipped_disabled", {
       providerResponse: {
         audit_code: holdDecision.auditCode,


### PR DESCRIPTION
Two changes, one product idea: **an alert the user configured should fire when its conditions match — and shouldn't point at a session that's dark.** Delivery is still switched off (`FORECAST_ALERT_DELIVERY_ENABLED` default-off from #531), so nothing sends on merge.

## 1. Delete the verdict and skill gates (net −41 lines)

Operator decision: *"If a user that's beginner creates an alert for an expert beach we should send the alert."*

The rule's own conditions already encode what the user wants. Quiver's opinion of session quality, and of whether the user is skilled enough for that beach, belong to the home-screen "make the call" surface — where Quiver volunteers a recommendation — not to a request the user explicitly configured.

Removed for forecast alerts:
- canonical verdict gate — `go`, `maybe` and `no` all deliver
- skill eligibility — `beach_skill_exceeds_user` no longer blocks

Kept, because they're hygiene rather than opinion: stale-forecast revalidation, cooldown, per-rule and per-user caps, channel enablement, destination presence, dedupe, quiet hours, and the **operator major-event hold** (a manual "no positive recommendations in this region" switch for a genuinely dangerous event). `hold_state_unavailable` no longer blocks — only a real active hold does.

Canonical verdicts are still **recorded** for shadow accounting. They just don't decide anything.

Named tests: `sends a beginner user's forecast alert for an expert beach`, `sends when major-event hold state is unavailable`, `consumes a real major-event hold as an explainable skip without degrading`. Similarity-alert route is **byte-identical to main** (0 diff lines).

Why this matters beyond the one case: `mellow_session` only fires between 1.5–4ft with wind under 8kt. On an `advanced` beach that's the *one kind of day* a less-experienced surfer can safely surf it — and the static rating was suppressing exactly that day. A beach-wide label can't describe today; the rule's conditions already do.

## 2. Require the whole forecast hour to fit in daylight

`filterToDaylight` validated a row's first instant while the window built from it spans a full hour. A 20:00 row against a 20:08 sunset passed as daylight and produced a 20:00–21:00 window that was dark for 52 of its 60 minutes.

Measured across all **1,011 `alert_queue` rows ever written**: **142 (14.0%)** had `window_end` after sunset. **Zero** started before sunrise or after sunset — the filter was correct on its own terms, it was checking the wrong span.

Not over-conservative: a 19:00 row ending at 20:00 against a 20:08 sunset still passes. Only rows whose hour runs into the dark are dropped.

This becomes load-bearing *because* of change 1. These windows mostly died to the verdict/skill gates; removing those would have started sending "Waddell Creek, 8–9pm" for a beach that's dark before you'd arrive.

## Verification

- `yarn typecheck` — pass (deps reinstalled against prod's lockfile)
- Alerts / notifications / cron / flags suites — **57 suites, 948 tests** pass
- Daylight fix has a test that **fails on current main and passes after** — pinned to the real Waddell Creek coordinates and its actual 20:08:42 sunset
- Cherry-picked onto `origin/prod` with **0 conflicts**. No migrations, no new routes.

## Rollback

Revert the merge. Delivery is flag-gated and off regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)