### PR TITLE
chore(discovery): remove dead scoreWindowWithEngine alias (wave-5 knip ratchet)

### DIFF
--- a/lib/services/discovery/index.ts
+++ b/lib/services/discovery/index.ts
@@ -58,7 +58,6 @@ export {
   capEndTimeToTimeSlot,
   scoreForecastWindow,
   scoreWindowConditionScore,
-  scoreWindowWithEngine,
   type WindowSelectorOptions,
 } from './window-selector';
 

--- a/lib/services/discovery/window-selector/index.ts
+++ b/lib/services/discovery/window-selector/index.ts
@@ -58,7 +58,6 @@ export {
   scoreForecastWindow,
   scoreWindowConditionScore,
   scoreWindowWithComposite,
-  scoreWindowWithEngine,
 } from './window-scorer';
 
 // Re-export scoring engine singleton

--- a/lib/services/discovery/window-selector/window-scorer.ts
+++ b/lib/services/discovery/window-selector/window-scorer.ts
@@ -175,9 +175,6 @@ export function scoreWindowConditionScore(
   return scoreNativeForecastSlot(forecast, resolvedSkillLevel);
 }
 
-/** @deprecated Use `scoreWindowConditionScore` for native-compatible display scoring. */
-export const scoreWindowWithEngine = scoreWindowConditionScore;
-
 /**
  * Score a forecast window for selector ranking, with a small board-aware
  * rideability nudge. The adjustment is intentionally kept out of


### PR DESCRIPTION
The wave-5 health gate caught one new knip finding beyond the documented 6-hold baseline: `scoreWindowWithEngine` in `lib/services/discovery/window-selector/window-scorer.ts` — a June 24 deprecated alias whose last consumers were deleted in the wave-3/4 dead-code sweeps. Removed the alias and its two barrel re-exports.

Verification (local, Node 22):
- `yarn typecheck` — clean
- `yarn test:unit __tests__/lib/services/discovery` — 480/480 pass
- `yarn deadcode` — back at the documented 6-hold baseline (no new findings)
- Exhaustive grep: no consumers outside the two barrels (e2e/scripts/supabase included)

Part of the 2026-08-10 wave-5 cleanup (`dev/handoffs/week-20260810/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)