### PR TITLE
feat(conditions-report): S1 — wire up the dark local-report feature (API + beach page)

### DIFF
--- a/__tests__/api/v1/conditions-reports.test.ts
+++ b/__tests__/api/v1/conditions-reports.test.ts
@@ -1,0 +1,124 @@
+/** @jest-environment node */
+
+import { NextRequest } from "next/server";
+
+let authenticated = true;
+
+jest.mock("@/lib/middleware/api-wrappers", () => {
+  const actual = jest.requireActual("@/lib/middleware/api-wrappers");
+  return {
+    ...actual,
+    withAuth: (handler: any) => async (request: any) => {
+      if (!authenticated) {
+        return new Response(JSON.stringify({ error: "Authentication required" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return handler(request, {
+        user: { id: "user-1" },
+        supabase: {},
+        params: {},
+      });
+    },
+  };
+});
+
+jest.mock("@/lib/conditions-report/submit-conditions-report", () => ({
+  submitConditionsReportCore: jest.fn(),
+}));
+
+import { submitConditionsReportCore as mockSubmitConditionsReportCore } from "@/lib/conditions-report/submit-conditions-report";
+import { GET, POST } from "@/app/api/v1/conditions-reports/route";
+
+const coreMock = mockSubmitConditionsReportCore as unknown as jest.Mock;
+
+const validBody = {
+  beachId: "beach-1",
+  waveSizeMin: 3,
+  waveSizeMax: 4,
+  vibe: "firing",
+  note: "Clean lines",
+};
+
+function request(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/v1/conditions-reports", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  authenticated = true;
+  coreMock.mockReset();
+});
+
+describe("POST /api/v1/conditions-reports", () => {
+  it("returns 201 with report identifiers and expiry", async () => {
+    coreMock.mockResolvedValue({
+      success: true,
+      data: {
+        intelPostId: "intel-1",
+        sessionId: "session-1",
+        expiresAt: "2026-08-11T00:00:00.000Z",
+      },
+    });
+
+    const response = await POST(request(validBody));
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({
+      reportId: "intel-1",
+      intelPostId: "intel-1",
+      expiresAt: "2026-08-11T00:00:00.000Z",
+    });
+    expect(response.headers.get("cache-control")).toContain("no-store");
+    expect(coreMock).toHaveBeenCalledWith(
+      expect.objectContaining({ beachId: "beach-1", waveSizeRange: "3-4ft" }),
+      { id: "user-1" },
+      {},
+    );
+  });
+
+  it("returns 409 when the user already reported today", async () => {
+    coreMock.mockResolvedValue({
+      success: false,
+      error: "ALREADY_REPORTED_TODAY",
+    });
+
+    const response = await POST(request(validBody));
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "already_reported_today" });
+  });
+
+  it.each([
+    [{ ...validBody, vibe: "epic" }, "invalid vibe"],
+    [{ ...validBody, waveSizeMin: 2, waveSizeMax: 5 }, "invalid wave size range"],
+  ])("returns 422 for %s", async (body, reason) => {
+    const response = await POST(request(body));
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toMatchObject({
+      error: "validation_failed",
+      reason,
+    });
+    expect(coreMock).not.toHaveBeenCalled();
+  });
+});
+
+it("returns 401 for an unauthenticated request", async () => {
+  authenticated = false;
+
+  const response = await POST(request(validBody));
+
+  expect(response.status).toBe(401);
+});
+
+it("returns 405 for non-POST requests", async () => {
+  const response = await GET({} as NextRequest);
+
+  expect(response.status).toBe(405);
+  expect(response.headers.get("allow")).toBe("POST");
+});

--- a/__tests__/components/beach-detail/conditions-report-card.test.tsx
+++ b/__tests__/components/beach-detail/conditions-report-card.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ConditionsReportCard } from "@/components/beach-detail/conditions-report-card";
+import { useAuth } from "@/context/auth-context";
+import { submitConditionsReport } from "@/actions/conditions-report-actions";
+
+jest.mock("@/context/auth-context");
+jest.mock("@/actions/conditions-report-actions", () => ({
+  submitConditionsReport: jest.fn(),
+}));
+jest.mock("@/lib/analytics", () => ({ track: jest.fn() }));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockSubmit = submitConditionsReport as jest.MockedFunction<
+  typeof submitConditionsReport
+>;
+
+const defaultProps = {
+  beachId: "beach-123",
+  beachName: "Blacks",
+};
+
+function signIn() {
+  mockUseAuth.mockReturnValue({ user: { id: "user-1" } } as ReturnType<
+    typeof useAuth
+  >);
+}
+
+function fillForm() {
+  fireEvent.click(screen.getByRole("button", { name: "2-3ft" }));
+  fireEvent.click(screen.getByRole("button", { name: /Fun/ }));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  signIn();
+});
+
+describe("ConditionsReportCard", () => {
+  it("disables submit until wave size and vibe are selected", () => {
+    render(<ConditionsReportCard {...defaultProps} />);
+    const submit = screen.getByRole("button", { name: "Share Report" });
+    expect(submit).toBeDisabled();
+    fillForm();
+    expect(submit).toBeEnabled();
+  });
+
+  it("submits the structured report and shows the success state", async () => {
+    mockSubmit.mockResolvedValue({
+      success: true,
+      data: { success: true, data: { intelPostId: "intel-1", sessionId: null } },
+    } as never);
+    render(<ConditionsReportCard {...defaultProps} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Share Report" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Report shared!/)).toBeInTheDocument()
+    );
+    expect(mockSubmit).toHaveBeenCalledWith({
+      beachId: "beach-123",
+      waveSizeRange: "2-3ft",
+      vibe: "fun",
+      note: undefined,
+    });
+  });
+
+  it("shows the already-reported state on dedupe", async () => {
+    mockSubmit.mockResolvedValue({
+      success: true,
+      data: { success: false, error: "ALREADY_REPORTED_TODAY" },
+    } as never);
+    render(<ConditionsReportCard {...defaultProps} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Share Report" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/already reported conditions at Blacks today/)
+      ).toBeInTheDocument()
+    );
+  });
+
+  it("self-guards auth: signed-out submit triggers onAuthRequired even without publicMode", async () => {
+    mockUseAuth.mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
+    const onAuthRequired = jest.fn();
+    render(
+      <ConditionsReportCard {...defaultProps} onAuthRequired={onAuthRequired} />
+    );
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Share Report" }));
+
+    await waitFor(() => expect(onAuthRequired).toHaveBeenCalled());
+    expect(mockSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/actions/conditions-report-actions.ts
+++ b/actions/conditions-report-actions.ts
@@ -8,41 +8,12 @@ import {
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { ActionResult } from "@/lib/action-utils";
 import type {
-  ConditionsReportInput,
   ConditionsReportData,
-  WaveSizeRange,
+  ConditionsReportInput,
   Vibe,
+  WaveSizeRange,
 } from "@/types/conditions-report";
-import {
-  buildConditionsContent,
-  WAVE_SIZE_OPTIONS,
-  VIBE_OPTIONS,
-} from "@/types/conditions-report";
-import { emitSessionCreatedEvent } from "@/lib/analytics/session-created";
-
-// ---------------------------------------------------------------------------
-// Validation helpers
-// ---------------------------------------------------------------------------
-
-const VALID_WAVE_SIZES = new Set<string>(WAVE_SIZE_OPTIONS.map((o) => o.value));
-const VALID_VIBES = new Set<string>(VIBE_OPTIONS.map((o) => o.value));
-const NOTE_MAX_LENGTH = 280;
-
-function validateInput(input: ConditionsReportInput): string | null {
-  if (!input.beachId?.trim()) {
-    return "Beach ID is required";
-  }
-  if (!VALID_WAVE_SIZES.has(input.waveSizeRange)) {
-    return "Invalid wave size selection";
-  }
-  if (!VALID_VIBES.has(input.vibe)) {
-    return "Invalid vibe selection";
-  }
-  if (input.note && input.note.length > NOTE_MAX_LENGTH) {
-    return `Note must be ${NOTE_MAX_LENGTH} characters or fewer`;
-  }
-  return null;
-}
+import { submitConditionsReportCore } from "@/lib/conditions-report/submit-conditions-report";
 
 // ---------------------------------------------------------------------------
 // submitConditionsReport
@@ -65,147 +36,11 @@ export const submitConditionsReport = makeAuthenticatedAction(
     supabase,
     input: ConditionsReportInput
   ): Promise<ActionResult<{ intelPostId: string; sessionId: string | null }>> => {
-    // --- Validate ---
-    const validationError = validateInput(input);
-    if (validationError) {
-      return { success: false, error: validationError };
+    const result = await submitConditionsReportCore(input, user, supabase);
+    if (result.success) {
+      revalidatePath(`/beach/${input.beachId}`);
     }
-
-    const { beachId, waveSizeRange, vibe, note } = input;
-    const trimmedNote = note?.trim() || null;
-
-    // --- Check for same-day dedup ---
-    // Use the start of the current UTC day as the boundary. This is a simple
-    // proxy; full locale-aware day boundaries are a future enhancement.
-    const todayStart = new Date();
-    todayStart.setUTCHours(0, 0, 0, 0);
-
-    const { data: existing, error: dupCheckError } = await supabase
-      .from("intel_posts")
-      .select("id")
-      .eq("user_id", user.id)
-      .eq("beach_id", beachId)
-      .not("wave_size_range", "is", null)
-      .gte("created_at", todayStart.toISOString())
-      .limit(1);
-
-    if (dupCheckError) {
-      console.error("[submitConditionsReport] Dedup check failed:", dupCheckError);
-      // Non-fatal — continue with submission
-    } else if (existing && existing.length > 0) {
-      return {
-        success: false,
-        error: "ALREADY_REPORTED_TODAY",
-      };
-    }
-
-    // --- Build the human-readable content string ---
-    const content = buildConditionsContent(
-      waveSizeRange as WaveSizeRange,
-      vibe as Vibe,
-      trimmedNote ?? undefined
-    );
-
-    // --- Fetch beach coords for the intel post (required fields) ---
-    const { data: beach, error: beachError } = await supabase
-      .from("beaches")
-      .select("lat, lon, name")
-      .eq("id", beachId)
-      .single();
-
-    if (beachError || !beach) {
-      console.error("[submitConditionsReport] Beach lookup failed:", beachError);
-      return { success: false, error: "Beach not found" };
-    }
-
-    const lat = beach.lat ?? 0;
-    const lon = beach.lon ?? 0;
-
-    // --- Create intel post ---
-    const { data: intelPost, error: intelError } = await supabase
-      .from("intel_posts")
-      .insert({
-        user_id: user.id,
-        beach_id: beachId,
-        latitude: lat,
-        longitude: lon,
-        tag: "conditions" as const,
-        title: `${waveSizeRange}, ${vibe}`,
-        description: content,
-        wave_size_range: waveSizeRange,
-        vibe,
-        is_active: true,
-        // Conditions reports expire after 24 hours — stale conditions data
-        // is misleading rather than informative.
-        expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      })
-      .select("id")
-      .single();
-
-    if (intelError || !intelPost) {
-      console.error("[submitConditionsReport] Intel post insert failed:", intelError);
-      return { success: false, error: "Failed to submit conditions report" };
-    }
-
-    // Fire-and-forget: emit to user_events for retention analytics. Failures are
-    // logged but never fail the user-visible submission.
-    void (async () => {
-      const { error: evtErr } = await supabase.from("user_events").insert({
-        user_id: user.id,
-        event_type: "intel_post_created",
-        beach_id: beachId,
-        metadata: {
-          source: "web-conditions-report",
-          wave_size_range: waveSizeRange,
-          vibe,
-          intel_post_id: intelPost.id,
-        },
-      });
-      if (evtErr) console.warn("[submitConditionsReport] user_events intel insert failed:", evtErr);
-    })();
-
-    // --- Create minimal session record (fire-and-forget for ML) ---
-    let sessionId: string | null = null;
-
-    const { data: session, error: sessionError } = await supabase
-      .from("sessions")
-      .insert({
-        user_id: user.id,
-        beach_id: beachId,
-        beach_name: beach.name,
-        arrival_time: new Date().toISOString(),
-        status: "completed",
-        source: "conditions_report",
-        notes: content,
-        duration_minutes: 0,
-      })
-      .select("id")
-      .single();
-
-    if (sessionError) {
-      // Non-fatal: the intel post was already created. Log but don't fail.
-      console.warn("[submitConditionsReport] Session insert failed (non-fatal):", sessionError);
-    } else {
-      sessionId = session?.id ?? null;
-      if (sessionId) {
-        await emitSessionCreatedEvent(supabase, {
-          userId: user.id,
-          session: {
-            id: sessionId,
-            beach_id: beachId,
-          },
-          source: "web-conditions-report",
-          surface: "conditions-report",
-        });
-      }
-    }
-
-    revalidatePath(`/beach/${beachId}`);
-
-    return {
-      success: true,
-      data: { intelPostId: intelPost.id, sessionId },
-    };
+    return result;
   }
 );
 

--- a/app/api/v1/conditions-reports/route.ts
+++ b/app/api/v1/conditions-reports/route.ts
@@ -1,0 +1,111 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  createErrorResponse,
+  methodNotAllowed,
+  type AuthenticatedContext,
+  withAuth,
+  withNoStore,
+} from "@/lib/middleware/api-wrappers";
+import {
+  submitConditionsReportCore,
+  type SubmitConditionsReportInput,
+} from "@/lib/conditions-report/submit-conditions-report";
+import type { WaveSizeRange, Vibe } from "@/types/conditions-report";
+import { VIBE_OPTIONS, WAVE_SIZE_OPTIONS } from "@/types/conditions-report";
+
+export const dynamic = "force-dynamic";
+
+// "1-2ft" → "1:2", "5+ft" → "5:5" — derived so the contract can't drift from the canonical options.
+const WAVE_RANGE_BY_BOUNDS: Record<string, WaveSizeRange> = Object.fromEntries(
+  WAVE_SIZE_OPTIONS.map((o) => {
+    const m = o.value.match(/^(\d+)(?:-(\d+))?/);
+    const min = Number(m?.[1]);
+    const max = m?.[2] !== undefined ? Number(m[2]) : min;
+    return [`${min}:${max}`, o.value];
+  }),
+);
+
+const VALID_VIBES = new Set<string>(VIBE_OPTIONS.map((o) => o.value));
+
+function validationError(reason: string): NextResponse {
+  return NextResponse.json({ error: "validation_failed", reason }, { status: 422 });
+}
+
+async function handler(
+  request: NextRequest,
+  { user, supabase }: AuthenticatedContext,
+): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return validationError("invalid_json");
+  }
+
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return validationError("body must be an object");
+  }
+
+  const raw = body as Record<string, unknown>;
+  const beachId = raw.beachId;
+  const waveSizeMin = raw.waveSizeMin;
+  const waveSizeMax = raw.waveSizeMax;
+  const vibe = raw.vibe;
+
+  if (typeof beachId !== "string" || !beachId.trim()) {
+    return validationError("beachId is required");
+  }
+  if (typeof waveSizeMin !== "number" || typeof waveSizeMax !== "number") {
+    return validationError("waveSizeMin and waveSizeMax must be numbers");
+  }
+
+  const waveSizeRange = WAVE_RANGE_BY_BOUNDS[`${waveSizeMin}:${waveSizeMax}`];
+  if (!waveSizeRange) return validationError("invalid wave size range");
+  if (typeof vibe !== "string" || !VALID_VIBES.has(vibe)) {
+    return validationError("invalid vibe");
+  }
+  if (raw.note !== undefined && typeof raw.note !== "string") {
+    return validationError("note must be a string");
+  }
+  if (typeof raw.note === "string" && raw.note.length > 280) {
+    return validationError("note must be 280 characters or fewer");
+  }
+  if (raw.photoStoragePath !== undefined && typeof raw.photoStoragePath !== "string") {
+    return validationError("photoStoragePath must be a string");
+  }
+
+  const input: SubmitConditionsReportInput = {
+    beachId,
+    waveSizeRange,
+    vibe: vibe as Vibe,
+    note: raw.note as string | undefined,
+    photoStoragePath: raw.photoStoragePath as string | undefined,
+  };
+  const result = await submitConditionsReportCore(input, user, supabase);
+
+  if (!result.success) {
+    if (result.error === "ALREADY_REPORTED_TODAY") {
+      return NextResponse.json({ error: "already_reported_today" }, { status: 409 });
+    }
+    if (result.error === "Beach not found") {
+      return validationError("beach_not_found");
+    }
+    return createErrorResponse(result.error ?? "submission_failed", undefined, 500);
+  }
+
+  return NextResponse.json(
+    {
+      reportId: result.data?.intelPostId,
+      intelPostId: result.data?.intelPostId,
+      expiresAt: result.data?.expiresAt,
+    },
+    { status: 201 },
+  );
+}
+
+export const POST = withNoStore(
+  withAuth(handler, { errorMessage: "Failed to submit conditions report" }),
+);
+
+export const GET = withNoStore(async () => methodNotAllowed(["POST"]));

--- a/components/beach-detail/conditions-report-card.tsx
+++ b/components/beach-detail/conditions-report-card.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { submitConditionsReport } from "@/actions/conditions-report-actions";
+import {
+  WAVE_SIZE_OPTIONS,
+  VIBE_OPTIONS,
+  type WaveSizeRange,
+  type Vibe,
+} from "@/types/conditions-report";
+import { cn } from "@/lib/utils";
+import { track } from "@/lib/analytics";
+import { useAuth } from "@/context/auth-context";
+
+interface ConditionsReportCardProps {
+  beachId: string;
+  beachName: string;
+  /** When true the user is not authenticated — show auth modal instead of the form */
+  publicMode?: boolean;
+  onAuthRequired?: () => void;
+  /** Called after a successful submission so the parent can refresh recent reports */
+  onSubmitSuccess?: () => void;
+  /** Called when the user dismisses/collapses the card */
+  onDismiss?: () => void;
+}
+
+type FormState = "idle" | "submitting" | "success" | "already_reported" | "error";
+
+export function ConditionsReportCard({
+  beachId,
+  beachName,
+  publicMode,
+  onAuthRequired,
+  onSubmitSuccess,
+  onDismiss,
+}: ConditionsReportCardProps) {
+  const [waveSizeRange, setWaveSizeRange] = useState<WaveSizeRange | null>(null);
+  const [vibe, setVibe] = useState<Vibe | null>(null);
+  const [note, setNote] = useState("");
+  const [formState, setFormState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // CTA defense-in-depth: never trust the parent's publicMode alone
+  const { user } = useAuth();
+  const effectivePublicMode = publicMode || !user;
+
+  const handleSubmit = useCallback(async () => {
+    if (effectivePublicMode) {
+      onAuthRequired?.();
+      return;
+    }
+
+    if (!waveSizeRange || !vibe) return;
+
+    setFormState("submitting");
+    setErrorMessage(null);
+
+    try {
+      const result = await submitConditionsReport({
+        beachId,
+        waveSizeRange,
+        vibe,
+        note: note.trim() || undefined,
+      });
+
+      // makeAuthenticatedAction wraps the result in { success, data }
+      // where data is the inner ActionResult
+      const inner =
+        result &&
+        typeof result === "object" &&
+        "data" in result &&
+        result.data &&
+        typeof result.data === "object" &&
+        "success" in result.data
+          ? (result.data as { success: boolean; error?: string })
+          : (result as { success: boolean; error?: string });
+
+      if (!inner.success) {
+        if (inner.error === "ALREADY_REPORTED_TODAY") {
+          setFormState("already_reported");
+        } else {
+          setFormState("error");
+          setErrorMessage(inner.error ?? "Something went wrong. Please try again.");
+        }
+        return;
+      }
+
+      setFormState("success");
+      track("intel_post_created", { beach_id: beachId, wave_size_range: waveSizeRange, vibe });
+      onSubmitSuccess?.();
+    } catch {
+      setFormState("error");
+      setErrorMessage("Something went wrong. Please try again.");
+    }
+  }, [effectivePublicMode, onAuthRequired, beachId, waveSizeRange, vibe, note, onSubmitSuccess]);
+
+  const canSubmit = Boolean(waveSizeRange && vibe);
+
+  // --- Success state ---
+  if (formState === "success") {
+    return (
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5 text-center space-y-2">
+        <p className="text-emerald-700 font-semibold text-base">
+          Report shared! Thanks for helping the community.
+        </p>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDismiss}
+          className="text-emerald-600 hover:text-emerald-700"
+        >
+          Close
+        </Button>
+      </div>
+    );
+  }
+
+  // --- Already reported state ---
+  if (formState === "already_reported") {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-center space-y-2">
+        <p className="text-amber-800 font-semibold text-base">
+          You already reported conditions at {beachName} today.
+        </p>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDismiss}
+          className="text-amber-700 hover:text-amber-800"
+        >
+          Close
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="conditions-report-card"
+      className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm space-y-5"
+    >
+      <h3 className="font-heading text-lg font-bold text-dark-grey">
+        How is it out there?
+      </h3>
+
+      {/* Wave size selector */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-gray-600">Waves</p>
+        <div className="flex flex-wrap gap-2">
+          {WAVE_SIZE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setWaveSizeRange(opt.value)}
+              className={cn(
+                "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+                waveSizeRange === opt.value
+                  ? "border-ocean-blue bg-ocean-blue text-white"
+                  : "border-gray-300 bg-white text-gray-700 hover:border-ocean-blue hover:text-ocean-blue"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Vibe selector */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-gray-600">Vibe</p>
+        <div className="flex flex-wrap gap-2">
+          {VIBE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setVibe(opt.value)}
+              className={cn(
+                "rounded-full border px-4 py-1.5 text-sm font-medium transition-colors",
+                vibe === opt.value
+                  ? "border-ocean-blue bg-ocean-blue text-white"
+                  : "border-gray-300 bg-white text-gray-700 hover:border-ocean-blue hover:text-ocean-blue"
+              )}
+            >
+              {opt.emoji} {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Optional note */}
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-gray-600">
+          Note{" "}
+          <span className="font-normal text-gray-400">(optional)</span>
+        </p>
+        <input
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          maxLength={280}
+          placeholder="Anything else surfers should know?"
+          className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 placeholder:text-gray-400 focus:border-ocean-blue focus:outline-none focus:ring-1 focus:ring-ocean-blue"
+        />
+      </div>
+
+      {/* Error message */}
+      {formState === "error" && errorMessage && (
+        <p className="text-sm text-red-600">{errorMessage}</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-3">
+        <Button
+          onClick={handleSubmit}
+          disabled={!canSubmit || formState === "submitting"}
+          className="flex-1 h-11 bg-ocean-blue hover:bg-ocean-blue/90 font-semibold"
+        >
+          {formState === "submitting" ? "Sharing..." : "Share Report"}
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={onDismiss}
+          className="text-gray-500 hover:text-gray-700"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/intel/beach-intel-section.tsx
+++ b/components/intel/beach-intel-section.tsx
@@ -13,6 +13,13 @@ const IntelPostForm = dynamic(
   () => import("./intel-post-form").then((m) => m.IntelPostForm),
   { ssr: false }
 );
+const ConditionsReportCard = dynamic(
+  () =>
+    import("@/components/beach-detail/conditions-report-card").then(
+      (m) => m.ConditionsReportCard
+    ),
+  { ssr: false }
+);
 import { useAuth } from "@/context/auth-context";
 import {
   confirmIntelPost,
@@ -73,6 +80,7 @@ export function BeachIntelSection({
 }: BeachIntelSectionProps) {
   const router = useRouter();
   const [showPostForm, setShowPostForm] = useState(false);
+  const [showConditionsCard, setShowConditionsCard] = useState(false);
   const [expandedPost, setExpandedPost] = useState<string | null>(null);
   const [showAll, setShowAll] = useState<boolean>(initialShowAll);
   const [confirmingPosts, setConfirmingPosts] = useState<Set<string>>(
@@ -322,20 +330,41 @@ export function BeachIntelSection({
             </CardTitle>
 
             {!publicMode && (
-              <Button
-                data-testid="add-intel"
-                onClick={() => setShowPostForm(true)}
-                size="sm"
-                className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white shadow-md transition-all duration-200 transform hover:scale-105"
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                Add Intel
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  data-testid="report-conditions"
+                  onClick={() => setShowConditionsCard((v) => !v)}
+                  size="sm"
+                  variant="outline"
+                  className="border-blue-200 text-blue-700 hover:bg-blue-50"
+                >
+                  Report conditions
+                </Button>
+                <Button
+                  data-testid="add-intel"
+                  onClick={() => setShowPostForm(true)}
+                  size="sm"
+                  className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white shadow-md transition-all duration-200 transform hover:scale-105"
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  Add Intel
+                </Button>
+              </div>
             )}
           </div>
         </CardHeader>
 
         <CardContent className="p-3 sm:p-4">
+          {showConditionsCard && !publicMode && (
+            <div className="mb-4" data-testid="conditions-report-slot">
+              <ConditionsReportCard
+                beachId={beachId}
+                beachName={beachName}
+                onSubmitSuccess={() => refetch()}
+                onDismiss={() => setShowConditionsCard(false)}
+              />
+            </div>
+          )}
           {error ? (
             <div className="text-center py-6">
               <AlertTriangle className="h-8 w-8 text-amber-500 mx-auto mb-2" />

--- a/lib/conditions-report/submit-conditions-report.ts
+++ b/lib/conditions-report/submit-conditions-report.ts
@@ -1,0 +1,166 @@
+import type { User } from "@supabase/supabase-js";
+import type { ActionResult } from "@/lib/action-utils";
+import { emitSessionCreatedEvent } from "@/lib/analytics/session-created";
+import type { SupabaseServerClient } from "@/types/supabase";
+import type {
+  ConditionsReportInput,
+  WaveSizeRange,
+  Vibe,
+} from "@/types/conditions-report";
+import {
+  buildConditionsContent,
+  WAVE_SIZE_OPTIONS,
+  VIBE_OPTIONS,
+} from "@/types/conditions-report";
+
+export interface SubmitConditionsReportInput extends ConditionsReportInput {
+  photoStoragePath?: string;
+}
+
+export interface SubmitConditionsReportData {
+  intelPostId: string;
+  sessionId: string | null;
+  expiresAt: string;
+}
+
+const VALID_WAVE_SIZES = new Set<string>(WAVE_SIZE_OPTIONS.map((o) => o.value));
+const VALID_VIBES = new Set<string>(VIBE_OPTIONS.map((o) => o.value));
+const NOTE_MAX_LENGTH = 280;
+
+function validateInput(input: SubmitConditionsReportInput): string | null {
+  if (!input.beachId?.trim()) return "Beach ID is required";
+  if (!VALID_WAVE_SIZES.has(input.waveSizeRange)) {
+    return "Invalid wave size selection";
+  }
+  if (!VALID_VIBES.has(input.vibe)) return "Invalid vibe selection";
+  if (input.note && input.note.length > NOTE_MAX_LENGTH) {
+    return `Note must be ${NOTE_MAX_LENGTH} characters or fewer`;
+  }
+  return null;
+}
+
+/** Shared submission logic used by the web action and native API route. */
+export async function submitConditionsReportCore(
+  input: SubmitConditionsReportInput,
+  user: User,
+  supabase: SupabaseServerClient,
+): Promise<ActionResult<SubmitConditionsReportData>> {
+  const validationError = validateInput(input);
+  if (validationError) return { success: false, error: validationError };
+
+  const { beachId, waveSizeRange, vibe, note, photoStoragePath } = input;
+  const trimmedNote = note?.trim() || null;
+
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+
+  const { data: existing, error: dupCheckError } = await supabase
+    .from("intel_posts")
+    .select("id")
+    .eq("user_id", user.id)
+    .eq("beach_id", beachId)
+    .not("wave_size_range", "is", null)
+    .gte("created_at", todayStart.toISOString())
+    .limit(1);
+
+  if (dupCheckError) {
+    console.error("[submitConditionsReport] Dedup check failed:", dupCheckError);
+  } else if (existing && existing.length > 0) {
+    return { success: false, error: "ALREADY_REPORTED_TODAY" };
+  }
+
+  const content = buildConditionsContent(
+    waveSizeRange as WaveSizeRange,
+    vibe as Vibe,
+    trimmedNote ?? undefined,
+  );
+
+  const { data: beach, error: beachError } = await supabase
+    .from("beaches")
+    .select("lat, lon, name")
+    .eq("id", beachId)
+    .single();
+
+  if (beachError || !beach) {
+    console.error("[submitConditionsReport] Beach lookup failed:", beachError);
+    return { success: false, error: "Beach not found" };
+  }
+
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+  const { data: intelPost, error: intelError } = await supabase
+    .from("intel_posts")
+    .insert({
+      user_id: user.id,
+      beach_id: beachId,
+      latitude: beach.lat ?? 0,
+      longitude: beach.lon ?? 0,
+      tag: "conditions" as const,
+      title: `${waveSizeRange}, ${vibe}`,
+      description: content,
+      wave_size_range: waveSizeRange,
+      vibe,
+      is_active: true,
+      expires_at: expiresAt,
+      // Photo URLs are supplied by the existing intel upload flow; this path
+      // is persisted for later resolution and photo_url remains null here.
+      photo_storage_path: photoStoragePath ?? null,
+      photo_url: null,
+    })
+    .select("id")
+    .single();
+
+  if (intelError || !intelPost) {
+    console.error("[submitConditionsReport] Intel post insert failed:", intelError);
+    return { success: false, error: "Failed to submit conditions report" };
+  }
+
+  void (async () => {
+    const { error: evtErr } = await supabase.from("user_events").insert({
+      user_id: user.id,
+      event_type: "intel_post_created",
+      beach_id: beachId,
+      metadata: {
+        source: "web-conditions-report",
+        wave_size_range: waveSizeRange,
+        vibe,
+        intel_post_id: intelPost.id,
+      },
+    });
+    if (evtErr) console.warn("[submitConditionsReport] user_events intel insert failed:", evtErr);
+  })();
+
+  let sessionId: string | null = null;
+  const { data: session, error: sessionError } = await supabase
+    .from("sessions")
+    .insert({
+      user_id: user.id,
+      beach_id: beachId,
+      beach_name: beach.name,
+      arrival_time: new Date().toISOString(),
+      status: "completed",
+      source: "conditions_report",
+      notes: content,
+      duration_minutes: 0,
+    })
+    .select("id")
+    .single();
+
+  if (sessionError) {
+    console.warn("[submitConditionsReport] Session insert failed (non-fatal):", sessionError);
+  } else {
+    sessionId = session?.id ?? null;
+    if (sessionId) {
+      await emitSessionCreatedEvent(supabase, {
+        userId: user.id,
+        session: { id: sessionId, beach_id: beachId },
+        source: "web-conditions-report",
+        surface: "conditions-report",
+      });
+    }
+  }
+
+  return {
+    success: true,
+    data: { intelPostId: intelPost.id, sessionId, expiresAt },
+  };
+}


### PR DESCRIPTION
First UGC slice per the adopted week plan (`.planning/ugc-local-reports-video-share-PLAN-20260810.md`).

**What was dark:** `submitConditionsReport` (structured wave-size + vibe + note, per-beach daily dedupe, 24h expiry) had zero consumers, and its intended UI `ConditionsReportCard` was built in March, never mounted, and correctly deleted as an orphan in wave-4 cleanup. The feature was finished except the last wire.

**This PR:**
- Extracts `submitConditionsReportCore` to `lib/conditions-report/` (action delegates; behavior unchanged, existing action tests untouched and green)
- Adds `POST /api/v1/conditions-reports` — `withAuth` + no-store, versioned mobile contract, real statuses (201/409/422/401/405); vibe/wave validation derives from the canonical option constants so the contract can't drift
- Restores `ConditionsReportCard`, adds `useAuth` self-guard (CTA defense-in-depth), drops two taxonomy-pruned analytics events, mounts it behind a **Report conditions** toggle in the beach intel section header
- New tests: 5 route tests + 4 component tests (22 + 30 targeted totals green)

**Verification:** `yarn typecheck` clean · targeted jest green · scoped eslint clean · dev-server check: control hidden for anonymous visitors; intel RPC failure seen locally is a pre-existing local-DB PostGIS gap, unrelated.
**Not run:** no Playwright E2E for the signed-in submit path yet (no existing intel spec to extend) — follow-up noted in the plan. Native client lands separately on the quiver-native side of S1.

Backend by Codex, review + contract-drift fixes + frontend by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)