### PR TITLE
feat(seo): outreach no-email guard + new-user activity enrichment

### DIFF
--- a/__tests__/lib/seo/agent-workflow/outreach-digest.test.ts
+++ b/__tests__/lib/seo/agent-workflow/outreach-digest.test.ts
@@ -102,8 +102,13 @@ describe("SEO workflow outreach digest", () => {
 
   it("hasDirectEmail requires an @ in the contact field", () => {
     expect(hasDirectEmail({ category: "surf-schools", target: "A", contact: "hi@example.com", status: "queued" })).toBe(true);
+    expect(hasDirectEmail({ category: "surf-schools", target: "A2", contact: "  hi@example.com  ", status: "queued" })).toBe(true);
+    expect(hasDirectEmail({ category: "surf-schools", target: "A3", contact: "mailto:hi@example.com", status: "queued" })).toBe(true);
+    expect(hasDirectEmail({ category: "surf-schools", target: "A4", contact: "808-637-2977 / hi@example.com", status: "queued" })).toBe(true);
+    expect(hasDirectEmail({ category: "surf-schools", target: "A5", contact: "first@example.com, second@example.com", status: "queued" })).toBe(true);
     expect(hasDirectEmail({ category: "surf-schools", target: "B", contact: "808-637-2977", status: "queued" })).toBe(false);
     expect(hasDirectEmail({ category: "surf-schools", target: "C", contact: "contact form only", status: "queued" })).toBe(false);
+    expect(hasDirectEmail({ category: "surf-schools", target: "C2", contact: "   ", status: "queued" })).toBe(false);
     expect(hasDirectEmail({ category: "surf-schools", target: "D", status: "queued" })).toBe(false);
   });
 

--- a/__tests__/lib/seo/agent-workflow/outreach-digest.test.ts
+++ b/__tests__/lib/seo/agent-workflow/outreach-digest.test.ts
@@ -1,5 +1,6 @@
 import {
   buildOutreachDigest,
+  hasDirectEmail,
   parseOutreachTracker,
   resolveOutreachRotation,
 } from "@/lib/seo/agent-workflow/outreach-digest";
@@ -14,15 +15,16 @@ const TRACKER = [
   "",
   "## Surf School Targets (Playbook Section 1.3)",
   "### California",
-  "| Target | Website | Nearest Beach | Status | Date | Notes |",
-  "| --- | --- | --- | --- | --- | --- |",
-  "| Surf Diva | surfdiva.com | La Jolla | queued | | women's school |",
-  "| Pacific Surf School | pacificsurfschool.com | San Diego | sent | | |",
+  "| Target | Website | Contact | Nearest Beach | Status | Date | Notes |",
+  "| --- | --- | --- | --- | --- | --- | --- |",
+  "| Surf Diva | surfdiva.com | askadiva@surfdiva.com | La Jolla | queued | | women's school |",
+  "| Pacific Surf School | pacificsurfschool.com | pacificsurf@pacificsurf.org | San Diego | sent | | |",
+  "| North Shore Surf Girls | northshoresurfgirls.com | 808-637-2977 | Haleiwa | queued | | phone only |",
   "",
   "## Surf Bloggers & Micro-Influencers",
-  "| Target | Website/Channel | Nearest Beach | Status | Date | Notes |",
-  "| --- | --- | --- | --- | --- | --- |",
-  "| Ben Gravy | YouTube 520K | East Coast | queued | | |",
+  "| Target | Website/Channel | Contact | Nearest Beach | Status | Date | Notes |",
+  "| --- | --- | --- | --- | --- | --- | --- |",
+  "| Ben Gravy | YouTube 520K | ben@bengravy.com | East Coast | queued | | |",
   "",
   "## Monthly Metrics",
   "| Month | Outreach Sent |",
@@ -57,8 +59,8 @@ describe("SEO workflow outreach digest", () => {
   it("parses target rows by section and ignores legend and metrics tables", () => {
     const parsed = parseOutreachTracker(TRACKER);
 
-    expect(parsed.totalRows).toBe(3);
-    expect(parsed.statusCounts).toEqual({ queued: 2, sent: 1 });
+    expect(parsed.totalRows).toBe(4);
+    expect(parsed.statusCounts).toEqual({ queued: 3, sent: 1 });
     expect(parsed.rows).toEqual(expect.arrayContaining([
       expect.objectContaining({
         target: "Surf Diva",
@@ -76,7 +78,7 @@ describe("SEO workflow outreach digest", () => {
     expect(parsed.rows.some((row) => row.target === "queued")).toBe(false);
   });
 
-  it("builds queued draft candidates for the current rotation category", () => {
+  it("builds queued draft candidates for the current rotation category, skipping rows without a direct email", () => {
     const digest = buildOutreachDigest("2026-07-06T12:00:00Z", {
       reportDate: "2026-07-06",
       markdown: TRACKER,
@@ -89,6 +91,20 @@ describe("SEO workflow outreach digest", () => {
     expect(digest.candidates[0]?.nearestBeach).toBe("La Jolla");
     expect(digest.candidates[0]?.subject).toContain("La Jolla");
     expect(digest.candidates[0]?.body).toContain("Hi Surf Diva team,");
+    expect(digest.candidates[0]?.body).toContain(
+      "https://www.quiversurf.app/for-surf-schools",
+    );
+    expect(digest.candidates.some((candidate) => candidate.target === "North Shore Surf Girls")).toBe(false);
+    expect(digest.missing).toEqual(expect.arrayContaining([
+      expect.stringContaining("North Shore Surf Girls"),
+    ]));
+  });
+
+  it("hasDirectEmail requires an @ in the contact field", () => {
+    expect(hasDirectEmail({ category: "surf-schools", target: "A", contact: "hi@example.com", status: "queued" })).toBe(true);
+    expect(hasDirectEmail({ category: "surf-schools", target: "B", contact: "808-637-2977", status: "queued" })).toBe(false);
+    expect(hasDirectEmail({ category: "surf-schools", target: "C", contact: "contact form only", status: "queued" })).toBe(false);
+    expect(hasDirectEmail({ category: "surf-schools", target: "D", status: "queued" })).toBe(false);
   });
 
   it("selects the rotation category from the report date", () => {

--- a/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
+++ b/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
@@ -371,6 +371,32 @@ describe("SEO workflow weekly report", () => {
     expect(report).toContain("Outreach coverage reads docs/seo/outreach-tracker.md: week-1 rotation, 1 draft candidate proposed.");
   });
 
+  it("distinguishes an empty rotation from queued rows skipped for lacking a direct email", () => {
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-07-06T12:00:00Z",
+      recommendations: [],
+      missing: [],
+      outreach: {
+        generatedAt: "2026-07-06T12:00:00Z",
+        reportDate: "2026-07-06",
+        rotationWeek: 1,
+        rotationCategory: "surf-schools",
+        statusCounts: { queued: 2 },
+        totalRows: 2,
+        candidates: [],
+        missing: [
+          'No direct email for outreach target "North Shore Surf Girls" — contact: 808-637-2977',
+          'No direct email for outreach target "Hawaiian Surfing Adventures" — contact: 808-482-0749',
+        ],
+      },
+    });
+
+    expect(report).toContain(
+      "2 queued targets in this week's rotation lack a direct email and were skipped; see missing data below.",
+    );
+    expect(report).not.toContain("No queued targets in this week's rotation category; nothing to draft.");
+  });
+
   it("turns weekly actions into an ordered execution plan", () => {
     const report = renderWeeklySeoReport({
       generatedAt: "2026-06-29T12:00:00Z",

--- a/docs/seo/outreach-tracker.md
+++ b/docs/seo/outreach-tracker.md
@@ -12,6 +12,19 @@ This tracker is read and updated by the weekly "SEO Outreach Drafter" scheduled 
 
 Steven reviews Gmail drafts and sends. Status updates happen here.
 
+**No-email guard (2026-08-10):** `buildOutreachDigest` (`lib/seo/agent-workflow/outreach-digest.ts`)
+only drafts a row whose `Contact`/`Notes` field contains an `@` address (`hasDirectEmail()`). A row
+with a phone number, "contact form only", or a blank contact is skipped and logged in the digest's
+`missing[]` instead of silently producing a phone number in an email draft. This currently drops:
+North Shore Surf Girls, Hawaiian Surfing Adventures, and Island Water Sports (phone/form only),
+Cocoa Beach Surf School (no email on its HTTP-only site), and the Santa Cruz "needs manual check" row.
+Those rows stay `queued` — they need a manually-found email address (or a different outreach channel,
+e.g. a DM) before they can surface as a draft candidate.
+
+**Email copy (2026-08-10):** the surf-schools template no longer references an iframe embed. It links
+to `https://www.quiversurf.app/for-surf-schools` as a plain, unlinked URL in the body so Gmail doesn't
+wrap it in a `google.com/url` redirect before the recipient sees the live widget.
+
 ---
 
 ## Status Legend
@@ -176,3 +189,12 @@ The SEO Outreach Drafter agent follows this rotation:
 | April 2026 | | | | |
 | May 2026 | | | | |
 | June 2026 | | | | |
+| August 2026 | 3 (+ 4 drafted, awaiting send) | 0 | 0 | 0 |
+
+**On the 0% reply rate (2026-08-10):** cold email to surf schools is notoriously low-response, so this
+alone isn't a signal to change tactics. Two things worth fixing before the next batch goes out:
+1. The embed freshness bug (`quiver/.planning/embed-freshness-fix-and-refactor-20260805.md`) blanks the
+   widget on stale data — any school that checked the link after getting the email likely saw nothing.
+   Wait for that fix to ship before sending more of this batch.
+2. A direct Instagram DM or a reply to a target's most recent post may convert better than cold email
+   for this audience — worth trying alongside (not instead of) email once volume picks back up.

--- a/lib/seo/agent-workflow/outreach-digest.ts
+++ b/lib/seo/agent-workflow/outreach-digest.ts
@@ -39,6 +39,10 @@ export interface OutreachTrackerParse {
   totalRows: number;
 }
 
+export function hasDirectEmail(row: OutreachTrackerRow): boolean {
+  return Boolean(row.contact && row.contact.includes("@"));
+}
+
 export function resolveOutreachRotation(date: string): {
   week: number;
   category: OutreachRotationCategory;
@@ -111,11 +115,18 @@ export function buildOutreachDigest(
     (row) => row.category === category && row.status === "queued",
   );
 
+  const emailable = queued.filter(hasDirectEmail);
+  for (const row of queued) {
+    if (!hasDirectEmail(row)) {
+      missing.push(`No direct email for outreach target "${row.target}" — contact: ${row.contact ?? "none"}`);
+    }
+  }
+
   if (markdown.trim() && queued.length === 0) {
     missing.push(`No queued outreach targets for rotation category "${category}"`);
   }
 
-  const candidates = queued
+  const candidates = emailable
     .slice(0, maxCandidates)
     .map((row) => buildDraftCandidate(row, category));
 
@@ -165,6 +176,7 @@ function draftCopy(
         "",
         `I run Quiver, a free surf-forecast app with ML-tuned forecasts for ${where} and 5,000+ US spots. No paywall.`,
         "Happy to set your school up with a free embeddable conditions widget for your site, or just be a resource your students can check before a session.",
+        "You can see it live here: https://www.quiversurf.app/for-surf-schools",
         "Would a quick look be useful?",
         "",
         signoff,

--- a/lib/seo/agent-workflow/weekly-report.ts
+++ b/lib/seo/agent-workflow/weekly-report.ts
@@ -376,7 +376,16 @@ function renderOutreach(outreach?: OutreachDigestInput): string {
   ];
 
   if (outreach.candidates.length === 0) {
-    rows.push("- No queued targets in this week's rotation category; nothing to draft.");
+    const skippedForEmail = (outreach.missing ?? []).filter((entry) =>
+      entry.startsWith("No direct email for outreach target"),
+    );
+    if (skippedForEmail.length > 0) {
+      rows.push(
+        `- ${skippedForEmail.length} queued target${skippedForEmail.length === 1 ? "" : "s"} in this week's rotation lack a direct email and were skipped; see missing data below.`,
+      );
+    } else {
+      rows.push("- No queued targets in this week's rotation category; nothing to draft.");
+    }
   } else {
     rows.push(`- Draft candidates ready for review (${outreach.candidates.length}):`);
     for (const candidate of outreach.candidates) {

--- a/scripts/list-new-users-week.ts
+++ b/scripts/list-new-users-week.ts
@@ -318,15 +318,17 @@ async function main(): Promise<void> {
   const cutoff = new Date(Date.now() - DAYS * 24 * 60 * 60 * 1000);
   const cutoffIso = cutoff.toISOString();
 
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("id, email, display_name, full_name, created_at, home_beach_id")
-    .eq("is_mock", false)
-    .gte("created_at", cutoffIso)
-    .order("created_at");
-  if (error) throw new Error(`profiles fetch failed: ${error.message}`);
+  const profileRows = await fetchAllPages<ProfileRow>("profiles", (from, to) =>
+    supabase
+      .from("profiles")
+      .select("id, email, display_name, full_name, created_at, home_beach_id")
+      .eq("is_mock", false)
+      .gte("created_at", cutoffIso)
+      .order("created_at")
+      .range(from, to)
+  );
 
-  const profiles: ProfileRow[] = (data ?? [])
+  const profiles: ProfileRow[] = profileRows
     .filter((row): row is ProfileRow & { email: string } => Boolean(row.email))
     .filter((row) => !TEST_EMAIL_PATTERNS.some((pattern) => pattern.test(row.email!)));
 

--- a/scripts/list-new-users-week.ts
+++ b/scripts/list-new-users-week.ts
@@ -3,9 +3,14 @@
  * (`sendable`) and Apple Hide-My-Email relays (`appleRelay`), which cannot be
  * emailed from a personal Gmail.
  *
+ * Each user carries the activity recorded *after* their signup that the weekly
+ * founder-outreach routine personalizes from: home break, most-viewed beaches,
+ * the latest unresolved abandoned session log, completed session count, and
+ * zero-result beach searches.
+ *
  * Usage: npx tsx scripts/list-new-users-week.ts
  */
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { config } from "dotenv";
 import path from "node:path";
 
@@ -24,11 +29,78 @@ const APPLE_RELAY_DOMAIN = "@privaterelay.appleid.com";
 const TEST_EMAIL_PATTERNS = [/@example\.invalid$/i, /@quiversurf\.test$/i, /^codex-/i, /^e2e-/i];
 const DAYS = 7;
 
+/** Max beaches reported per user in `beachesViewed`. */
+const MAX_BEACHES_VIEWED = 3;
+/** PostgREST caps a single response at 1000 rows; page through anything larger. */
+const PAGE_SIZE = 1000;
+/** Keep `.in()` filter lists short enough to stay under URL length limits. */
+const IN_CHUNK_SIZE = 100;
+
+const VIEW_EVENT = "beach_view";
+const ABANDON_EVENT = "session_log_abandon";
+const SEARCH_EVENT = "beach_search";
+const NATIVE_NO_RESULTS_EVENT = "session_spot_search_no_results";
+const ACTIVITY_EVENT_TYPES = [
+  VIEW_EVENT,
+  ABANDON_EVENT,
+  SEARCH_EVENT,
+  NATIVE_NO_RESULTS_EVENT,
+] as const;
+
+type BeachRef = {
+  id: string;
+  name: string;
+};
+
+type BeachViewed = BeachRef & {
+  viewCount: number;
+  lastViewedAt: string;
+};
+
+type AbandonedSession = {
+  beachName: string | null;
+  abandonedAt: string;
+  maxStepReached: string | null;
+};
+
+type ZeroResultSearch = {
+  count: number;
+  lastSearchedAt: string;
+};
+
 type NewUser = {
   email: string;
   greeting: string | null;
   displayName: string | null;
   createdAt: string;
+  homeBreak: BeachRef | null;
+  beachesViewed: BeachViewed[];
+  latestAbandonedSession: AbandonedSession | null;
+  completedSessionCount: number;
+  zeroResultSearch: ZeroResultSearch | null;
+};
+
+type ProfileRow = {
+  id: string;
+  email: string | null;
+  display_name: string | null;
+  full_name: string | null;
+  created_at: string;
+  home_beach_id: string | null;
+};
+
+type EventRow = {
+  user_id: string | null;
+  event_type: string;
+  beach_id: string | null;
+  metadata: unknown;
+  created_at: string;
+};
+
+type SessionRow = {
+  user_id: string;
+  beach_id: string;
+  created_at: string;
 };
 
 /** Junk-name heuristics: initials, handles, single letters, digits, emails. */
@@ -43,40 +115,283 @@ function toGreeting(displayName: string | null): string | null {
   return first.charAt(0).toUpperCase() + first.slice(1);
 }
 
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+type PageResult<T> = PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
+
+/** Runs a range-paged query to exhaustion so results are never silently truncated. */
+async function fetchAllPages<T>(
+  label: string,
+  page: (from: number, to: number) => PageResult<T>
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await page(from, from + PAGE_SIZE - 1);
+    if (error) throw new Error(`${label} fetch failed: ${error.message}`);
+    const batch = data ?? [];
+    rows.push(...batch);
+    if (batch.length < PAGE_SIZE) return rows;
+  }
+}
+
+async function fetchActivityEvents(
+  supabase: SupabaseClient,
+  userIds: string[],
+  cutoffIso: string
+): Promise<EventRow[]> {
+  const rows: EventRow[] = [];
+  for (const ids of chunk(userIds, IN_CHUNK_SIZE)) {
+    const batch = await fetchAllPages<EventRow>("user_events", (from, to) =>
+      supabase
+        .from("user_events")
+        .select("user_id, event_type, beach_id, metadata, created_at")
+        .in("user_id", ids)
+        .in("event_type", [...ACTIVITY_EVENT_TYPES])
+        .gte("created_at", cutoffIso)
+        // Excludes traffic tagged by the bot-ingest filter; NULL stays included.
+        .not("bot_flagged", "is", true)
+        .order("created_at")
+        .range(from, to)
+    );
+    rows.push(...batch);
+  }
+  return rows;
+}
+
+async function fetchCompletedSessions(
+  supabase: SupabaseClient,
+  userIds: string[],
+  cutoffIso: string
+): Promise<SessionRow[]> {
+  const rows: SessionRow[] = [];
+  for (const ids of chunk(userIds, IN_CHUNK_SIZE)) {
+    const batch = await fetchAllPages<SessionRow>("sessions", (from, to) =>
+      supabase
+        .from("sessions")
+        .select("user_id, beach_id, created_at")
+        .in("user_id", ids)
+        .eq("status", "completed")
+        .is("deleted_at", null)
+        .gte("created_at", cutoffIso)
+        .order("created_at")
+        .range(from, to)
+    );
+    rows.push(...batch);
+  }
+  return rows;
+}
+
+async function fetchBeachNames(
+  supabase: SupabaseClient,
+  beachIds: string[]
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  for (const ids of chunk(beachIds, IN_CHUNK_SIZE)) {
+    const { data, error } = await supabase.from("beaches").select("id, name").in("id", ids);
+    if (error) throw new Error(`beaches fetch failed: ${error.message}`);
+    for (const row of data ?? []) names.set(row.id, row.name);
+  }
+  return names;
+}
+
+function groupBy<T>(rows: T[], key: (row: T) => string | null): Map<string, T[]> {
+  const out = new Map<string, T[]>();
+  for (const row of rows) {
+    const k = key(row);
+    if (!k) continue;
+    const bucket = out.get(k);
+    if (bucket) bucket.push(row);
+    else out.set(k, [row]);
+  }
+  return out;
+}
+
+function toBeachesViewed(
+  events: EventRow[],
+  beachNames: Map<string, string>
+): BeachViewed[] {
+  const byBeach = groupBy(events, (event) => event.beach_id);
+  const viewed: BeachViewed[] = [];
+
+  for (const [beachId, beachEvents] of byBeach) {
+    const name = beachNames.get(beachId);
+    if (!name) continue;
+    const lastViewedAt = beachEvents.reduce(
+      (latest, event) => (event.created_at > latest ? event.created_at : latest),
+      beachEvents[0].created_at
+    );
+    viewed.push({ id: beachId, name, viewCount: beachEvents.length, lastViewedAt });
+  }
+
+  return viewed
+    .sort((a, b) => b.viewCount - a.viewCount || b.lastViewedAt.localeCompare(a.lastViewedAt))
+    .slice(0, MAX_BEACHES_VIEWED);
+}
+
+/**
+ * The most recent abandoned log the user never came back and finished.
+ *
+ * Two payload shapes exist in `user_events` and only one is nameable. The web
+ * form (components/session-forms/SessionScrollForm.tsx) sends `beach_id` plus
+ * `max_step_reached`. Native sends neither — it reports `has_beach` and
+ * `touched_fields`, so the spot cannot be resolved and `beachName` comes back
+ * null. As of 2026-08-10 that is 104 of 105 rows all-time, so a null beachName
+ * is the normal case, not an edge case. `touched_fields` is deliberately NOT
+ * mapped onto `maxStepReached`: they are different concepts and inventing a
+ * mapping would put a fabricated step in front of a user.
+ */
+function toLatestAbandonedSession(
+  events: EventRow[],
+  completedSessions: SessionRow[],
+  beachNames: Map<string, string>
+): AbandonedSession | null {
+  const completedAtBeach = groupBy(completedSessions, (session) => session.beach_id);
+
+  const candidates = events
+    .map((event) => {
+      const metadata = asRecord(event.metadata);
+      const metadataBeachId = metadata.beach_id;
+      const beachId =
+        event.beach_id ?? (typeof metadataBeachId === "string" ? metadataBeachId : null);
+      const maxStep = metadata.max_step_reached;
+      return {
+        beachId,
+        abandonedAt: event.created_at,
+        maxStepReached: typeof maxStep === "string" ? maxStep : null,
+      };
+    })
+    .sort((a, b) => b.abandonedAt.localeCompare(a.abandonedAt));
+
+  for (const candidate of candidates) {
+    // "Not followed by a completed session for the same beach." When the beach
+    // is unknown we cannot check per-beach, so fall back to the stricter test —
+    // any later completed session disqualifies it — rather than risk telling
+    // someone they bailed on a log they actually finished.
+    const laterSessions = candidate.beachId
+      ? (completedAtBeach.get(candidate.beachId) ?? [])
+      : completedSessions;
+    if (laterSessions.some((session) => session.created_at > candidate.abandonedAt)) continue;
+
+    return {
+      beachName: candidate.beachId ? (beachNames.get(candidate.beachId) ?? null) : null,
+      abandonedAt: candidate.abandonedAt,
+      maxStepReached: candidate.maxStepReached,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Searches that returned nothing. The query text is deliberately never stored
+ * (see BeachSearchMetadata), so only counts and timing are available.
+ */
+function toZeroResultSearch(events: EventRow[]): ZeroResultSearch | null {
+  const empty = events.filter((event) => {
+    if (event.event_type === NATIVE_NO_RESULTS_EVENT) return true;
+    if (event.event_type !== SEARCH_EVENT) return false;
+    return asRecord(event.metadata).zero_results === true;
+  });
+  if (empty.length === 0) return null;
+
+  const lastSearchedAt = empty.reduce(
+    (latest, event) => (event.created_at > latest ? event.created_at : latest),
+    empty[0].created_at
+  );
+  return { count: empty.length, lastSearchedAt };
+}
+
 async function main(): Promise<void> {
   const supabase = createClient(SUPABASE_URL!, SERVICE_ROLE_KEY!, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
 
   const cutoff = new Date(Date.now() - DAYS * 24 * 60 * 60 * 1000);
+  const cutoffIso = cutoff.toISOString();
 
   const { data, error } = await supabase
     .from("profiles")
-    .select("email, display_name, full_name, created_at")
+    .select("id, email, display_name, full_name, created_at, home_beach_id")
     .eq("is_mock", false)
-    .gte("created_at", cutoff.toISOString())
+    .gte("created_at", cutoffIso)
     .order("created_at");
   if (error) throw new Error(`profiles fetch failed: ${error.message}`);
 
-  const all: NewUser[] = (data ?? [])
-    .filter((row): row is typeof row & { email: string } => Boolean(row.email))
-    .filter((row) => !TEST_EMAIL_PATTERNS.some((pattern) => pattern.test(row.email)))
-    .map((row) => {
-      const displayName = row.display_name ?? row.full_name ?? null;
-      return {
-        email: row.email,
-        greeting: toGreeting(displayName),
-        displayName,
-        createdAt: row.created_at,
-      };
-    });
+  const profiles: ProfileRow[] = (data ?? [])
+    .filter((row): row is ProfileRow & { email: string } => Boolean(row.email))
+    .filter((row) => !TEST_EMAIL_PATTERNS.some((pattern) => pattern.test(row.email!)));
+
+  const userIds = profiles.map((row) => row.id);
+  const [events, completedSessions] = userIds.length
+    ? await Promise.all([
+        fetchActivityEvents(supabase, userIds, cutoffIso),
+        fetchCompletedSessions(supabase, userIds, cutoffIso),
+      ])
+    : [[] as EventRow[], [] as SessionRow[]];
+
+  const eventsByUser = groupBy(events, (event) => event.user_id);
+  const sessionsByUser = groupBy(completedSessions, (session) => session.user_id);
+
+  const beachIds = new Set<string>();
+  for (const row of profiles) if (row.home_beach_id) beachIds.add(row.home_beach_id);
+  for (const event of events) {
+    if (event.beach_id) beachIds.add(event.beach_id);
+    const metadataBeachId = asRecord(event.metadata).beach_id;
+    if (typeof metadataBeachId === "string") beachIds.add(metadataBeachId);
+  }
+  const beachNames = await fetchBeachNames(supabase, [...beachIds]);
+
+  const all: NewUser[] = profiles.map((row) => {
+    const displayName = row.display_name ?? row.full_name ?? null;
+
+    // Activity is only meaningful from the moment the account existed.
+    const userEvents = (eventsByUser.get(row.id) ?? []).filter(
+      (event) => event.created_at >= row.created_at
+    );
+    const userSessions = (sessionsByUser.get(row.id) ?? []).filter(
+      (session) => session.created_at >= row.created_at
+    );
+
+    const homeBeachName = row.home_beach_id ? beachNames.get(row.home_beach_id) : undefined;
+
+    return {
+      email: row.email!,
+      greeting: toGreeting(displayName),
+      displayName,
+      createdAt: row.created_at,
+      homeBreak:
+        row.home_beach_id && homeBeachName
+          ? { id: row.home_beach_id, name: homeBeachName }
+          : null,
+      beachesViewed: toBeachesViewed(
+        userEvents.filter((event) => event.event_type === VIEW_EVENT),
+        beachNames
+      ),
+      latestAbandonedSession: toLatestAbandonedSession(
+        userEvents.filter((event) => event.event_type === ABANDON_EVENT),
+        userSessions,
+        beachNames
+      ),
+      completedSessionCount: userSessions.length,
+      zeroResultSearch: toZeroResultSearch(userEvents),
+    };
+  });
 
   const isRelay = (u: NewUser) => u.email.toLowerCase().endsWith(APPLE_RELAY_DOMAIN);
 
   console.log(
     JSON.stringify(
       {
-        since: cutoff.toISOString(),
+        since: cutoffIso,
         total: all.length,
         sendable: all.filter((u) => !isRelay(u)),
         appleRelay: all.filter(isRelay),


### PR DESCRIPTION
Completes the parked SEO agent-workflow branch (DQ6 from the wave-5 decision queue; Steven asked for Codex completion 2026-08-10).

**What it does:**
- `hasDirectEmail()` guard: outreach tracker rows without a real `@` contact no longer produce Gmail draft candidates (previously drafts could target phone numbers); skipped rows are surfaced in the digest's `missing[]` and counted in the weekly report
- Surf-schools email copy links the live `/for-surf-schools` page as a plain URL (no iframe pitch)
- `scripts/list-new-users-week.ts`: each new user is enriched with post-signup activity for founder-outreach personalization (home break, top-3 viewed beaches, latest abandoned session log, completed session count, zero-result searches) — fully paginated, `.in()` chunked
- Tracker doc notes, incl. **hold further sends until the embed-freshness fix ships** (widget blanks on stale data)

**Completion pass (Codex):** profiles fetch paginated (was silently capped at 1,000 rows), `hasDirectEmail` edge tests; all four queried event names verified present in the taxonomy.

**Verification:** `yarn typecheck` clean · `yarn test:unit __tests__/lib/seo/agent-workflow` 100/100 · scoped eslint clean · live end-to-end script run against the real backend prints enriched output (confirmed, no writes — read-only SELECTs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)