### PR TITLE
feat(conditions-report): S1b — reports feed ground-truth + calibration lanes

### DIFF
--- a/__tests__/actions/conditions-report-actions.test.ts
+++ b/__tests__/actions/conditions-report-actions.test.ts
@@ -79,6 +79,8 @@ const mockIntelPost = { id: "intel-post-abc" };
 // A completed sessions insert result
 const mockSession = { id: "session-xyz" };
 
+let mockSubmitForecastFeedback: jest.MockedFunction<(...args: any[]) => any>;
+
 /** Simulate no existing reports today (dedup check returns empty) */
 const noExistingReports = { data: [], error: null };
 
@@ -103,9 +105,24 @@ beforeEach(async () => {
     createSupabaseServerClient: jest.fn(),
     createSupabaseServiceRoleClient: jest.fn(),
   }));
+  jest.mock("@/lib/forecast-feedback/submit-feedback", () => ({
+    submitForecastFeedback: jest.fn(),
+  }));
 
   const serverModule = await import("@/lib/supabase/server");
   createSupabaseServerClient = serverModule.createSupabaseServerClient as jest.MockedFunction<any>;
+  const feedbackModule = await import("@/lib/forecast-feedback/submit-feedback");
+  mockSubmitForecastFeedback = feedbackModule.submitForecastFeedback as jest.MockedFunction<
+    (...args: any[]) => any
+  >;
+  mockSubmitForecastFeedback.mockResolvedValue({
+    success: true,
+    data: {
+      id: "feedback-1",
+      contractVersion: "forecast-feedback-context.v1",
+      correlationId: "corr-1",
+    },
+  });
 
   const actionsModule = await import("@/actions/conditions-report-actions");
   submitConditionsReport = actionsModule.submitConditionsReport as any;
@@ -232,6 +249,32 @@ describe("submitConditionsReport", () => {
       expect(inner.success).toBe(true);
       expect(inner.data?.intelPostId).toBe("intel-post-abc");
       expect(inner.data?.sessionId).toBe("session-xyz");
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockSubmitForecastFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ user: mockUser, supabase }),
+        expect.objectContaining({
+          beachId: "beach-1",
+          forecastAt: expect.stringMatching(/:00\.000Z$/),
+          feedbackKind: "condition_report",
+          feedbackValue: "3-4ft",
+          feedbackNote: "Clean lines",
+          observedFaceHeightFt: 3.5,
+          displayedContext: {
+            source: "conditions_report",
+            waveSizeRange: "3-4ft",
+            vibe: "firing",
+          },
+        }),
+        expect.objectContaining({ requireForecast: true }),
+      );
+
+      const sessionInsert = supabase.insert.mock.calls.find(
+        ([payload]) => payload?.source === "conditions_report",
+      );
+      expect(sessionInsert?.[0]).toEqual(
+        expect.objectContaining({ wave_height_ft: 3.5 }),
+      );
     });
 
     test("emits intel_post_created and session_created, not session_log_submit", async () => {
@@ -309,6 +352,31 @@ describe("submitConditionsReport", () => {
       expect(inner.data?.intelPostId).toBe("intel-post-abc");
       // sessionId is null because the insert failed (non-fatal)
       expect(inner.data?.sessionId).toBeNull();
+    });
+
+    test("succeeds when forecast feedback forwarding fails", async () => {
+      const supabase = createSupabaseMock();
+      supabase.auth.getUser.mockResolvedValue({ data: { user: mockUser }, error: null } as any);
+      mockSupabaseClient(supabase);
+      mockSubmitForecastFeedback.mockRejectedValueOnce(new Error("Seaside unavailable"));
+
+      supabase.limit.mockResolvedValueOnce(noExistingReports);
+      supabase.single
+        .mockResolvedValueOnce({ data: mockBeach, error: null })
+        .mockResolvedValueOnce({ data: mockIntelPost, error: null })
+        .mockResolvedValueOnce({ data: mockSession, error: null });
+
+      const result = await submitConditionsReport({
+        beachId: "beach-1",
+        waveSizeRange: "5+ft",
+        vibe: "fun",
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const inner = result?.data ?? result;
+      expect(inner.success).toBe(true);
+      expect(inner.data?.intelPostId).toBe("intel-post-abc");
+      expectConsoleWarnings([/Forecast feedback failed/i]);
     });
   });
 

--- a/__tests__/api/v1/conditions-reports.test.ts
+++ b/__tests__/api/v1/conditions-reports.test.ts
@@ -81,6 +81,26 @@ describe("POST /api/v1/conditions-reports", () => {
     );
   });
 
+  it("preserves the core result when its non-fatal feedback forward is handled there", async () => {
+    coreMock.mockResolvedValue({
+      success: true,
+      data: {
+        intelPostId: "intel-2",
+        sessionId: null,
+        expiresAt: "2026-08-11T00:00:00.000Z",
+      },
+    });
+
+    const response = await POST(request(validBody));
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      reportId: "intel-2",
+    });
+    expect(body).not.toHaveProperty("sessionId");
+  });
+
   it("returns 409 when the user already reported today", async () => {
     coreMock.mockResolvedValue({
       success: false,

--- a/app/api/forecast-feedback/route.ts
+++ b/app/api/forecast-feedback/route.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import {
   createErrorResponse,
@@ -9,154 +8,20 @@ import {
 } from "@/lib/middleware/api-wrappers";
 import {
   ForecastFeedbackClientPayloadSchema,
-  buildSeasideForecastFeedbackPayload,
   type ForecastFeedbackClientPayload,
 } from "@/lib/services/forecast/forecast-feedback";
-import type { Json } from "@/types/database.generated";
-import { createServiceRoleClient } from "@/lib/supabase";
+import {
+  isForecastFeedbackServiceConfigured,
+  submitForecastFeedback,
+} from "@/lib/forecast-feedback/submit-feedback";
 
 export const dynamic = "force-dynamic";
-
-type SeasideFeedbackResponse = {
-  ok?: boolean;
-  id?: string | null;
-  contract_version?: string;
-  correlation_id?: string | null;
-};
-
-type ExistingFeedbackContext = {
-  id: string;
-  contract_version: string;
-  correlation_id: string | null;
-};
-
-const FORECAST_ACCURACY_VOTE_VALUES: Record<string, boolean> = {
-  about_right: true,
-  too_low: false,
-  too_high: false,
-};
-
-function normalizedEnv(name: string): string | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const normalized = value.replace(/\\n/g, "").trim();
-  return normalized ? normalized : null;
-}
-
-function readMlServiceUrl(): string {
-  return (
-    normalizedEnv("ML_SERVICE_URL") ?? "https://quiver-ml.fly.dev"
-  ).replace(/\/+$/, "");
-}
-
-function readMlInternalSecret(): string | null {
-  return normalizedEnv("ML_INTERNAL_SECRET") ?? normalizedEnv("INTERNAL_SECRET");
-}
-
-async function parseJsonResponse(
-  response: Response,
-): Promise<SeasideFeedbackResponse | null> {
-  try {
-    return (await response.json()) as SeasideFeedbackResponse;
-  } catch {
-    return null;
-  }
-}
-
-async function findExistingFeedbackContext(
-  userId: string,
-  requestId: string,
-): Promise<ExistingFeedbackContext | null> {
-  try {
-    const serviceClient = createServiceRoleClient();
-    const { data, error } = await serviceClient
-      .from("forecast_feedback_contexts")
-      .select("id,contract_version,correlation_id")
-      .eq("user_id", userId)
-      .eq("request_id", requestId)
-      .maybeSingle();
-    if (error) return null;
-    return (data as ExistingFeedbackContext | null) ?? null;
-  } catch {
-    return null;
-  }
-}
-
-function existingFeedbackResponse(
-  existing: ExistingFeedbackContext,
-  fallbackCorrelationId: string,
-): NextResponse {
-  return createSuccessResponse({
-    id: existing.id,
-    contractVersion: existing.contract_version,
-    correlationId: existing.correlation_id ?? fallbackCorrelationId,
-  });
-}
-
-function forecastAccuracyVoteValue(
-  input: ForecastFeedbackClientPayload,
-): boolean | null {
-  if (input.feedbackKind !== "forecast_accuracy") return null;
-  return FORECAST_ACCURACY_VOTE_VALUES[input.feedbackValue] ?? null;
-}
-
-function nonEmptyJsonRecordOrNull(
-  value: Record<string, unknown> | undefined,
-): Json | null {
-  if (!value || Object.keys(value).length === 0) return null;
-  return value as Json;
-}
-
-async function persistForecastAccuracyVote(
-  { user, supabase }: AuthenticatedContext,
-  input: ForecastFeedbackClientPayload,
-): Promise<void> {
-  const wasAccurate = forecastAccuracyVoteValue(input);
-  if (wasAccurate == null) return;
-
-  const { data: forecast, error: forecastError } = await supabase
-    .from("enhanced_forecasts")
-    .select("id")
-    .eq("beach_id", input.beachId)
-    .eq("forecast_at", input.forecastAt)
-    .maybeSingle();
-
-  if (forecastError) {
-    throw new Error("Forecast vote target lookup failed");
-  }
-
-  if (!forecast?.id) {
-    throw new Error("Forecast vote target not found");
-  }
-
-  const { error } = await supabase
-    .from("forecast_accuracy_votes")
-    .upsert(
-      {
-        user_id: user.id,
-        forecast_id: forecast.id,
-        beach_id: input.beachId,
-        was_accurate: wasAccurate,
-        actual_conditions: nonEmptyJsonRecordOrNull(input.displayedContext),
-        notes: input.feedbackNote?.trim() || null,
-        photo_url: null,
-      },
-      { onConflict: "user_id,forecast_id" },
-    )
-    .select("id")
-    .single();
-
-  if (error) {
-    throw new Error("Forecast vote storage failed");
-  }
-}
 
 async function forecastFeedbackHandler(
   request: NextRequest,
   context: AuthenticatedContext,
 ): Promise<NextResponse> {
-  const secret = readMlInternalSecret();
-  if (!secret) {
+  if (!isForecastFeedbackServiceConfigured()) {
     return createErrorResponse("Feedback service not configured", undefined, 500);
   }
 
@@ -177,78 +42,30 @@ async function forecastFeedbackHandler(
     );
   }
 
-  const correlationId = validation.data.correlationId ?? randomUUID();
-  const requestId = validation.data.requestId ?? randomUUID();
-  const existing = await findExistingFeedbackContext(
-    context.user.id,
-    requestId,
-  );
-  if (existing) return existingFeedbackResponse(existing, correlationId);
-
-  try {
-    await persistForecastAccuracyVote(context, validation.data);
-  } catch {
+  const result = await submitForecastFeedback(context, validation.data);
+  if (result.success) return createSuccessResponse(result.data);
+  if (result.reason === "not_configured") {
+    return createErrorResponse("Feedback service not configured", undefined, 500);
+  }
+  if (result.reason === "vote_storage_failed") {
     return createErrorResponse(
       "Forecast vote storage failed",
-      { correlationId },
+      { correlationId: result.correlationId },
       500,
     );
   }
-
-  const payload = buildSeasideForecastFeedbackPayload(validation.data, {
-    userId: context.user.id,
-    ingestPath: "quiver-api/forecast-feedback",
-    requestId,
-    correlationId,
-    clientSource: "quiver-web",
-    clientVersion:
-      normalizedEnv("VERCEL_GIT_COMMIT_SHA") ??
-      normalizedEnv("NEXT_PUBLIC_VERCEL_ENV"),
-  });
-
-  let response: Response;
-  try {
-    response = await fetch(`${readMlServiceUrl()}/internal/forecast-feedback`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Internal-Secret": secret,
-      },
-      body: JSON.stringify(payload),
-      cache: "no-store",
-    });
-  } catch {
-    const recovered = await findExistingFeedbackContext(
-      context.user.id,
-      requestId,
-    );
-    if (recovered) return existingFeedbackResponse(recovered, correlationId);
+  if (result.reason === "network_error") {
     return createErrorResponse(
       "Feedback storage failed",
-      { correlationId, service: "seaside", status: "network_error" },
+      { correlationId: result.correlationId, service: "seaside", status: "network_error" },
       502,
     );
   }
-
-  const responseBody = await parseJsonResponse(response);
-  if (!response.ok || responseBody?.ok !== true) {
-    const recovered = await findExistingFeedbackContext(
-      context.user.id,
-      requestId,
-    );
-    if (recovered) return existingFeedbackResponse(recovered, correlationId);
-    return createErrorResponse(
-      "Feedback storage failed",
-      { correlationId, service: "seaside", status: response.status },
-      502,
-    );
-  }
-
-  return createSuccessResponse({
-    id: responseBody.id ?? null,
-    contractVersion: responseBody.contract_version ?? payload.contract_version,
-    correlationId: responseBody.correlation_id ?? correlationId,
-  });
+  return createErrorResponse(
+    "Feedback storage failed",
+    { correlationId: result.correlationId, service: "seaside", status: result.status },
+    502,
+  );
 }
 
 export const POST = withAuth(forecastFeedbackHandler, {

--- a/lib/conditions-report/submit-conditions-report.ts
+++ b/lib/conditions-report/submit-conditions-report.ts
@@ -2,6 +2,7 @@ import type { User } from "@supabase/supabase-js";
 import type { ActionResult } from "@/lib/action-utils";
 import { emitSessionCreatedEvent } from "@/lib/analytics/session-created";
 import type { SupabaseServerClient } from "@/types/supabase";
+import { submitForecastFeedback } from "@/lib/forecast-feedback/submit-feedback";
 import type {
   ConditionsReportInput,
   WaveSizeRange,
@@ -26,6 +27,16 @@ export interface SubmitConditionsReportData {
 const VALID_WAVE_SIZES = new Set<string>(WAVE_SIZE_OPTIONS.map((o) => o.value));
 const VALID_VIBES = new Set<string>(VIBE_OPTIONS.map((o) => o.value));
 const NOTE_MAX_LENGTH = 280;
+
+function waveSizeMidpoint(waveSizeRange: WaveSizeRange): number | null {
+  const option = WAVE_SIZE_OPTIONS.find(({ value }) => value === waveSizeRange);
+  const match = option?.value.match(/^(\d+)(?:-(\d+)|\+)?ft$/);
+  if (!match) return null;
+
+  const min = Number(match[1]);
+  const max = match[2] ? Number(match[2]) : min + 1;
+  return (min + max) / 2;
+}
 
 function validateInput(input: SubmitConditionsReportInput): string | null {
   if (!input.beachId?.trim()) return "Beach ID is required";
@@ -114,6 +125,68 @@ export async function submitConditionsReportCore(
     return { success: false, error: "Failed to submit conditions report" };
   }
 
+  const forecastAt = new Date();
+  forecastAt.setUTCMinutes(0, 0, 0);
+  const observedFaceHeightFt = waveSizeMidpoint(waveSizeRange as WaveSizeRange);
+
+  void (async () => {
+    try {
+      const feedbackResult = await submitForecastFeedback(
+        { user, supabase },
+        {
+          beachId,
+          forecastAt: forecastAt.toISOString(),
+          windowStart: null,
+          windowEnd: null,
+          issuedAt: null,
+          predictedAt: null,
+          forecastHorizonHours: null,
+          feedbackKind: "condition_report",
+          feedbackValue: waveSizeRange,
+          feedbackNote: note ?? null,
+          observedFaceHeightFt,
+          displayedContext: {
+            source: "conditions_report",
+            waveSizeRange,
+            vibe,
+          },
+          sourceModelContext: {},
+          calibrationContext: {},
+          surfCallContext: {},
+          missingFlags: {},
+          auditMetadata: {},
+          clientSource: "quiver-web",
+          clientVersion: null,
+          sessionId: null,
+          anonymousClientId: null,
+          correlationId: null,
+          requestId: null,
+          extraContext: null,
+        },
+        {
+          ingestPath: "quiver-web/conditions-report",
+          requireForecast: true,
+        },
+      );
+
+      if (!feedbackResult.success) {
+        console.warn("[submitConditionsReport] Forecast feedback skipped", {
+          beachId,
+          forecastAt: forecastAt.toISOString(),
+          reason: feedbackResult.reason,
+          feedbackKind: "condition_report",
+        });
+      }
+    } catch (error) {
+      console.warn("[submitConditionsReport] Forecast feedback failed", {
+        beachId,
+        forecastAt: forecastAt.toISOString(),
+        reason: "unexpected_forwarding_error",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })();
+
   void (async () => {
     const { error: evtErr } = await supabase.from("user_events").insert({
       user_id: user.id,
@@ -141,6 +214,7 @@ export async function submitConditionsReportCore(
       source: "conditions_report",
       notes: content,
       duration_minutes: 0,
+      wave_height_ft: observedFaceHeightFt,
     })
     .select("id")
     .single();

--- a/lib/forecast-feedback/submit-feedback.ts
+++ b/lib/forecast-feedback/submit-feedback.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from "crypto";
+import {
+  buildSeasideForecastFeedbackPayload,
+  type ForecastFeedbackClientPayload,
+} from "@/lib/services/forecast/forecast-feedback";
+import { createServiceRoleClient } from "@/lib/supabase";
+import type { SupabaseServerClient } from "@/types/supabase";
+import type { Json } from "@/types/database.generated";
+
+type SeasideFeedbackResponse = {
+  ok?: boolean;
+  id?: string | null;
+  contract_version?: string;
+  correlation_id?: string | null;
+};
+
+type ExistingFeedbackContext = {
+  id: string;
+  contract_version: string;
+  correlation_id: string | null;
+};
+
+export interface ForecastFeedbackContext {
+  user: { id: string };
+  supabase: SupabaseServerClient;
+}
+
+export interface SubmitForecastFeedbackOptions {
+  ingestPath?: string;
+  clientSource?: string;
+  requireForecast?: boolean;
+}
+
+export type SubmitForecastFeedbackResult =
+  | {
+      success: true;
+      data: {
+        id: string | null;
+        contractVersion: string;
+        correlationId: string;
+      };
+    }
+  | {
+      success: false;
+      reason:
+        | "not_configured"
+        | "forecast_lookup_failed"
+        | "forecast_not_found"
+        | "vote_storage_failed"
+        | "network_error"
+        | "seaside_error";
+      correlationId: string;
+      status?: number;
+    };
+
+const FORECAST_ACCURACY_VOTE_VALUES: Record<string, boolean> = {
+  about_right: true,
+  too_low: false,
+  too_high: false,
+};
+
+function normalizedEnv(name: string): string | null {
+  const value = process.env[name];
+  if (!value) return null;
+  const normalized = value.replace(/\\n/g, "").trim();
+  return normalized ? normalized : null;
+}
+
+function readMlServiceUrl(): string {
+  return (normalizedEnv("ML_SERVICE_URL") ?? "https://quiver-ml.fly.dev").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+function readMlInternalSecret(): string | null {
+  return normalizedEnv("ML_INTERNAL_SECRET") ?? normalizedEnv("INTERNAL_SECRET");
+}
+
+export function isForecastFeedbackServiceConfigured(): boolean {
+  return readMlInternalSecret() !== null;
+}
+
+async function parseJsonResponse(
+  response: Response,
+): Promise<SeasideFeedbackResponse | null> {
+  try {
+    return (await response.json()) as SeasideFeedbackResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function findExistingFeedbackContext(
+  userId: string,
+  requestId: string,
+): Promise<ExistingFeedbackContext | null> {
+  try {
+    const serviceClient = createServiceRoleClient();
+    const { data, error } = await serviceClient
+      .from("forecast_feedback_contexts")
+      .select("id,contract_version,correlation_id")
+      .eq("user_id", userId)
+      .eq("request_id", requestId)
+      .maybeSingle();
+    if (error) return null;
+    return (data as ExistingFeedbackContext | null) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveForecastId(
+  supabase: SupabaseServerClient,
+  input: ForecastFeedbackClientPayload,
+): Promise<{ id: string | null; error: boolean }> {
+  const { data, error } = await supabase
+    .from("enhanced_forecasts")
+    .select("id")
+    .eq("beach_id", input.beachId)
+    .eq("forecast_at", input.forecastAt)
+    .maybeSingle();
+  return { id: data?.id ?? null, error: Boolean(error) };
+}
+
+function forecastAccuracyVoteValue(
+  input: ForecastFeedbackClientPayload,
+): boolean | null {
+  if (input.feedbackKind !== "forecast_accuracy") return null;
+  return FORECAST_ACCURACY_VOTE_VALUES[input.feedbackValue] ?? null;
+}
+
+function nonEmptyJsonRecordOrNull(
+  value: Record<string, unknown> | undefined,
+): Json | null {
+  if (!value || Object.keys(value).length === 0) return null;
+  return value as Json;
+}
+
+async function persistForecastAccuracyVote(
+  context: ForecastFeedbackContext,
+  input: ForecastFeedbackClientPayload,
+): Promise<void> {
+  const wasAccurate = forecastAccuracyVoteValue(input);
+  if (wasAccurate == null) return;
+
+  const forecast = await resolveForecastId(context.supabase, input);
+  if (forecast.error) throw new Error("Forecast vote target lookup failed");
+  if (!forecast.id) throw new Error("Forecast vote target not found");
+
+  const { error } = await context.supabase
+    .from("forecast_accuracy_votes")
+    .upsert(
+      {
+        user_id: context.user.id,
+        forecast_id: forecast.id,
+        beach_id: input.beachId,
+        was_accurate: wasAccurate,
+        actual_conditions: nonEmptyJsonRecordOrNull(input.displayedContext),
+        notes: input.feedbackNote?.trim() || null,
+        photo_url: null,
+      },
+      { onConflict: "user_id,forecast_id" },
+    )
+    .select("id")
+    .single();
+
+  if (error) throw new Error("Forecast vote storage failed");
+}
+
+export async function submitForecastFeedback(
+  context: ForecastFeedbackContext,
+  input: ForecastFeedbackClientPayload,
+  options: SubmitForecastFeedbackOptions = {},
+): Promise<SubmitForecastFeedbackResult> {
+  const secret = readMlInternalSecret();
+  const correlationId = input.correlationId ?? randomUUID();
+  const requestId = input.requestId ?? randomUUID();
+
+  if (!secret) {
+    return { success: false, reason: "not_configured", correlationId };
+  }
+
+  if (options.requireForecast) {
+    const forecast = await resolveForecastId(context.supabase, input);
+    if (forecast.error) {
+      return { success: false, reason: "forecast_lookup_failed", correlationId };
+    }
+    if (!forecast.id) {
+      return { success: false, reason: "forecast_not_found", correlationId };
+    }
+  }
+
+  const existing = await findExistingFeedbackContext(context.user.id, requestId);
+  if (existing) {
+    return {
+      success: true,
+      data: {
+        id: existing.id,
+        contractVersion: existing.contract_version,
+        correlationId: existing.correlation_id ?? correlationId,
+      },
+    };
+  }
+
+  try {
+    await persistForecastAccuracyVote(context, input);
+  } catch {
+    return { success: false, reason: "vote_storage_failed", correlationId };
+  }
+
+  const payload = buildSeasideForecastFeedbackPayload(input, {
+    userId: context.user.id,
+    ingestPath: options.ingestPath ?? "quiver-api/forecast-feedback",
+    requestId,
+    correlationId,
+    clientSource: options.clientSource ?? "quiver-web",
+    clientVersion:
+      normalizedEnv("VERCEL_GIT_COMMIT_SHA") ??
+      normalizedEnv("NEXT_PUBLIC_VERCEL_ENV"),
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`${readMlServiceUrl()}/internal/forecast-feedback`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Internal-Secret": secret,
+      },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    });
+  } catch {
+    const recovered = await findExistingFeedbackContext(context.user.id, requestId);
+    if (recovered) {
+      return {
+        success: true,
+        data: {
+          id: recovered.id,
+          contractVersion: recovered.contract_version,
+          correlationId: recovered.correlation_id ?? correlationId,
+        },
+      };
+    }
+    return { success: false, reason: "network_error", correlationId };
+  }
+
+  const responseBody = await parseJsonResponse(response);
+  if (!response.ok || responseBody?.ok !== true) {
+    const recovered = await findExistingFeedbackContext(context.user.id, requestId);
+    if (recovered) {
+      return {
+        success: true,
+        data: {
+          id: recovered.id,
+          contractVersion: recovered.contract_version,
+          correlationId: recovered.correlation_id ?? correlationId,
+        },
+      };
+    }
+    return {
+      success: false,
+      reason: "seaside_error",
+      correlationId,
+      status: response.status,
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      id: responseBody.id ?? null,
+      contractVersion: responseBody.contract_version ?? payload.contract_version,
+      correlationId: responseBody.correlation_id ?? correlationId,
+    },
+  };
+}

--- a/lib/services/forecast/forecast-feedback.ts
+++ b/lib/services/forecast/forecast-feedback.ts
@@ -77,7 +77,7 @@ export const ForecastFeedbackClientPayloadSchema = z
     const isMismatch =
       input.feedbackKind === "forecast_accuracy" &&
       (input.feedbackValue === "too_low" || input.feedbackValue === "too_high");
-    if (isMismatch) return;
+    if (isMismatch || input.feedbackKind === "condition_report") return;
 
     context.addIssue({
       code: "custom",


### PR DESCRIPTION
Backend half of Steven's decision that the conditions report replaces 'Did this forecast feel right?' (native counterpart: quiver-native #128). The report now carries the data value that card provided — upgraded from a 3-button vote to an observed height:

- `sessions.wave_height_ft` = reported range midpoint (derived from canonical WAVE_SIZE_OPTIONS) → the ground-truth accuracy lane treats each report like a logged session
- `condition_report` feedback context forwarded to the calibration pipeline (`observedFaceHeightFt`, additive schema change) — fire-and-forget, non-fatal skip with structured log when no forecast row matches
- `lib/forecast-feedback/submit-feedback.ts` extracted from `/api/forecast-feedback` with the mobile-consumed route contract preserved — its existing tests pass unchanged

Verification (independent rerun): `yarn typecheck` clean · 35 focused tests green incl. route tests unchanged · scoped eslint clean.

Implementation by Codex; cross-review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)