### PR TITLE
feat(intel): S1c web — structured report chips + animated thanks

### DIFF
--- a/__tests__/components/beach-detail/conditions-report-card.test.tsx
+++ b/__tests__/components/beach-detail/conditions-report-card.test.tsx
@@ -10,6 +10,10 @@ jest.mock("@/actions/conditions-report-actions", () => ({
   submitConditionsReport: jest.fn(),
 }));
 jest.mock("@/lib/analytics", () => ({ track: jest.fn() }));
+jest.mock("framer-motion", () => ({
+  ...jest.requireActual("framer-motion"),
+  useReducedMotion: jest.fn(() => true),
+}));
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockSubmit = submitConditionsReport as jest.MockedFunction<
@@ -47,11 +51,17 @@ describe("ConditionsReportCard", () => {
   });
 
   it("submits the structured report and shows the success state", async () => {
+    const onSubmitSuccess = jest.fn();
     mockSubmit.mockResolvedValue({
       success: true,
       data: { success: true, data: { intelPostId: "intel-1", sessionId: null } },
     } as never);
-    render(<ConditionsReportCard {...defaultProps} />);
+    render(
+      <ConditionsReportCard
+        {...defaultProps}
+        onSubmitSuccess={onSubmitSuccess}
+      />
+    );
     fillForm();
     fireEvent.click(screen.getByRole("button", { name: "Share Report" }));
 
@@ -64,6 +74,29 @@ describe("ConditionsReportCard", () => {
       vibe: "fun",
       note: undefined,
     });
+    expect(onSubmitSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a static zine success state when reduced motion is preferred", async () => {
+    mockSubmit.mockResolvedValue({
+      success: true,
+      data: { success: true, data: { intelPostId: "intel-1", sessionId: null } },
+    } as never);
+
+    render(<ConditionsReportCard {...defaultProps} />);
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Share Report" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conditions-report-success")).toHaveAttribute(
+        "data-reduced-motion",
+        "true"
+      );
+    });
+    expect(
+      screen.getByText("Report shared! Thanks for helping the Blacks crew.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("community")).not.toBeInTheDocument();
   });
 
   it("shows the already-reported state on dedupe", async () => {

--- a/__tests__/components/intel/beach-intel-section.test.tsx
+++ b/__tests__/components/intel/beach-intel-section.test.tsx
@@ -286,6 +286,38 @@ describe("BeachIntelSection", () => {
       expect(avatarBtn).toHaveAttribute("data-user-id", mockIntelPost.user_id);
     });
 
+    it("renders structured conditions fields as chips", () => {
+      mockUseIntelData.mockReturnValue(mockIntelDataReturn({
+        data: {
+          posts: [
+            {
+              ...mockIntelPost,
+              wave_size_range: "2-3ft",
+              vibe: "fun",
+              description: "Clean lines and a light offshore breeze",
+            },
+          ] as any,
+        },
+      }));
+
+      render(<BeachIntelSection {...defaultProps} />);
+
+      expect(screen.getByTestId("conditions-chips")).toHaveTextContent("2-3ft");
+      expect(screen.getByTestId("conditions-chips")).toHaveTextContent("🤙 Fun");
+      expect(screen.getByText("Clean lines and a light offshore breeze")).toBeInTheDocument();
+    });
+
+    it("keeps legacy conditions posts text-only when structured fields are absent", () => {
+      mockUseIntelData.mockReturnValue(mockIntelDataReturn({
+        data: { posts: [mockIntelPost] as any },
+      }));
+
+      render(<BeachIntelSection {...defaultProps} />);
+
+      expect(screen.queryByTestId("conditions-chips")).not.toBeInTheDocument();
+      expect(screen.getByText(mockIntelPost.description)).toBeInTheDocument();
+    });
+
     it("shows post count badge when posts exist", () => {
       mockUseIntelData.mockReturnValue(mockIntelDataReturn({
         data: { posts: [mockIntelPost] as any },

--- a/components/beach-detail/conditions-report-card.tsx
+++ b/components/beach-detail/conditions-report-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { Check } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { submitConditionsReport } from "@/actions/conditions-report-actions";
 import {
@@ -42,6 +44,7 @@ export function ConditionsReportCard({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // CTA defense-in-depth: never trust the parent's publicMode alone
   const { user } = useAuth();
+  const prefersReducedMotion = useReducedMotion() ?? false;
   const effectivePublicMode = publicMode || !user;
 
   const handleSubmit = useCallback(async () => {
@@ -99,15 +102,64 @@ export function ConditionsReportCard({
   // --- Success state ---
   if (formState === "success") {
     return (
-      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5 text-center space-y-2">
-        <p className="text-emerald-700 font-semibold text-base">
-          Report shared! Thanks for helping the community.
+      <div
+        className="relative overflow-hidden rounded-xl border-2 border-[var(--ink)] bg-[var(--paper)] p-5 text-center text-[var(--ink)] shadow-[4px_4px_0_var(--ink)]"
+        data-testid="conditions-report-success"
+        data-reduced-motion={prefersReducedMotion}
+        aria-live="polite"
+      >
+        {!prefersReducedMotion && (
+          <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+            {[
+              { x: -42, y: -30, rotate: -20, color: "var(--q-orange)" },
+              { x: 38, y: -34, rotate: 18, color: "var(--stamp-blue)" },
+              { x: -50, y: 18, rotate: 28, color: "var(--hi-yellow)" },
+              { x: 48, y: 20, rotate: -24, color: "var(--q-orange)" },
+              { x: -20, y: 42, rotate: 12, color: "var(--stamp-blue)" },
+              { x: 20, y: 42, rotate: -12, color: "var(--hi-yellow)" },
+            ].map((particle, index) => (
+              <motion.span
+                key={index}
+                className="absolute left-1/2 top-1/2 h-2 w-1 rounded-sm"
+                style={{ backgroundColor: particle.color }}
+                initial={{ opacity: 0, scale: 0, x: 0, y: 0, rotate: 0 }}
+                animate={{
+                  opacity: [0, 1, 0],
+                  scale: [0, 1, 0.8],
+                  x: particle.x,
+                  y: particle.y,
+                  rotate: particle.rotate,
+                }}
+                transition={{
+                  duration: 0.8,
+                  delay: index * 0.04,
+                  ease: "easeOut",
+                }}
+              />
+            ))}
+          </div>
+        )}
+        <motion.div
+          className="relative mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full border-2 border-[var(--ink)] bg-[var(--q-orange)]"
+          initial={prefersReducedMotion ? false : { scale: 0.5, rotate: -8 }}
+          animate={prefersReducedMotion ? undefined : { scale: 1, rotate: 0 }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 420, damping: 18 }
+          }
+          aria-hidden="true"
+        >
+          <Check className="h-6 w-6 stroke-[3] text-[var(--ink)]" />
+        </motion.div>
+        <p className="relative font-heading text-base font-semibold">
+          Report shared! Thanks for helping the {beachName} crew.
         </p>
         <Button
           variant="ghost"
           size="sm"
           onClick={onDismiss}
-          className="text-emerald-600 hover:text-emerald-700"
+          className="relative text-[var(--ink)] hover:bg-[var(--paper-shadow)]"
         >
           Close
         </Button>

--- a/components/intel/beach-intel-section.tsx
+++ b/components/intel/beach-intel-section.tsx
@@ -50,6 +50,7 @@ import {
   getConfidenceColor,
   getConfidenceLabel,
 } from "@/lib/constants/intel";
+import { getVibeEmoji, VIBE_OPTIONS } from "@/types/conditions-report";
 import type { IntelPostWithUser, IntelPostTag } from "@/types/database";
 import { PartialContentGate } from "@/components/ui/partial-content-gate";
 
@@ -553,6 +554,19 @@ function IntelPostCard({
               <span>{timeAgo}</span>
             </div>
           </div>
+
+          {post.tag === "conditions" &&
+            post.wave_size_range &&
+            post.vibe && (
+              <div className="mb-2 flex flex-wrap gap-1.5" data-testid="conditions-chips">
+                <span className="rounded-full border border-[var(--ink)]/25 bg-[var(--paper)] px-2 py-0.5 text-xs font-medium text-[var(--ink)]">
+                  {post.wave_size_range}
+                </span>
+                <span className="rounded-full border border-[var(--ink)]/25 bg-[var(--paper)] px-2 py-0.5 text-xs font-medium text-[var(--ink)]">
+                  {getVibeEmoji(post.vibe)} {VIBE_OPTIONS.find((option) => option.value === post.vibe)?.label ?? post.vibe}
+                </span>
+              </div>
+            )}
 
           {/* Description */}
           <p


### PR DESCRIPTION
Web half of S1c (native: quiver-native #129). Conditions reports render structured wave/vibe chips in the intel feed (legacy fallback preserved; fields were already selected), and the report card's success state gets the zine treatment + Framer Motion celebration (reduced-motion safe), copy aligned with native.

Verification (independent rerun): typecheck clean · card + intel suites green · scoped eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)