### PR TITLE
feat(session-video): S2 backend — storage, routes, moderation queue

### DIFF
--- a/__tests__/api/session-videos.test.ts
+++ b/__tests__/api/session-videos.test.ts
@@ -1,0 +1,105 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+jest.mock("next/server", () => require("@/__tests__/setup/mock-next-server"));
+
+const mockFrom = jest.fn();
+const mockStorage = jest.fn();
+const mockRequireOwnership = jest.fn();
+
+jest.mock("@/lib/middleware/api-wrappers", () => ({
+  withAuth: (handler: any) => async (request: any, context: any) => {
+    if (request.testRole === "none") return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    return handler(request, { ...context, user: { id: request.testUserId ?? "user-1" }, supabase: { from: mockFrom, storage: { from: mockStorage } } });
+  },
+  withAdminAuth: (handler: any) => async (request: any) => {
+    if (request.testRole !== "admin") return NextResponse.json({ error: request.testRole === "none" ? "Authentication required" : "Admin access required" }, { status: request.testRole === "none" ? 401 : 403 });
+    return handler(request, { user: { id: "admin-1" }, supabase: { from: mockFrom, storage: { from: mockStorage } } });
+  },
+  requireOwnership: mockRequireOwnership,
+}));
+
+function request(body: unknown, role = "user"): NextRequest & { testRole: string } {
+  return { testRole: role, json: async () => body } as unknown as NextRequest & { testRole: string };
+}
+
+function chain(result: unknown): Record<string, jest.Mock> {
+  const value = jest.fn().mockReturnValue(undefined);
+  const self: Record<string, jest.Mock> = { select: value, eq: value, is: value, order: value, update: value, insert: value, single: jest.fn(), maybeSingle: jest.fn() };
+  Object.values(self).forEach((fn) => fn.mockReturnValue(self));
+  self.single.mockResolvedValue(result);
+  self.maybeSingle.mockResolvedValue(result);
+  return self;
+}
+
+describe("session video routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireOwnership.mockResolvedValue({ data: { id: "session-1" } });
+  });
+
+  it.each([
+    ["too_long", { storagePath: "session-1/user-1/a.mp4", durationSec: 61, sizeBytes: 1 }],
+    ["too_large", { storagePath: "session-1/user-1/a.mp4", durationSec: 1, sizeBytes: 62914561 }],
+    ["bad_type", { storagePath: "session-1/user-1/a.txt", durationSec: 1, sizeBytes: 1 }],
+    ["bad_path", { storagePath: "other/user-1/a.mp4", durationSec: 1, sizeBytes: 1 }],
+  ])("rejects %s", async (code, body) => {
+    const { POST } = await import("@/app/api/sessions/[id]/videos/route");
+    const response = await POST(request(body), { params: { id: "session-1" } });
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({ error: code });
+  });
+
+  it("finalizes a video as pending", async () => {
+    const insert = chain({ data: { id: "media-1" }, error: null });
+    mockFrom.mockReturnValue(insert);
+    const { POST } = await import("@/app/api/sessions/[id]/videos/route");
+    const response = await POST(request({ storagePath: "session-1/user-1/a.mp4", durationSec: 12, sizeBytes: 10 }), { params: { id: "session-1" } });
+    expect(response.status).toBe(201);
+    expect(insert.insert).toHaveBeenCalledWith(expect.objectContaining({ moderation_status: "pending" }));
+  });
+
+  it("returns 403 for a non-owner and 405 for unsupported methods", async () => {
+    mockRequireOwnership.mockResolvedValue({ error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) });
+    const route = await import("@/app/api/sessions/[id]/videos/route");
+    expect((await route.POST(request({}), { params: { id: "session-1" } })).status).toBe(403);
+    expect((await route.GET()).status).toBe(405);
+  });
+
+  it("returns 401 before finalization", async () => {
+    const { POST } = await import("@/app/api/sessions/[id]/videos/route");
+    expect((await POST(request({}, "none"), { params: { id: "session-1" } })).status).toBe(401);
+  });
+
+  it.each([
+    ["owner", "pending", false, 200], ["public approved", "approved", true, 200],
+    ["private approved", "approved", false, 403], ["public pending", "pending", true, 403],
+  ])("playback visibility: %s", async (_name, status, isPublic, expected) => {
+    const select = chain({ data: { id: "media-1", user_id: _name === "owner" ? "user-1" : "other", storage_path: "x.mp4", moderation_status: status, sessions: { is_public: isPublic } }, error: null });
+    mockFrom.mockReturnValue(select);
+    mockStorage.mockReturnValue({ createSignedUrl: jest.fn().mockResolvedValue({ data: { signedUrl: "https://signed" }, error: null }) });
+    const { GET } = await import("@/app/api/sessions/[id]/videos/[mediaId]/route");
+    expect((await GET({} as NextRequest, { params: { id: "session-1", mediaId: "media-1" } })).status).toBe(expected);
+  });
+
+  it("returns 404 when playback media is absent", async () => {
+    mockFrom.mockReturnValue(chain({ data: null, error: null }));
+    const { GET } = await import("@/app/api/sessions/[id]/videos/[mediaId]/route");
+    expect((await GET({} as NextRequest, { params: { id: "s", mediaId: "m" } })).status).toBe(404);
+  });
+});
+
+describe("admin session video moderation", () => {
+  it("rejects non-admins", async () => {
+    const { POST } = await import("@/app/api/admin/session-videos/route");
+    expect((await POST(request({ mediaId: "m", action: "approve" }, "user"))).status).toBe(403);
+  });
+
+  it.each([["approve", "approved", undefined], ["reject", "rejected", "privacy"]])("persists %s transition", async (action, status, reason) => {
+    const update = chain({ error: null });
+    mockFrom.mockReturnValue(update);
+    const { POST } = await import("@/app/api/admin/session-videos/route");
+    const response = await POST(request({ mediaId: "media-1", action, ...(reason ? { reason } : {}) }, "admin"));
+    expect(response.status).toBe(200);
+    expect(update.update).toHaveBeenCalledWith({ moderation_status: status, moderation_reason: reason ?? null });
+  });
+});

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -63,6 +63,7 @@ const navItems = [
     href: "/admin/community-photos",
     icon: ImageIcon,
   },
+  { title: "Session Videos", href: "/admin/session-videos", icon: ImageIcon },
   {
     title: "Intel",
     href: "/admin/intel",

--- a/app/admin/session-videos/page.tsx
+++ b/app/admin/session-videos/page.tsx
@@ -1,0 +1,5 @@
+import type { Metadata } from "next";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
+import { SessionVideoQueue } from "@/components/admin/session-video-queue";
+export const metadata: Metadata = { title: "Session Videos", description: "Moderate session videos" };
+export default function SessionVideosPage() { return <div className="space-y-6"><AdminPageHeader title="Session Videos" description="Review pending session video uploads." /><SessionVideoQueue /></div>; }

--- a/app/api/admin/session-videos/route.ts
+++ b/app/api/admin/session-videos/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAdminAuth, type AdminAuthenticatedContext } from "@/lib/middleware/api-wrappers";
+
+const headers = { "Cache-Control": "private, no-store" };
+export const GET = withAdminAuth(async (_request: NextRequest, { supabase }: AdminAuthenticatedContext) => {
+  const { data, error } = await (supabase.from("session_media") as any)
+    .select("id, session_id, user_id, storage_path, file_size, metadata, created_at, moderation_status, sessions!inner(is_public, beach_name)")
+    .eq("media_type", "video").eq("moderation_status", "pending").is("deleted_at", null).order("created_at", { ascending: true });
+  if (error) throw error;
+  const rows = await Promise.all((data ?? []).map(async (row: any) => {
+    const signed = await supabase.storage.from("session-videos").createSignedUrl(row.storage_path, 300);
+    return { ...row, previewUrl: signed.data?.signedUrl ?? null };
+  }));
+  return NextResponse.json({ videos: rows }, { headers });
+});
+
+export const POST = withAdminAuth(async (request: NextRequest, { supabase }: AdminAuthenticatedContext) => {
+  const body = await request.json().catch(() => null) as { mediaId?: unknown; action?: unknown; reason?: unknown } | null;
+  if (typeof body?.mediaId !== "string" || !["approve", "reject"].includes(String(body.action))) {
+    return NextResponse.json({ error: "invalid_request" }, { status: 422, headers });
+  }
+  if (body.action === "reject" && (typeof body.reason !== "string" || !body.reason.trim())) {
+    return NextResponse.json({ error: "reason_required" }, { status: 422, headers });
+  }
+  const { error } = await (supabase.from("session_media") as any).update({
+    moderation_status: body.action === "approve" ? "approved" : "rejected",
+    moderation_reason: typeof body.reason === "string" ? body.reason.trim() : null,
+  }).eq("id", body.mediaId).eq("media_type", "video").eq("moderation_status", "pending");
+  if (error) throw error;
+  return NextResponse.json({ ok: true }, { headers });
+});

--- a/app/api/sessions/[id]/videos/[mediaId]/route.ts
+++ b/app/api/sessions/[id]/videos/[mediaId]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
+const noStore = (r: NextResponse): NextResponse => { r.headers.set("Cache-Control", "no-store"); return r; };
+export const GET = withAuth(async (_request: NextRequest, { params, user, supabase }: AuthenticatedContext) => {
+  const { data: media, error: mediaError } = await (supabase.from("session_media") as any)
+    .select("id, session_id, user_id, storage_path, moderation_status, sessions!inner(is_public)")
+    .eq("id", params.mediaId).eq("session_id", params.id).eq("media_type", "video").is("deleted_at", null).maybeSingle();
+  if (mediaError) throw mediaError;
+  if (!media) return noStore(NextResponse.json({ error: "Not found" }, { status: 404 }));
+  const visible = media.user_id === user.id || (media.moderation_status === "approved" && media.sessions?.is_public === true);
+  if (!visible) return noStore(NextResponse.json({ error: "Forbidden" }, { status: 403 }));
+  const { data, error: signError } = await supabase.storage.from("session-videos").createSignedUrl(media.storage_path, 300);
+  if (signError) throw signError;
+  return noStore(NextResponse.json({ url: data.signedUrl, expiresIn: 300 }));
+});

--- a/app/api/sessions/[id]/videos/route.ts
+++ b/app/api/sessions/[id]/videos/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth, requireOwnership, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
+
+const MAX_SIZE = 62914560;
+const noStore = (response: NextResponse): NextResponse => { response.headers.set("Cache-Control", "no-store"); return response; };
+const error = (code: string, status = 422): NextResponse => noStore(NextResponse.json({ error: code }, { status }));
+
+export const POST = withAuth(async (request: NextRequest, { params, user, supabase }: AuthenticatedContext) => {
+  const ownership = await requireOwnership(supabase, "sessions", params.id, user.id, "Session");
+  if ("error" in ownership) return noStore(ownership.error);
+  let body: { storagePath?: unknown; durationSec?: unknown; sizeBytes?: unknown };
+  try { body = await request.json(); } catch { return error("bad_path"); }
+  const storagePath = typeof body.storagePath === "string" ? body.storagePath : "";
+  const durationSec = typeof body.durationSec === "number" ? body.durationSec : NaN;
+  const sizeBytes = typeof body.sizeBytes === "number" ? body.sizeBytes : NaN;
+  if (!Number.isFinite(durationSec) || durationSec > 60 || durationSec < 0) return error("too_long");
+  if (!Number.isFinite(sizeBytes) || sizeBytes > MAX_SIZE || sizeBytes < 0) return error("too_large");
+  const prefix = `${params.id}/${user.id}/`;
+  if (!storagePath.startsWith(prefix) || storagePath.includes("..")) return error("bad_path");
+  if (!/\.(mp4|mov)$/i.test(storagePath)) return error("bad_type");
+  const { data, error: insertError } = await (supabase.from("session_media") as any).insert({
+    session_id: params.id, user_id: user.id, storage_path: storagePath, public_url: "",
+    file_size: sizeBytes, media_type: "video", metadata: { durationSec },
+    moderation_status: "pending", thumbnail_path: null,
+  }).select("id").single();
+  if (insertError) throw insertError;
+  return noStore(NextResponse.json({ mediaId: data.id }, { status: 201 }));
+}, { errorMessage: "Failed to finalize session video" });
+
+export const GET = () => error("Method Not Allowed", 405);

--- a/components/admin/session-video-queue.tsx
+++ b/components/admin/session-video-queue.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect, useState } from "react";
+type Video = { id: string; previewUrl: string | null; file_size: number; created_at: string; sessions?: { beach_name?: string | null } };
+export function SessionVideoQueue() {
+  const [videos, setVideos] = useState<Video[]>([]);
+  useEffect(() => { void fetch("/api/admin/session-videos", { cache: "no-store" }).then((r) => r.json()).then((v) => setVideos(v.videos ?? [])); }, []);
+  async function moderate(mediaId: string, action: "approve" | "reject") {
+    const reason = action === "reject" ? window.prompt("Rejection reason") : null;
+    if (action === "reject" && !reason) return;
+    await fetch("/api/admin/session-videos", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ mediaId, action, reason }) });
+    setVideos((current) => current.filter((video) => video.id !== mediaId));
+  }
+  return <div className="grid gap-4">{videos.map((video) => <article key={video.id} className="rounded border p-4"><p>{video.sessions?.beach_name ?? "Unknown beach"} · {video.file_size} bytes</p>{video.previewUrl && <video controls preload="metadata" src={video.previewUrl} className="mt-2 max-h-80 w-full" />}<div className="mt-3 flex gap-2"><button onClick={() => void moderate(video.id, "approve")} className="rounded bg-green-600 px-3 py-2 text-white">Approve</button><button onClick={() => void moderate(video.id, "reject")} className="rounded bg-red-600 px-3 py-2 text-white">Reject</button></div></article>)}</div>;
+}

--- a/supabase/migrations/20260811020500_create_session_videos.sql
+++ b/supabase/migrations/20260811020500_create_session_videos.sql
@@ -1,0 +1,46 @@
+BEGIN;
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('session-videos', 'session-videos', false, 62914560, ARRAY['video/mp4', 'video/quicktime'])
+ON CONFLICT (id) DO UPDATE SET public = false, file_size_limit = 62914560,
+  allowed_mime_types = ARRAY['video/mp4', 'video/quicktime'];
+
+DROP POLICY IF EXISTS "Users can upload their own session videos" ON storage.objects;
+CREATE POLICY "Users can upload their own session videos" ON storage.objects
+FOR INSERT TO authenticated WITH CHECK (
+  bucket_id = 'session-videos' AND auth.uid()::text = (storage.foldername(name))[2]
+);
+DROP POLICY IF EXISTS "Users can read their own session videos" ON storage.objects;
+CREATE POLICY "Users can read their own session videos" ON storage.objects
+FOR SELECT TO authenticated USING (
+  bucket_id = 'session-videos' AND auth.uid()::text = (storage.foldername(name))[2]
+);
+
+ALTER TABLE public.session_media ADD COLUMN IF NOT EXISTS moderation_status text NOT NULL DEFAULT 'approved';
+-- Shipped native binaries insert photo rows without this column; keep photos public by default after migration.
+ALTER TABLE public.session_media ADD COLUMN IF NOT EXISTS thumbnail_path text;
+ALTER TABLE public.session_media ADD COLUMN IF NOT EXISTS moderation_reason text;
+DO $$ BEGIN
+  ALTER TABLE public.session_media ADD CONSTRAINT session_media_moderation_status_check
+    CHECK (moderation_status IN ('pending', 'approved', 'rejected'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+UPDATE public.session_media SET moderation_status = 'approved'
+WHERE media_type = 'photo' AND moderation_status = 'pending';
+
+DROP POLICY IF EXISTS "Public can view media from public sessions" ON public.session_media;
+CREATE POLICY "Public can view approved media from public sessions" ON public.session_media
+FOR SELECT USING (
+  deleted_at IS NULL AND (
+    user_id = auth.uid() OR
+    (moderation_status = 'approved' AND EXISTS (
+      SELECT 1 FROM public.sessions s WHERE s.id = session_media.session_id
+        AND s.is_public = true AND s.deleted_at IS NULL
+    ))
+  )
+);
+
+DO $$ BEGIN
+  ALTER TYPE content_report_target ADD VALUE IF NOT EXISTS 'session_media';
+EXCEPTION WHEN undefined_object THEN NULL; END $$;
+
+COMMIT;


### PR DESCRIPTION
S2 of the UGC week plan (`.planning/ugc-local-reports-video-share-PLAN-20260810.md`). Private `session-videos` bucket + additive `session_media` moderation columns (photo-safe: DEFAULT 'approved' because installed binaries can't set the column — videos set 'pending' explicitly), finalize + signed-playback routes with the full visibility matrix, admin moderation queue (App Store 1.2 evidence), `content_report_target` + `session_media`.

**Migration application is deliberately NOT part of this PR** — the file lands with main; applying it to the shared DB is an operator step (tracked in MASTER-PLAN).

Review round caught before merge: moderation default that would have made every new photo from installed apps owner-only; duplicate migration timestamp; skipped tests (now 15/15). Native counterpart in flight on `feat/s2-video-attach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)