### PR TITLE
feat(seo): source freshness + week-over-week movement in the weekly report

### DIFF
--- a/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
+++ b/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
@@ -1,4 +1,7 @@
-import { renderWeeklySeoReport } from "@/lib/seo/agent-workflow/weekly-report";
+import {
+  buildWeeklySeoComparison,
+  renderWeeklySeoReport,
+} from "@/lib/seo/agent-workflow/weekly-report";
 
 function extractSection(report: string, heading: string): string {
   const start = report.indexOf(heading);
@@ -9,6 +12,122 @@ function extractSection(report: string, heading: string): string {
 }
 
 describe("SEO workflow weekly report", () => {
+  it("renders source freshness, week-over-week movement, and Ahrefs issues under technical health", () => {
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-08-10T12:00:00Z",
+      auditDate: "2026-08-10",
+      recommendations: [{
+        id: "ahrefs-missing-alt-text-root",
+        createdAt: "2026-08-10T12:00:00Z",
+        source: "ahrefs-audit",
+        priority: "medium",
+        canonicalPath: "/",
+        summary: "Ahrefs found missing alt text on 299 crawled URLs.",
+        evidence: ["affectedUrls=299"],
+        status: "open",
+      }],
+      sourceFreshness: [{
+        source: "Competitor deep-dive",
+        observedAt: "2026-07-27",
+        status: "stale",
+        note: "run date 2026-07-27 (14 days old)",
+      }],
+      weekOverWeek: {
+        previousAuditDate: "2026-08-03",
+        metrics: [{
+          label: "GSC clicks (28d vs prior report)",
+          current: 998,
+          previous: 1034,
+          unit: "clicks",
+        }],
+      },
+      technical: [],
+      missing: [],
+    });
+
+    expect(report).toContain("## Source Freshness");
+    expect(report).toContain("Competitor deep-dive: STALE (2026-07-27)");
+    expect(report).toContain("## Week-over-Week Movement");
+    expect(report).toContain("GSC clicks (28d vs prior report): 998 clicks; prior 1,034; change -36 (-3.5%).");
+    expect(extractSection(report, "## Technical Crawl Health")).toContain(
+      "MEDIUM: `/` - Ahrefs found missing alt text on 299 crawled URLs.",
+    );
+    expect(report).not.toContain("No technical crawl issues in available inputs.");
+  });
+
+  // Site-audit findings previously matched both the technical merge and the
+  // keyword-movement filter, so every one of them printed twice in the report.
+  it("routes each ahrefs-audit finding to exactly one section", () => {
+    const base = {
+      createdAt: "2026-08-10T12:00:00Z",
+      source: "ahrefs-audit" as const,
+      priority: "medium" as const,
+      canonicalPath: "/",
+      evidence: [],
+      status: "open" as const,
+    };
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-08-10T12:00:00Z",
+      auditDate: "2026-08-10",
+      recommendations: [
+        { ...base, id: "ahrefs-noindex-sitemap", summary: "SITE_AUDIT_FINDING" },
+        {
+          ...base,
+          id: "ahrefs-keyword-gap",
+          summary: "KEYWORD_FINDING",
+          targetKeyword: "surf report san diego",
+        },
+      ],
+      technical: [],
+      missing: [],
+    });
+
+    const technicalSection = extractSection(report, "## Technical Crawl Health");
+    const keywordSection = extractSection(report, "## Keyword / Ranking Movement");
+
+    // A finding with no target keyword belongs to technical health only.
+    expect(technicalSection).toContain("SITE_AUDIT_FINDING");
+    expect(keywordSection).not.toContain("SITE_AUDIT_FINDING");
+
+    // A keyword-targeted finding belongs to ranking movement only.
+    expect(keywordSection).toContain("KEYWORD_FINDING");
+    expect(technicalSection).not.toContain("KEYWORD_FINDING");
+
+    // Belt and braces: neither summary appears more than once in the whole report.
+    expect(report.split("SITE_AUDIT_FINDING").length - 1).toBe(1);
+    expect(report.split("KEYWORD_FINDING").length - 1).toBe(1);
+  });
+
+  it("builds seven-day week-over-week metrics from the current GSC export", () => {
+    const comparison = buildWeeklySeoComparison({
+      generatedAt: "2026-08-10T12:00:00Z",
+      recommendations: [],
+      missing: [],
+      gsc: {
+        generatedAt: "2026-08-10T12:00:00Z",
+        siteUrl: "https://www.quiversurf.app/",
+        dateRanges: {
+          last7d: { start: "2026-08-04", end: "2026-08-10" },
+          prior7d: { start: "2026-07-28", end: "2026-08-03" },
+          last28d: { start: "2026-07-14", end: "2026-08-10" },
+        },
+        last7d: [{ page: "/", clicks: 12, impressions: 120 }],
+        prior7d: [{ page: "/", clicks: 8, impressions: 100 }],
+        last28d: [],
+        sitemapPaths: [],
+        topQueries: [],
+        topPages: [],
+        byDevice: [],
+        byCountry: [],
+      },
+    });
+
+    expect(comparison?.metrics).toEqual(expect.arrayContaining([
+      { label: "GSC clicks (last 7d vs prior 7d)", current: 12, previous: 8, unit: "clicks" },
+      { label: "GSC impressions (last 7d vs prior 7d)", current: 120, previous: 100, unit: "impressions" },
+    ]));
+  });
+
   it("renders required sections and free-data limitations with partial inputs", () => {
     const report = renderWeeklySeoReport({
       generatedAt: "2026-05-20T12:00:00Z",

--- a/docs/seo/SEO_AGENT_WORKFLOW.md
+++ b/docs/seo/SEO_AGENT_WORKFLOW.md
@@ -29,6 +29,7 @@ yarn seo:enrich --source posthog --input path/to/posthog-export.json
 yarn seo:enrich --source ahrefs --input ../Brand-Vault/seo-audit/YYYY-MM-DD/AHREFS-SCREENSHOT-INPUT.json --output ../Brand-Vault/seo-audit/YYYY-MM-DD/AHREFS-ENRICHMENT.json
 yarn seo:recommend --input ../Brand-Vault/seo-audit/YYYY-MM-DD/GSC-REFRESH.json --input ../Brand-Vault/seo-audit/YYYY-MM-DD/TECHNICAL-AUDIT.json --input ../Brand-Vault/seo-audit/YYYY-MM-DD/VERCEL-ENRICHMENT.json
 yarn seo:weekly-report
+yarn seo:weekly-report --dir ../Brand-Vault/seo-audit/YYYY-MM-DD --audit-date YYYY-MM-DD
 ```
 
 The commands generate dashboard updates or review reports only. They do not publish content, apply migrations, commit, push, or mutate production data. Weekly audit artifacts default to `../Brand-Vault/seo-audit/YYYY-MM-DD/` so generated marketing intelligence stays outside the app repo.
@@ -52,6 +53,7 @@ The weekly report is the single home for the SEO workflow's deterministic report
 
 - **Broken-link scanner (deterministic):** `seo:technical-audit` extracts same-origin `<a href>` links from the pages it already crawls and HEAD-checks a bounded sample (cap 40, 8s timeout). Broken links (status >= 400) surface under Technical Crawl Health.
 - **AEO citation monitor:** the report folds the latest `docs/seo/reports/aeo-citation-tracking/*.md` baseline into the AI Citation / AEO Signals section. The audit is a search-presence proxy, not a true multi-engine AI-answer citation measurement. Keep queries stable and append rather than replace so the citation rate stays comparable.
+- **Weekly freshness and movement guard:** the weekly report records source age for GSC, Vercel, PostHog, DataForSEO, store, Ahrefs, competitor, AEO-baseline, and backlink inputs. It labels sources as fresh, lagged, stale, or missing, compares the current bundle with the previous dated audit when available, and surfaces Ahrefs audit recommendations under Technical Crawl Health. Pass `--audit-date` when a scheduler needs the report date pinned independently of UTC.
 - **Backlink scanner:** the report folds the latest `docs/seo/backlink-reports/*.md` confirmed/unverified target list into the Backlink / Referrer Signals section, alongside referrer/embed/manual-export signals.
 - **Outreach drafter:** `seo:outreach-digest` reads `docs/seo/outreach-tracker.md`, picks this week's rotation category (Week 1 schools, Week 2 bloggers, Week 3 coastal businesses, Week 4 publications, by week-of-month), and emits draft candidates into the Outreach Queue section. In live mode, the agent may create those as Gmail drafts, never sent, and mark the tracker rows `drafted` after verifying the drafts exist. Review drafts in Gmail before sending.
 

--- a/lib/seo/agent-workflow/types.ts
+++ b/lib/seo/agent-workflow/types.ts
@@ -551,8 +551,31 @@ export interface OutreachDigestInput {
   missing?: string[];
 }
 
+export type WeeklySeoSourceFreshnessStatus = "fresh" | "lagged" | "stale" | "missing";
+
+export interface WeeklySeoSourceFreshness {
+  source: string;
+  observedAt?: string;
+  status: WeeklySeoSourceFreshnessStatus;
+  note: string;
+}
+
+export interface WeeklySeoMetricDelta {
+  label: string;
+  current: number;
+  previous: number;
+  unit: string;
+}
+
+export interface WeeklySeoComparison {
+  previousAuditDate?: string;
+  metrics: WeeklySeoMetricDelta[];
+  missing?: string[];
+}
+
 export interface WeeklySeoReportInput {
   generatedAt: string;
+  auditDate?: string;
   recommendations: SeoRecommendation[];
   gsc?: GscExportInput;
   vercel?: VercelExportInput;
@@ -565,6 +588,8 @@ export interface WeeklySeoReportInput {
   outreach?: OutreachDigestInput;
   technical?: SeoRecommendation[];
   metadata?: SeoMetadataAuditInput;
+  sourceFreshness?: WeeklySeoSourceFreshness[];
+  weekOverWeek?: WeeklySeoComparison;
   missing: string[];
 }
 

--- a/lib/seo/agent-workflow/weekly-report.ts
+++ b/lib/seo/agent-workflow/weekly-report.ts
@@ -14,6 +14,7 @@ import type {
   StoreSnapshotInput,
   VercelExportInput,
   WeeklyActionItem,
+  WeeklySeoComparison,
   WeeklySeoReportInput,
 } from "./types";
 import {
@@ -50,13 +51,21 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
   const actionQueue = synthesizeWeeklyActionQueue(input);
 
   return [
-    `# Quiver Weekly SEO + ASO Report - ${input.generatedAt.slice(0, 10)}`,
+    `# Quiver Weekly SEO + ASO Report - ${input.auditDate ?? input.generatedAt.slice(0, 10)}`,
     "",
     "Report-only output. No publishing, migrations, commits, pushes, runtime page edits, or production mutations were performed.",
     "",
     "## Bottom Line",
     "",
     renderBottomLine(input, openRecommendations),
+    "",
+    "## Source Freshness",
+    "",
+    renderSourceFreshness(input.sourceFreshness),
+    "",
+    "## Week-over-Week Movement",
+    "",
+    renderWeekOverWeek(input.weekOverWeek),
     "",
     "## Web SEO",
     "",
@@ -88,7 +97,10 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
     "",
     "## Technical Crawl Health",
     "",
-    renderRecommendations(input.technical ?? [], "No technical crawl issues in available inputs."),
+    renderRecommendations(
+      mergeTechnicalRecommendations(input.technical ?? [], input.recommendations),
+      "No technical crawl issues in available inputs.",
+    ),
     "",
     "## Backlink / Referrer Signals",
     "",
@@ -131,6 +143,147 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
     renderCoverageNotes(input),
     "",
   ].join("\n");
+}
+
+export function buildWeeklySeoComparison(
+  current: WeeklySeoReportInput,
+  previous?: WeeklySeoReportInput,
+  previousAuditDate?: string,
+): WeeklySeoComparison | undefined {
+  const metrics: WeeklySeoComparison["metrics"] = [];
+  const currentGsc = current.gsc;
+
+  if (currentGsc) {
+    addMetric(
+      metrics,
+      "GSC clicks (last 7d vs prior 7d)",
+      sum(currentGsc.last7d.map((row) => row.clicks)),
+      sum(currentGsc.prior7d.map((row) => row.clicks)),
+      "clicks",
+    );
+    addMetric(
+      metrics,
+      "GSC impressions (last 7d vs prior 7d)",
+      sum(currentGsc.last7d.map((row) => row.impressions)),
+      sum(currentGsc.prior7d.map((row) => row.impressions)),
+      "impressions",
+    );
+  }
+
+  if (current.vercel) {
+    const currentVisits = sum(current.vercel.pages.map((page) => page.visits ?? 0));
+    const previousVisits = sum(current.vercel.pages.map((page) => page.previousVisits ?? 0));
+    if (currentVisits > 0 && previousVisits > 0) {
+      addMetric(
+        metrics,
+        "Vercel SEO page visits",
+        currentVisits,
+        previousVisits,
+        "visits",
+      );
+    }
+  }
+
+  if (previous?.gsc && currentGsc) {
+    addMetric(
+      metrics,
+      "GSC clicks (28d vs prior report)",
+      sum(currentGsc.last28d.map((row) => row.clicks)),
+      sum(previous.gsc.last28d.map((row) => row.clicks)),
+      "clicks",
+    );
+    addMetric(
+      metrics,
+      "GSC impressions (28d vs prior report)",
+      sum(currentGsc.last28d.map((row) => row.impressions)),
+      sum(previous.gsc.last28d.map((row) => row.impressions)),
+      "impressions",
+    );
+  }
+
+  if (previous?.vercel && current.vercel) {
+    addMetric(
+      metrics,
+      "Vercel adjusted pageviews",
+      current.vercel.adjustedPageViews,
+      previous.vercel.adjustedPageViews,
+      "pageviews",
+    );
+  }
+
+  if (previous?.dataforseo && current.dataforseo) {
+    addMetric(
+      metrics,
+      "DataForSEO Google top-100 checks",
+      countTop100(current.dataforseo.googleRankings),
+      countTop100(previous.dataforseo.googleRankings),
+      "checks",
+    );
+    addMetric(
+      metrics,
+      "DataForSEO ASO top-100 checks",
+      countTop100(current.dataforseo.asoRankings),
+      countTop100(previous.dataforseo.asoRankings),
+      "checks",
+    );
+  }
+
+  if (metrics.length === 0) return undefined;
+  return { previousAuditDate, metrics };
+}
+
+function addMetric(
+  metrics: WeeklySeoComparison["metrics"],
+  label: string,
+  current: number,
+  previous: number,
+  unit: string,
+): void {
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return;
+  if (current === 0 && previous === 0) return;
+  metrics.push({ label, current, previous, unit });
+}
+
+function countTop100(rows: Array<{ quiverRank: number | null }>): number {
+  return rows.filter((row) => row.quiverRank !== null && row.quiverRank <= 100).length;
+}
+
+function renderSourceFreshness(
+  freshness: WeeklySeoReportInput["sourceFreshness"],
+): string {
+  if (!freshness?.length) return "- Source freshness was not recorded for this run.";
+  return [
+    "- Freshness policy: FRESH = 0–1 days old; LAGGED = 2–3 days; STALE = more than 3 days; MISSING = no dated input.",
+    ...freshness.map((source) =>
+      `- ${source.source}: ${source.status.toUpperCase()}${source.observedAt ? ` (${source.observedAt})` : ""} — ${source.note}`,
+    ),
+  ].join("\n");
+}
+
+function renderWeekOverWeek(comparison?: WeeklySeoComparison): string {
+  if (!comparison?.metrics.length) return "- No comparable prior-week metrics were available.";
+  const rows = comparison.previousAuditDate
+    ? [`- Comparison baseline: audit ${comparison.previousAuditDate}.`]
+    : [];
+  rows.push(...comparison.metrics.map((metric) => {
+    const delta = metric.current - metric.previous;
+    const percent = metric.previous === 0 ? "n/a" : `${formatSigned((delta / metric.previous) * 100, 1)}%`;
+    return `- ${metric.label}: ${formatMetricNumber(metric.current)} ${metric.unit}; prior ${formatMetricNumber(metric.previous)}; change ${formatSigned(delta, 0)} (${percent}).`;
+  }));
+  if (comparison.missing?.length) {
+    rows.push(...comparison.missing.map((item) => `- Comparison gap: ${item}`));
+  }
+  return rows.join("\n");
+}
+
+function mergeTechnicalRecommendations(
+  technical: SeoRecommendation[],
+  recommendations: SeoRecommendation[],
+): SeoRecommendation[] {
+  const ahrefsIssues = recommendations.filter((item) =>
+    item.source === "ahrefs-audit" && !item.targetKeyword,
+  );
+  return [...new Map([...technical, ...ahrefsIssues].map((item) => [item.id, item])).values()];
 }
 
 function renderBottomLine(
@@ -192,8 +345,11 @@ function renderKeywordMovement(
   dataforseo: DataForSeoExportInput | undefined,
   recommendations: SeoRecommendation[],
 ): string {
+  // Non-keyword ahrefs-audit findings render under Technical Crawl Health via
+  // mergeTechnicalRecommendations. Keeping them here too printed each one twice.
   const keywordRecs = recommendations.filter((item) =>
-    item.source === "gsc-decay" || item.source === "ahrefs-audit",
+    item.source === "gsc-decay" ||
+    (item.source === "ahrefs-audit" && Boolean(item.targetKeyword)),
   );
   const rows = [
     ...renderDataForSeoGoogleRanks(dataforseo),
@@ -894,6 +1050,17 @@ function isAmbiguousAsoBrandKeyword(keyword: string): boolean {
 
 function sum(values: number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+function formatMetricNumber(value: number): string {
+  return Number.isInteger(value) ? value.toLocaleString("en-US") : value.toFixed(1);
+}
+
+function formatSigned(value: number, decimals: number): string {
+  const rounded = decimals === 0
+    ? Math.abs(Math.round(value)).toLocaleString("en-US")
+    : Math.abs(value).toFixed(decimals);
+  return `${value >= 0 ? "+" : "-"}${rounded}`;
 }
 
 function formatNumber(value: number | undefined): string {

--- a/scripts/seo/weekly-report.ts
+++ b/scripts/seo/weekly-report.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { currentAuditDate, resolveSeoAuditDir } from "../../lib/seo/agent-workflow/audit-paths";
-import { renderWeeklySeoReport } from "../../lib/seo/agent-workflow/weekly-report";
+import {
+  buildWeeklySeoComparison,
+  renderWeeklySeoReport,
+} from "../../lib/seo/agent-workflow/weekly-report";
 import type {
   AeoCitationInput,
   BacklinkProxyInput,
@@ -16,10 +19,14 @@ import type {
   StoreSnapshotInput,
   VercelExportInput,
   WeeklySeoReportInput,
+  WeeklySeoSourceFreshness,
+  WeeklySeoSourceFreshnessStatus,
 } from "../../lib/seo/agent-workflow/types";
 
 const auditDir = getFlag("--dir") ?? resolveSeoAuditDir(currentAuditDate());
 const outputPath = getFlag("--output") ?? path.join(auditDir, "SEO-WEEKLY-REPORT.md");
+const auditDate = getFlag("--audit-date") ?? inferAuditDate(auditDir);
+const previousAuditDir = findPreviousAuditDir(auditDir);
 
 const inputFiles = [
   "GSC-REFRESH.json",
@@ -29,47 +36,154 @@ const inputFiles = [
 ];
 const optionalInputFiles = ["AHREFS-ENRICHMENT.json"];
 
-const missing: string[] = [];
-const metadata = readJsonIfExists<SeoMetadataAuditInput>(
-  path.join(auditDir, "SEO-METADATA-AUDIT.json"),
-  missing,
-) ?? undefined;
-
-const recommendations = inputFiles.flatMap((fileName) =>
-  readJsonIfExists<SeoRecommendation[]>(path.join(auditDir, fileName), missing) ?? [],
-).concat(metadata?.recommendations ?? [], optionalInputFiles.flatMap((fileName) =>
-  readJsonIfExists<SeoRecommendation[]>(path.join(auditDir, fileName)) ?? [],
-));
-const technical = readJsonIfExists<SeoRecommendation[]>(
-  path.join(auditDir, "TECHNICAL-AUDIT.json"),
-  missing,
-) ?? [];
-
-const input: WeeklySeoReportInput = {
-  generatedAt: new Date().toISOString(),
-  recommendations,
-  technical,
-  gsc: readJsonIfExists<GscExportInput>(path.join(auditDir, "GSC-EXPORT.json"), missing) ?? undefined,
-  vercel: readJsonIfExists<VercelExportInput>(path.join(auditDir, "VERCEL-EXPORT.json"), missing) ?? undefined,
-  posthog: readJsonIfExists<PostHogExportInput>(path.join(auditDir, "POSTHOG-EXPORT.json"), missing) ?? undefined,
-  store: readJsonIfExists<StoreSnapshotInput>(path.join(auditDir, "STORE-SNAPSHOT.json"), missing) ?? undefined,
-  dataforseo: readJsonIfExists<DataForSeoExportInput>(path.join(auditDir, "DATAFORSEO-EXPORT.json")) ?? undefined,
-  backlink: readJsonIfExists<BacklinkProxyInput>(path.join(auditDir, "BACKLINK-PROXY.json"), missing) ?? undefined,
-  competitor: readJsonIfExists<CompetitorIntelligenceInput>(path.join(auditDir, "COMPETITOR-EXPORT.json"), missing) ?? undefined,
-  aeo: readJsonIfExists<AeoCitationInput>(path.join(auditDir, "AEO-EXPORT.json"), missing) ?? undefined,
-  outreach: readJsonIfExists<OutreachDigestInput>(path.join(auditDir, "OUTREACH-DIGEST.json"), missing) ?? undefined,
-  metadata,
-  missing,
-};
+const input = readWeeklyReportInput(auditDir, new Date().toISOString(), auditDate, true);
+const previousInput = previousAuditDir
+  ? readWeeklyReportInput(previousAuditDir, new Date().toISOString(), path.basename(previousAuditDir), false)
+  : undefined;
+const ahrefsSnapshot = readJsonIfExists<AhrefsFreshnessSnapshot>(
+  path.join(auditDir, "AHREFS-SCREENSHOT-INPUT.json"),
+);
+input.sourceFreshness = buildSourceFreshness(input, auditDate, ahrefsSnapshot);
+input.weekOverWeek = buildWeeklySeoComparison(
+  input,
+  previousInput,
+  previousAuditDir ? path.basename(previousAuditDir) : undefined,
+);
 
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, renderWeeklySeoReport(input));
 
 console.log(JSON.stringify({
   outputPath,
-  recommendations: recommendations.length,
-  missing: missing.length,
+  recommendations: input.recommendations.length,
+  missing: input.missing.length,
+  previousAuditDate: previousAuditDir ? path.basename(previousAuditDir) : null,
+  staleSources: input.sourceFreshness.filter((source) => source.status === "stale").map((source) => source.source),
 }, null, 2));
+
+function readWeeklyReportInput(
+  dir: string,
+  generatedAt: string,
+  reportDate: string,
+  trackMissing: boolean,
+): WeeklySeoReportInput {
+  const missing: string[] = [];
+  const missingList = trackMissing ? missing : undefined;
+  const metadata = readJsonIfExists<SeoMetadataAuditInput>(
+    path.join(dir, "SEO-METADATA-AUDIT.json"),
+    missingList,
+  ) ?? undefined;
+  const recommendations = inputFiles.flatMap((fileName) =>
+    readJsonIfExists<SeoRecommendation[]>(path.join(dir, fileName), missingList) ?? [],
+  ).concat(metadata?.recommendations ?? [], optionalInputFiles.flatMap((fileName) =>
+    readJsonIfExists<SeoRecommendation[]>(path.join(dir, fileName)) ?? [],
+  ));
+  const technical = readJsonIfExists<SeoRecommendation[]>(
+    path.join(dir, "TECHNICAL-AUDIT.json"),
+    missingList,
+  ) ?? [];
+
+  return {
+    generatedAt,
+    auditDate: reportDate,
+    recommendations,
+    technical,
+    gsc: readJsonIfExists<GscExportInput>(path.join(dir, "GSC-EXPORT.json"), missingList) ?? undefined,
+    vercel: readJsonIfExists<VercelExportInput>(path.join(dir, "VERCEL-EXPORT.json"), missingList) ?? undefined,
+    posthog: readJsonIfExists<PostHogExportInput>(path.join(dir, "POSTHOG-EXPORT.json"), missingList) ?? undefined,
+    store: readJsonIfExists<StoreSnapshotInput>(path.join(dir, "STORE-SNAPSHOT.json"), missingList) ?? undefined,
+    dataforseo: readJsonIfExists<DataForSeoExportInput>(path.join(dir, "DATAFORSEO-EXPORT.json")) ?? undefined,
+    backlink: readJsonIfExists<BacklinkProxyInput>(path.join(dir, "BACKLINK-PROXY.json"), missingList) ?? undefined,
+    competitor: readJsonIfExists<CompetitorIntelligenceInput>(path.join(dir, "COMPETITOR-EXPORT.json"), missingList) ?? undefined,
+    aeo: readJsonIfExists<AeoCitationInput>(path.join(dir, "AEO-EXPORT.json"), missingList) ?? undefined,
+    outreach: readJsonIfExists<OutreachDigestInput>(path.join(dir, "OUTREACH-DIGEST.json"), missingList) ?? undefined,
+    metadata,
+    missing,
+  };
+}
+
+interface AhrefsFreshnessSnapshot {
+  capturedAt?: string;
+  capturedForAuditDate?: string;
+  crawl?: { latestRun?: { date?: string } };
+}
+
+function buildSourceFreshness(
+  input: WeeklySeoReportInput,
+  reportDate: string,
+  ahrefs?: AhrefsFreshnessSnapshot | null,
+): WeeklySeoSourceFreshness[] {
+  return [
+    makeFreshness("GSC Search Console", input.gsc?.dateRanges.last28d.end, reportDate, "data through"),
+    makeFreshness("Vercel Analytics", input.vercel?.dateRange.to, reportDate, "window ends"),
+    makeFreshness("PostHog", input.posthog?.dateRange.to, reportDate, "window ends"),
+    makeFreshness("DataForSEO", input.dataforseo?.generatedAt, reportDate, "export generated"),
+    makeFreshness("Store listings", input.store?.generatedAt, reportDate, "snapshot generated"),
+    makeFreshness(
+      "Ahrefs Site Audit",
+      ahrefs?.capturedForAuditDate ?? ahrefs?.crawl?.latestRun?.date ?? ahrefs?.capturedAt,
+      reportDate,
+      "capture date",
+    ),
+    makeFreshness("Competitor deep-dive", dateFromRunId(input.competitor?.runId), reportDate, "run date"),
+    makeFreshness("AEO citation baseline", input.aeo?.narrativeBaseline?.reportDate, reportDate, "30-query audit date"),
+    makeFreshness("Backlink target report", input.backlink?.narrativeTargets?.reportDate, reportDate, "target report date"),
+  ];
+}
+
+function makeFreshness(
+  source: string,
+  observedAt: string | undefined,
+  reportDate: string,
+  label: string,
+): WeeklySeoSourceFreshness {
+  const date = dateOnly(observedAt);
+  if (!date) {
+    return { source, status: "missing", note: "no dated input was available" };
+  }
+  const ageDays = dayDifference(reportDate, date);
+  const status: WeeklySeoSourceFreshnessStatus = ageDays <= 1
+    ? "fresh"
+    : ageDays <= 3
+      ? "lagged"
+      : "stale";
+  const ageNote = ageDays === 0 ? "same-day" : `${ageDays} day${ageDays === 1 ? "" : "s"} old`;
+  return { source, observedAt: date, status, note: `${label} ${date} (${ageNote})` };
+}
+
+function findPreviousAuditDir(auditDirPath: string): string | null {
+  const auditRoot = path.dirname(auditDirPath);
+  const currentDate = path.basename(auditDirPath);
+  if (!fs.existsSync(auditRoot)) return null;
+  const previous = fs.readdirSync(auditRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(entry.name) && entry.name < currentDate)
+    .map((entry) => entry.name)
+    .sort()
+    .at(-1);
+  return previous ? path.join(auditRoot, previous) : null;
+}
+
+function inferAuditDate(auditDirPath: string): string {
+  const date = path.basename(auditDirPath);
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : currentAuditDate();
+}
+
+function dateFromRunId(runId?: string): string | undefined {
+  const compact = runId?.match(/^(\d{4})(\d{2})(\d{2})/);
+  if (compact) return `${compact[1]}-${compact[2]}-${compact[3]}`;
+  return runId?.match(/^(\d{4}-\d{2}-\d{2})/)?.[1];
+}
+
+function dateOnly(value?: string): string | undefined {
+  return value?.match(/\d{4}-\d{2}-\d{2}/)?.[0];
+}
+
+function dayDifference(later: string, earlier: string): number {
+  const laterMs = Date.parse(`${later}T00:00:00Z`);
+  const earlierMs = Date.parse(`${earlier}T00:00:00Z`);
+  if (!Number.isFinite(laterMs) || !Number.isFinite(earlierMs)) return 999;
+  return Math.max(0, Math.round((laterMs - earlierMs) / 86_400_000));
+}
 
 function readJsonIfExists<T>(filePath: string, missingList?: string[]): T | null {
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
Adds two sections to the weekly SEO report and fixes a duplication bug found while reviewing it.

## What it adds

- **Source Freshness** — ages every input (GSC, Vercel, PostHog, DataForSEO, store, Ahrefs, competitor, AEO baseline, backlinks) and labels each `fresh` / `lagged` / `stale` / `missing` against a stated policy. Run against the real `2026-08-10` audit it surfaces a **56-day-old backlink report** and two 14-day-old sources that were previously invisible.
- **Week-over-Week Movement** — compares against the previous dated audit directory: 7d-vs-prior-7d GSC deltas, plus cross-report 28d, Vercel and DataForSEO metrics where both sides exist.
- Ahrefs site-audit findings now render under Technical Crawl Health.
- `--audit-date` pins the report date so a scheduler isn't at the mercy of UTC.

## Bug fixed in review

Site-audit findings matched **both** the technical merge and the keyword-movement filter, so **4 of 8 printed twice**. Confirmed by diffing generated output against baseline `main`: 1 occurrence before, 2 after.

The predicates are now complementary — `!targetKeyword` → Technical Crawl Health, `targetKeyword` → Keyword / Ranking Movement — so every finding lands in exactly one section and none are dropped. Dropping `ahrefs-audit` from the keyword filter outright would have silently lost keyword-targeted site-audit findings.

## Verification

- End-to-end against real audit data: duplicated ahrefs lines **4 → 0**, `missing: 0`, three stale sources still correctly flagged
- `tsc --noEmit` clean · **1,277 suites / 16,603 tests passing**
- The regression test was verified to actually guard: reverting only the one-line fix while keeping the test makes it fail (`✕ routes each ahrefs-audit finding to exactly one section`)

## Known limitations, not addressed here

- The 28-day comparison uses overlapping windows (28d vs 28d offset by 7 days, ~75% autocorrelated). Today it reads `-1.9%` while 7d-vs-7d reads `+59.6%`; both are true but the label invites misreading.
- `makeFreshness`, `dayDifference`, `findPreviousAuditDir`, and `dateFromRunId` are pure functions with real edge cases sitting untested in `scripts/seo/weekly-report.ts`, which is eslint-ignored. They belong in `lib/seo/agent-workflow/` alongside `buildWeeklySeoComparison`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)