### PR TITLE
promote: IndexNow accounting, App Store campaigns, forecast zine, SEO report freshness

### DIFF
--- a/__tests__/app/api/app-link-email.test.ts
+++ b/__tests__/app/api/app-link-email.test.ts
@@ -16,9 +16,7 @@ import { POST } from "@/app/api/app-link-email/route";
 const send = jest.fn<
   Promise<{ data: { id: string }; error: Error | null }>,
   [unknown]
->(() =>
-  Promise.resolve({ data: { id: "email_1" }, error: null }),
-);
+>(() => Promise.resolve({ data: { id: "email_1" }, error: null }));
 
 jest.mock("@/lib/mailer/client", () => ({
   resend: { emails: { send: (arg: unknown) => send(arg) } },
@@ -29,7 +27,10 @@ jest.mock("@/lib/mailer/client", () => ({
 
 jest.mock("@/lib/middleware/api-wrappers", () => {
   const actual = jest.requireActual("@/lib/middleware/api-wrappers");
-  return { ...actual, withBotBlockingAndRateLimit: (handler: unknown) => handler };
+  return {
+    ...actual,
+    withBotBlockingAndRateLimit: (handler: unknown) => handler,
+  };
 });
 
 function req(body: unknown): never {
@@ -75,6 +76,7 @@ describe("POST /api/app-link-email", () => {
     expect(JSON.stringify(arg.react)).toContain(
       "handoff_id=33333333-3333-4333-8333-333333333333",
     );
+    expect(JSON.stringify(arg.react)).toContain("utm_campaign=app_first_v1");
   });
 
   it("never echoes the recipient address into the email body", async () => {

--- a/__tests__/app/api/cron/indexnow-submit.test.ts
+++ b/__tests__/app/api/cron/indexnow-submit.test.ts
@@ -137,8 +137,10 @@ describe("IndexNow submit cron route", () => {
     (flattenIndexNowUrlGroups as jest.Mock).mockReturnValue(flattenedUrls);
     (submitUrlsInBatches as jest.Mock).mockResolvedValue({
       totalSubmitted: 3,
-      batches: [{ urls: flattenedUrls }],
+      totalPending: 0,
+      batches: [{ urls: flattenedUrls, statusCode: 200 }],
       errors: [],
+      warnings: [],
     });
 
     const response = await GET(
@@ -154,7 +156,10 @@ describe("IndexNow submit cron route", () => {
       success: true,
       data: {
         submitted: 3,
+        pending: 0,
         totalUrls: 3,
+        statusCodes: [200],
+        warnings: [],
         breakdown: {
           intent: 1,
           location: 2,

--- a/__tests__/app/app-handoff-page.test.tsx
+++ b/__tests__/app/app-handoff-page.test.tsx
@@ -88,9 +88,36 @@ describe("/app handoff page", () => {
       }),
     );
     expect(mockRedirect).toHaveBeenCalledWith(
-      expect.stringContaining("ct=app_first_v1"),
+      expect.stringContaining("ct=web"),
     );
   });
+
+  it.each([
+    ["email", { utm_source: "email", utm_medium: "app_link" }, "ct=email"],
+    [
+      "partner QR",
+      { surface: "partner_landing", utm_campaign: "partner_SURF12" },
+      "ct=partner_qr",
+    ],
+  ])(
+    "normalizes %s App Store attribution",
+    async (_label, params, expected) => {
+      mockHeadersGet.mockReturnValue(IPHONE_UA);
+
+      await expect(
+        AppHandoffPage({
+          searchParams: Promise.resolve({
+            handoff_id: HANDOFF_ID,
+            ...params,
+          }),
+        }),
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(mockRedirect).toHaveBeenCalledWith(
+        expect.stringContaining(expected),
+      );
+    },
+  );
 
   it("logs and redirects Android visitors to the guided Android beta page", async () => {
     mockHeadersGet.mockReturnValue(ANDROID_UA);

--- a/__tests__/app/app-spot-handoff-page.test.tsx
+++ b/__tests__/app/app-spot-handoff-page.test.tsx
@@ -11,7 +11,7 @@ import AppSpotHandoffPage, {
   generateMetadata,
 } from "@/app/app/spot/[slug]/page";
 import * as handoffModule from "@/app/app/spot/[slug]/page";
-import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import { track } from "@/lib/analytics";
 
 jest.mock("@/lib/analytics", () => ({
@@ -49,8 +49,7 @@ function positiveMetadata(overrides: Record<string, unknown> = {}) {
     locationLabel: "La Jolla, CA",
     ogImagePath:
       "/api/og/forecast-window?slug=server-beach&window=2026-06-03T14%3A30%3A00.000Z",
-    appSpotPath:
-      "/app/spot/server-beach?window=2026-06-03T14%3A30%3A00.000Z",
+    appSpotPath: "/app/spot/server-beach?window=2026-06-03T14%3A30%3A00.000Z",
     isFallback: false,
     ...overrides,
   });
@@ -61,7 +60,8 @@ function firstOpenGraphImageUrl(
 ): string {
   const images = metadata.openGraph?.images;
   const image = Array.isArray(images) ? images[0] : images;
-  if (typeof image === "string" || image instanceof URL) return image.toString();
+  if (typeof image === "string" || image instanceof URL)
+    return image.toString();
   return image?.url?.toString() ?? "";
 }
 
@@ -191,7 +191,7 @@ describe("/app/spot/[slug] handoff page", () => {
 
     expect(
       screen.getByRole("link", { name: /open in the app store/i }),
-    ).toHaveAttribute("href", IOS_APP_STORE_URL);
+    ).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
     expect(
       screen.getByRole("link", { name: /continue on web/i }),
     ).toHaveAttribute("href", "/beach/ocean-beach");

--- a/__tests__/app/app-store-route.test.ts
+++ b/__tests__/app/app-store-route.test.ts
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+import { GET } from "@/app/app-store/route";
+
+describe("GET /app-store", () => {
+  const originalProviderToken = process.env.IOS_APP_STORE_PROVIDER_TOKEN;
+
+  afterEach(() => {
+    if (originalProviderToken === undefined) {
+      delete process.env.IOS_APP_STORE_PROVIDER_TOKEN;
+    } else {
+      process.env.IOS_APP_STORE_PROVIDER_TOKEN = originalProviderToken;
+    }
+  });
+
+  it.each(["web", "email", "partner_qr"])(
+    "redirects the %s campaign with provider attribution",
+    (campaign) => {
+      process.env.IOS_APP_STORE_PROVIDER_TOKEN = "123456";
+
+      const response = GET(
+        new NextRequest(`https://www.quiversurf.app/app-store?ct=${campaign}`),
+      );
+      const destination = new URL(response.headers.get("location") ?? "");
+
+      expect(response.status).toBe(307);
+      expect(destination.hostname).toBe("apps.apple.com");
+      expect(destination.searchParams.get("pt")).toBe("123456");
+      expect(destination.searchParams.get("ct")).toBe(campaign);
+      expect(destination.searchParams.get("mt")).toBe("8");
+    },
+  );
+
+  it("normalizes unknown campaigns to web", () => {
+    const response = GET(
+      new NextRequest("https://www.quiversurf.app/app-store?ct=one-off"),
+    );
+    const destination = new URL(response.headers.get("location") ?? "");
+
+    expect(destination.searchParams.get("ct")).toBe("web");
+  });
+});

--- a/__tests__/app/features-page.test.tsx
+++ b/__tests__/app/features-page.test.tsx
@@ -3,9 +3,8 @@ import type { ReactNode } from "react";
 
 import FeaturesPage, { metadata } from "@/app/features/page";
 import {
-  APP_FIRST_CAMPAIGN,
   IOS_APP_STORE_CTA,
-  iosAppStoreUrlWithCampaign,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 jest.mock("next/image", () => ({
@@ -97,9 +96,8 @@ describe("FeaturesPage", () => {
       name: new RegExp(IOS_APP_STORE_CTA, "i"),
     });
     expect(appStoreLinks).toHaveLength(2);
-    const expectedAppStoreUrl = iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN);
     appStoreLinks.forEach((link) => {
-      expect(link).toHaveAttribute("href", expectedAppStoreUrl);
+      expect(link).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
     });
 
     const androidWaitlistButtons = screen.getAllByTestId(
@@ -122,9 +120,7 @@ describe("FeaturesPage", () => {
     expect(
       screen.getByAltText(/home screen showing a session logging prompt/i),
     ).toBeInTheDocument();
-    expect(
-      screen.getByAltText(/custom spot editor/i),
-    ).toBeInTheDocument();
+    expect(screen.getByAltText(/custom spot editor/i)).toBeInTheDocument();
     expect(
       screen.getAllByAltText(/alerts screen/i).length,
     ).toBeGreaterThanOrEqual(1);

--- a/__tests__/app/invite/invite-landing-client.test.tsx
+++ b/__tests__/app/invite/invite-landing-client.test.tsx
@@ -4,6 +4,7 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { InviteLandingClient } from "@/app/invite/[token]/invite-landing-client";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 
 jest.mock("@/lib/utils/visitor-id", () => ({
   getVisitorId: () => "12345678-1234-1234-1234-123456789012",
@@ -86,7 +87,7 @@ describe("InviteLandingClient", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /open app store/i }),
-    ).toHaveAttribute("href", expect.stringContaining("apps.apple.com"));
+    ).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
     expect(
       screen.getByRole("link", { name: /already have the app/i }),
     ).toHaveAttribute("href", "quiver://invite/raw-token");
@@ -121,15 +122,21 @@ describe("InviteLandingClient", () => {
         }),
       }),
     );
-    expect(JSON.stringify(eventBody("invite_link_opened").metadata)).not.toContain("raw-token");
-    expect(JSON.stringify(eventBody("app_handoff_qr_rendered").metadata)).not.toContain("raw-token");
+    expect(
+      JSON.stringify(eventBody("invite_link_opened").metadata),
+    ).not.toContain("raw-token");
+    expect(
+      JSON.stringify(eventBody("app_handoff_qr_rendered").metadata),
+    ).not.toContain("raw-token");
   });
 
   it("tracks App Store and web fallback CTA clicks by destination type", async () => {
     render(<InviteLandingClient {...defaultProps} />);
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
 
-    clickWithoutNavigation(screen.getByRole("link", { name: /open app store/i }));
+    clickWithoutNavigation(
+      screen.getByRole("link", { name: /open app store/i }),
+    );
     expect(latestEventBody()).toEqual(
       expect.objectContaining({
         eventType: "invite_app_store_clicked",
@@ -142,7 +149,9 @@ describe("InviteLandingClient", () => {
       }),
     );
 
-    clickWithoutNavigation(screen.getByRole("link", { name: /continue on web/i }));
+    clickWithoutNavigation(
+      screen.getByRole("link", { name: /continue on web/i }),
+    );
     expect(latestEventBody()).toEqual(
       expect.objectContaining({
         eventType: "invite_continue_web_clicked",
@@ -161,9 +170,7 @@ describe("InviteLandingClient", () => {
     expect(
       await screen.findByText(/Android beta access is open/i),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/Open the iPhone app/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Open the iPhone app/i)).not.toBeInTheDocument();
 
     const androidCta = await screen.findByRole("button", {
       name: /get the android beta/i,

--- a/__tests__/app/p/partner-qr-landing-client.test.tsx
+++ b/__tests__/app/p/partner-qr-landing-client.test.tsx
@@ -81,16 +81,18 @@ describe("PartnerQrLandingClient", () => {
     expect(svg).toHaveAttribute("data-smart-url", defaultProps.qrUrl);
   });
 
-  it("links App Store clicks with a per-partner campaign token", () => {
+  it("links App Store clicks with the shared low-volume partner campaign", () => {
     render(<PartnerQrLandingClient {...defaultProps} />);
 
     const appStoreUrl = new URL(
-      screen.getByRole("link", { name: /open app store/i }).getAttribute("href") ??
-        "",
+      screen
+        .getByRole("link", { name: /open app store/i })
+        .getAttribute("href") ?? "",
+      "https://www.quiversurf.app",
     );
 
-    expect(appStoreUrl.searchParams.get("ct")).toBe("partner_SURF12");
-    expect(appStoreUrl.searchParams.get("mt")).toBe("8");
+    expect(appStoreUrl.pathname).toBe("/app-store");
+    expect(appStoreUrl.searchParams.get("ct")).toBe("partner_qr");
   });
 
   it("fires app_handoff_qr_rendered and invite_link_opened on mount with partner metadata", async () => {

--- a/__tests__/app/root-app-store-metadata.test.ts
+++ b/__tests__/app/root-app-store-metadata.test.ts
@@ -6,15 +6,15 @@ import { metadata } from "@/app/layout";
 
 describe("root App Store metadata", () => {
   it("emits the Apple Smart App Banner app id and attributed app argument", () => {
-    const appArgument = new URL(String(metadata.itunes?.appArgument));
+    const content = String(metadata.other?.["apple-itunes-app"]);
+    const appArgumentValue = content.match(/app-argument=([^,]+)/)?.[1];
+    const appArgument = new URL(String(appArgumentValue));
 
-    expect(metadata.itunes?.appId).toBe("6759300320");
+    expect(content).toContain("app-id=6759300320");
     expect(appArgument.origin + appArgument.pathname).toBe(
       "https://www.quiversurf.app/app",
     );
-    expect(appArgument.searchParams.get("source")).toBe(
-      "ios_smart_app_banner",
-    );
+    expect(appArgument.searchParams.get("source")).toBe("ios_smart_app_banner");
     expect(appArgument.searchParams.get("utm_campaign")).toBe("app_first_v1");
   });
 });

--- a/__tests__/components/app-store/ios-app-store-cta.test.tsx
+++ b/__tests__/components/app-store/ios-app-store-cta.test.tsx
@@ -2,10 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { IosAppStoreCta } from "@/components/app-store/ios-app-store-cta";
-import {
-  APP_FIRST_CAMPAIGN,
-  iosAppStoreUrlWithCampaign,
-} from "@/lib/constants/app-store";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import { IOS_APP_STORE_CTA } from "@/lib/constants/app-store";
 import { trackIosAppCtaClick } from "@/lib/analytics/ios-app-cta-tracking";
 
@@ -17,7 +14,7 @@ jest.mock("@/lib/analytics/ios-app-cta-tracking", () => ({
 describe("IosAppStoreCta", () => {
   it("uses the campaign-tagged App Store URL for href and click analytics", async () => {
     const user = userEvent.setup();
-    const destinationUrl = iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN);
+    const destinationUrl = IOS_APP_STORE_WEB_REDIRECT_PATH;
 
     render(
       <IosAppStoreCta

--- a/__tests__/components/app-store/iphone-app-banner.test.tsx
+++ b/__tests__/components/app-store/iphone-app-banner.test.tsx
@@ -6,7 +6,7 @@ import { IPHONE_APP_BANNER_DISMISSAL_STORAGE_KEY } from "@/lib/app-store/iphone-
 import {
   IOS_APP_STORE_CTA,
   IOS_APP_STORE_DESTINATION_STATUS,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 jest.mock("next/navigation", () => ({
@@ -65,17 +65,17 @@ describe("IphoneAppBanner", () => {
           cta_text: IOS_APP_STORE_CTA,
           destination_type: "app_store",
           destination_status: IOS_APP_STORE_DESTINATION_STATUS,
-          destination_url: IOS_APP_STORE_URL,
+          destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
           browser: "chrome_ios",
           pathname: "/map",
-        })
+        }),
       );
       expect(mockedTrack).toHaveBeenCalledWith(
         "iphone_app_banner_view",
         expect.objectContaining({
           browser: "chrome_ios",
           pathname: "/map",
-        })
+        }),
       );
     });
   });
@@ -86,7 +86,7 @@ describe("IphoneAppBanner", () => {
     const cta = await screen.findByRole("link", {
       name: IOS_APP_STORE_CTA,
     });
-    expect(cta).toHaveAttribute("href", IOS_APP_STORE_URL);
+    expect(cta).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
 
     fireEvent.click(cta);
 
@@ -97,8 +97,8 @@ describe("IphoneAppBanner", () => {
         pathname: "/map",
         cta_text: IOS_APP_STORE_CTA,
         destination_status: IOS_APP_STORE_DESTINATION_STATUS,
-        destination_url: IOS_APP_STORE_URL,
-      })
+        destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
+      }),
     );
   });
 
@@ -108,19 +108,19 @@ describe("IphoneAppBanner", () => {
     fireEvent.click(
       await screen.findByRole("button", {
         name: "Dismiss iPhone app banner",
-      })
+      }),
     );
 
     expect(screen.queryByTestId("iphone-app-banner")).not.toBeInTheDocument();
     expect(
-      window.localStorage.getItem(IPHONE_APP_BANNER_DISMISSAL_STORAGE_KEY)
+      window.localStorage.getItem(IPHONE_APP_BANNER_DISMISSAL_STORAGE_KEY),
     ).not.toBeNull();
     expect(mockedTrack).toHaveBeenCalledWith(
       "iphone_app_banner_dismiss",
       expect.objectContaining({
         browser: "chrome_ios",
         pathname: "/map",
-      })
+      }),
     );
   });
 
@@ -136,7 +136,7 @@ describe("IphoneAppBanner", () => {
         expect.objectContaining({
           browser: "safari",
           pathname: "/map",
-        })
+        }),
       );
       expect(mockedTrack).toHaveBeenCalledWith(
         "iphone_app_banner_suppressed",
@@ -144,7 +144,7 @@ describe("IphoneAppBanner", () => {
           browser: "safari",
           pathname: "/map",
           suppression_reason: "safari_native_banner",
-        })
+        }),
       );
     });
   });
@@ -161,7 +161,7 @@ describe("IphoneAppBanner", () => {
         expect.objectContaining({
           suppression_reason: "excluded_route",
           pathname: "/",
-        })
+        }),
       );
     });
   });

--- a/__tests__/components/landing-page/cta-section.test.tsx
+++ b/__tests__/components/landing-page/cta-section.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/analytics/ios-app-cta-tracking";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import {
   trackSignupCtaClick,
@@ -116,9 +116,7 @@ describe("CTASection", () => {
       />,
     );
 
-    await user.click(
-      screen.getByRole("button", { name: /get my surf call/i }),
-    );
+    await user.click(screen.getByRole("button", { name: /get my surf call/i }));
 
     expect(mockTrackSignupCtaClick).toHaveBeenCalledWith({
       source: "landing-final-cta",
@@ -136,12 +134,7 @@ describe("CTASection", () => {
   it("renders and tracks the App Store CTA variant", async () => {
     const user = userEvent.setup();
 
-    render(
-      <CTASection
-        source="landing-final-cta"
-        variant="app-store"
-      />,
-    );
+    render(<CTASection source="landing-final-cta" variant="app-store" />);
 
     await waitFor(() => {
       expect(mockTrackIosAppCtaView).toHaveBeenCalledWith({
@@ -156,11 +149,9 @@ describe("CTASection", () => {
     });
     link.addEventListener("click", (event) => event.preventDefault());
 
-    expect(link).toHaveAttribute("href", IOS_APP_STORE_URL);
+    expect(link).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
     expect(
-      screen.getByText(
-        "Opens the current iPhone App Store listing.",
-      ),
+      screen.getByText("Opens the current iPhone App Store listing."),
     ).toBeInTheDocument();
 
     await user.click(link);
@@ -170,7 +161,7 @@ describe("CTASection", () => {
       surface: "landing-page",
       placement: "landing_final_cta",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
     });
     expect(mockTrackSignupCtaClick).not.toHaveBeenCalled();
     expect(screen.queryByTestId("auth-modal")).not.toBeInTheDocument();

--- a/__tests__/components/landing-page/forecast-section.test.tsx
+++ b/__tests__/components/landing-page/forecast-section.test.tsx
@@ -7,7 +7,10 @@ import {
   trackIosAppCtaClick,
   trackIosAppCtaView,
 } from "@/lib/analytics/ios-app-cta-tracking";
-import { IOS_APP_STORE_CTA, IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import {
+  IOS_APP_STORE_CTA,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
+} from "@/lib/constants/app-store";
 
 jest.mock("next/image", () => ({
   __esModule: true,
@@ -96,7 +99,9 @@ describe("ForecastSection", () => {
     await user.click(screen.getAllByRole("tab", { name: /check/i })[0]);
 
     expect(
-      screen.getByRole("heading", { name: /check the beach before you commit/i }),
+      screen.getByRole("heading", {
+        name: /check the beach before you commit/i,
+      }),
     ).toBeInTheDocument();
     expect(screen.getByText(/ground-truth the call/i)).toBeInTheDocument();
   });
@@ -115,7 +120,7 @@ describe("ForecastSection", () => {
 
     const cta = screen.getByRole("link", { name: IOS_APP_STORE_CTA });
     cta.addEventListener("click", (event) => event.preventDefault());
-    expect(cta).toHaveAttribute("href", IOS_APP_STORE_URL);
+    expect(cta).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
 
     await user.click(cta);
 
@@ -124,7 +129,7 @@ describe("ForecastSection", () => {
       surface: "landing-page",
       placement: "forecast_section",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
     });
   });
 });

--- a/__tests__/components/landing/hero-section.test.tsx
+++ b/__tests__/components/landing/hero-section.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HeroSection } from "@/components/landing-page/hero-section";
 import { useAuth } from "@/context/auth-context";
@@ -9,7 +15,10 @@ import {
   trackIosAppCtaClick,
   trackIosAppCtaView,
 } from "@/lib/analytics/ios-app-cta-tracking";
-import { IOS_APP_STORE_CTA, IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import {
+  IOS_APP_STORE_CTA,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
+} from "@/lib/constants/app-store";
 import { trackAppHandoffView } from "@/lib/analytics/app-handoff-tracking";
 
 jest.mock("next/image", () => ({
@@ -138,7 +147,7 @@ function setMediaState(
     readyState?: number;
     networkState?: number;
     currentSrc?: string;
-  } = {}
+  } = {},
 ) {
   Object.defineProperty(video, "error", {
     configurable: true,
@@ -161,8 +170,7 @@ function setMediaState(
   });
   Object.defineProperty(video, "currentSrc", {
     configurable: true,
-    value:
-      overrides.currentSrc ?? "/videos/quiver-landing-hero-1280.mp4",
+    value: overrides.currentSrc ?? "/videos/quiver-landing-hero-1280.mp4",
   });
 }
 
@@ -217,10 +225,9 @@ describe("HeroSection", () => {
     expect(cta).toHaveAttribute("data-source", "landing_hero");
     expect(cta).toHaveAttribute("data-surface", "landing-page");
     expect(cta).toHaveAttribute("data-placement", "hero_primary");
-    expect(screen.getByRole("link", { name: /see how it works/i })).toHaveAttribute(
-      "href",
-      "#proof",
-    );
+    expect(
+      screen.getByRole("link", { name: /see how it works/i }),
+    ).toHaveAttribute("href", "#proof");
 
     await waitFor(() => {
       expect(mockTrackAppHandoffView).toHaveBeenCalledWith(
@@ -274,7 +281,7 @@ describe("HeroSection", () => {
     fireEvent.ended(video);
 
     const link = await screen.findByRole("link", { name: IOS_APP_STORE_CTA });
-    expect(link).toHaveAttribute("href", IOS_APP_STORE_URL);
+    expect(link).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
   });
 
   it("tracks the hero video overlay button view after the video ends", async () => {
@@ -292,7 +299,7 @@ describe("HeroSection", () => {
         surface: "landing-page",
         placement: "hero_video_overlay",
         cta_text: IOS_APP_STORE_CTA,
-        destination_url: IOS_APP_STORE_URL,
+        destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
         video_loaded: true,
         video_completed: true,
       });
@@ -317,7 +324,7 @@ describe("HeroSection", () => {
       surface: "landing-page",
       placement: "hero_video_overlay",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
       video_loaded: true,
       video_completed: true,
     });
@@ -329,7 +336,7 @@ describe("HeroSection", () => {
     render(<HeroSection />);
 
     const link = await screen.findByRole("link", { name: IOS_APP_STORE_CTA });
-    expect(link).toHaveAttribute("href", IOS_APP_STORE_URL);
+    expect(link).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
   });
 
   it("does not render the video immediately so the poster can paint first", () => {
@@ -387,7 +394,7 @@ describe("HeroSection", () => {
     });
     expect(mockTrack).not.toHaveBeenCalledWith(
       "landing_hero_video_failed_to_start",
-      expect.anything()
+      expect.anything(),
     );
 
     jest.useRealTimers();
@@ -422,11 +429,11 @@ describe("HeroSection", () => {
 
     expect(mockTrack).toHaveBeenCalledWith(
       "landing_hero_video_error",
-      expectedMetadata
+      expectedMetadata,
     );
     expect(mockTrack).toHaveBeenCalledWith(
       "landing_hero_video_failed_to_start",
-      expectedMetadata
+      expectedMetadata,
     );
   });
 
@@ -440,12 +447,14 @@ describe("HeroSection", () => {
     fireEvent.error(video);
 
     expect(
-      mockTrack.mock.calls.filter(([event]) => event === "landing_hero_video_error")
+      mockTrack.mock.calls.filter(
+        ([event]) => event === "landing_hero_video_error",
+      ),
     ).toHaveLength(1);
     expect(
       mockTrack.mock.calls.filter(
-        ([event]) => event === "landing_hero_video_failed_to_start"
-      )
+        ([event]) => event === "landing_hero_video_failed_to_start",
+      ),
     ).toHaveLength(1);
   });
 
@@ -456,7 +465,7 @@ describe("HeroSection", () => {
     await mountLazyVideo();
 
     expect(
-      screen.queryByRole("link", { name: IOS_APP_STORE_CTA })
+      screen.queryByRole("link", { name: IOS_APP_STORE_CTA }),
     ).not.toBeInTheDocument();
 
     act(() => {
@@ -472,10 +481,10 @@ describe("HeroSection", () => {
         has_loaded: false,
         has_started: false,
         visibility_state: "visible",
-      })
+      }),
     );
     expect(
-      screen.getByRole("link", { name: IOS_APP_STORE_CTA })
+      screen.getByRole("link", { name: IOS_APP_STORE_CTA }),
     ).toBeInTheDocument();
   });
 
@@ -492,7 +501,7 @@ describe("HeroSection", () => {
 
     expect(mockTrack).not.toHaveBeenCalledWith(
       "landing_hero_video_failed_to_start",
-      expect.anything()
+      expect.anything(),
     );
   });
 
@@ -508,11 +517,11 @@ describe("HeroSection", () => {
     });
 
     expect(
-      screen.queryByRole("link", { name: IOS_APP_STORE_CTA })
+      screen.queryByRole("link", { name: IOS_APP_STORE_CTA }),
     ).not.toBeInTheDocument();
     expect(mockTrack).not.toHaveBeenCalledWith(
       "landing_hero_video_failed_to_start",
-      expect.anything()
+      expect.anything(),
     );
 
     act(() => {
@@ -521,11 +530,11 @@ describe("HeroSection", () => {
     });
 
     expect(
-      screen.getByRole("link", { name: IOS_APP_STORE_CTA })
+      screen.getByRole("link", { name: IOS_APP_STORE_CTA }),
     ).toBeInTheDocument();
     expect(mockTrack).not.toHaveBeenCalledWith(
       "landing_hero_video_failed_to_start",
-      expect.anything()
+      expect.anything(),
     );
 
     act(() => {
@@ -541,7 +550,7 @@ describe("HeroSection", () => {
         has_loaded: false,
         has_started: false,
         visibility_state: "visible",
-      })
+      }),
     );
   });
 
@@ -553,7 +562,7 @@ describe("HeroSection", () => {
 
     expect(video).toHaveAttribute(
       "src",
-      "/videos/quiver-landing-hero-1280.mp4"
+      "/videos/quiver-landing-hero-1280.mp4",
     );
     expect(video.querySelector("source")).not.toBeInTheDocument();
   });
@@ -574,9 +583,6 @@ describe("HeroSection", () => {
 
     const video = await mountLazyVideo();
 
-    expect(video).toHaveAttribute(
-      "src",
-      "/videos/quiver-landing-hero-720.mp4"
-    );
+    expect(video).toHaveAttribute("src", "/videos/quiver-landing-hero-720.mp4");
   });
 });

--- a/__tests__/components/pricing/founding-offer-surface.test.tsx
+++ b/__tests__/components/pricing/founding-offer-surface.test.tsx
@@ -1,13 +1,11 @@
 import { render, screen } from "@testing-library/react";
 
 import { FoundingOfferSurface } from "@/components/pricing/founding-offer-surface";
-import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 
 jest.mock("@/components/pricing/founding-access-cta", () => ({
   FoundingAccessCta: () => (
-    <div data-testid="founding-access-cta">
-      Get the Android beta
-    </div>
+    <div data-testid="founding-access-cta">Get the Android beta</div>
   ),
 }));
 
@@ -31,9 +29,7 @@ describe("FoundingOfferSurface", () => {
         name: /get quiver/i,
       }),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/14 days free/i).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/14 days free/i).length).toBeGreaterThan(0);
     expect(
       screen.getByText(/app store shows the current plan/i),
     ).toBeInTheDocument();
@@ -48,10 +44,8 @@ describe("FoundingOfferSurface", () => {
     expect(screen.queryByText(/android waitlist/i)).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /open app store/i }),
-    ).toHaveAttribute("href", IOS_APP_STORE_URL);
-    expect(
-      screen.getByText("iPhone"),
-    ).toBeInTheDocument();
+    ).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
+    expect(screen.getByText("iPhone")).toBeInTheDocument();
     expect(screen.getAllByText(/app store live/i).length).toBeGreaterThan(0);
     expect(screen.getByTestId("founding-access-cta")).toBeInTheDocument();
 

--- a/__tests__/components/send-to-phone-cta.test.tsx
+++ b/__tests__/components/send-to-phone-cta.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { SendToPhoneCta } from "@/components/app-store/send-to-phone-cta";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import {
   trackAppHandoffEmailSent,
   trackAppHandoffEmailSubmit,
@@ -48,7 +49,9 @@ describe("SendToPhoneCta", () => {
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByText(/send link/i)).toBeInTheDocument();
     expect(screen.queryByText("quiversurf.app/app")).not.toBeInTheDocument();
-    expect(screen.queryByText(/utm_medium=desktop_handoff/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/utm_medium=desktop_handoff/i),
+    ).not.toBeInTheDocument();
     expect(screen.getByText(/open app store anyway/i)).toBeInTheDocument();
 
     await waitFor(() => {
@@ -83,9 +86,7 @@ describe("SendToPhoneCta", () => {
     const fallback = screen.getByRole("link", {
       name: /open app store anyway/i,
     });
-    expect(fallback.getAttribute("href")).toMatch(
-      /^https:\/\/apps\.apple\.com\//,
-    );
+    expect(fallback).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
   });
 
   it("adds the rollout cohort to QR render tracking when provided", () => {

--- a/__tests__/components/session-intelligence/app-deep-link-cta.test.tsx
+++ b/__tests__/components/session-intelligence/app-deep-link-cta.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { AppDeepLinkCTA } from "@/components/session-intelligence";
-import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import type { SurfWindowLinks } from "@/types/session-intelligence";
 
 const mockTrack = jest.fn();
@@ -18,13 +18,15 @@ function preventAnchorNavigation(): () => void {
     }
   };
   document.addEventListener("click", handler, { capture: true });
-  return () => document.removeEventListener("click", handler, { capture: true });
+  return () =>
+    document.removeEventListener("click", handler, { capture: true });
 }
 
 function makeLinks(overrides: Partial<SurfWindowLinks> = {}): SurfWindowLinks {
   return {
     appDeepLink: "/app/spot/ocean-beach?window=window-1",
-    universalLink: "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1",
+    universalLink:
+      "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1",
     canonicalWebUrl: "https://www.quiversurf.app/ca/san-diego/ocean-beach",
     ...overrides,
   };
@@ -46,19 +48,20 @@ describe("AppDeepLinkCTA", () => {
   it("prefers universal links", () => {
     render(<AppDeepLinkCTA links={makeLinks()} />);
 
-    expect(screen.getByRole("link", { name: "Open this window in Quiver" })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: "Open this window in Quiver" }),
+    ).toHaveAttribute(
       "href",
-      "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1"
+      "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1",
     );
   });
 
   it("falls back to app deep link when universal link is unavailable", () => {
     render(<AppDeepLinkCTA links={makeLinks({ universalLink: null })} />);
 
-    expect(screen.getByRole("link", { name: "Open this window in Quiver" })).toHaveAttribute(
-      "href",
-      "/app/spot/ocean-beach?window=window-1"
-    );
+    expect(
+      screen.getByRole("link", { name: "Open this window in Quiver" }),
+    ).toHaveAttribute("href", "/app/spot/ocean-beach?window=window-1");
   });
 
   it("falls back to App Store URL when recommendation links are unavailable", () => {
@@ -68,18 +71,18 @@ describe("AppDeepLinkCTA", () => {
           appDeepLink: null,
           universalLink: null,
         })}
-      />
+      />,
     );
 
-    expect(screen.getByRole("link", { name: "Open App Store" })).toHaveAttribute(
-      "href",
-      IOS_APP_STORE_URL
-    );
+    expect(
+      screen.getByRole("link", { name: "Open App Store" }),
+    ).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
   });
 
   it("tracks surf-window and app-deeplink clicks with fallback context", async () => {
     const user = userEvent.setup();
-    const targetHref = "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1";
+    const targetHref =
+      "https://www.quiversurf.app/app/spot/ocean-beach?window=window-1";
 
     render(
       <AppDeepLinkCTA
@@ -92,10 +95,12 @@ describe("AppDeepLinkCTA", () => {
           windowId: "window-1",
           rank: 1,
         }}
-      />
+      />,
     );
 
-    await user.click(screen.getByRole("link", { name: "Open this window in Quiver" }));
+    await user.click(
+      screen.getByRole("link", { name: "Open this window in Quiver" }),
+    );
 
     const expectedPayload = {
       beachId: "beach-1",
@@ -112,8 +117,14 @@ describe("AppDeepLinkCTA", () => {
       }),
       debounceMs: 0,
     };
-    expect(mockTrack).toHaveBeenCalledWith("surf_window_click", expectedPayload);
-    expect(mockTrack).toHaveBeenCalledWith("app_deeplink_clicked", expectedPayload);
+    expect(mockTrack).toHaveBeenCalledWith(
+      "surf_window_click",
+      expectedPayload,
+    );
+    expect(mockTrack).toHaveBeenCalledWith(
+      "app_deeplink_clicked",
+      expectedPayload,
+    );
   });
 
   it("tracks App Store fallback clicks", async () => {
@@ -126,7 +137,7 @@ describe("AppDeepLinkCTA", () => {
           surface: "dev_preview",
           windowId: "window-1",
         }}
-      />
+      />,
     );
 
     await user.click(screen.getByRole("link", { name: "Open App Store" }));
@@ -135,7 +146,7 @@ describe("AppDeepLinkCTA", () => {
       metadata: expect.objectContaining({
         surface: "dev_preview",
         window_id: "window-1",
-        target_href: IOS_APP_STORE_URL,
+        target_href: IOS_APP_STORE_WEB_REDIRECT_PATH,
         link_type: "app_store",
         fallback_to_app_store: true,
       }),

--- a/__tests__/lib/analytics/ios-app-cta-tracking.test.ts
+++ b/__tests__/lib/analytics/ios-app-cta-tracking.test.ts
@@ -6,10 +6,9 @@ import {
 } from "@/lib/analytics/ios-app-cta-tracking";
 import { track } from "@/lib/analytics";
 import {
-  APP_FIRST_CAMPAIGN,
   IOS_APP_STORE_CTA,
   IOS_APP_STORE_DESTINATION_STATUS,
-  iosAppStoreUrlWithCampaign,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 jest.mock("@/lib/analytics", () => ({
@@ -22,8 +21,7 @@ jest.mock("@/lib/utils/visitor-id", () => ({
 
 const mockFetch = jest.fn(() => Promise.resolve({ ok: true } as Response));
 const mockTrack = track as jest.Mock;
-const IOS_APP_STORE_CAMPAIGN_URL =
-  iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN);
+const IOS_APP_STORE_CAMPAIGN_URL = IOS_APP_STORE_WEB_REDIRECT_PATH;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -138,7 +136,7 @@ describe("ios-app-cta-tracking", () => {
         page_type: "city_water_temp",
         query_intent: "water_temp",
         seo_landing_page: true,
-      })
+      }),
     );
   });
 });

--- a/__tests__/lib/constants/app-handoff.test.ts
+++ b/__tests__/lib/constants/app-handoff.test.ts
@@ -43,9 +43,7 @@ describe("app-handoff constants", () => {
     expect(path).toContain("source=landing_hero");
     expect(path).toContain("surface=landing-page");
     expect(path).toContain("placement=hero_primary");
-    expect(path).toContain(
-      "handoff_id=33333333-3333-4333-8333-333333333333",
-    );
+    expect(path).toContain("handoff_id=33333333-3333-4333-8333-333333333333");
     expect(path).toContain("qr_id=hero_qr");
     expect(path).toContain("target=download");
     expect(path).toContain("utm_source=qr");
@@ -85,9 +83,9 @@ describe("app-handoff constants", () => {
   });
 
   it("appends Apple campaign tokens to the App Store URL", () => {
-    const url = iosAppStoreUrlWithCampaign("app_first_v1");
+    const url = iosAppStoreUrlWithCampaign("web");
     expect(url.startsWith(IOS_APP_STORE_URL)).toBe(true);
-    expect(url).toContain("ct=app_first_v1");
+    expect(url).toContain("ct=web");
     expect(url).toContain("mt=8");
   });
 });

--- a/__tests__/lib/constants/app-store.test.ts
+++ b/__tests__/lib/constants/app-store.test.ts
@@ -6,11 +6,16 @@ import {
   ANDROID_BETA_LANDING_URL,
   ANDROID_BETA_PLAY_URL,
   IOS_APP_STORE_APP_ID,
+  IOS_APP_STORE_CAMPAIGNS,
   IOS_APP_STORE_CTA,
   IOS_APP_STORE_DESTINATION_STATUS,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
   IOS_APP_STORE_SMART_BANNER_ARGUMENT,
   IOS_APP_STORE_URL,
+  buildIosAppStoreRedirectPath,
+  buildIosSmartAppBannerContent,
   iosAppStoreUrlWithCampaign,
+  resolveIosAppStoreCampaign,
 } from "@/lib/constants/app-store";
 
 describe("app-store constants", () => {
@@ -71,24 +76,61 @@ describe("app-store constants", () => {
   });
 
   it("builds campaign URLs with App Store app-link attribution", () => {
-    delete process.env.IOS_APP_STORE_PROVIDER_TOKEN;
-
-    const url = iosAppStoreUrlWithCampaign("app_first_v1");
+    const url = iosAppStoreUrlWithCampaign(IOS_APP_STORE_CAMPAIGNS.WEB);
     const parsed = new URL(url);
 
     expect(parsed.origin + parsed.pathname).toBe(IOS_APP_STORE_URL);
-    expect(parsed.searchParams.get("ct")).toBe("app_first_v1");
+    expect(parsed.searchParams.get("ct")).toBe("web");
     expect(parsed.searchParams.get("mt")).toBe("8");
   });
 
   it("preserves the optional App Store provider token", () => {
-    process.env.IOS_APP_STORE_PROVIDER_TOKEN = "123456";
-
-    const url = iosAppStoreUrlWithCampaign("app_first_v1");
+    const url = iosAppStoreUrlWithCampaign(
+      IOS_APP_STORE_CAMPAIGNS.EMAIL,
+      "123456",
+    );
     const parsed = new URL(url);
 
     expect(parsed.searchParams.get("pt")).toBe("123456");
-    expect(parsed.searchParams.get("ct")).toBe("app_first_v1");
+    expect(parsed.searchParams.get("ct")).toBe("email");
     expect(parsed.searchParams.get("mt")).toBe("8");
+  });
+
+  it("omits malformed provider tokens", () => {
+    const url = new URL(
+      iosAppStoreUrlWithCampaign(IOS_APP_STORE_CAMPAIGNS.WEB, "not-a-token"),
+    );
+
+    expect(url.searchParams.has("pt")).toBe(false);
+  });
+
+  it("builds server redirect paths without exposing the provider token", () => {
+    expect(IOS_APP_STORE_WEB_REDIRECT_PATH).toBe("/app-store?ct=web");
+    expect(buildIosAppStoreRedirectPath(IOS_APP_STORE_CAMPAIGNS.EMAIL)).toBe(
+      "/app-store?ct=email",
+    );
+  });
+
+  it("adds Apple campaign attribution to Smart App Banner metadata", () => {
+    const content = buildIosSmartAppBannerContent("123456");
+
+    expect(content).toContain("app-id=6759300320");
+    expect(content).toContain("affiliate-data=pt=123456&ct=web");
+    expect(content).toContain(
+      `app-argument=${IOS_APP_STORE_SMART_BANNER_ARGUMENT}`,
+    );
+  });
+
+  it("normalizes Apple attribution to three low-volume campaigns", () => {
+    expect(resolveIosAppStoreCampaign({ campaign: "email" })).toBe("email");
+    expect(
+      resolveIosAppStoreCampaign({
+        campaign: "partner_sandys",
+        surface: "partner_landing",
+      }),
+    ).toBe("partner_qr");
+    expect(resolveIosAppStoreCampaign({ campaign: "one-off-experiment" })).toBe(
+      "web",
+    );
   });
 });

--- a/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
+++ b/__tests__/lib/seo/agent-workflow/weekly-report.test.ts
@@ -1,4 +1,7 @@
-import { renderWeeklySeoReport } from "@/lib/seo/agent-workflow/weekly-report";
+import {
+  buildWeeklySeoComparison,
+  renderWeeklySeoReport,
+} from "@/lib/seo/agent-workflow/weekly-report";
 
 function extractSection(report: string, heading: string): string {
   const start = report.indexOf(heading);
@@ -9,6 +12,122 @@ function extractSection(report: string, heading: string): string {
 }
 
 describe("SEO workflow weekly report", () => {
+  it("renders source freshness, week-over-week movement, and Ahrefs issues under technical health", () => {
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-08-10T12:00:00Z",
+      auditDate: "2026-08-10",
+      recommendations: [{
+        id: "ahrefs-missing-alt-text-root",
+        createdAt: "2026-08-10T12:00:00Z",
+        source: "ahrefs-audit",
+        priority: "medium",
+        canonicalPath: "/",
+        summary: "Ahrefs found missing alt text on 299 crawled URLs.",
+        evidence: ["affectedUrls=299"],
+        status: "open",
+      }],
+      sourceFreshness: [{
+        source: "Competitor deep-dive",
+        observedAt: "2026-07-27",
+        status: "stale",
+        note: "run date 2026-07-27 (14 days old)",
+      }],
+      weekOverWeek: {
+        previousAuditDate: "2026-08-03",
+        metrics: [{
+          label: "GSC clicks (28d vs prior report)",
+          current: 998,
+          previous: 1034,
+          unit: "clicks",
+        }],
+      },
+      technical: [],
+      missing: [],
+    });
+
+    expect(report).toContain("## Source Freshness");
+    expect(report).toContain("Competitor deep-dive: STALE (2026-07-27)");
+    expect(report).toContain("## Week-over-Week Movement");
+    expect(report).toContain("GSC clicks (28d vs prior report): 998 clicks; prior 1,034; change -36 (-3.5%).");
+    expect(extractSection(report, "## Technical Crawl Health")).toContain(
+      "MEDIUM: `/` - Ahrefs found missing alt text on 299 crawled URLs.",
+    );
+    expect(report).not.toContain("No technical crawl issues in available inputs.");
+  });
+
+  // Site-audit findings previously matched both the technical merge and the
+  // keyword-movement filter, so every one of them printed twice in the report.
+  it("routes each ahrefs-audit finding to exactly one section", () => {
+    const base = {
+      createdAt: "2026-08-10T12:00:00Z",
+      source: "ahrefs-audit" as const,
+      priority: "medium" as const,
+      canonicalPath: "/",
+      evidence: [],
+      status: "open" as const,
+    };
+    const report = renderWeeklySeoReport({
+      generatedAt: "2026-08-10T12:00:00Z",
+      auditDate: "2026-08-10",
+      recommendations: [
+        { ...base, id: "ahrefs-noindex-sitemap", summary: "SITE_AUDIT_FINDING" },
+        {
+          ...base,
+          id: "ahrefs-keyword-gap",
+          summary: "KEYWORD_FINDING",
+          targetKeyword: "surf report san diego",
+        },
+      ],
+      technical: [],
+      missing: [],
+    });
+
+    const technicalSection = extractSection(report, "## Technical Crawl Health");
+    const keywordSection = extractSection(report, "## Keyword / Ranking Movement");
+
+    // A finding with no target keyword belongs to technical health only.
+    expect(technicalSection).toContain("SITE_AUDIT_FINDING");
+    expect(keywordSection).not.toContain("SITE_AUDIT_FINDING");
+
+    // A keyword-targeted finding belongs to ranking movement only.
+    expect(keywordSection).toContain("KEYWORD_FINDING");
+    expect(technicalSection).not.toContain("KEYWORD_FINDING");
+
+    // Belt and braces: neither summary appears more than once in the whole report.
+    expect(report.split("SITE_AUDIT_FINDING").length - 1).toBe(1);
+    expect(report.split("KEYWORD_FINDING").length - 1).toBe(1);
+  });
+
+  it("builds seven-day week-over-week metrics from the current GSC export", () => {
+    const comparison = buildWeeklySeoComparison({
+      generatedAt: "2026-08-10T12:00:00Z",
+      recommendations: [],
+      missing: [],
+      gsc: {
+        generatedAt: "2026-08-10T12:00:00Z",
+        siteUrl: "https://www.quiversurf.app/",
+        dateRanges: {
+          last7d: { start: "2026-08-04", end: "2026-08-10" },
+          prior7d: { start: "2026-07-28", end: "2026-08-03" },
+          last28d: { start: "2026-07-14", end: "2026-08-10" },
+        },
+        last7d: [{ page: "/", clicks: 12, impressions: 120 }],
+        prior7d: [{ page: "/", clicks: 8, impressions: 100 }],
+        last28d: [],
+        sitemapPaths: [],
+        topQueries: [],
+        topPages: [],
+        byDevice: [],
+        byCountry: [],
+      },
+    });
+
+    expect(comparison?.metrics).toEqual(expect.arrayContaining([
+      { label: "GSC clicks (last 7d vs prior 7d)", current: 12, previous: 8, unit: "clicks" },
+      { label: "GSC impressions (last 7d vs prior 7d)", current: 120, previous: 100, unit: "impressions" },
+    ]));
+  });
+
   it("renders required sections and free-data limitations with partial inputs", () => {
     const report = renderWeeklySeoReport({
       generatedAt: "2026-05-20T12:00:00Z",

--- a/__tests__/lib/services/indexnow-service.test.ts
+++ b/__tests__/lib/services/indexnow-service.test.ts
@@ -1,5 +1,8 @@
 import { SITE_URL } from "@/lib/constants/seo";
-import { submitUrlsToIndexNow } from "@/lib/services/indexnow-service";
+import {
+  submitUrlsInBatches,
+  submitUrlsToIndexNow,
+} from "@/lib/services/indexnow-service";
 
 describe("IndexNow service", () => {
   const originalFetch = global.fetch;
@@ -24,5 +27,105 @@ describe("IndexNow service", () => {
     };
 
     expect(body.keyLocation).toBe(`${SITE_URL}/indexnow-key.txt`);
+  });
+
+  // Observed against the live API on 2026-08-10: a key that does not match the
+  // verification file returns 403 *or* 202, not reliably an error. Counting 202
+  // as delivered made a wrong key indistinguishable from a working one.
+  describe("delivery accounting", () => {
+    const urls = [`${SITE_URL}/water-temp/corolla`];
+
+    function mockStatus(status: number) {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ status }) as unknown as typeof fetch;
+    }
+
+    beforeEach(() => {
+      process.env.INDEXNOW_KEY = "test-indexnow-key";
+    });
+
+    it("counts a 200 as verified delivery", async () => {
+      mockStatus(200);
+      const result = await submitUrlsToIndexNow(urls);
+      expect(result).toMatchObject({
+        success: true,
+        statusCode: 200,
+        submitted: 1,
+        pending: 0,
+      });
+    });
+
+    it("counts a 202 as pending, not as delivered", async () => {
+      mockStatus(202);
+      const result = await submitUrlsToIndexNow(urls);
+      expect(result).toMatchObject({
+        success: true,
+        statusCode: 202,
+        submitted: 0,
+        pending: 1,
+      });
+    });
+
+    it("counts a 403 as neither delivered nor pending", async () => {
+      mockStatus(403);
+      const result = await submitUrlsToIndexNow(urls);
+      expect(result).toMatchObject({
+        success: false,
+        statusCode: 403,
+        submitted: 0,
+        pending: 0,
+      });
+    });
+  });
+
+  describe("submitUrlsInBatches", () => {
+    beforeEach(() => {
+      process.env.INDEXNOW_KEY = "test-indexnow-key";
+    });
+
+    it("reports pending separately and warns instead of claiming delivery", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ status: 202 }) as unknown as typeof fetch;
+
+      const result = await submitUrlsInBatches([
+        `${SITE_URL}/water-temp/corolla`,
+        `${SITE_URL}/tide/monterey`,
+      ]);
+
+      expect(result.totalSubmitted).toBe(0);
+      expect(result.totalPending).toBe(2);
+      expect(result.errors).toEqual([]);
+      expect(result.warnings).toEqual([
+        "Batch 1: HTTP 202 - key validation pending, delivery unconfirmed",
+      ]);
+      expect(result.batches[0].statusCode).toBe(202);
+    });
+
+    it("reports a verified batch with no warnings", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ status: 200 }) as unknown as typeof fetch;
+
+      const result = await submitUrlsInBatches([`${SITE_URL}/tide/monterey`]);
+
+      expect(result.totalSubmitted).toBe(1);
+      expect(result.totalPending).toBe(0);
+      expect(result.warnings).toEqual([]);
+      expect(result.errors).toEqual([]);
+    });
+
+    it("still records hard failures as errors", async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({ status: 403 }) as unknown as typeof fetch;
+
+      const result = await submitUrlsInBatches([`${SITE_URL}/tide/monterey`]);
+
+      expect(result.totalSubmitted).toBe(0);
+      expect(result.totalPending).toBe(0);
+      expect(result.errors).toEqual(["Batch 1: HTTP 403"]);
+    });
   });
 });

--- a/app/api/cron/indexnow-submit/route.ts
+++ b/app/api/cron/indexnow-submit/route.ts
@@ -47,7 +47,13 @@ async function _GET(request: Request): Promise<Response> {
 
     return createSuccessResponse({
       submitted: result.totalSubmitted,
+      // 202 means IndexNow deferred key validation — the URLs are NOT confirmed
+      // delivered. A pending count equal to totalUrls is the signature of an
+      // INDEXNOW_KEY that no longer matches public/indexnow-key.txt.
+      pending: result.totalPending,
       totalUrls: uniqueUrls.length,
+      statusCodes: result.batches.map((batch) => batch.statusCode),
+      warnings: result.warnings,
       breakdown: {
         intent: urlGroups.intentUrls.length,
         location: urlGroups.locationUrls.length,

--- a/app/app-store/route.ts
+++ b/app/app-store/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import {
+  iosAppStoreUrlWithCampaign,
+  resolveIosAppStoreCampaign,
+} from "@/lib/constants/app-store";
+
+export function GET(request: NextRequest): NextResponse {
+  const campaign = resolveIosAppStoreCampaign({
+    campaign: request.nextUrl.searchParams.get("ct") ?? undefined,
+  });
+  const destination = iosAppStoreUrlWithCampaign(
+    campaign,
+    process.env.IOS_APP_STORE_PROVIDER_TOKEN,
+  );
+
+  return NextResponse.redirect(destination, 307);
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -8,7 +8,11 @@ import {
   APP_FIRST_CAMPAIGN,
   iosAppStoreUrlWithCampaign,
 } from "@/lib/constants/app-handoff";
-import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import {
+  type IosAppStoreCampaign,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
+  resolveIosAppStoreCampaign,
+} from "@/lib/constants/app-store";
 import { buildAndroidBetaHandoffPath } from "@/lib/install-attribution";
 import { DesktopHandoff } from "./desktop-handoff";
 import { isValidUUID } from "@/lib/utils/validation";
@@ -32,9 +36,7 @@ function readSource(searchParams: Awaited<SearchParams>): string {
 
 function resolveHandoffId(searchParams: Awaited<SearchParams>): string {
   const handoffId = readFirstParam(searchParams, "handoff_id");
-  return handoffId && isValidUUID(handoffId)
-    ? handoffId
-    : crypto.randomUUID();
+  return handoffId && isValidUUID(handoffId) ? handoffId : crypto.randomUUID();
 }
 
 function buildHandoffMetadata(
@@ -79,6 +81,18 @@ function campaignFromParams(searchParams: Awaited<SearchParams>): string {
   return readFirstParam(searchParams, "utm_campaign") ?? APP_FIRST_CAMPAIGN;
 }
 
+function appStoreCampaignFromParams(
+  searchParams: Awaited<SearchParams>,
+): IosAppStoreCampaign {
+  return resolveIosAppStoreCampaign({
+    campaign: readFirstParam(searchParams, "utm_campaign"),
+    medium: readFirstParam(searchParams, "utm_medium"),
+    placement: readFirstParam(searchParams, "placement"),
+    source: readFirstParam(searchParams, "utm_source"),
+    surface: readFirstParam(searchParams, "surface"),
+  });
+}
+
 function androidDestination(searchParams: Awaited<SearchParams>): {
   type: string;
   url: string;
@@ -105,7 +119,10 @@ export default async function AppHandoffPage({
   const handoffId = resolveHandoffId(sp);
 
   if (platform === "ios") {
-    const destinationUrl = iosAppStoreUrlWithCampaign(campaignFromParams(sp));
+    const destinationUrl = iosAppStoreUrlWithCampaign(
+      appStoreCampaignFromParams(sp),
+      process.env.IOS_APP_STORE_PROVIDER_TOKEN,
+    );
     await logAppHandoffLinkOpenedServer({
       sessionId: handoffId,
       metadata: buildHandoffMetadata(sp, handoffId, "ios", {
@@ -137,7 +154,9 @@ export default async function AppHandoffPage({
       />
       <noscript>
         <p>
-          <a href={IOS_APP_STORE_URL}>Download Quiver on the App Store</a>
+          <a href={IOS_APP_STORE_WEB_REDIRECT_PATH}>
+            Download Quiver on the App Store
+          </a>
           {" · "}
           <a href={buildAndroidBetaHandoffPath({})}>Get the Android beta</a>
         </p>

--- a/app/app/spot/[slug]/page.tsx
+++ b/app/app/spot/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import type { ReactElement } from "react";
 import { ExternalLink, Smartphone, Waves } from "lucide-react";
 
-import { IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import { loadForecastWindowShareMetadata } from "@/lib/share/forecast-window-share";
 import { ShareLinkOpenTracker } from "./share-link-open-tracker";
 
@@ -77,7 +77,9 @@ export async function generateMetadata({
   };
 }
 
-function firstSearchValue(value: string | string[] | undefined): string | undefined {
+function firstSearchValue(
+  value: string | string[] | undefined,
+): string | undefined {
   if (Array.isArray(value)) return value[0];
   return value;
 }
@@ -113,7 +115,10 @@ export default async function AppSpotHandoffPage({
 
   return (
     <main className="min-h-screen bg-[#101436] px-5 py-12 text-white sm:px-8">
-      <ShareLinkOpenTracker slug={safeDecodeSlug(slug)} windowValue={windowId ?? null} />
+      <ShareLinkOpenTracker
+        slug={safeDecodeSlug(slug)}
+        windowValue={windowId ?? null}
+      />
       <section className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-3xl flex-col justify-center">
         <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-md bg-[#F78E42] text-[#11100D] shadow-lg shadow-black/25">
           <Waves className="h-7 w-7" aria-hidden="true" />
@@ -135,7 +140,7 @@ export default async function AppSpotHandoffPage({
 
         <div className="mt-8 flex flex-col gap-3 sm:flex-row">
           <a
-            href={IOS_APP_STORE_URL}
+            href={IOS_APP_STORE_WEB_REDIRECT_PATH}
             className="inline-flex min-h-12 items-center justify-center gap-2 rounded-md bg-[#F78E42] px-5 py-3 text-base font-black text-[#11100D] transition hover:bg-[#FDB84B] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FDB84B] focus-visible:ring-offset-2 focus-visible:ring-offset-[#101436]"
           >
             <Smartphone className="h-5 w-5" aria-hidden="true" />
@@ -151,8 +156,8 @@ export default async function AppSpotHandoffPage({
         </div>
 
         <p className="mt-6 max-w-xl text-sm font-semibold leading-6 text-[#91A0C8]">
-          Open Quiver from the App Store, or keep reading this spot forecast
-          on the web.
+          Open Quiver from the App Store, or keep reading this spot forecast on
+          the web.
         </p>
       </section>
     </main>

--- a/app/forecast/page.tsx
+++ b/app/forecast/page.tsx
@@ -16,6 +16,7 @@ import { getCurrentUser } from "@/lib/auth/admin";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { buildPageMetadata } from "@/lib/seo/meta";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
 import { BestRightNow } from "@/components/forecast";
 import { RegionalCallHero } from "@/components/forecast/regional-call-hero";
 import { RegionalBestSurfWindows } from "@/components/forecast/regional-best-surf-windows";
@@ -60,7 +61,9 @@ export const metadata: Metadata = buildPageMetadata({
  * isn't explicitly listed don't silently lose to the IP cookie path.
  * Returns null on any failure — never throws the page.
  */
-async function getAuthedUserHomeRegionSlug(userId: string): Promise<string | null> {
+async function getAuthedUserHomeRegionSlug(
+  userId: string,
+): Promise<string | null> {
   try {
     const supabase = await createSupabaseServerClient();
     const { data, error } = await supabase
@@ -69,8 +72,11 @@ async function getAuthedUserHomeRegionSlug(userId: string): Promise<string | nul
       .eq("id", userId)
       .maybeSingle();
     if (error || !data) return null;
-    const homeBeach = (data as { home_beach: { city?: string | null; state?: string | null } | null })
-      .home_beach;
+    const homeBeach = (
+      data as {
+        home_beach: { city?: string | null; state?: string | null } | null;
+      }
+    ).home_beach;
     if (!homeBeach) return null;
 
     // 1. Prefer an exact city match — surfaces the most specific sub-region
@@ -87,7 +93,7 @@ async function getAuthedUserHomeRegionSlug(userId: string): Promise<string | nul
     if (homeBeach.state) {
       const state = homeBeach.state.toLowerCase();
       const matches = Object.values(FORECAST_REGIONS).filter((r) =>
-        r.states.some((s) => s.toLowerCase() === state)
+        r.states.some((s) => s.toLowerCase() === state),
       );
       if (matches.length > 0) {
         const subRegion = matches.find((r) => r.cities && r.cities.length > 0);
@@ -141,7 +147,7 @@ export default async function ForecastHubPage({
       forecastRegion.slug === region.slug
         ? activeSummary
         : createEmptyRegionalSummary(forecastRegion),
-    ])
+    ]),
   );
 
   // Deduplicated guide cross-links (multiple regions can share a guide).
@@ -168,8 +174,39 @@ export default async function ForecastHubPage({
       }));
   })();
 
+  const browseCards = [
+    {
+      href: "/beaches/usa",
+      title: "United States",
+      desc: "All U.S. surf beaches by state",
+      sticker: "creamCoastMap",
+      stickerClassName: "-right-5 -top-8 w-24 -rotate-6",
+    },
+    {
+      href: "/beaches/mexico",
+      title: "Mexico",
+      desc: "Baja, mainland, and island spots",
+      sticker: "orangeMap",
+      stickerClassName: "-right-3 -top-7 w-20 rotate-6",
+    },
+    {
+      href: "/beginner/ca",
+      title: "Beginner Spots",
+      desc: "Gentle waves for learning",
+      sticker: "singleFin",
+      stickerClassName: "-right-5 -top-8 w-20 rotate-12",
+    },
+    {
+      href: "/tide/san-diego",
+      title: "Tide Charts",
+      desc: "Tidal conditions and timing",
+      sticker: "spotTideWindow",
+      stickerClassName: "-right-4 -top-7 w-20 -rotate-6",
+    },
+  ] as const;
+
   return (
-    <div className="min-h-screen bg-[#252D6B] noise-texture-subtle">
+    <>
       <BreadcrumbStructuredData
         items={[
           { name: "Quiver", url: baseUrl },
@@ -207,131 +244,154 @@ export default async function ForecastHubPage({
         }}
       />
 
-      <div className="container mx-auto max-w-7xl px-4 py-8">
-        <RegionalCallHero
-          region={region}
-          summary={activeSummary}
-          isAuthed={isAuthed}
-        />
-
-        <RegionalBestSurfWindows
-          regionName={region.name}
-          recommendations={activeSummary?.bestSurfWindows}
-        />
-
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,26rem)] xl:items-start">
-          <SevenDayOutlook summary={activeSummary} regionName={region.name} />
-
-          {/* Top spots scoped to the active region via explicit coords override */}
-          <section
-            className="mb-10 min-w-0"
-            aria-labelledby="top-spots-heading"
-            data-testid="forecast-top-spots-panel"
-          >
-            <h2
-              id="top-spots-heading"
-              className="mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
-            >
-              Top spots now
-            </h2>
-            <BestRightNow
-              userCoordsOverride={{
-                lat: region.centerLat,
-                lon: region.centerLon,
-              }}
-              headingOverride="Top spots now"
-            />
-          </section>
-        </div>
-
-        <OtherRegionsStrip summaries={summaries} excludeSlug={region.slug} />
-
-        {/* Regional Surf Guides — asymmetric, photo-backed, sticker rotations */}
-        <RegionalGuidesStrip
-          summaries={summaries}
-          activeRegionSlug={region.slug}
-          guideLinks={guideLinks}
-        />
-
-        {/* Browse Beaches */}
-        <section className="mb-10">
-          <h2 className="mb-4 font-[var(--font-heading)] text-2xl font-bold text-white">
-            Browse Beaches
-          </h2>
-          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
-            {[
-              { href: "/beaches/usa", title: "United States", desc: "All U.S. surf beaches by state" },
-              { href: "/beaches/mexico", title: "Mexico", desc: "Baja, mainland, and island spots" },
-              { href: "/beginner/ca", title: "Beginner Spots", desc: "Gentle waves for learning" },
-              { href: "/tide/san-diego", title: "Tide Charts", desc: "Tidal conditions and timing" },
-            ].map((card) => (
-              <Link
-                key={card.href}
-                href={card.href}
-                className="group block rounded-xl border border-white/10 bg-white/[0.03] p-4 transition hover:border-[#F78E42]/40 hover:bg-white/[0.06]"
-              >
-                <h3 className="mb-1 font-[var(--font-heading)] text-base font-semibold text-white group-hover:text-[#F78E42]">
-                  {card.title}
-                </h3>
-                <p className="text-sm text-white/70">{card.desc}</p>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        {/* Bottom CTA — sign-in-aware, sticker-styled, no glassmorphism */}
-        <section
-          className="relative mb-4 overflow-hidden rounded-2xl bg-[#1b2255] px-6 py-8 sm:px-8"
-          data-testid="forecast-bottom-cta"
-        >
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 opacity-[0.07]"
-            style={{
-              backgroundImage:
-                "repeating-linear-gradient(90deg, rgba(255,255,255,0.4) 0 1px, transparent 1px 4px)",
-            }}
+      <ZineSurface
+        sectionLabel="Surf forecast"
+        editionLabel="Updated hourly"
+        data-testid="forecast-hub-zine-surface"
+        paperClassName="overflow-hidden px-4 py-6 sm:px-6 sm:py-8 lg:px-8"
+      >
+        <main>
+          <RegionalCallHero
+            region={region}
+            summary={activeSummary}
+            isAuthed={isAuthed}
           />
-          <div className="relative max-w-2xl">
-            {isAuthed ? (
-              <>
-                <h2 className="mb-2 font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl">
-                  Open the Oracle for your home beach
-                </h2>
-                <p className="mb-5 text-sm text-white/75 sm:text-base">
-                  This is the regional call. The Oracle gives you hour-by-hour
-                  windows for your spot.
-                </p>
-                <Link
-                  href="/"
-                  className="inline-flex items-center gap-2 rounded-[14px_6px_16px_4px] bg-[#F78E42] px-5 py-3 font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-[#252D6B] shadow-[0_2px_0_rgba(0,0,0,0.25)] transition hover:bg-[#ffa760]"
-                >
-                  Open Oracle →
-                </Link>
-              </>
-            ) : (
-              <>
-                <h2 className="mb-2 font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl">
-                  Sign up for your local beach
-                </h2>
-                <p className="mb-5 text-sm text-white/75 sm:text-base">
-                  Sign up to get this call dialed in for YOUR home beach — hour
-                  by hour, with alerts when it lights up.
-                </p>
-                <Link
-                  href="/auth/sign-up"
-                  className="inline-flex items-center gap-2 rounded-[14px_6px_16px_4px] bg-[#F78E42] px-5 py-3 font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-[#252D6B] shadow-[0_2px_0_rgba(0,0,0,0.25)] transition hover:bg-[#ffa760]"
-                >
-                  Sign up for YOUR home beach →
-                </Link>
-              </>
-            )}
+
+          <RegionalBestSurfWindows
+            regionName={region.name}
+            recommendations={activeSummary?.bestSurfWindows}
+            variant="zine"
+          />
+
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,26rem)] xl:items-start">
+            <SevenDayOutlook
+              summary={activeSummary}
+              regionName={region.name}
+              variant="zine"
+            />
+
+            {/* Top spots scoped to the active region via explicit coords override */}
+            <section
+              className="mb-10 min-w-0"
+              aria-labelledby="top-spots-heading"
+              data-testid="forecast-top-spots-panel"
+            >
+              <h2
+                id="top-spots-heading"
+                className="mb-4 font-display text-3xl font-black uppercase leading-tight text-[#11100D]"
+              >
+                Top spots now
+              </h2>
+              <BestRightNow
+                userCoordsOverride={{
+                  lat: region.centerLat,
+                  lon: region.centerLon,
+                }}
+                headingOverride="Top spots now"
+              />
+            </section>
           </div>
-        </section>
-      </div>
+
+          <OtherRegionsStrip
+            summaries={summaries}
+            excludeSlug={region.slug}
+            variant="zine"
+          />
+
+          {/* Regional Surf Guides — asymmetric, photo-backed, sticker rotations */}
+          <RegionalGuidesStrip
+            summaries={summaries}
+            activeRegionSlug={region.slug}
+            guideLinks={guideLinks}
+            variant="zine"
+          />
+
+          {/* Browse Beaches */}
+          <section className="mb-10" data-testid="forecast-browse-cards">
+            <h2 className="label-black mb-5">Browse Beaches</h2>
+            <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+              {browseCards.map((card) => (
+                <Link
+                  key={card.href}
+                  href={card.href}
+                  className="group relative block min-h-36 overflow-hidden rounded-[24px_10px_28px_12px] border-2 border-[#11100D] bg-[#FBF6E8] p-4 shadow-[3px_4px_0_rgba(17,16,13,0.2)] transition-transform hover:-translate-y-1"
+                >
+                  <QuiverSticker
+                    sticker={card.sticker}
+                    className={`pointer-events-none absolute opacity-75 drop-shadow-sm transition-transform group-hover:rotate-2 group-hover:scale-105 ${card.stickerClassName}`}
+                    priority
+                    sizes="96px"
+                  />
+                  <div className="relative z-10 pr-10">
+                    <h3 className="mb-1 font-display text-lg font-black uppercase leading-tight text-[#11100D] group-hover:text-[#B56A2B]">
+                      {card.title}
+                    </h3>
+                    <p className="text-sm leading-relaxed text-[#11100D]/68">
+                      {card.desc}
+                    </p>
+                    <span className="mt-4 inline-flex font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-[#B56A2B] group-hover:underline">
+                      Explore →
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          {/* Bottom CTA — sign-in-aware, sticker-styled, no glassmorphism */}
+          <section
+            className="relative mb-4 overflow-hidden rounded-2xl bg-[#1b2255] px-6 py-8 sm:px-8"
+            data-testid="forecast-bottom-cta"
+          >
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-0 opacity-[0.07]"
+              style={{
+                backgroundImage:
+                  "repeating-linear-gradient(90deg, rgba(255,255,255,0.4) 0 1px, transparent 1px 4px)",
+              }}
+            />
+            <div className="relative max-w-2xl">
+              {isAuthed ? (
+                <>
+                  <h2 className="mb-2 font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl">
+                    Open the Oracle for your home beach
+                  </h2>
+                  <p className="mb-5 text-sm text-white/75 sm:text-base">
+                    This is the regional call. The Oracle gives you hour-by-hour
+                    windows for your spot.
+                  </p>
+                  <Link
+                    href="/"
+                    className="inline-flex items-center gap-2 rounded-[14px_6px_16px_4px] bg-[#F78E42] px-5 py-3 font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-[#252D6B] shadow-[0_2px_0_rgba(0,0,0,0.25)] transition hover:bg-[#ffa760]"
+                  >
+                    Open Oracle →
+                  </Link>
+                </>
+              ) : (
+                <>
+                  <h2 className="mb-2 font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl">
+                    Sign up for your local beach
+                  </h2>
+                  <p className="mb-5 text-sm text-white/75 sm:text-base">
+                    Sign up to get this call dialed in for YOUR home beach —
+                    hour by hour, with alerts when it lights up.
+                  </p>
+                  <Link
+                    href="/auth/sign-up"
+                    className="inline-flex items-center gap-2 rounded-[14px_6px_16px_4px] bg-[#F78E42] px-5 py-3 font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-[#252D6B] shadow-[0_2px_0_rgba(0,0,0,0.25)] transition hover:bg-[#ffa760]"
+                  >
+                    Sign up for YOUR home beach →
+                  </Link>
+                </>
+              )}
+            </div>
+          </section>
+        </main>
+      </ZineSurface>
 
       {/* Mobile Sticky Signup Bar (self-guards for authed users) */}
       <StickySignupBar source="forecast-hub" />
-    </div>
+    </>
   );
 }

--- a/app/invite/[token]/invite-landing-client.tsx
+++ b/app/invite/[token]/invite-landing-client.tsx
@@ -13,7 +13,7 @@ import { ArrowRight, ExternalLink, Smartphone } from "lucide-react";
 import { AndroidWaitlistCta } from "@/components/pricing/android-waitlist-cta";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import { trackAppHandoffQrRendered } from "@/lib/analytics/app-handoff-tracking";
 import { getBrowserSessionId } from "@/lib/utils/browser-session-id";
@@ -54,7 +54,10 @@ type InviteDestinationType =
   | "web_signup"
   | "android_waitlist";
 
-type InviteMetadataOverride = Record<string, string | number | boolean | undefined>;
+type InviteMetadataOverride = Record<
+  string,
+  string | number | boolean | undefined
+>;
 
 function detectPlatform(): InviteLandingPlatform {
   if (typeof navigator === "undefined") return "desktop";
@@ -223,7 +226,7 @@ export function InviteLandingClient({
                 </AndroidWaitlistCta>
               ) : (
                 <a
-                  href={IOS_APP_STORE_URL}
+                  href={IOS_APP_STORE_WEB_REDIRECT_PATH}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={() =>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,20 @@
 import type React from "react";
 import type { Metadata, Viewport } from "next";
-import { DM_Sans, Space_Grotesk, Space_Mono, Caveat, Bowlby_One, Permanent_Marker } from "next/font/google";
+import {
+  DM_Sans,
+  Space_Grotesk,
+  Space_Mono,
+  Caveat,
+  Bowlby_One,
+  Permanent_Marker,
+} from "next/font/google";
 import "./globals.css";
 import { SEO_CONFIG } from "@/lib/constants/seo";
 import { Providers } from "@/components/providers";
 import { SiteFooter } from "@/components/shared/site-footer";
 import { HideOnRoutes } from "@/components/hide-on-routes";
 import { buildRootStructuredDataGraph } from "@/lib/seo/root-structured-data";
-import {
-  IOS_APP_STORE_APP_ID,
-  IOS_APP_STORE_SMART_BANNER_ARGUMENT,
-} from "@/lib/constants/app-store";
+import { buildIosSmartAppBannerContent } from "@/lib/constants/app-store";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -71,13 +75,12 @@ export const metadata: Metadata = {
     default: "Quiver | Surf Reports, Forecasts & Conditions",
     template: "%s | Quiver",
   },
-  description:
-    SEO_CONFIG.description,
+  description: SEO_CONFIG.description,
   generator: "Next.js",
 
   // Performance optimizations
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
   ),
 
   // Favicon configuration
@@ -140,18 +143,25 @@ export const metadata: Metadata = {
     },
   },
 
-  itunes: {
-    appId: IOS_APP_STORE_APP_ID,
-    appArgument: IOS_APP_STORE_SMART_BANNER_ARGUMENT,
-  },
-
   // Performance hints
   other: {
     ...SEO_CONFIG.additionalMeta,
+    "apple-itunes-app": buildIosSmartAppBannerContent(
+      process.env.IOS_APP_STORE_PROVIDER_TOKEN,
+    ),
   },
 };
 
-const hideFooterPrefixes = ["/auth", "/admin", "/profile", "/sessions", "/prefs", "/embed", "/welcome", "/map"];
+const hideFooterPrefixes = [
+  "/auth",
+  "/admin",
+  "/profile",
+  "/sessions",
+  "/prefs",
+  "/embed",
+  "/welcome",
+  "/map",
+];
 
 export default function RootLayout({
   children,
@@ -296,7 +306,9 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body className={`${dmSans.className} font-sans antialiased theme-retro-dark noise-texture-subtle`}>
+      <body
+        className={`${dmSans.className} font-sans antialiased theme-retro-dark noise-texture-subtle`}
+      >
         {/* Skip link — must be the first focusable element in the DOM.
             sr-only hides it visually until focused (keyboard/screen-reader users).
             Targets #main-content which wraps all page content below the nav. */}

--- a/app/p/[partnerCode]/partner-qr-landing-client.tsx
+++ b/app/p/[partnerCode]/partner-qr-landing-client.tsx
@@ -12,8 +12,9 @@ import { QRCodeSVG } from "qrcode.react";
 import { ArrowRight, ExternalLink, Smartphone } from "lucide-react";
 import { AndroidWaitlistCta } from "@/components/pricing/android-waitlist-cta";
 import {
+  IOS_APP_STORE_CAMPAIGNS,
   IOS_APP_STORE_CTA,
-  iosAppStoreUrlWithCampaign,
+  buildIosAppStoreRedirectPath,
 } from "@/lib/constants/app-store";
 import { trackAppHandoffQrRendered } from "@/lib/analytics/app-handoff-tracking";
 import { getBrowserSessionId } from "@/lib/utils/browser-session-id";
@@ -148,8 +149,8 @@ export function PartnerQrLandingClient({
 
   const isAndroid = platform === "android";
   const partnerLabel = partnerName?.trim() || "A Quiver partner";
-  const appStoreUrl = iosAppStoreUrlWithCampaign(
-    `partner_${partnerCode.toUpperCase()}`,
+  const appStoreUrl = buildIosAppStoreRedirectPath(
+    IOS_APP_STORE_CAMPAIGNS.PARTNER_QR,
   );
   const leadCopy = isAndroid
     ? "Android beta access is open through Google Play closed testing. Get the beta or continue on web to start with Quiver."

--- a/components/app-store/ARCHITECTURE.md
+++ b/components/app-store/ARCHITECTURE.md
@@ -7,6 +7,8 @@
 ## Source Of Truth
 
 - `lib/constants/app-store.ts` owns the shared App Store app id, App Store URL, CTA text, destination status, smart banner argument, and Android beta landing/group/contact constants.
+- Browser install CTAs use `/app-store?ct=...`, whose server route adds `IOS_APP_STORE_PROVIDER_TOKEN` before redirecting to Apple. Client bundles never read that environment variable directly.
+- Apple campaign labels are deliberately limited to `web`, `email`, and `partner_qr`; Quiver source/surface/placement/UTM fields retain their own higher-resolution attribution.
 - Landing, forecast, final CTA, iPhone banner, and iOS CTA analytics read these constants instead of hardcoding destination copy.
 - Android beta remains a separate web landing path. Web pricing and founding access copy must not imply Android closed-beta access is the same as the public iOS install path.
 

--- a/components/app-store/ios-app-store-cta.tsx
+++ b/components/app-store/ios-app-store-cta.tsx
@@ -7,9 +7,8 @@ import {
   trackIosAppCtaView,
 } from "@/lib/analytics/ios-app-cta-tracking";
 import {
-  APP_FIRST_CAMPAIGN,
   IOS_APP_STORE_CTA,
-  iosAppStoreUrlWithCampaign,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 interface IosAppStoreCtaProps {
@@ -20,8 +19,7 @@ interface IosAppStoreCtaProps {
   children?: ReactNode;
 }
 
-const IOS_APP_STORE_CAMPAIGN_URL =
-  iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN);
+const IOS_APP_STORE_CAMPAIGN_URL = IOS_APP_STORE_WEB_REDIRECT_PATH;
 
 export function IosAppStoreCta({
   source,

--- a/components/app-store/iphone-app-banner.tsx
+++ b/components/app-store/iphone-app-banner.tsx
@@ -8,7 +8,7 @@ import { track } from "@/lib/analytics";
 import {
   IOS_APP_STORE_CTA,
   IOS_APP_STORE_DESTINATION_STATUS,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import {
   getIphoneAppBannerDecision,
@@ -41,7 +41,7 @@ function setDismissedAt(): void {
   try {
     window.localStorage.setItem(
       IPHONE_APP_BANNER_DISMISSAL_STORAGE_KEY,
-      new Date().toISOString()
+      new Date().toISOString(),
     );
   } catch {
     // Ignore storage failures so private browsing modes do not break the page.
@@ -51,7 +51,9 @@ function setDismissedAt(): void {
 export function IphoneAppBanner() {
   const pathname = usePathname();
   const trackedKeysRef = useRef<Set<string>>(new Set());
-  const [decision, setDecision] = useState<IphoneAppBannerDecision | null>(null);
+  const [decision, setDecision] = useState<IphoneAppBannerDecision | null>(
+    null,
+  );
   const [dismissed, setDismissed] = useState(false);
 
   const analyticsProps = useMemo(() => {
@@ -64,7 +66,7 @@ export function IphoneAppBanner() {
       cta_text: IOS_APP_STORE_CTA,
       destination_type: "app_store",
       destination_status: IOS_APP_STORE_DESTINATION_STATUS,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
       browser: decision.browser,
       pathname,
       ...(decision.suppressionReason
@@ -80,7 +82,7 @@ export function IphoneAppBanner() {
       trackedKeysRef.current.add(key);
       track(event, props);
     },
-    [pathname]
+    [pathname],
   );
 
   useEffect(() => {
@@ -149,7 +151,7 @@ export function IphoneAppBanner() {
           </p>
         </div>
         <a
-          href={IOS_APP_STORE_URL}
+          href={IOS_APP_STORE_WEB_REDIRECT_PATH}
           target="_blank"
           rel="noopener noreferrer"
           onClick={handleClick}

--- a/components/app-store/send-to-phone-cta.tsx
+++ b/components/app-store/send-to-phone-cta.tsx
@@ -16,11 +16,8 @@ import {
   trackAppHandoffEmailSubmit,
   trackAppHandoffQrRendered,
 } from "@/lib/analytics/app-handoff-tracking";
-import {
-  APP_FIRST_CAMPAIGN,
-  buildSmartQrHandoffUrl,
-  iosAppStoreUrlWithCampaign,
-} from "@/lib/constants/app-handoff";
+import { buildSmartQrHandoffUrl } from "@/lib/constants/app-handoff";
+import { IOS_APP_STORE_WEB_REDIRECT_PATH } from "@/lib/constants/app-store";
 import { cn } from "@/lib/utils";
 
 interface SendToPhoneCtaProps {
@@ -61,25 +58,24 @@ export function SendToPhoneCta({
   const qrTracked = useRef(false);
 
   useEffect(() => {
-    setHandoffId((current) => current ?? providedHandoffId ?? crypto.randomUUID());
+    setHandoffId(
+      (current) => current ?? providedHandoffId ?? crypto.randomUUID(),
+    );
   }, [providedHandoffId]);
 
-  const qrValue = useMemo(
-    () => {
-      if (!handoffId) return null;
+  const qrValue = useMemo(() => {
+    if (!handoffId) return null;
 
-      return buildSmartQrHandoffUrl({
-        source,
-        surface,
-        placement,
-        handoff_id: handoffId,
-        qr_id: qrId ?? `${surface}_${placement}_qr`,
-        target: target ?? "download",
-        utm_medium: "desktop_handoff",
-      });
-    },
-    [handoffId, placement, qrId, source, surface, target],
-  );
+    return buildSmartQrHandoffUrl({
+      source,
+      surface,
+      placement,
+      handoff_id: handoffId,
+      qr_id: qrId ?? `${surface}_${placement}_qr`,
+      target: target ?? "download",
+      utm_medium: "desktop_handoff",
+    });
+  }, [handoffId, placement, qrId, source, surface, target]);
 
   useEffect(() => {
     if (!handoffId || !qrValue || qrTracked.current) return;
@@ -266,14 +262,19 @@ export function SendToPhoneCta({
                 </button>
               </div>
 
-              <div aria-live="polite" className="mt-2 min-h-5 font-sans text-sm">
+              <div
+                aria-live="polite"
+                className="mt-2 min-h-5 font-sans text-sm"
+              >
                 {inlineError ? (
                   <span className="text-sunset-orange">{inlineError}</span>
                 ) : null}
                 {statusCopy ? (
                   <span
                     className={
-                      state === "sent" ? "text-emerald-300" : "text-sunset-orange"
+                      state === "sent"
+                        ? "text-emerald-300"
+                        : "text-sunset-orange"
                     }
                   >
                     {statusCopy}
@@ -284,7 +285,7 @@ export function SendToPhoneCta({
           ) : null}
 
           <a
-            href={iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN)}
+            href={IOS_APP_STORE_WEB_REDIRECT_PATH}
             className="mt-2 inline-block font-sans text-sm text-white/72 underline underline-offset-2 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-blue-decorative"
           >
             Open App Store anyway

--- a/components/forecast/other-regions-strip.tsx
+++ b/components/forecast/other-regions-strip.tsx
@@ -24,6 +24,7 @@ import { getScoreColorClasses } from "@/lib/utils/score-color-utils";
 interface OtherRegionsStripProps {
   summaries: Record<string, RegionalForecastSummary>;
   excludeSlug: string;
+  variant?: "default" | "zine";
 }
 
 interface ChipData {
@@ -39,7 +40,9 @@ function peakWeekScore(summary: RegionalForecastSummary | undefined): number {
 export function OtherRegionsStrip({
   summaries,
   excludeSlug,
+  variant = "default",
 }: OtherRegionsStripProps) {
+  const isZine = variant === "zine";
   const chips: ChipData[] = Object.values(FORECAST_REGIONS)
     .filter((region) => region.slug !== excludeSlug)
     .map((region) => ({
@@ -55,17 +58,31 @@ export function OtherRegionsStrip({
     <section
       id="other-regions-strip"
       aria-labelledby="other-regions-heading"
-      className="mb-10"
+      className={
+        isZine
+          ? "torn torn-tb mb-10 border-2 border-[#11100D] bg-[#F0E5CC] p-4 sm:p-5"
+          : "mb-10"
+      }
       data-testid="other-regions-strip"
     >
       <div className="mb-4 flex items-baseline justify-between gap-3">
         <h2
           id="other-regions-heading"
-          className="font-[var(--font-heading)] text-2xl font-bold text-white"
+          className={
+            isZine
+              ? "font-display text-3xl font-black uppercase leading-tight text-[#11100D]"
+              : "font-[var(--font-heading)] text-2xl font-bold text-white"
+          }
         >
           Going elsewhere?
         </h2>
-        <span className="font-mono text-xs uppercase tracking-wide text-white/50">
+        <span
+          className={
+            isZine
+              ? "font-mono text-xs uppercase tracking-wide text-[#11100D]/55"
+              : "font-mono text-xs uppercase tracking-wide text-white/50"
+          }
+        >
           {chips.length} regions
         </span>
       </div>
@@ -79,11 +96,15 @@ export function OtherRegionsStrip({
               <Link
                 href={`/forecast?region=${region.slug}`}
                 data-testid={`other-region-chip-${region.slug}`}
-                className="group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-sm text-white/80 transition hover:border-white/30 hover:bg-white/[0.08] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#252D6B]"
+                className={
+                  isZine
+                    ? "group inline-flex items-center gap-2 rounded-[14px_5px_16px_6px] border-2 border-[#11100D]/35 bg-[#FBF6E8] px-3 py-1.5 text-sm text-[#11100D]/78 shadow-[2px_2px_0_rgba(17,16,13,0.16)] transition hover:-translate-y-0.5 hover:border-[#B56A2B] hover:text-[#11100D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#F0E5CC]"
+                    : "group inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/[0.04] px-3 py-1.5 text-sm text-white/80 transition hover:border-white/30 hover:bg-white/[0.08] hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#252D6B]"
+                }
               >
                 <span>{region.name}</span>
                 <span
-                  className={`inline-flex h-5 min-w-[1.75rem] items-center justify-center rounded-full px-1 text-[10px] font-bold text-white ${scoreColors.bg}`}
+                  className={`inline-flex h-5 min-w-[1.75rem] items-center justify-center rounded-full px-1 text-[10px] font-bold text-white ${scoreColors.bg} ${isZine ? "border border-[#11100D]/20" : ""}`}
                   aria-label={`Peak score ${score}`}
                 >
                   {score > 0 ? score : "—"}
@@ -94,8 +115,14 @@ export function OtherRegionsStrip({
         })}
       </ul>
 
-      <details className="mt-4 group" data-testid="other-regions-details">
-        <summary className="inline-flex cursor-pointer items-center gap-1 font-mono text-xs uppercase tracking-wide text-white/60 transition hover:text-white">
+      <details className="group mt-4" data-testid="other-regions-details">
+        <summary
+          className={
+            isZine
+              ? "inline-flex cursor-pointer items-center gap-1 font-mono text-xs uppercase tracking-wide text-[#11100D]/62 transition hover:text-[#B56A2B]"
+              : "inline-flex cursor-pointer items-center gap-1 font-mono text-xs uppercase tracking-wide text-white/60 transition hover:text-white"
+          }
+        >
           <span>Browse all region pages</span>
           <span className="transition group-open:rotate-180">▾</span>
         </summary>
@@ -104,9 +131,18 @@ export function OtherRegionsStrip({
             <li key={`direct-${region.slug}`}>
               <Link
                 href={`/forecast/${region.slug}`}
-                className="block rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 text-sm text-white/75 transition hover:border-white/25 hover:bg-white/[0.06] hover:text-white"
+                className={
+                  isZine
+                    ? "block rounded-[10px_4px_12px_5px] border border-[#11100D]/20 bg-[#FBF6E8]/70 px-3 py-2 text-sm text-[#11100D]/72 transition hover:border-[#B56A2B] hover:text-[#11100D]"
+                    : "block rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2 text-sm text-white/75 transition hover:border-white/25 hover:bg-white/[0.06] hover:text-white"
+                }
               >
-                {region.name} <span className="text-white/40">/forecast/{region.slug}</span>
+                {region.name}{" "}
+                <span
+                  className={isZine ? "text-[#11100D]/40" : "text-white/40"}
+                >
+                  /forecast/{region.slug}
+                </span>
               </Link>
             </li>
           ))}

--- a/components/forecast/regional-best-surf-windows.tsx
+++ b/components/forecast/regional-best-surf-windows.tsx
@@ -4,13 +4,16 @@ import type { SurfWindowRecommendation } from "@/types/session-intelligence";
 export interface RegionalBestSurfWindowsProps {
   regionName: string;
   recommendations?: SurfWindowRecommendation[];
+  variant?: "default" | "zine";
 }
 
 export function RegionalBestSurfWindows({
   regionName,
   recommendations = [],
+  variant = "default",
 }: RegionalBestSurfWindowsProps) {
   const visibleRecommendations = recommendations.slice(0, 5);
+  const isZine = variant === "zine";
 
   if (visibleRecommendations.length === 0) {
     return (
@@ -18,15 +21,30 @@ export function RegionalBestSurfWindows({
         id="best-windows-this-week"
         data-testid="regional-best-surf-windows"
         aria-labelledby="best-windows-this-week-heading"
-        className="mb-10 rounded-2xl border border-white/10 bg-white/[0.035] px-5 py-6"
+        className={
+          isZine
+            ? "torn torn-tb mb-10 border-2 border-[#11100D] bg-[#FBF6E8] px-5 py-6"
+            : "mb-10 rounded-2xl border border-white/10 bg-white/[0.035] px-5 py-6"
+        }
       >
         <h2
           id="best-windows-this-week-heading"
-          className="font-[var(--font-heading)] text-2xl font-bold text-white"
+          className={
+            isZine
+              ? "font-display text-3xl font-black uppercase leading-tight text-[#11100D]"
+              : "font-[var(--font-heading)] text-2xl font-bold text-white"
+          }
         >
           Best windows this week
         </h2>
-        <p className="mt-2 text-sm text-white/64" role="status">
+        <p
+          className={
+            isZine
+              ? "mt-2 text-sm text-[#11100D]/64"
+              : "mt-2 text-sm text-white/64"
+          }
+          role="status"
+        >
           Best windows are still building for {regionName}.
         </p>
       </section>
@@ -38,7 +56,11 @@ export function RegionalBestSurfWindows({
       id="best-windows-this-week"
       data-testid="regional-best-surf-windows"
       aria-labelledby="best-windows-this-week-heading"
-      className="mb-10"
+      className={
+        isZine
+          ? "mb-10 rounded-[24px_10px_28px_12px] border-2 border-[#11100D] bg-[#252D6B] p-4 shadow-[4px_5px_0_rgba(17,16,13,0.22)] sm:p-6"
+          : "mb-10"
+      }
     >
       <BestSurfWindows
         recommendations={visibleRecommendations}

--- a/components/forecast/regional-guides-strip.tsx
+++ b/components/forecast/regional-guides-strip.tsx
@@ -27,6 +27,7 @@ interface RegionalGuidesStripProps {
   summaries: Record<string, RegionalForecastSummary>;
   activeRegionSlug: string;
   guideLinks: GuideLink[];
+  variant?: "default" | "zine";
 }
 
 // Cycling sticker-aesthetic knobs. Indexing by card position keeps the
@@ -72,11 +73,11 @@ interface GuideCardData {
 function pickFeaturedIndex(
   guideLinks: GuideLink[],
   activeRegionSlug: string,
-  summaries: Record<string, RegionalForecastSummary>
+  summaries: Record<string, RegionalForecastSummary>,
 ): number {
   // Prefer a guide whose mapped region matches the active region.
   const activeIdx = guideLinks.findIndex(
-    (g) => g.region.slug === activeRegionSlug
+    (g) => g.region.slug === activeRegionSlug,
   );
   if (activeIdx >= 0) return activeIdx;
 
@@ -87,10 +88,7 @@ function pickFeaturedIndex(
   guideLinks.forEach((g, i) => {
     const summary = summaries[g.region.slug];
     if (!summary || summary.days.length === 0) return;
-    const peak = summary.days.reduce(
-      (m, d) => (d.score > m ? d.score : m),
-      0
-    );
+    const peak = summary.days.reduce((m, d) => (d.score > m ? d.score : m), 0);
     if (peak > bestScore) {
       bestScore = peak;
       bestIdx = i;
@@ -99,11 +97,7 @@ function pickFeaturedIndex(
   return bestIdx;
 }
 
-function FeaturedGuideCard({
-  region,
-  guideSlug,
-  photoUrl,
-}: GuideCardData) {
+function FeaturedGuideCard({ region, guideSlug, photoUrl }: GuideCardData) {
   const subtitle = getRegionalGuideSubtitle(guideSlug);
   return (
     <Link
@@ -210,13 +204,16 @@ export function RegionalGuidesStrip({
   summaries,
   activeRegionSlug,
   guideLinks,
+  variant = "default",
 }: RegionalGuidesStripProps) {
   if (guideLinks.length === 0) return null;
+
+  const isZine = variant === "zine";
 
   const featuredIdx = pickFeaturedIndex(
     guideLinks,
     activeRegionSlug,
-    summaries
+    summaries,
   );
 
   // Reorder: featured first, remaining retain their relative order.
@@ -247,11 +244,21 @@ export function RegionalGuidesStrip({
       <div className="mb-5 flex items-end justify-between gap-3">
         <h2
           id="regional-guides-heading"
-          className="font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl"
+          className={
+            isZine
+              ? "font-display text-3xl font-black uppercase leading-tight text-[#11100D]"
+              : "font-[var(--font-heading)] text-2xl font-bold text-white sm:text-3xl"
+          }
         >
           Regional Surf Guides
         </h2>
-        <span className="font-[var(--font-handwritten)] text-lg text-white/55">
+        <span
+          className={
+            isZine
+              ? "font-[var(--font-handwritten)] text-lg text-[#11100D]/55"
+              : "font-[var(--font-handwritten)] text-lg text-white/55"
+          }
+        >
           local knowledge, by region
         </span>
       </div>

--- a/components/forecast/seven-day-outlook.tsx
+++ b/components/forecast/seven-day-outlook.tsx
@@ -19,46 +19,75 @@ import { SwellArc, type SwellArcPoint } from "./swell-arc";
 interface SevenDayOutlookProps {
   summary: RegionalForecastSummary | undefined;
   regionName: string;
+  variant?: "default" | "zine";
 }
 
 function daySubtitle(
   windConditions: "offshore" | "light" | "onshore",
-  score: number
+  score: number,
 ): string {
-  if (score >= 80) return windConditions === "offshore" ? "Glassy, all timing." : "Firing.";
+  if (score >= 80)
+    return windConditions === "offshore" ? "Glassy, all timing." : "Firing.";
   if (score >= 60)
     return windConditions === "offshore"
       ? "Offshore AM, get on it."
       : "Solid — pick your window.";
   if (score >= 40)
-    return windConditions === "onshore" ? "Wind-chopped but rideable." : "Small but fun.";
-  return windConditions === "onshore" ? "Call it a no." : "Marginal — longboard day.";
+    return windConditions === "onshore"
+      ? "Wind-chopped but rideable."
+      : "Small but fun.";
+  return windConditions === "onshore"
+    ? "Call it a no."
+    : "Marginal — longboard day.";
 }
 
-function trendIcon(delta: number): { label: string; char: string; color: string } {
-  if (delta >= 5) return { label: "building", char: "↗", color: "text-emerald-400" };
-  if (delta <= -5) return { label: "dropping", char: "↘", color: "text-rose-400" };
+function trendIcon(delta: number): {
+  label: string;
+  char: string;
+  color: string;
+} {
+  if (delta >= 5)
+    return { label: "building", char: "↗", color: "text-emerald-400" };
+  if (delta <= -5)
+    return { label: "dropping", char: "↘", color: "text-rose-400" };
   return { label: "holding", char: "→", color: "text-white/50" };
 }
 
 export function SevenDayOutlook({
   summary,
   regionName,
+  variant = "default",
 }: SevenDayOutlookProps) {
+  const isZine = variant === "zine";
+
   if (!summary || summary.days.length === 0) {
     return (
       <section
         aria-labelledby="seven-day-outlook-heading"
-        className="mb-10 min-w-0"
+        className={
+          isZine
+            ? "torn torn-tb mb-10 min-w-0 border-2 border-[#11100D] bg-[#FBF6E8] p-4 sm:p-5"
+            : "mb-10 min-w-0"
+        }
         data-testid="seven-day-outlook"
       >
         <h2
           id="seven-day-outlook-heading"
-          className="mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
+          className={
+            isZine
+              ? "mb-4 font-display text-3xl font-black uppercase leading-tight text-[#11100D]"
+              : "mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
+          }
         >
           7-Day Region Outlook
         </h2>
-        <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-8 text-sm text-white/60">
+        <div
+          className={
+            isZine
+              ? "border-2 border-dashed border-[#11100D]/30 px-5 py-8 text-sm text-[#11100D]/60"
+              : "rounded-2xl border border-white/10 bg-white/[0.03] px-5 py-8 text-sm text-white/60"
+          }
+        >
           Forecast catching up for {regionName}. Try again in a few.
         </div>
       </section>
@@ -84,12 +113,20 @@ export function SevenDayOutlook({
   return (
     <section
       aria-labelledby="seven-day-outlook-heading"
-      className="mb-10 min-w-0"
+      className={
+        isZine
+          ? "mb-10 min-w-0 rounded-[24px_10px_28px_12px] border-2 border-[#11100D] bg-[#252D6B] p-4 text-white shadow-[4px_5px_0_rgba(17,16,13,0.22)] sm:p-5"
+          : "mb-10 min-w-0"
+      }
       data-testid="seven-day-outlook"
     >
       <h2
         id="seven-day-outlook-heading"
-        className="mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
+        className={
+          isZine
+            ? "mb-4 font-display text-3xl font-black uppercase leading-tight text-[#F4EBD8]"
+            : "mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
+        }
       >
         7-Day Region Outlook
       </h2>
@@ -135,7 +172,9 @@ export function SevenDayOutlook({
                 <div className="font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-white">
                   {day.dayOfWeek.slice(0, 3)}
                 </div>
-                <div className="font-mono text-xs text-white/50">{monthDay}</div>
+                <div className="font-mono text-xs text-white/50">
+                  {monthDay}
+                </div>
               </div>
 
               {/* Score badge */}

--- a/components/landing-page/cta-section.tsx
+++ b/components/landing-page/cta-section.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/analytics/ios-app-cta-tracking";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import {
   trackSignupCtaClick,
@@ -73,7 +73,15 @@ export function CTASection({
       cta_type: ctaType,
       cta_copy_variant: ctaCopyVariant,
     });
-  }, [ctaCopyVariant, ctaType, isAppStoreCta, isInView, isLoading, source, user]);
+  }, [
+    ctaCopyVariant,
+    ctaType,
+    isAppStoreCta,
+    isInView,
+    isLoading,
+    source,
+    user,
+  ]);
 
   // Don't render for authenticated users (show during loading to avoid CLS)
   if (!isLoading && user) return null;
@@ -122,14 +130,14 @@ export function CTASection({
               asChild
             >
               <a
-                href={IOS_APP_STORE_URL}
+                href={IOS_APP_STORE_WEB_REDIRECT_PATH}
                 onClick={() => {
                   trackIosAppCtaClick({
                     source,
                     surface: "landing-page",
                     placement: "landing_final_cta",
                     cta_text: IOS_APP_STORE_CTA,
-                    destination_url: IOS_APP_STORE_URL,
+                    destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
                   });
                 }}
               >

--- a/components/landing-page/forecast-section.tsx
+++ b/components/landing-page/forecast-section.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/lib/analytics/ios-app-cta-tracking";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 type FeatureId = "forecast" | "journal" | "intel";
@@ -35,7 +35,8 @@ const FEATURES: Feature[] = [
     headline: CONTENT.sections.forecast.title,
     body: CONTENT.sections.forecast.subtitle,
     imageSrc: "/images/app-screenshots/surf-call-720.webp",
-    imageAlt: "Quiver app showing a La Jolla Shores surf call with best-window, swell, wind, tide, and session guidance.",
+    imageAlt:
+      "Quiver app showing a La Jolla Shores surf call with best-window, swell, wind, tide, and session guidance.",
   },
   {
     id: "journal",
@@ -43,7 +44,8 @@ const FEATURES: Feature[] = [
     headline: "Log what actually happened",
     body: "After your session, save the beach, board, rating, notes, and wave check so Quiver has real surf signal to learn from.",
     imageSrc: "/images/app-screenshots/session-log-720.webp",
-    imageAlt: "Quiver Log Session screen with beach search, board picker, duration, rating, and wave conditions.",
+    imageAlt:
+      "Quiver Log Session screen with beach search, board picker, duration, rating, and wave conditions.",
   },
   {
     id: "intel",
@@ -51,7 +53,8 @@ const FEATURES: Feature[] = [
     headline: "Check the beach before you commit",
     body: "Use local reports, photos, and spot context to ground-truth the call before you drive or paddle out.",
     imageSrc: "/images/app-screenshots/local-intel-720.webp",
-    imageAlt: "Quiver beach finder screen showing nearby surf spots, skill filters, and trending local breaks.",
+    imageAlt:
+      "Quiver beach finder screen showing nearby surf spots, skill filters, and trending local breaks.",
   },
 ];
 
@@ -62,7 +65,8 @@ export function ForecastSection() {
   const { user } = useAuth();
   const hasTrackedView = useRef(false);
 
-  const activeFeature = FEATURES.find((f) => f.id === activeFeatureId) || FEATURES[0];
+  const activeFeature =
+    FEATURES.find((f) => f.id === activeFeatureId) || FEATURES[0];
 
   useEffect(() => {
     if (user || !isInView || hasTrackedView.current) return;
@@ -80,20 +84,22 @@ export function ForecastSection() {
       surface: "landing-page",
       placement: "forecast_section",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
     });
   }, []);
 
   // Navigation handlers
   const handlePrevious = useCallback(() => {
     const currentIndex = FEATURES.findIndex((f) => f.id === activeFeatureId);
-    const previousIndex = currentIndex === 0 ? FEATURES.length - 1 : currentIndex - 1;
+    const previousIndex =
+      currentIndex === 0 ? FEATURES.length - 1 : currentIndex - 1;
     setActiveFeatureId(FEATURES[previousIndex].id);
   }, [activeFeatureId]);
 
   const handleNext = useCallback(() => {
     const currentIndex = FEATURES.findIndex((f) => f.id === activeFeatureId);
-    const nextIndex = currentIndex === FEATURES.length - 1 ? 0 : currentIndex + 1;
+    const nextIndex =
+      currentIndex === FEATURES.length - 1 ? 0 : currentIndex + 1;
     setActiveFeatureId(FEATURES[nextIndex].id);
   }, [activeFeatureId]);
 
@@ -109,10 +115,12 @@ export function ForecastSection() {
 
       if (e.key === "ArrowDown" || e.key === "ArrowRight") {
         e.preventDefault();
-        targetIndex = currentIndex === FEATURES.length - 1 ? 0 : currentIndex + 1;
+        targetIndex =
+          currentIndex === FEATURES.length - 1 ? 0 : currentIndex + 1;
       } else if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
         e.preventDefault();
-        targetIndex = currentIndex === 0 ? FEATURES.length - 1 : currentIndex - 1;
+        targetIndex =
+          currentIndex === 0 ? FEATURES.length - 1 : currentIndex - 1;
       } else if (e.key === "Home") {
         e.preventDefault();
         targetIndex = 0;
@@ -130,17 +138,20 @@ export function ForecastSection() {
         // Focus the new tab
         setTimeout(() => {
           const newTab = document.querySelector(
-            `[data-feature-id="${FEATURES[targetIndex].id}"]`
+            `[data-feature-id="${FEATURES[targetIndex].id}"]`,
           ) as HTMLElement;
           newTab?.focus();
         }, 0);
       }
     },
-    []
+    [],
   );
 
   return (
-    <SectionWrapper className="relative overflow-hidden pt-8 pb-8 md:pt-10 md:pb-10 px-4 bg-[#252D6B]" maxWidth="6xl">
+    <SectionWrapper
+      className="relative overflow-hidden pt-8 pb-8 md:pt-10 md:pb-10 px-4 bg-[#252D6B]"
+      maxWidth="6xl"
+    >
       {/* Ambient glow */}
       <div className="absolute top-1/2 left-1/4 w-[400px] h-[400px] bg-ocean-blue/[0.06] rounded-full blur-[100px] pointer-events-none" />
 
@@ -304,7 +315,7 @@ export function ForecastSection() {
                   data-testid={`forecast-cta-${activeFeatureId}`}
                 >
                   <a
-                    href={IOS_APP_STORE_URL}
+                    href={IOS_APP_STORE_WEB_REDIRECT_PATH}
                     onClick={handleIosAppClick}
                   >
                     {IOS_APP_STORE_CTA}

--- a/components/landing-page/hero-section.tsx
+++ b/components/landing-page/hero-section.tsx
@@ -20,12 +20,11 @@ import {
 } from "@/lib/analytics/ios-app-cta-tracking";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import type { FirstTouchPlatform } from "@/lib/analytics/web-context";
 
-const LANDING_HERO_VIDEO_DESKTOP_SRC =
-  "/videos/quiver-landing-hero-1280.mp4";
+const LANDING_HERO_VIDEO_DESKTOP_SRC = "/videos/quiver-landing-hero-1280.mp4";
 const LANDING_HERO_VIDEO_MOBILE_SRC = "/videos/quiver-landing-hero-720.mp4";
 const LANDING_HERO_POSTER_SRC = "/images/hero/quiver-landing-hero-poster.jpg";
 const HERO_VIDEO_LOAD_DELAY_MS = 2500;
@@ -181,8 +180,7 @@ function LegacyHeroSection(): ReactElement {
   const [hasVideoEnded, setHasVideoEnded] = useState(false);
   const [hasVideoError, setHasVideoError] = useState(false);
   const [hasVideoFailedToStart, setHasVideoFailedToStart] = useState(false);
-  const [videoVariant, setVideoVariant] =
-    useState<HeroVideoVariant>("desktop");
+  const [videoVariant, setVideoVariant] = useState<HeroVideoVariant>("desktop");
   const videoSrc =
     videoVariant === "mobile"
       ? LANDING_HERO_VIDEO_MOBILE_SRC
@@ -247,7 +245,7 @@ function LegacyHeroSection(): ReactElement {
       surface: "landing-page",
       placement: "hero_video_overlay",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
       video_loaded: shouldLoadVideo,
       video_completed: hasVideoEnded,
     });
@@ -265,7 +263,7 @@ function LegacyHeroSection(): ReactElement {
       surface: "landing-page",
       placement: "hero_video_overlay",
       cta_text: IOS_APP_STORE_CTA,
-      destination_url: IOS_APP_STORE_URL,
+      destination_url: IOS_APP_STORE_WEB_REDIRECT_PATH,
       video_loaded: shouldLoadVideo,
       video_completed: hasVideoEnded,
     });
@@ -434,10 +432,7 @@ function LegacyHeroSection(): ReactElement {
                   const diagnostics = getVideoDiagnostics(event.currentTarget);
                   if (!hasTrackedVideoError.current) {
                     hasTrackedVideoError.current = true;
-                    trackVideoEvent(
-                      "landing_hero_video_error",
-                      diagnostics,
-                    );
+                    trackVideoEvent("landing_hero_video_error", diagnostics);
                   }
                   if (!hasVideoLoaded.current && !hasVideoStarted.current) {
                     trackFailedStart(diagnostics);
@@ -447,7 +442,7 @@ function LegacyHeroSection(): ReactElement {
             ) : null}
             {isAppStoreCtaVisible ? (
               <a
-                href={IOS_APP_STORE_URL}
+                href={IOS_APP_STORE_WEB_REDIRECT_PATH}
                 data-testid="hero-video-app-store-cta"
                 aria-label={IOS_APP_STORE_CTA}
                 onClick={handleIosAppClick}

--- a/components/pricing/founding-offer-surface.tsx
+++ b/components/pricing/founding-offer-surface.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import {
   Apple,
   ArrowRight,
@@ -17,10 +16,14 @@ import type { LucideIcon } from "lucide-react";
 
 import { FoundingAccessCta } from "@/components/pricing/founding-access-cta";
 import { ScrollReveal } from "@/components/ui/scroll-reveal";
-import { QuiverSticker, type QuiverStickerProps, ZineSurface } from "@/components/zine";
+import {
+  QuiverSticker,
+  type QuiverStickerProps,
+  ZineSurface,
+} from "@/components/zine";
 import {
   IOS_APP_STORE_CTA,
-  IOS_APP_STORE_URL,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 
 const TRIAL_STEPS = [
@@ -204,13 +207,13 @@ export function FoundingOfferSurface() {
                 })}
               </div>
 
-              <Link
-                href={IOS_APP_STORE_URL}
+              <a
+                href={IOS_APP_STORE_WEB_REDIRECT_PATH}
                 className="mt-7 inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-full border-2 border-[#11100D] bg-[#F78E42] px-6 font-semibold text-[#11100D] shadow-[3px_3px_0_rgba(17,16,13,0.35)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#11100D] sm:max-w-sm"
               >
                 {IOS_APP_STORE_CTA}
                 <ArrowRight className="h-4 w-4" aria-hidden />
-              </Link>
+              </a>
               <p className="mt-3 text-center text-xs font-medium text-[#11100D]/64 sm:max-w-sm">
                 Cancel anytime in Apple subscriptions.
               </p>
@@ -228,7 +231,10 @@ export function FoundingOfferSurface() {
                   </div>
                   <div className="rounded-full border-2 border-[#11100D] bg-[#FFF7E6] px-3 py-2 shadow-[2px_2px_0_rgba(17,16,13,0.18)]">
                     <div className="flex items-center gap-2 text-sm font-semibold text-[#11100D]">
-                      <Smartphone className="h-4 w-4 text-[#252D6B]" aria-hidden />
+                      <Smartphone
+                        className="h-4 w-4 text-[#252D6B]"
+                        aria-hidden
+                      />
                       Android
                     </div>
                     <p className="mt-1 font-mono text-[10px] font-semibold uppercase tracking-widest text-[#252D6B]">
@@ -251,10 +257,7 @@ export function FoundingOfferSurface() {
                 className="pointer-events-none absolute -right-3 -top-4 w-20 rotate-12 opacity-40"
                 sizes="5rem"
               />
-              <p
-                id="plans-included-heading"
-                className="typewriter mb-1"
-              >
+              <p id="plans-included-heading" className="typewriter mb-1">
                 Pro membership includes
               </p>
               <div className="mt-5 divide-y-2 divide-dashed divide-[#11100D]/20">
@@ -272,7 +275,10 @@ export function FoundingOfferSurface() {
                           className="absolute -right-6 -top-4 w-20 rotate-12 opacity-55"
                           sizes="5rem"
                         />
-                        <Icon className="relative z-10 h-6 w-6 text-[#252D6B]" aria-hidden />
+                        <Icon
+                          className="relative z-10 h-6 w-6 text-[#252D6B]"
+                          aria-hidden
+                        />
                       </div>
                       <div>
                         <h3 className="font-display text-base font-black uppercase leading-tight text-[#11100D] sm:text-lg">

--- a/components/session-intelligence/app-deep-link-cta.tsx
+++ b/components/session-intelligence/app-deep-link-cta.tsx
@@ -4,7 +4,10 @@ import { ExternalLink, Smartphone } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useTrackEvent } from "@/hooks/use-track-event";
-import { IOS_APP_STORE_CTA, IOS_APP_STORE_URL } from "@/lib/constants/app-store";
+import {
+  IOS_APP_STORE_CTA,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
+} from "@/lib/constants/app-store";
 import { cn } from "@/lib/utils";
 import type { SurfWindowLinks } from "@/types/session-intelligence";
 import {
@@ -22,7 +25,9 @@ export interface AppDeepLinkCTAProps {
 }
 
 function resolveHref(links: SurfWindowLinks): string {
-  return links.universalLink ?? links.appDeepLink ?? IOS_APP_STORE_URL;
+  return (
+    links.universalLink ?? links.appDeepLink ?? IOS_APP_STORE_WEB_REDIRECT_PATH
+  );
 }
 
 export function AppDeepLinkCTA({
@@ -34,13 +39,14 @@ export function AppDeepLinkCTA({
 }: AppDeepLinkCTAProps) {
   const { track } = useTrackEvent();
   const resolvedLabel =
-    label ?? (variant === "ghost" ? "Take it with you" : "Open this window in Quiver");
+    label ??
+    (variant === "ghost" ? "Take it with you" : "Open this window in Quiver");
   const href = resolveHref(links);
-  const isFallback = href === IOS_APP_STORE_URL;
+  const isFallback = href === IOS_APP_STORE_WEB_REDIRECT_PATH;
   const ctaLabel = isFallback ? IOS_APP_STORE_CTA : resolvedLabel;
   const metadata = buildSurfWindowTrackingMetadata(tracking ?? {}, {
     targetHref: href,
-    linkType: resolveAppDeepLinkType(href),
+    linkType: isFallback ? "app_store" : resolveAppDeepLinkType(href),
     fallbackToAppStore: isFallback,
   });
 
@@ -64,7 +70,7 @@ export function AppDeepLinkCTA({
         variant === "ghost"
           ? "h-10 w-full border-white/15 bg-transparent text-white/75 hover:bg-white/[0.06] hover:text-white sm:w-auto"
           : "h-10 w-full bg-ocean-blue text-white hover:bg-ocean-blue/90 sm:w-auto",
-        className
+        className,
       )}
     >
       <a

--- a/docs/seo/SEO_AGENT_WORKFLOW.md
+++ b/docs/seo/SEO_AGENT_WORKFLOW.md
@@ -29,6 +29,7 @@ yarn seo:enrich --source posthog --input path/to/posthog-export.json
 yarn seo:enrich --source ahrefs --input ../Brand-Vault/seo-audit/YYYY-MM-DD/AHREFS-SCREENSHOT-INPUT.json --output ../Brand-Vault/seo-audit/YYYY-MM-DD/AHREFS-ENRICHMENT.json
 yarn seo:recommend --input ../Brand-Vault/seo-audit/YYYY-MM-DD/GSC-REFRESH.json --input ../Brand-Vault/seo-audit/YYYY-MM-DD/TECHNICAL-AUDIT.json --input ../Brand-Vault/seo-audit/YYYY-MM-DD/VERCEL-ENRICHMENT.json
 yarn seo:weekly-report
+yarn seo:weekly-report --dir ../Brand-Vault/seo-audit/YYYY-MM-DD --audit-date YYYY-MM-DD
 ```
 
 The commands generate dashboard updates or review reports only. They do not publish content, apply migrations, commit, push, or mutate production data. Weekly audit artifacts default to `../Brand-Vault/seo-audit/YYYY-MM-DD/` so generated marketing intelligence stays outside the app repo.
@@ -52,6 +53,7 @@ The weekly report is the single home for the SEO workflow's deterministic report
 
 - **Broken-link scanner (deterministic):** `seo:technical-audit` extracts same-origin `<a href>` links from the pages it already crawls and HEAD-checks a bounded sample (cap 40, 8s timeout). Broken links (status >= 400) surface under Technical Crawl Health.
 - **AEO citation monitor:** the report folds the latest `docs/seo/reports/aeo-citation-tracking/*.md` baseline into the AI Citation / AEO Signals section. The audit is a search-presence proxy, not a true multi-engine AI-answer citation measurement. Keep queries stable and append rather than replace so the citation rate stays comparable.
+- **Weekly freshness and movement guard:** the weekly report records source age for GSC, Vercel, PostHog, DataForSEO, store, Ahrefs, competitor, AEO-baseline, and backlink inputs. It labels sources as fresh, lagged, stale, or missing, compares the current bundle with the previous dated audit when available, and surfaces Ahrefs audit recommendations under Technical Crawl Health. Pass `--audit-date` when a scheduler needs the report date pinned independently of UTC.
 - **Backlink scanner:** the report folds the latest `docs/seo/backlink-reports/*.md` confirmed/unverified target list into the Backlink / Referrer Signals section, alongside referrer/embed/manual-export signals.
 - **Outreach drafter:** `seo:outreach-digest` reads `docs/seo/outreach-tracker.md`, picks this week's rotation category (Week 1 schools, Week 2 bloggers, Week 3 coastal businesses, Week 4 publications, by week-of-month), and emits draft candidates into the Outreach Queue section. In live mode, the agent may create those as Gmail drafts, never sent, and mark the tracker rows `drafted` after verifying the drafts exist. Review drafts in Gmail before sending.
 

--- a/e2e/forecast-hub.spec.ts
+++ b/e2e/forecast-hub.spec.ts
@@ -24,7 +24,9 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     errorCapture = setupErrorDetection(page);
   });
 
-  test("loads and paints the default region on first byte", async ({ page }) => {
+  test("loads and paints the default region on first byte", async ({
+    page,
+  }) => {
     await page.goto("/forecast");
     await waitForPageLoad(page);
     await dismissOnboardingWizard(page);
@@ -38,10 +40,14 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     await expect(h1).toBeVisible();
     const h1Text = (await h1.textContent()) ?? "";
     // Default is Southern California (largest user base) when no cookie
-    expect(h1Text).toMatch(/Southern California|California|Hawaii|Oregon|Florida|San Diego|Orange County|Los Angeles|Santa Cruz|Ventura|Puerto Rico|New York|New Jersey|Outer Banks|Washington|Northern California|Baja/);
+    expect(h1Text).toMatch(
+      /Southern California|California|Hawaii|Oregon|Florida|San Diego|Orange County|Los Angeles|Santa Cruz|Ventura|Puerto Rico|New York|New Jersey|Outer Banks|Washington|Northern California|Baja/,
+    );
   });
 
-  test("`?region=hawaii` drives hero copy and primary CTA href", async ({ page }) => {
+  test("`?region=hawaii` drives hero copy and primary CTA href", async ({
+    page,
+  }) => {
     await page.goto("/forecast?region=hawaii");
     await waitForPageLoad(page);
     await dismissOnboardingWizard(page);
@@ -66,7 +72,10 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     await expect(h1).toContainText(/Southern California/);
 
     const primaryCta = page.getByTestId("primary-cta");
-    await expect(primaryCta).toHaveAttribute("href", "/forecast/southern-california");
+    await expect(primaryCta).toHaveAttribute(
+      "href",
+      "/forecast/southern-california",
+    );
   });
 
   test("anonymous visitor sees the signup CTA", async ({ page }) => {
@@ -92,8 +101,38 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     await dismissOnboardingWizard(page);
 
     // Old card grid used WaveSparkline; new design has zero sparklines
-    const sparklines = page.locator('[data-testid*="sparkline"], [aria-label*="sparkline" i]');
+    const sparklines = page.locator(
+      '[data-testid*="sparkline"], [aria-label*="sparkline" i]',
+    );
     await expect(sparklines).toHaveCount(0);
+  });
+
+  test("uses the zine surface and restores browse-card artwork", async ({
+    page,
+  }) => {
+    await page.goto("/forecast");
+    await waitForPageLoad(page);
+    await dismissOnboardingWizard(page);
+
+    await expect(page.getByTestId("forecast-hub-zine-surface")).toBeVisible();
+
+    const browseCards = page.getByTestId("forecast-browse-cards");
+    await expect(browseCards).toBeVisible();
+    await expect(browseCards.locator("a")).toHaveCount(4);
+    const stickerImages = browseCards.locator("[data-zine-sticker]");
+    await expect(stickerImages).toHaveCount(4);
+    await expect
+      .poll(() =>
+        stickerImages.evaluateAll((images) =>
+          images.every(
+            (image) =>
+              image instanceof HTMLImageElement &&
+              image.complete &&
+              image.naturalWidth > 0,
+          ),
+        ),
+      )
+      .toBe(true);
   });
 
   test("'Going elsewhere?' strip shows the OTHER regions (not the active one)", async ({
@@ -107,7 +146,9 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     await expect(strip).toBeVisible();
 
     // Active region (Hawaii) must NOT appear as a chip
-    const hawaiiChip = strip.locator('[data-testid="other-region-chip-hawaii"]');
+    const hawaiiChip = strip.locator(
+      '[data-testid="other-region-chip-hawaii"]',
+    );
     await expect(hawaiiChip).toHaveCount(0);
 
     // At least 4 other regions should be chipped
@@ -115,7 +156,9 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     expect(await chips.count()).toBeGreaterThanOrEqual(4);
   });
 
-  test("best windows section and seven-day outlook both render", async ({ page }) => {
+  test("best windows section and seven-day outlook both render", async ({
+    page,
+  }) => {
     await page.goto("/forecast?region=southern-california");
     await waitForPageLoad(page);
     await dismissOnboardingWizard(page);
@@ -123,7 +166,7 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     const bestWindows = page.getByTestId("regional-best-surf-windows");
     await expect(bestWindows).toBeVisible();
     await expect(
-      bestWindows.getByRole("heading", { name: /best windows this week/i })
+      bestWindows.getByRole("heading", { name: /best windows this week/i }),
     ).toBeVisible();
 
     const outlook = page.getByTestId("seven-day-outlook");
@@ -132,7 +175,7 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
     // Heading is always present regardless of data availability. Component
     // copy is "7-Day Region Outlook" — match the variable middle word.
     await expect(
-      outlook.getByRole("heading", { name: /7-Day.*Outlook/i })
+      outlook.getByRole("heading", { name: /7-Day.*Outlook/i }),
     ).toBeVisible();
 
     // Either day rows render OR the empty-state message renders. We assert
@@ -160,9 +203,7 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
 
     expect(outlookBox).not.toBeNull();
     expect(topSpotsBox).not.toBeNull();
-    expect(topSpotsBox!.x).toBeGreaterThan(
-      outlookBox!.x + outlookBox!.width
-    );
+    expect(topSpotsBox!.x).toBeGreaterThan(outlookBox!.x + outlookBox!.width);
     expect(Math.abs(topSpotsBox!.y - outlookBox!.y)).toBeLessThan(80);
   });
 
@@ -185,7 +226,7 @@ test.describe("Forecast Hub (Regional Oracle)", () => {
 
     const scripts = await jsonLd.all();
     const parsedSchemas = await Promise.all(
-      scripts.map(async (s) => (await s.textContent()) ?? "")
+      scripts.map(async (s) => (await s.textContent()) ?? ""),
     );
     const webPageSchema = parsedSchemas
       .filter((c) => c.includes('"@type":"WebPage"'))

--- a/e2e/guest-app-handoff.spec.ts
+++ b/e2e/guest-app-handoff.spec.ts
@@ -204,7 +204,7 @@ test.describe("/app/handoff route", () => {
 
     expect([301, 302, 307, 308]).toContain(response.status());
     expect(response.headers()["location"] ?? "").toContain("apps.apple.com");
-    expect(response.headers()["location"] ?? "").toContain("ct=app_first_v1");
+    expect(response.headers()["location"] ?? "").toContain("ct=web");
   });
 
   test("Android UA redirects to the guided beta page", async ({ page }) => {

--- a/e2e/guest-smoke.spec.ts
+++ b/e2e/guest-smoke.spec.ts
@@ -17,10 +17,6 @@ import {
 } from './utils/error-detection';
 import { TEST_BEACHES } from './fixtures/test-data';
 import { buildBeachUrl } from '@/lib/utils/beach-url-utils';
-import {
-  APP_FIRST_CAMPAIGN,
-  iosAppStoreUrlWithCampaign,
-} from '@/lib/constants/app-store';
 import { isVisibleSafe } from './utils/strict-helpers';
 
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -55,7 +51,7 @@ test.describe('Guest Smoke: Critical Pages', () => {
     await expect(page.getByRole('heading', { name: /custom alerts/i })).toBeVisible();
     await expect(
       page.getByRole('link', { name: /open app store/i }).first(),
-    ).toHaveAttribute('href', iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN));
+    ).toHaveAttribute('href', '/app-store?ct=web');
     await expect(
       page.getByRole('link', { name: /get the android beta/i }).first(),
       // The CTA carries waitlist attribution (source/surface/placement), which
@@ -127,7 +123,6 @@ test.describe('Guest Smoke: Critical Pages', () => {
     // No visible error assertions — 404 console/network errors are expected
   });
 });
-
 test.describe('Guest Smoke: SEO Infrastructure', () => {
   test('Sitemap returns valid XML response @smoke', async ({ request }) => {
     const response = await request.get('/sitemap.xml', { timeout: 10000 });

--- a/lib/analytics/ios-app-cta-tracking.ts
+++ b/lib/analytics/ios-app-cta-tracking.ts
@@ -1,17 +1,15 @@
 import { track } from "@/lib/analytics";
 import { deriveSeoPageContextFromPath } from "@/lib/analytics/web-context";
 import {
-  APP_FIRST_CAMPAIGN,
   IOS_APP_STORE_CTA,
   IOS_APP_STORE_DESTINATION_STATUS,
-  iosAppStoreUrlWithCampaign,
+  IOS_APP_STORE_WEB_REDIRECT_PATH,
 } from "@/lib/constants/app-store";
 import { getVisitorId } from "@/lib/utils/visitor-id";
 
 export const IOS_APP_CTA_VIEW_EVENT = "ios_app_cta_view";
 export const IOS_APP_CTA_CLICK_EVENT = "ios_app_cta_click";
-const IOS_APP_STORE_CAMPAIGN_URL =
-  iosAppStoreUrlWithCampaign(APP_FIRST_CAMPAIGN);
+const IOS_APP_STORE_CAMPAIGN_URL = IOS_APP_STORE_WEB_REDIRECT_PATH;
 
 type InternalCtaEventType = "cta_impression" | "cta_click";
 
@@ -29,7 +27,7 @@ export interface IosAppCtaMetadata {
 }
 
 function buildIosAppCtaMetadata(
-  metadata: IosAppCtaMetadata
+  metadata: IosAppCtaMetadata,
 ): IosAppCtaMetadata {
   const seoPageContext = deriveSeoPageContextFromPath();
 
@@ -47,7 +45,7 @@ function buildIosAppCtaMetadata(
 
 function fireToUserEvents(
   eventType: InternalCtaEventType,
-  metadata: IosAppCtaMetadata
+  metadata: IosAppCtaMetadata,
 ): void {
   if (typeof window === "undefined") return;
 

--- a/lib/constants/app-store.ts
+++ b/lib/constants/app-store.ts
@@ -3,40 +3,123 @@ export const IOS_APP_STORE_APP_ID = "6759300320";
 export const IOS_APP_STORE_URL =
   "https://apps.apple.com/us/app/surf-forecast-quiver/id6759300320";
 
-/** Canonical campaign label for the web -> native funnel. */
+export const IOS_APP_STORE_CAMPAIGNS = {
+  WEB: "web",
+  EMAIL: "email",
+  PARTNER_QR: "partner_qr",
+} as const;
+
+export type IosAppStoreCampaign =
+  (typeof IOS_APP_STORE_CAMPAIGNS)[keyof typeof IOS_APP_STORE_CAMPAIGNS];
+
+/** Canonical campaign label for the default web -> native funnel. */
 export const APP_FIRST_CAMPAIGN = "app_first_v1";
+
+export const IOS_APP_STORE_REDIRECT_PATH = "/app-store";
+
+interface IosAppStoreCampaignSignals {
+  campaign?: string;
+  medium?: string;
+  placement?: string;
+  source?: string;
+  surface?: string;
+}
+
+/** Keep Apple's campaign grain intentionally small so low-volume campaigns can report. */
+export function resolveIosAppStoreCampaign({
+  campaign,
+  medium,
+  placement,
+  source,
+  surface,
+}: IosAppStoreCampaignSignals): IosAppStoreCampaign {
+  if (campaign === IOS_APP_STORE_CAMPAIGNS.EMAIL) {
+    return IOS_APP_STORE_CAMPAIGNS.EMAIL;
+  }
+  if (campaign === IOS_APP_STORE_CAMPAIGNS.PARTNER_QR) {
+    return IOS_APP_STORE_CAMPAIGNS.PARTNER_QR;
+  }
+  if (campaign === IOS_APP_STORE_CAMPAIGNS.WEB) {
+    return IOS_APP_STORE_CAMPAIGNS.WEB;
+  }
+
+  if (source === "email" || medium === "email" || medium === "app_link") {
+    return IOS_APP_STORE_CAMPAIGNS.EMAIL;
+  }
+  if (
+    source === "partner_qr" ||
+    surface === "partner_landing" ||
+    placement === "desktop_partner_qr"
+  ) {
+    return IOS_APP_STORE_CAMPAIGNS.PARTNER_QR;
+  }
+
+  return IOS_APP_STORE_CAMPAIGNS.WEB;
+}
 
 /** Apple App Store campaign attribution. `ct` is our free-form campaign label;
  *  `pt` is set only when IOS_APP_STORE_PROVIDER_TOKEN is configured in App
  *  Store Connect. `mt=8` marks the link as an app link. */
-export function iosAppStoreUrlWithCampaign(campaign: string): string {
+export function iosAppStoreUrlWithCampaign(
+  campaign: IosAppStoreCampaign,
+  providerToken?: string,
+): string {
   const search = new URLSearchParams();
-  const providerToken = process.env.IOS_APP_STORE_PROVIDER_TOKEN;
-  if (providerToken) search.set("pt", providerToken);
+  const normalizedProviderToken =
+    normalizeIosAppStoreProviderToken(providerToken);
+  if (normalizedProviderToken) search.set("pt", normalizedProviderToken);
   search.set("ct", campaign);
   search.set("mt", "8");
   return `${IOS_APP_STORE_URL}?${search.toString()}`;
+}
+
+export function buildIosAppStoreRedirectPath(
+  campaign: IosAppStoreCampaign,
+): string {
+  const search = new URLSearchParams({ ct: campaign });
+  return `${IOS_APP_STORE_REDIRECT_PATH}?${search.toString()}`;
+}
+
+export const IOS_APP_STORE_WEB_REDIRECT_PATH = buildIosAppStoreRedirectPath(
+  IOS_APP_STORE_CAMPAIGNS.WEB,
+);
+
+export function normalizeIosAppStoreProviderToken(
+  providerToken?: string,
+): string | undefined {
+  const normalized = providerToken?.trim();
+  return normalized && /^\d+$/.test(normalized) ? normalized : undefined;
+}
+
+export function buildIosSmartAppBannerContent(providerToken?: string): string {
+  const parts = [`app-id=${IOS_APP_STORE_APP_ID}`];
+  const normalizedProviderToken =
+    normalizeIosAppStoreProviderToken(providerToken);
+  if (normalizedProviderToken) {
+    parts.push(
+      `affiliate-data=pt=${normalizedProviderToken}&ct=${IOS_APP_STORE_CAMPAIGNS.WEB}`,
+    );
+  }
+  parts.push(`app-argument=${IOS_APP_STORE_SMART_BANNER_ARGUMENT}`);
+  return parts.join(", ");
 }
 
 export const IOS_APP_STORE_CTA = "Open App Store";
 
 export const IOS_APP_STORE_DESTINATION_STATUS = "app_store_live";
 
-export const IOS_APP_STORE_SMART_BANNER_ARGUMENT =
-  `https://www.quiversurf.app/app?source=ios_smart_app_banner&surface=web&placement=apple_smart_banner&utm_source=ios_safari&utm_medium=smart_banner&utm_campaign=${APP_FIRST_CAMPAIGN}`;
+export const IOS_APP_STORE_SMART_BANNER_ARGUMENT = `https://www.quiversurf.app/app?source=ios_smart_app_banner&surface=web&placement=apple_smart_banner&utm_source=ios_safari&utm_medium=smart_banner&utm_campaign=${APP_FIRST_CAMPAIGN}`;
 
 export const ANDROID_BETA_LANDING_PATH = "/android-beta";
 
-export const ANDROID_BETA_LANDING_URL =
-  `https://www.quiversurf.app${ANDROID_BETA_LANDING_PATH}`;
+export const ANDROID_BETA_LANDING_URL = `https://www.quiversurf.app${ANDROID_BETA_LANDING_PATH}`;
 
 export const ANDROID_BETA_GROUP_URL =
   "https://groups.google.com/g/quiver-android-testers";
 
 export const ANDROID_BETA_CONTACT_EMAIL = "steven@quiversurf.app";
 
-export const ANDROID_BETA_CONTACT_MAILTO =
-  `mailto:${ANDROID_BETA_CONTACT_EMAIL}`;
+export const ANDROID_BETA_CONTACT_MAILTO = `mailto:${ANDROID_BETA_CONTACT_EMAIL}`;
 
 export const ANDROID_BETA_PLAY_URL: string | null =
   "https://play.google.com/apps/testing/app.quiversurf.surf";

--- a/lib/seo/agent-workflow/types.ts
+++ b/lib/seo/agent-workflow/types.ts
@@ -551,8 +551,31 @@ export interface OutreachDigestInput {
   missing?: string[];
 }
 
+export type WeeklySeoSourceFreshnessStatus = "fresh" | "lagged" | "stale" | "missing";
+
+export interface WeeklySeoSourceFreshness {
+  source: string;
+  observedAt?: string;
+  status: WeeklySeoSourceFreshnessStatus;
+  note: string;
+}
+
+export interface WeeklySeoMetricDelta {
+  label: string;
+  current: number;
+  previous: number;
+  unit: string;
+}
+
+export interface WeeklySeoComparison {
+  previousAuditDate?: string;
+  metrics: WeeklySeoMetricDelta[];
+  missing?: string[];
+}
+
 export interface WeeklySeoReportInput {
   generatedAt: string;
+  auditDate?: string;
   recommendations: SeoRecommendation[];
   gsc?: GscExportInput;
   vercel?: VercelExportInput;
@@ -565,6 +588,8 @@ export interface WeeklySeoReportInput {
   outreach?: OutreachDigestInput;
   technical?: SeoRecommendation[];
   metadata?: SeoMetadataAuditInput;
+  sourceFreshness?: WeeklySeoSourceFreshness[];
+  weekOverWeek?: WeeklySeoComparison;
   missing: string[];
 }
 

--- a/lib/seo/agent-workflow/weekly-report.ts
+++ b/lib/seo/agent-workflow/weekly-report.ts
@@ -14,6 +14,7 @@ import type {
   StoreSnapshotInput,
   VercelExportInput,
   WeeklyActionItem,
+  WeeklySeoComparison,
   WeeklySeoReportInput,
 } from "./types";
 import {
@@ -50,13 +51,21 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
   const actionQueue = synthesizeWeeklyActionQueue(input);
 
   return [
-    `# Quiver Weekly SEO + ASO Report - ${input.generatedAt.slice(0, 10)}`,
+    `# Quiver Weekly SEO + ASO Report - ${input.auditDate ?? input.generatedAt.slice(0, 10)}`,
     "",
     "Report-only output. No publishing, migrations, commits, pushes, runtime page edits, or production mutations were performed.",
     "",
     "## Bottom Line",
     "",
     renderBottomLine(input, openRecommendations),
+    "",
+    "## Source Freshness",
+    "",
+    renderSourceFreshness(input.sourceFreshness),
+    "",
+    "## Week-over-Week Movement",
+    "",
+    renderWeekOverWeek(input.weekOverWeek),
     "",
     "## Web SEO",
     "",
@@ -88,7 +97,10 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
     "",
     "## Technical Crawl Health",
     "",
-    renderRecommendations(input.technical ?? [], "No technical crawl issues in available inputs."),
+    renderRecommendations(
+      mergeTechnicalRecommendations(input.technical ?? [], input.recommendations),
+      "No technical crawl issues in available inputs.",
+    ),
     "",
     "## Backlink / Referrer Signals",
     "",
@@ -131,6 +143,147 @@ export function renderWeeklySeoReport(input: WeeklySeoReportInput): string {
     renderCoverageNotes(input),
     "",
   ].join("\n");
+}
+
+export function buildWeeklySeoComparison(
+  current: WeeklySeoReportInput,
+  previous?: WeeklySeoReportInput,
+  previousAuditDate?: string,
+): WeeklySeoComparison | undefined {
+  const metrics: WeeklySeoComparison["metrics"] = [];
+  const currentGsc = current.gsc;
+
+  if (currentGsc) {
+    addMetric(
+      metrics,
+      "GSC clicks (last 7d vs prior 7d)",
+      sum(currentGsc.last7d.map((row) => row.clicks)),
+      sum(currentGsc.prior7d.map((row) => row.clicks)),
+      "clicks",
+    );
+    addMetric(
+      metrics,
+      "GSC impressions (last 7d vs prior 7d)",
+      sum(currentGsc.last7d.map((row) => row.impressions)),
+      sum(currentGsc.prior7d.map((row) => row.impressions)),
+      "impressions",
+    );
+  }
+
+  if (current.vercel) {
+    const currentVisits = sum(current.vercel.pages.map((page) => page.visits ?? 0));
+    const previousVisits = sum(current.vercel.pages.map((page) => page.previousVisits ?? 0));
+    if (currentVisits > 0 && previousVisits > 0) {
+      addMetric(
+        metrics,
+        "Vercel SEO page visits",
+        currentVisits,
+        previousVisits,
+        "visits",
+      );
+    }
+  }
+
+  if (previous?.gsc && currentGsc) {
+    addMetric(
+      metrics,
+      "GSC clicks (28d vs prior report)",
+      sum(currentGsc.last28d.map((row) => row.clicks)),
+      sum(previous.gsc.last28d.map((row) => row.clicks)),
+      "clicks",
+    );
+    addMetric(
+      metrics,
+      "GSC impressions (28d vs prior report)",
+      sum(currentGsc.last28d.map((row) => row.impressions)),
+      sum(previous.gsc.last28d.map((row) => row.impressions)),
+      "impressions",
+    );
+  }
+
+  if (previous?.vercel && current.vercel) {
+    addMetric(
+      metrics,
+      "Vercel adjusted pageviews",
+      current.vercel.adjustedPageViews,
+      previous.vercel.adjustedPageViews,
+      "pageviews",
+    );
+  }
+
+  if (previous?.dataforseo && current.dataforseo) {
+    addMetric(
+      metrics,
+      "DataForSEO Google top-100 checks",
+      countTop100(current.dataforseo.googleRankings),
+      countTop100(previous.dataforseo.googleRankings),
+      "checks",
+    );
+    addMetric(
+      metrics,
+      "DataForSEO ASO top-100 checks",
+      countTop100(current.dataforseo.asoRankings),
+      countTop100(previous.dataforseo.asoRankings),
+      "checks",
+    );
+  }
+
+  if (metrics.length === 0) return undefined;
+  return { previousAuditDate, metrics };
+}
+
+function addMetric(
+  metrics: WeeklySeoComparison["metrics"],
+  label: string,
+  current: number,
+  previous: number,
+  unit: string,
+): void {
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return;
+  if (current === 0 && previous === 0) return;
+  metrics.push({ label, current, previous, unit });
+}
+
+function countTop100(rows: Array<{ quiverRank: number | null }>): number {
+  return rows.filter((row) => row.quiverRank !== null && row.quiverRank <= 100).length;
+}
+
+function renderSourceFreshness(
+  freshness: WeeklySeoReportInput["sourceFreshness"],
+): string {
+  if (!freshness?.length) return "- Source freshness was not recorded for this run.";
+  return [
+    "- Freshness policy: FRESH = 0–1 days old; LAGGED = 2–3 days; STALE = more than 3 days; MISSING = no dated input.",
+    ...freshness.map((source) =>
+      `- ${source.source}: ${source.status.toUpperCase()}${source.observedAt ? ` (${source.observedAt})` : ""} — ${source.note}`,
+    ),
+  ].join("\n");
+}
+
+function renderWeekOverWeek(comparison?: WeeklySeoComparison): string {
+  if (!comparison?.metrics.length) return "- No comparable prior-week metrics were available.";
+  const rows = comparison.previousAuditDate
+    ? [`- Comparison baseline: audit ${comparison.previousAuditDate}.`]
+    : [];
+  rows.push(...comparison.metrics.map((metric) => {
+    const delta = metric.current - metric.previous;
+    const percent = metric.previous === 0 ? "n/a" : `${formatSigned((delta / metric.previous) * 100, 1)}%`;
+    return `- ${metric.label}: ${formatMetricNumber(metric.current)} ${metric.unit}; prior ${formatMetricNumber(metric.previous)}; change ${formatSigned(delta, 0)} (${percent}).`;
+  }));
+  if (comparison.missing?.length) {
+    rows.push(...comparison.missing.map((item) => `- Comparison gap: ${item}`));
+  }
+  return rows.join("\n");
+}
+
+function mergeTechnicalRecommendations(
+  technical: SeoRecommendation[],
+  recommendations: SeoRecommendation[],
+): SeoRecommendation[] {
+  const ahrefsIssues = recommendations.filter((item) =>
+    item.source === "ahrefs-audit" && !item.targetKeyword,
+  );
+  return [...new Map([...technical, ...ahrefsIssues].map((item) => [item.id, item])).values()];
 }
 
 function renderBottomLine(
@@ -192,8 +345,11 @@ function renderKeywordMovement(
   dataforseo: DataForSeoExportInput | undefined,
   recommendations: SeoRecommendation[],
 ): string {
+  // Non-keyword ahrefs-audit findings render under Technical Crawl Health via
+  // mergeTechnicalRecommendations. Keeping them here too printed each one twice.
   const keywordRecs = recommendations.filter((item) =>
-    item.source === "gsc-decay" || item.source === "ahrefs-audit",
+    item.source === "gsc-decay" ||
+    (item.source === "ahrefs-audit" && Boolean(item.targetKeyword)),
   );
   const rows = [
     ...renderDataForSeoGoogleRanks(dataforseo),
@@ -885,6 +1041,17 @@ function isAmbiguousAsoBrandKeyword(keyword: string): boolean {
 
 function sum(values: number[]): number {
   return values.reduce((total, value) => total + value, 0);
+}
+
+function formatMetricNumber(value: number): string {
+  return Number.isInteger(value) ? value.toLocaleString("en-US") : value.toFixed(1);
+}
+
+function formatSigned(value: number, decimals: number): string {
+  const rounded = decimals === 0
+    ? Math.abs(Math.round(value)).toLocaleString("en-US")
+    : Math.abs(value).toFixed(decimals);
+  return `${value >= 0 ? "+" : "-"}${rounded}`;
 }
 
 function formatNumber(value: number | undefined): string {

--- a/lib/services/indexnow-service.ts
+++ b/lib/services/indexnow-service.ts
@@ -21,31 +21,41 @@ const BATCH_SIZE = 10_000;
 export interface IndexNowResult {
   success: boolean;
   statusCode: number;
+  /** URLs the API confirmed (HTTP 200 — key verified against keyLocation). */
   submitted: number;
+  /** URLs accepted with key validation deferred (HTTP 202). Not yet delivered. */
+  pending: number;
 }
 
 export interface IndexNowBatchResult {
   totalSubmitted: number;
+  totalPending: number;
   batches: IndexNowResult[];
   errors: string[];
+  /** Non-fatal conditions that still mean delivery is unconfirmed. */
+  warnings: string[];
 }
 
 /**
  * Submit a batch of URLs to the IndexNow API.
  *
- * Returns 200 (OK), 202 (Accepted), or error codes.
- * Rate-limited requests return 429.
+ * Only HTTP 200 counts as delivered. A 202 means IndexNow accepted the payload
+ * but deferred key validation, and a key that does not match the file at
+ * `keyLocation` returns 202 as often as it returns 403 (observed against the
+ * live API, 2026-08-10). Counting 202 as delivered therefore made a broken key
+ * indistinguishable from a working one — the weekly cron reported thousands of
+ * successful submissions while Bing silently discarded every URL.
  */
 export async function submitUrlsToIndexNow(
   urls: string[]
 ): Promise<IndexNowResult> {
   const key = process.env.INDEXNOW_KEY;
   if (!key) {
-    return { success: false, statusCode: 0, submitted: 0 };
+    return { success: false, statusCode: 0, submitted: 0, pending: 0 };
   }
 
   if (urls.length === 0) {
-    return { success: true, statusCode: 200, submitted: 0 };
+    return { success: true, statusCode: 200, submitted: 0, pending: 0 };
   }
 
   const host = new URL(SITE_URL).host;
@@ -61,12 +71,14 @@ export async function submitUrlsToIndexNow(
     }),
   });
 
-  const success = response.status === 200 || response.status === 202;
+  const verified = response.status === 200;
+  const deferred = response.status === 202;
 
   return {
-    success,
+    success: verified || deferred,
     statusCode: response.status,
-    submitted: success ? urls.length : 0,
+    submitted: verified ? urls.length : 0,
+    pending: deferred ? urls.length : 0,
   };
 }
 
@@ -78,30 +90,39 @@ export async function submitUrlsInBatches(
 ): Promise<IndexNowBatchResult> {
   const results: IndexNowResult[] = [];
   const errors: string[] = [];
+  const warnings: string[] = [];
   let totalSubmitted = 0;
+  let totalPending = 0;
 
   for (let i = 0; i < urls.length; i += BATCH_SIZE) {
     const batch = urls.slice(i, i + BATCH_SIZE);
+    const batchNumber = Math.floor(i / BATCH_SIZE) + 1;
 
     try {
       const result = await submitUrlsToIndexNow(batch);
       results.push(result);
       totalSubmitted += result.submitted;
+      totalPending += result.pending;
 
       if (!result.success) {
-        errors.push(
-          `Batch ${Math.floor(i / BATCH_SIZE) + 1}: HTTP ${result.statusCode}`
+        errors.push(`Batch ${batchNumber}: HTTP ${result.statusCode}`);
+      } else if (result.pending > 0) {
+        warnings.push(
+          `Batch ${batchNumber}: HTTP 202 - key validation pending, delivery unconfirmed`
         );
       }
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unknown error";
-      errors.push(
-        `Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${message}`
-      );
-      results.push({ success: false, statusCode: 0, submitted: 0 });
+      errors.push(`Batch ${batchNumber}: ${message}`);
+      results.push({
+        success: false,
+        statusCode: 0,
+        submitted: 0,
+        pending: 0,
+      });
     }
   }
 
-  return { totalSubmitted, batches: results, errors };
+  return { totalSubmitted, totalPending, batches: results, errors, warnings };
 }

--- a/scripts/seo/weekly-report.ts
+++ b/scripts/seo/weekly-report.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { currentAuditDate, resolveSeoAuditDir } from "../../lib/seo/agent-workflow/audit-paths";
-import { renderWeeklySeoReport } from "../../lib/seo/agent-workflow/weekly-report";
+import {
+  buildWeeklySeoComparison,
+  renderWeeklySeoReport,
+} from "../../lib/seo/agent-workflow/weekly-report";
 import type {
   AeoCitationInput,
   BacklinkProxyInput,
@@ -16,10 +19,14 @@ import type {
   StoreSnapshotInput,
   VercelExportInput,
   WeeklySeoReportInput,
+  WeeklySeoSourceFreshness,
+  WeeklySeoSourceFreshnessStatus,
 } from "../../lib/seo/agent-workflow/types";
 
 const auditDir = getFlag("--dir") ?? resolveSeoAuditDir(currentAuditDate());
 const outputPath = getFlag("--output") ?? path.join(auditDir, "SEO-WEEKLY-REPORT.md");
+const auditDate = getFlag("--audit-date") ?? inferAuditDate(auditDir);
+const previousAuditDir = findPreviousAuditDir(auditDir);
 
 const inputFiles = [
   "GSC-REFRESH.json",
@@ -29,47 +36,154 @@ const inputFiles = [
 ];
 const optionalInputFiles = ["AHREFS-ENRICHMENT.json"];
 
-const missing: string[] = [];
-const metadata = readJsonIfExists<SeoMetadataAuditInput>(
-  path.join(auditDir, "SEO-METADATA-AUDIT.json"),
-  missing,
-) ?? undefined;
-
-const recommendations = inputFiles.flatMap((fileName) =>
-  readJsonIfExists<SeoRecommendation[]>(path.join(auditDir, fileName), missing) ?? [],
-).concat(metadata?.recommendations ?? [], optionalInputFiles.flatMap((fileName) =>
-  readJsonIfExists<SeoRecommendation[]>(path.join(auditDir, fileName)) ?? [],
-));
-const technical = readJsonIfExists<SeoRecommendation[]>(
-  path.join(auditDir, "TECHNICAL-AUDIT.json"),
-  missing,
-) ?? [];
-
-const input: WeeklySeoReportInput = {
-  generatedAt: new Date().toISOString(),
-  recommendations,
-  technical,
-  gsc: readJsonIfExists<GscExportInput>(path.join(auditDir, "GSC-EXPORT.json"), missing) ?? undefined,
-  vercel: readJsonIfExists<VercelExportInput>(path.join(auditDir, "VERCEL-EXPORT.json"), missing) ?? undefined,
-  posthog: readJsonIfExists<PostHogExportInput>(path.join(auditDir, "POSTHOG-EXPORT.json"), missing) ?? undefined,
-  store: readJsonIfExists<StoreSnapshotInput>(path.join(auditDir, "STORE-SNAPSHOT.json"), missing) ?? undefined,
-  dataforseo: readJsonIfExists<DataForSeoExportInput>(path.join(auditDir, "DATAFORSEO-EXPORT.json")) ?? undefined,
-  backlink: readJsonIfExists<BacklinkProxyInput>(path.join(auditDir, "BACKLINK-PROXY.json"), missing) ?? undefined,
-  competitor: readJsonIfExists<CompetitorIntelligenceInput>(path.join(auditDir, "COMPETITOR-EXPORT.json"), missing) ?? undefined,
-  aeo: readJsonIfExists<AeoCitationInput>(path.join(auditDir, "AEO-EXPORT.json"), missing) ?? undefined,
-  outreach: readJsonIfExists<OutreachDigestInput>(path.join(auditDir, "OUTREACH-DIGEST.json"), missing) ?? undefined,
-  metadata,
-  missing,
-};
+const input = readWeeklyReportInput(auditDir, new Date().toISOString(), auditDate, true);
+const previousInput = previousAuditDir
+  ? readWeeklyReportInput(previousAuditDir, new Date().toISOString(), path.basename(previousAuditDir), false)
+  : undefined;
+const ahrefsSnapshot = readJsonIfExists<AhrefsFreshnessSnapshot>(
+  path.join(auditDir, "AHREFS-SCREENSHOT-INPUT.json"),
+);
+input.sourceFreshness = buildSourceFreshness(input, auditDate, ahrefsSnapshot);
+input.weekOverWeek = buildWeeklySeoComparison(
+  input,
+  previousInput,
+  previousAuditDir ? path.basename(previousAuditDir) : undefined,
+);
 
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, renderWeeklySeoReport(input));
 
 console.log(JSON.stringify({
   outputPath,
-  recommendations: recommendations.length,
-  missing: missing.length,
+  recommendations: input.recommendations.length,
+  missing: input.missing.length,
+  previousAuditDate: previousAuditDir ? path.basename(previousAuditDir) : null,
+  staleSources: input.sourceFreshness.filter((source) => source.status === "stale").map((source) => source.source),
 }, null, 2));
+
+function readWeeklyReportInput(
+  dir: string,
+  generatedAt: string,
+  reportDate: string,
+  trackMissing: boolean,
+): WeeklySeoReportInput {
+  const missing: string[] = [];
+  const missingList = trackMissing ? missing : undefined;
+  const metadata = readJsonIfExists<SeoMetadataAuditInput>(
+    path.join(dir, "SEO-METADATA-AUDIT.json"),
+    missingList,
+  ) ?? undefined;
+  const recommendations = inputFiles.flatMap((fileName) =>
+    readJsonIfExists<SeoRecommendation[]>(path.join(dir, fileName), missingList) ?? [],
+  ).concat(metadata?.recommendations ?? [], optionalInputFiles.flatMap((fileName) =>
+    readJsonIfExists<SeoRecommendation[]>(path.join(dir, fileName)) ?? [],
+  ));
+  const technical = readJsonIfExists<SeoRecommendation[]>(
+    path.join(dir, "TECHNICAL-AUDIT.json"),
+    missingList,
+  ) ?? [];
+
+  return {
+    generatedAt,
+    auditDate: reportDate,
+    recommendations,
+    technical,
+    gsc: readJsonIfExists<GscExportInput>(path.join(dir, "GSC-EXPORT.json"), missingList) ?? undefined,
+    vercel: readJsonIfExists<VercelExportInput>(path.join(dir, "VERCEL-EXPORT.json"), missingList) ?? undefined,
+    posthog: readJsonIfExists<PostHogExportInput>(path.join(dir, "POSTHOG-EXPORT.json"), missingList) ?? undefined,
+    store: readJsonIfExists<StoreSnapshotInput>(path.join(dir, "STORE-SNAPSHOT.json"), missingList) ?? undefined,
+    dataforseo: readJsonIfExists<DataForSeoExportInput>(path.join(dir, "DATAFORSEO-EXPORT.json")) ?? undefined,
+    backlink: readJsonIfExists<BacklinkProxyInput>(path.join(dir, "BACKLINK-PROXY.json"), missingList) ?? undefined,
+    competitor: readJsonIfExists<CompetitorIntelligenceInput>(path.join(dir, "COMPETITOR-EXPORT.json"), missingList) ?? undefined,
+    aeo: readJsonIfExists<AeoCitationInput>(path.join(dir, "AEO-EXPORT.json"), missingList) ?? undefined,
+    outreach: readJsonIfExists<OutreachDigestInput>(path.join(dir, "OUTREACH-DIGEST.json"), missingList) ?? undefined,
+    metadata,
+    missing,
+  };
+}
+
+interface AhrefsFreshnessSnapshot {
+  capturedAt?: string;
+  capturedForAuditDate?: string;
+  crawl?: { latestRun?: { date?: string } };
+}
+
+function buildSourceFreshness(
+  input: WeeklySeoReportInput,
+  reportDate: string,
+  ahrefs?: AhrefsFreshnessSnapshot | null,
+): WeeklySeoSourceFreshness[] {
+  return [
+    makeFreshness("GSC Search Console", input.gsc?.dateRanges.last28d.end, reportDate, "data through"),
+    makeFreshness("Vercel Analytics", input.vercel?.dateRange.to, reportDate, "window ends"),
+    makeFreshness("PostHog", input.posthog?.dateRange.to, reportDate, "window ends"),
+    makeFreshness("DataForSEO", input.dataforseo?.generatedAt, reportDate, "export generated"),
+    makeFreshness("Store listings", input.store?.generatedAt, reportDate, "snapshot generated"),
+    makeFreshness(
+      "Ahrefs Site Audit",
+      ahrefs?.capturedForAuditDate ?? ahrefs?.crawl?.latestRun?.date ?? ahrefs?.capturedAt,
+      reportDate,
+      "capture date",
+    ),
+    makeFreshness("Competitor deep-dive", dateFromRunId(input.competitor?.runId), reportDate, "run date"),
+    makeFreshness("AEO citation baseline", input.aeo?.narrativeBaseline?.reportDate, reportDate, "30-query audit date"),
+    makeFreshness("Backlink target report", input.backlink?.narrativeTargets?.reportDate, reportDate, "target report date"),
+  ];
+}
+
+function makeFreshness(
+  source: string,
+  observedAt: string | undefined,
+  reportDate: string,
+  label: string,
+): WeeklySeoSourceFreshness {
+  const date = dateOnly(observedAt);
+  if (!date) {
+    return { source, status: "missing", note: "no dated input was available" };
+  }
+  const ageDays = dayDifference(reportDate, date);
+  const status: WeeklySeoSourceFreshnessStatus = ageDays <= 1
+    ? "fresh"
+    : ageDays <= 3
+      ? "lagged"
+      : "stale";
+  const ageNote = ageDays === 0 ? "same-day" : `${ageDays} day${ageDays === 1 ? "" : "s"} old`;
+  return { source, observedAt: date, status, note: `${label} ${date} (${ageNote})` };
+}
+
+function findPreviousAuditDir(auditDirPath: string): string | null {
+  const auditRoot = path.dirname(auditDirPath);
+  const currentDate = path.basename(auditDirPath);
+  if (!fs.existsSync(auditRoot)) return null;
+  const previous = fs.readdirSync(auditRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(entry.name) && entry.name < currentDate)
+    .map((entry) => entry.name)
+    .sort()
+    .at(-1);
+  return previous ? path.join(auditRoot, previous) : null;
+}
+
+function inferAuditDate(auditDirPath: string): string {
+  const date = path.basename(auditDirPath);
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : currentAuditDate();
+}
+
+function dateFromRunId(runId?: string): string | undefined {
+  const compact = runId?.match(/^(\d{4})(\d{2})(\d{2})/);
+  if (compact) return `${compact[1]}-${compact[2]}-${compact[3]}`;
+  return runId?.match(/^(\d{4}-\d{2}-\d{2})/)?.[1];
+}
+
+function dateOnly(value?: string): string | undefined {
+  return value?.match(/\d{4}-\d{2}-\d{2}/)?.[0];
+}
+
+function dayDifference(later: string, earlier: string): number {
+  const laterMs = Date.parse(`${later}T00:00:00Z`);
+  const earlierMs = Date.parse(`${earlier}T00:00:00Z`);
+  if (!Number.isFinite(laterMs) || !Number.isFinite(earlierMs)) return 999;
+  return Math.max(0, Math.round((laterMs - earlierMs) / 86_400_000));
+}
 
 function readJsonIfExists<T>(filePath: string, missingList?: string[]): T | null {
   if (!fs.existsSync(filePath)) {


### PR DESCRIPTION
Promotes four reviewed commits from `main` to `prod` as a targeted slice. `prod` is 147 commits behind `main`, so a full merge is not viable — these four cherry-picked cleanly with **zero conflicts**.

## What's in it

- `bab02b212` — **fix(seo): stop counting IndexNow 202 responses as delivered.** This is the one that only matters on prod: the IndexNow cron runs on Production only. Verified against the live API — a key that does not match `keyLocation` returns 403 *or* 202, so counting 202 as success made a broken `INDEXNOW_KEY` indistinguishable from a working one. The weekly cron reported `submitted: 1733, errors: []` with no way to tell. Now only 200 counts as delivered; 202 is tracked as `pending` with a warning, and the response carries `pending`, `statusCodes`, and `warnings`. **`pending` equal to `totalUrls` is the signature of a key that no longer matches `public/indexnow-key.txt`.**
- `58a1e5bd3` — feat(attribution): App Store campaign redirects, adding the `/app-store` route and campaign-tagged App Store URLs.
- `a5ebbf03c` — feat(forecast): forecast hub in the zine design.
- `3ecbfb317` — feat(seo): source freshness + week-over-week movement in the weekly report. Script-only; no runtime surface.

## Route closure

`/app-store` is a **new route on prod**, referenced by `IOS_APP_STORE_REDIRECT_PATH` in `lib/constants/app-store.ts`. Import-graph closure would not have caught a missing route — `tsc` and `next build` only see modules. Confirmed `app/app-store/route.ts` came across in the cherry-pick, appears in the build manifest as `ƒ /app-store`, and returns a live redirect. Swept all internal path literals in the 25 changed source files against the slice's app tree: **0 unresolved**.

## Verification (local production build)

- `tsc --noEmit` clean — **0 errors**, so the import graph is closed
- **1,317 suites / 17,252 tests passing**
- `VERCEL_ENV=production next build` — exit 0, 163/163 static pages
- Smoked on `next start`:
  - `/app-store` → `307` → `apps.apple.com/...?pt=128222562&ct=web&mt=8`
  - `/forecast` → `200`, rendering `zine-page` / `zine-paper`
  - `/`, `/map`, `/beaches`, `/ca/la-jolla/windansea` → all `200`
  - `/api/cron/indexnow-submit` → `200` with `submitted: 1733, pending: 0, statusCodes: [200], warnings: []`

Note: that cron returns `500 "INDEXNOW_KEY environment variable is not set"` when the key is absent — that is the intended guard, not a defect. It was re-run with a key supplied to produce the result above. `INDEXNOW_KEY` is already set in Vercel Production.

## Rollback

No feature flags in this slice, so rollback is **revert the merge**, not a flag flip. Blast radius is small: one new route, one forecast page redesign, one service-layer accounting change, and a reporting script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)