### PR TITLE
promote: alert quality guards (late-send + minimum score) ahead of enabling delivery

### DIFF
--- a/__tests__/api/cron/condition-alert-deliver.test.ts
+++ b/__tests__/api/cron/condition-alert-deliver.test.ts
@@ -364,6 +364,7 @@ function expectQueueReasonTotals(body: {
     [
       "delivered",
       "stale",
+      "below_score_floor",
       "major_event_hold",
       "canonical_safety_rejected",
       "shadow_withheld",
@@ -823,7 +824,7 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
       id: "00000000-0000-0000-0000-0000000000c2",
       rule_id: "00000000-0000-0000-0000-0000000000a2",
       beach_id: "00000000-0000-0000-0000-0000000000b2",
-      best_score: 0.25,
+      best_score: 0.35,
       alert_rules: { name: "Lower score rule", notify_email: true, notify_push: false },
       beaches: {
         name: "Lower Score Beach",
@@ -866,6 +867,91 @@ describe("condition-alert-deliver — kill switch + allowlist + per-attempt rows
     ]);
     expectQueueReasonTotals(body);
   });
+
+  it("suppresses a queued alert whose best score is below the floor", async () => {
+    seedQueueRow({
+      best_score: 0.09,
+      alert_rules: {
+        name: "Pipes low-score rule",
+        notify_email: true,
+        notify_push: false,
+      },
+    });
+    seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.queue_marked_by_reason.below_score_floor).toBe(1);
+    expect(body.queue_marked_by_reason.delivered).toBe(0);
+    expect(mockEmailsSend).not.toHaveBeenCalled();
+    expect(mockEnqueueNotification).not.toHaveBeenCalled();
+    expect(store.attemptInserts).toHaveLength(0);
+    expect(store.deliveryInserts).toHaveLength(0);
+    expect(store.queueUpdates).toEqual([{ ids: [QUEUE_1], sent: true }]);
+  });
+
+  it.each([0.3, 0.64])(
+    "still delivers a queued alert with best score %s at or above the floor",
+    async (bestScore) => {
+      seedQueueRow({
+        best_score: bestScore,
+        alert_rules: {
+          name: "Deliverable score rule",
+          notify_email: true,
+          notify_push: false,
+        },
+      });
+      seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.queue_marked_by_reason.below_score_floor).toBe(0);
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+      expect(store.attemptInserts).toContainEqual(
+        expect.objectContaining({
+          queue_id: QUEUE_1,
+          channel: "email",
+          status: "sent",
+        }),
+      );
+    },
+  );
+
+  it.each([
+    { label: "null", bestScore: null },
+    { label: "unparseable", bestScore: "not-a-score" },
+  ])(
+    "keeps a queue row with a $label best score deliverable",
+    async ({ bestScore }) => {
+      seedQueueRow({
+        best_score: bestScore,
+        alert_rules: {
+          name: "Fail-open score rule",
+          notify_email: true,
+          notify_push: false,
+        },
+      });
+      seedProfile({ notif_email_enabled: true, notif_push_enabled: false });
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.queue_marked_by_reason.below_score_floor).toBe(0);
+      expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+      expect(store.attemptInserts).toContainEqual(
+        expect.objectContaining({
+          queue_id: QUEUE_1,
+          channel: "email",
+          status: "sent",
+        }),
+      );
+    },
+  );
 
   it("email-only rule, profile.email is null → skipped_no_email, no Resend call, queue still marked sent", async () => {
     // Regression for the 2026-04-27 failed_provider crash where Resend rejected

--- a/__tests__/lib/alerts/actionable-window-selector.test.ts
+++ b/__tests__/lib/alerts/actionable-window-selector.test.ts
@@ -1,9 +1,21 @@
 import {
+  ALERT_MIN_ACTIONABLE_LEAD_MINUTES,
   ALERT_SCORE_MATERIAL_MARGIN,
   ALERT_SCORE_TIE_TOLERANCE,
   selectActionableAlertWindow,
 } from "@/lib/alerts/actionable-window-selector";
 import type { FoundWindow } from "@/lib/alerts/window-finder";
+
+function window(overrides: Partial<FoundWindow> = {}): FoundWindow {
+  return {
+    window_start: "2026-08-10T15:00:00.000Z",
+    window_end: "2026-08-10T16:00:00.000Z",
+    best_hour: "2026-08-10T15:00:00.000Z",
+    best_score: 0.7,
+    conditions_snapshot: {},
+    ...overrides,
+  } as FoundWindow;
+}
 
 function windowAt(
   hour: number,
@@ -62,5 +74,40 @@ describe("selectActionableAlertWindow", () => {
     );
 
     expect(selected?.window_start).toBe("2026-06-20T15:00:00.000Z");
+  });
+});
+
+describe("late-window suppression", () => {
+  // Reproduces production 2026-08-10: window_end was 2 minutes away so the old
+  // `window_end > now` test passed, but best_hour was already 58 minutes gone.
+  it("rejects a window whose best hour has already passed", () => {
+    const now = new Date("2026-08-10T15:58:49.000Z");
+    expect(selectActionableAlertWindow([window()], now)).toBeNull();
+  });
+
+  it("keeps a window whose best hour is still ahead", () => {
+    const now = new Date("2026-08-10T13:00:00.000Z");
+    expect(selectActionableAlertWindow([window()], now)?.best_hour).toBe(
+      "2026-08-10T15:00:00.000Z",
+    );
+  });
+
+  it("allows a short grace so a just-started session still sends", () => {
+    const graceMs = (ALERT_MIN_ACTIONABLE_LEAD_MINUTES - 1) * 60_000;
+    const now = new Date(Date.parse("2026-08-10T15:00:00.000Z") + graceMs);
+    expect(selectActionableAlertWindow([window()], now)).not.toBeNull();
+  });
+
+  it("prefers a later actionable window over a stale earlier one", () => {
+    const now = new Date("2026-08-10T15:58:49.000Z");
+    const later = window({
+      window_start: "2026-08-10T18:00:00.000Z",
+      window_end: "2026-08-10T19:00:00.000Z",
+      best_hour: "2026-08-10T18:00:00.000Z",
+      best_score: 0.5,
+    });
+    expect(selectActionableAlertWindow([window(), later], now)?.best_hour).toBe(
+      "2026-08-10T18:00:00.000Z",
+    );
   });
 });

--- a/app/api/cron/condition-alert-deliver/route.ts
+++ b/app/api/cron/condition-alert-deliver/route.ts
@@ -76,6 +76,7 @@ const HOLD_STATE_UNAVAILABLE_MAX_ATTEMPTS = 3;
 const QUEUE_MARK_REASONS = [
   "delivered",
   "stale",
+  "below_score_floor",
   "major_event_hold",
   "canonical_safety_rejected",
   "shadow_withheld",
@@ -96,6 +97,13 @@ const QUEUE_MARK_REASONS = [
 ] as const;
 
 type QueueMarkReason = (typeof QUEUE_MARK_REASONS)[number];
+
+/**
+ * Minimum best_score worth interrupting someone for. Rules match on thresholds, which
+ * says a session is acceptable, not that it is worth the drive. In the 7 days after the
+ * 2026-08-10 pipeline repair, 9 of 56 queued alerts scored below this — the weakest 0.09.
+ */
+const ALERT_MIN_DELIVERABLE_SCORE = 0.3;
 
 type RecordedAttempt = {
   channel: Channel;
@@ -220,8 +228,15 @@ function toRevalidationBeachMeta(
 }
 
 function parseQueuedBestScore(value: unknown): number {
-  const score = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(score) ? score : 0;
+  const score =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  if (Number.isFinite(score)) return score;
+  // Fail open so malformed queue data cannot silently mute the alert channel.
+  return ALERT_MIN_DELIVERABLE_SCORE;
 }
 
 function resolveRuleWeeklyCap(conditions?: AlertConditions | null): number | null {
@@ -806,6 +821,18 @@ export async function GET(request: Request): Promise<NextResponse> {
           if (marked) result.skippedStale += staleItems.length;
         }
 
+        const lowScoreItems = items.filter(
+          (item) =>
+            parseQueuedBestScore(item.best_score) < ALERT_MIN_DELIVERABLE_SCORE,
+        );
+        if (lowScoreItems.length > 0) {
+          await markQueueItemsConsumed(lowScoreItems, "below_score_floor");
+        }
+        const scoreEligibleItems = items.filter(
+          (item) =>
+            parseQueuedBestScore(item.best_score) >= ALERT_MIN_DELIVERABLE_SCORE,
+        );
+
         // 3. Fetch profile data for the queue's user set in a single query.
         //    profiles.id is a 1:1 mirror of auth.users.id, so we can key by user_id.
         type ProfileRow = {
@@ -858,7 +885,7 @@ export async function GET(request: Request): Promise<NextResponse> {
         // delivery candidates regardless of verdict or skill eligibility.
         const deliverableItems: QueueItemWithMeta[] = [];
         const itemsByUser = new Map<string, QueueItemWithMeta[]>();
-        for (const item of items) {
+        for (const item of scoreEligibleItems) {
           const userItems = itemsByUser.get(item.user_id) ?? [];
           userItems.push(item);
           itemsByUser.set(item.user_id, userItems);

--- a/lib/alerts/actionable-window-selector.ts
+++ b/lib/alerts/actionable-window-selector.ts
@@ -3,14 +3,29 @@ import type { FoundWindow } from "@/lib/alerts/window-finder";
 export const ALERT_SCORE_TIE_TOLERANCE = 0.04;
 export const ALERT_SCORE_MATERIAL_MARGIN = 0.08;
 
+/**
+ * How far past `best_hour` a window may still be sent. A surfer who gets the alert a
+ * few minutes into the best hour can still act on it; an hour late they cannot.
+ * Production 2026-08-10 sent 11 alerts up to 58 minutes after best_hour because the
+ * only guard was `window_end > now`, and a 15:00-16:00 window is still "unfinished"
+ * at 15:58.
+ */
+export const ALERT_MIN_ACTIONABLE_LEAD_MINUTES = 15;
+
 export function selectActionableAlertWindow(
   windows: FoundWindow[],
   now: Date = new Date()
 ): FoundWindow | null {
   const nowMs = now.getTime();
   const futureWindows = windows.filter((window) => {
+    const bestHourMs = new Date(window.best_hour).getTime();
     const endMs = new Date(window.window_end).getTime();
-    return Number.isFinite(endMs) && endMs > nowMs;
+    if (!Number.isFinite(bestHourMs) || !Number.isFinite(endMs)) return false;
+    // The window must not be over AND the best hour must still be reachable.
+    return (
+      endMs > nowMs &&
+      bestHourMs + ALERT_MIN_ACTIONABLE_LEAD_MINUTES * 60_000 > nowMs
+    );
   });
 
   if (futureWindows.length === 0) return null;


### PR DESCRIPTION
Promotes the two alert guards from `main` to `prod`. Both cherry-picked cleanly.

**This must land before `FORECAST_ALERT_DELIVERY_ENABLED` is turned on.** Without them, the first live run sends exactly the alerts we built these to stop.

## What's in it

- `f00348050` — **do not recommend a window whose best hour has passed.** `selectActionableAlertWindow` filtered on `window_end > now`, so a 15:00–16:00 window still passed at 15:58 with `best_hour` 58 minutes gone. Production 2026-08-10 queued 11 such alerts, scoring 0.64–0.82 — good surf, recommended too late to act on. Now also requires `best_hour` to be reachable, with a 15-minute grace so a just-started session still sends.
- `eaa83ed5b` — **suppress deliveries below `best_score` 0.3.** 9 of 56 queued alerts scored below that, weakest 0.09 at Pipes (2.3 ft @ 12 s) — inside the user's thresholds, not worth the drive. Applied at the delivery gate so queue rows remain the record of what matched and `queueMarkedByReason.below_score_floor` makes suppression measurable.

## Effect, re-derived from the production queue

```
total queued:              56
below score floor (<0.3):   9
late beyond 15m grace:     11
overlap:                    0
WOULD STILL SEND:          36
```

## Reviewer attention

`parseQueuedBestScore` is shared; its fallback changed from `0` to the floor so malformed data fails **open** rather than being silently muted. Its third caller feeds `item.best_score`, which is a fallback for similarity-match display scores — so with both that and the snapshot score null, a similarity alert would show `3` instead of `0`. Currently unreachable: **0 of 1,036 queue rows have a null `best_score`**.

## Verification (local production build)

`tsc --noEmit` clean · 32 suites / 392 tests passing · `VERCEL_ENV=production next build` exit 0, 163/163 static pages.

## Rollback

No flags on the guards themselves — rollback is reverting the merge. Delivery remains independently gated by `FORECAST_ALERT_DELIVERY_ENABLED`, which this PR does not change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)