### PR TITLE
feat(conditions-report): S2c — video on local spot reports

### DIFF
--- a/__tests__/actions/conditions-report-actions.test.ts
+++ b/__tests__/actions/conditions-report-actions.test.ts
@@ -45,6 +45,9 @@ const createSupabaseMock = () => {
     from: jest.fn().mockReturnThis() as MockFn,
     select: jest.fn().mockReturnThis() as MockFn,
     insert: jest.fn().mockReturnThis() as MockFn,
+    update: jest.fn().mockImplementation(() => ({
+      eq: jest.fn().mockImplementation(() => Promise.resolve({ error: null })) as unknown as MockFn,
+    })) as unknown as MockFn,
     eq: jest.fn().mockReturnThis() as MockFn,
     not: jest.fn().mockReturnThis() as MockFn,
     gte: jest.fn().mockReturnThis() as MockFn,

--- a/__tests__/actions/intel/intel-query-actions.test.ts
+++ b/__tests__/actions/intel/intel-query-actions.test.ts
@@ -30,11 +30,12 @@ const mockServerClient = {
   select: jest.fn().mockReturnThis(),
   insert: jest.fn().mockReturnThis(),
   eq: jest.fn().mockReturnThis(),
-  in: jest.fn(),
+  in: jest.fn().mockResolvedValue({ data: [], error: null }),
   gte: jest.fn().mockReturnThis(),
   or: jest.fn().mockReturnThis(),
   order: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
   single: jest.fn(),
   rpc: jest.fn(),
 };
@@ -49,10 +50,11 @@ const mockServiceRoleClient = {
   from: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
   eq: jest.fn().mockReturnThis(),
-  in: jest.fn(),
+  in: jest.fn().mockResolvedValue({ data: [], error: null }),
   or: jest.fn().mockReturnThis(),
   order: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
   rpc: jest.fn(),
 };
 
@@ -320,8 +322,8 @@ describe("getNearbyIntelPosts", () => {
     });
 
     expect(result.success).toBe(true);
-    // in() should be called only once (profiles), not twice
-    expect(mockServiceRoleClient.in).toHaveBeenCalledTimes(1);
+    // The conditions linkage lookup is also batched, even when it returns no rows.
+    expect(mockServiceRoleClient.in).toHaveBeenCalledTimes(2);
     expect(result.data?.posts[0].user_has_confirmed).toBe(false);
   });
 
@@ -371,8 +373,8 @@ describe("getPublicIntelPosts", () => {
 
     expect(result.success).toBe(true);
     expect(result.data?.posts[0].user_has_confirmed).toBe(false);
-    // in() should be called once (profiles), no confirmations
-    expect(mockServerClient.in).toHaveBeenCalledTimes(1);
+    // The conditions linkage lookup is also batched, even when it returns no rows.
+    expect(mockServerClient.in).toHaveBeenCalledTimes(2);
   });
 
   test("returns empty results when RPC fails", async () => {

--- a/__tests__/api/session-videos.test.ts
+++ b/__tests__/api/session-videos.test.ts
@@ -6,6 +6,10 @@ const mockFrom = jest.fn();
 const mockStorage = jest.fn();
 const mockRequireOwnership = jest.fn();
 
+jest.mock("@/lib/supabase", () => ({
+  createServiceRoleClient: () => ({ storage: { from: mockStorage } }),
+}));
+
 jest.mock("@/lib/middleware/api-wrappers", () => ({
   withAuth: (handler: any) => async (request: any, context: any) => {
     if (request.testRole === "none") return NextResponse.json({ error: "Authentication required" }, { status: 401 });
@@ -85,6 +89,15 @@ describe("session video routes", () => {
     mockFrom.mockReturnValue(chain({ data: null, error: null }));
     const { GET } = await import("@/app/api/sessions/[id]/videos/[mediaId]/route");
     expect((await GET({} as NextRequest, { params: { id: "s", mediaId: "m" } })).status).toBe(404);
+  });
+
+  it("returns 404 when the approved media object is missing from storage", async () => {
+    mockFrom.mockReturnValue(chain({ data: { id: "media-1", user_id: "other", storage_path: "missing.mp4", moderation_status: "approved", sessions: { is_public: true } }, error: null }));
+    mockStorage.mockReturnValue({ createSignedUrl: jest.fn().mockResolvedValue({ data: null, error: { statusCode: "404", message: "Object not found" } }) });
+    const { GET } = await import("@/app/api/sessions/[id]/videos/[mediaId]/route");
+    const response = await GET({} as NextRequest, { params: { id: "session-1", mediaId: "media-1" } });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Not found" });
   });
 });
 

--- a/__tests__/api/v1/conditions-reports.test.ts
+++ b/__tests__/api/v1/conditions-reports.test.ts
@@ -71,6 +71,7 @@ describe("POST /api/v1/conditions-reports", () => {
     expect(await response.json()).toEqual({
       reportId: "intel-1",
       intelPostId: "intel-1",
+      sessionId: "session-1",
       expiresAt: "2026-08-11T00:00:00.000Z",
     });
     expect(response.headers.get("cache-control")).toContain("no-store");
@@ -98,7 +99,7 @@ describe("POST /api/v1/conditions-reports", () => {
     expect(body).toMatchObject({
       reportId: "intel-2",
     });
-    expect(body).not.toHaveProperty("sessionId");
+    expect(body).toHaveProperty("sessionId", null);
   });
 
   it("returns 409 when the user already reported today", async () => {

--- a/__tests__/components/intel/beach-intel-section.test.tsx
+++ b/__tests__/components/intel/beach-intel-section.test.tsx
@@ -318,6 +318,29 @@ describe("BeachIntelSection", () => {
       expect(screen.getByText(mockIntelPost.description)).toBeInTheDocument();
     });
 
+    it("resolves an approved report video only after the tile is clicked", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ url: "https://signed.example/report.mp4" }), { status: 200 }),
+      );
+      mockUseIntelData.mockReturnValue(mockIntelDataReturn({
+        data: {
+          posts: [{ ...mockIntelPost, session_id: "session-report", video_media_id: "media-report" }] as any,
+        },
+      }));
+
+      render(<BeachIntelSection {...defaultProps} />);
+
+      expect(screen.getByRole("button", { name: "Play local spot report video" })).toBeInTheDocument();
+      expect(fetchMock).not.toHaveBeenCalled();
+      fireEvent.click(screen.getByRole("button", { name: "Play local spot report video" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/session-report/videos/media-report",
+      ));
+      await waitFor(() => expect(document.querySelector("video")).toHaveAttribute("src", "https://signed.example/report.mp4"));
+      fetchMock.mockRestore();
+    });
+
     it("shows post count badge when posts exist", () => {
       mockUseIntelData.mockReturnValue(mockIntelDataReturn({
         data: { posts: [mockIntelPost] as any },

--- a/actions/intel/intel-query-actions.ts
+++ b/actions/intel/intel-query-actions.ts
@@ -15,6 +15,13 @@ import type {
 import type { IntelPostsData, IntelPostRPCResult } from "./intel-types";
 import { GLOBAL_INTEL_FALLBACK } from "./intel-types";
 
+interface ConditionReportRow {
+  id: string;
+  session_id: string | null;
+  wave_size_range: string | null;
+  vibe: string | null;
+}
+
 /**
  * Get nearby intel posts (authenticated)
  */
@@ -114,16 +121,52 @@ export async function getNearbyIntelPosts(
       (confirmations || []).map((c) => c.intel_post_id)
     );
 
+    const conditionPostIds = intelPosts
+      .filter((post) => post.tag === "conditions")
+      .map((post) => post.id);
+    const conditionLookup = conditionPostIds.length
+      ? await (supabase.from("intel_posts") as any)
+          .select("id, session_id, wave_size_range, vibe")
+          .in("id", conditionPostIds)
+      : { data: [] as ConditionReportRow[], error: null };
+    const conditionRows = (conditionLookup.data ?? []) as ConditionReportRow[];
+    const conditionRowsError = conditionLookup.error;
+    if (conditionRowsError) {
+      console.warn("Conditions linkage lookup failed in getNearbyIntelPosts", conditionRowsError);
+    }
+    const conditionMap = new Map((conditionRows ?? []).map((row) => [row.id, row]));
+    const sessionIds = (conditionRows ?? [])
+      .map((row) => row.session_id)
+      .filter((id): id is string => Boolean(id));
+    const { data: approvedVideos, error: approvedVideosError } = sessionIds.length
+      ? await supabase
+          .from("session_media")
+          .select("id, session_id")
+          .in("session_id", sessionIds)
+          .eq("media_type", "video")
+          .eq("moderation_status", "approved")
+          .is("deleted_at", null)
+      : { data: [], error: null };
+    if (approvedVideosError) {
+      console.warn("Approved report video lookup failed in getNearbyIntelPosts", approvedVideosError);
+    }
+    const approvedVideoMap = new Map(
+      (approvedVideos ?? []).map((video) => [video.session_id, video.id]),
+    );
+
     const enrichedPosts: IntelPostWithUser[] = intelPosts.map((post: IntelPostRPCResult) => {
       const profile = profilesMap.get(post.user_id);
+      const condition = conditionMap.get(post.id);
       return {
         ...post,
         dedupe_hash: null,
         emoji_rating: null,
         photo_storage_path: null,
         report_count: 0,
-        vibe: post.vibe ?? null,
-        wave_size_range: post.wave_size_range ?? null,
+        vibe: condition?.vibe ?? post.vibe ?? null,
+        wave_size_range: condition?.wave_size_range ?? post.wave_size_range ?? null,
+        session_id: condition?.session_id ?? null,
+        video_media_id: condition?.session_id ? approvedVideoMap.get(condition.session_id) ?? null : null,
         user: {
           full_name: profile?.full_name || post.user_name || "Anonymous",
           avatar_url: profile?.avatar_url || null,
@@ -225,16 +268,52 @@ export async function getPublicIntelPosts(
     // Combine data (no user confirmations for public access)
     const profilesMap = new Map(profiles?.map((p) => [p.id, p]) || []);
 
+    const conditionPostIds = intelPosts
+      .filter((post) => post.tag === "conditions")
+      .map((post) => post.id);
+    const conditionLookup = conditionPostIds.length
+      ? await (supabase.from("intel_posts") as any)
+          .select("id, session_id, wave_size_range, vibe")
+          .in("id", conditionPostIds)
+      : { data: [] as ConditionReportRow[], error: null };
+    const conditionRows = (conditionLookup.data ?? []) as ConditionReportRow[];
+    const conditionRowsError = conditionLookup.error;
+    if (conditionRowsError) {
+      console.warn("Conditions linkage lookup failed in getPublicIntelPosts", conditionRowsError);
+    }
+    const conditionMap = new Map((conditionRows ?? []).map((row) => [row.id, row]));
+    const sessionIds = (conditionRows ?? [])
+      .map((row) => row.session_id)
+      .filter((id): id is string => Boolean(id));
+    const { data: approvedVideos, error: approvedVideosError } = sessionIds.length
+      ? await supabase
+          .from("session_media")
+          .select("id, session_id")
+          .in("session_id", sessionIds)
+          .eq("media_type", "video")
+          .eq("moderation_status", "approved")
+          .is("deleted_at", null)
+      : { data: [], error: null };
+    if (approvedVideosError) {
+      console.warn("Approved report video lookup failed in getPublicIntelPosts", approvedVideosError);
+    }
+    const approvedVideoMap = new Map(
+      (approvedVideos ?? []).map((video) => [video.session_id, video.id]),
+    );
+
     const enrichedPosts: IntelPostWithUser[] = intelPosts.map((post: IntelPostRPCResult) => {
       const profile = profilesMap.get(post.user_id);
+      const condition = conditionMap.get(post.id);
       return {
         ...post,
         dedupe_hash: null,
         emoji_rating: null,
         photo_storage_path: null,
         report_count: 0,
-        vibe: post.vibe ?? null,
-        wave_size_range: post.wave_size_range ?? null,
+        vibe: condition?.vibe ?? post.vibe ?? null,
+        wave_size_range: condition?.wave_size_range ?? post.wave_size_range ?? null,
+        session_id: condition?.session_id ?? null,
+        video_media_id: condition?.session_id ? approvedVideoMap.get(condition.session_id) ?? null : null,
         user: {
           full_name: profile?.full_name || post.user_name || "Anonymous",
           avatar_url: profile?.avatar_url || null,

--- a/actions/intel/intel-types.ts
+++ b/actions/intel/intel-types.ts
@@ -72,6 +72,7 @@ export interface IntelPostRPCResult {
   surf_conditions: import("@/types/database.generated").Json | null;
   vibe: string | null;
   wave_size_range: string | null;
+  session_id?: string | null;
 }
 
 export type TrackXPFn = (

--- a/app/api/sessions/[id]/videos/[mediaId]/route.ts
+++ b/app/api/sessions/[id]/videos/[mediaId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { withAuth, type AuthenticatedContext } from "@/lib/middleware/api-wrappers";
+import { createServiceRoleClient } from "@/lib/supabase";
 const noStore = (r: NextResponse): NextResponse => { r.headers.set("Cache-Control", "no-store"); return r; };
 export const GET = withAuth(async (_request: NextRequest, { params, user, supabase }: AuthenticatedContext) => {
   const { data: media, error: mediaError } = await (supabase.from("session_media") as any)
@@ -9,7 +10,16 @@ export const GET = withAuth(async (_request: NextRequest, { params, user, supaba
   if (!media) return noStore(NextResponse.json({ error: "Not found" }, { status: 404 }));
   const visible = media.user_id === user.id || (media.moderation_status === "approved" && media.sessions?.is_public === true);
   if (!visible) return noStore(NextResponse.json({ error: "Forbidden" }, { status: 403 }));
-  const { data, error: signError } = await supabase.storage.from("session-videos").createSignedUrl(media.storage_path, 300);
-  if (signError) throw signError;
+  // DB visibility is enforced above with the user-scoped client. Signing must
+  // bypass object-owner storage RLS so approved public clips can play for other users.
+  const { data, error: signError } = await createServiceRoleClient().storage.from("session-videos").createSignedUrl(media.storage_path, 300);
+  if (signError) {
+    const storageStatus = String((signError as { statusCode?: unknown }).statusCode ?? "");
+    const storageMessage = String((signError as { message?: unknown }).message ?? "").toLowerCase();
+    if (storageStatus === "404" || storageMessage.includes("object not found")) {
+      return noStore(NextResponse.json({ error: "Not found" }, { status: 404 }));
+    }
+    throw signError;
+  }
   return noStore(NextResponse.json({ url: data.signedUrl, expiresIn: 300 }));
 });

--- a/app/api/v1/conditions-reports/route.ts
+++ b/app/api/v1/conditions-reports/route.ts
@@ -98,6 +98,7 @@ async function handler(
     {
       reportId: result.data?.intelPostId,
       intelPostId: result.data?.intelPostId,
+      sessionId: result.data?.sessionId ?? null,
       expiresAt: result.data?.expiresAt,
     },
     { status: 201 },

--- a/components/intel/beach-intel-section.tsx
+++ b/components/intel/beach-intel-section.tsx
@@ -39,6 +39,7 @@ import {
   Loader2,
   AlertTriangle,
   Eye,
+  Play,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { toast } from "sonner";
@@ -495,6 +496,39 @@ interface IntelPostCardProps {
   isConfirming: boolean;
 }
 
+function ReportVideoTile({ sessionId, mediaId }: { sessionId: string; mediaId: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const resolvePlayback = async (): Promise<void> => {
+    if (url || loading) return;
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/sessions/${sessionId}/videos/${mediaId}`);
+      if (!response.ok) return;
+      const body = (await response.json()) as { url?: string };
+      if (body.url) setUrl(body.url);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return url ? (
+    <video className="mt-3 w-full rounded-lg" controls playsInline src={url} />
+  ) : (
+    <button
+      type="button"
+      className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-blue-100 bg-blue-50 px-4 py-6 text-sm font-medium text-blue-800 hover:bg-blue-100"
+      onClick={resolvePlayback}
+      disabled={loading}
+      aria-label="Play local spot report video"
+    >
+      <Play className="h-4 w-4 fill-current" />
+      {loading ? "Loading video…" : "Play spot report video"}
+    </button>
+  );
+}
+
 function IntelPostCard({
   post,
   onConfirm,
@@ -567,6 +601,10 @@ function IntelPostCard({
                 </span>
               </div>
             )}
+
+          {post.tag === "conditions" && post.session_id && post.video_media_id && (
+            <ReportVideoTile sessionId={post.session_id} mediaId={post.video_media_id} />
+          )}
 
           {/* Description */}
           <p

--- a/lib/conditions-report/submit-conditions-report.ts
+++ b/lib/conditions-report/submit-conditions-report.ts
@@ -212,6 +212,9 @@ export async function submitConditionsReportCore(
       arrival_time: new Date().toISOString(),
       status: "completed",
       source: "conditions_report",
+      // Conditions reports are public content; their hidden session must be
+      // public so approved report videos satisfy the public media RLS arm.
+      is_public: true,
       notes: content,
       duration_minutes: 0,
       wave_height_ft: observedFaceHeightFt,
@@ -222,11 +225,26 @@ export async function submitConditionsReportCore(
   if (sessionError) {
     console.warn("[submitConditionsReport] Session insert failed (non-fatal):", sessionError);
   } else {
-    sessionId = session?.id ?? null;
-    if (sessionId) {
+    const createdSessionId = session?.id ?? null;
+    sessionId = createdSessionId;
+    if (createdSessionId) {
+      try {
+        const { error: linkageError } = await (supabase.from("intel_posts") as any)
+          .update({ session_id: createdSessionId })
+          .eq("id", intelPost.id);
+        if (linkageError) {
+          console.warn("[submitConditionsReport] Intel/session linkage failed (non-fatal):", linkageError);
+          sessionId = null;
+        }
+      } catch (error) {
+        console.warn("[submitConditionsReport] Intel/session linkage threw (non-fatal):", error);
+        sessionId = null;
+      }
+    }
+    if (createdSessionId) {
       await emitSessionCreatedEvent(supabase, {
         userId: user.id,
-        session: { id: sessionId, beach_id: beachId },
+        session: { id: createdSessionId, beach_id: beachId },
         source: "web-conditions-report",
         surface: "conditions-report",
       });

--- a/scripts/validation/ugc-data-validation.ts
+++ b/scripts/validation/ugc-data-validation.ts
@@ -22,6 +22,7 @@ type Check = { phase: string; name: string; status: CheckStatus; evidence: strin
 type Client = SupabaseClient<any, any, any>;
 
 const checks: Check[] = [];
+let failureObserved = false;
 const remoteReadonly = process.argv.includes("--remote-readonly");
 const withServer = process.argv.includes("--with-server");
 const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
@@ -44,6 +45,7 @@ function record(phase: string, name: string, status: CheckStatus, evidence: unkn
 function pass(phase: string, name: string, evidence: unknown): void { record(phase, name, "PASS", evidence); }
 function skip(phase: string, name: string, evidence: unknown): void { record(phase, name, "SKIP", evidence); }
 function fail(phase: string, name: string, error: unknown): void {
+  failureObserved = true;
   record(phase, name, "FAIL", error instanceof Error ? error.message : JSON.stringify(error));
 }
 
@@ -74,10 +76,29 @@ function sql(query: string): string {
   ).trim();
 }
 
+function sqlLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function printFailureEvidence(mediaId: string | null, paths: string[]): void {
+  const pathValues = paths.length > 0 ? paths.map(sqlLiteral).join(", ") : "NULL";
+  const mediaPredicate = mediaId
+    ? `(id = ${sqlLiteral(mediaId)} OR storage_path IN (${pathValues}))`
+    : `storage_path IN (${pathValues})`;
+  const evidence = sql(`
+    SELECT json_build_object(
+      'session_media', (SELECT COALESCE(json_agg(row_to_json(sm) ORDER BY sm.created_at), '[]'::json) FROM public.session_media sm WHERE ${mediaPredicate}),
+      'storage_objects', (SELECT COALESCE(json_agg(row_to_json(so) ORDER BY so.created_at), '[]'::json) FROM storage.objects so WHERE so.bucket_id = 'session-videos' AND so.name IN (${pathValues}))
+    )
+  `);
+  console.error(`FAILURE EVIDENCE ${evidence}`);
+}
+
 function localDatabaseTruth(): Record<string, unknown> {
   const raw = sql(`
     SELECT json_build_object(
       'bucket', (SELECT row_to_json(b) FROM storage.buckets b WHERE b.id = 'session-videos'),
+      'intel_session_column', (SELECT row_to_json(c) FROM information_schema.columns c WHERE c.table_schema = 'public' AND c.table_name = 'intel_posts' AND c.column_name = 'session_id'),
       'column', (SELECT row_to_json(c) FROM information_schema.columns c WHERE c.table_schema = 'public' AND c.table_name = 'session_media' AND c.column_name = 'moderation_status'),
       'check', (SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'public.session_media'::regclass AND conname = 'session_media_moderation_status_check'),
       'enum', (SELECT EXISTS (SELECT 1 FROM pg_enum e JOIN pg_type t ON t.oid = e.enumtypid WHERE t.typname = 'content_report_target' AND e.enumlabel = 'session_media')),
@@ -113,6 +134,9 @@ async function schemaPhase(service: Client): Promise<void> {
   const mime = JSON.stringify(bucket.allowed_mime_types ?? []);
   assert(mime.includes("video/mp4") && mime.includes("video/quicktime"), `bucket MIME types ${mime}`);
   pass(phase, "session-videos bucket", bucket);
+  const intelSessionColumn = truth.intel_session_column as Record<string, unknown> | null;
+  assert(intelSessionColumn, "intel_posts.session_id column is missing");
+  pass(phase, "intel_posts.session_id column", intelSessionColumn);
   const column = truth.column as Record<string, unknown> | null;
   assert(column, "moderation_status column is missing");
   assert(column.column_default === "'approved'::text", `moderation_status default is ${column.column_default}`);
@@ -160,8 +184,9 @@ async function conditionsPhase(a: { client: Client; user: User }, service: Clien
   const user = a.user;
   const first = await submitConditionsReportCore(input as any, user, a.client as any);
   assert(first.success, `conditions report failed: ${JSON.stringify(first)}`);
-  const intel = requireValue((await service.from("intel_posts").select("tag,wave_size_range,vibe").eq("id", first.data.intelPostId).single()).data, "intel row missing");
+  const intel = requireValue((await service.from("intel_posts").select("tag,wave_size_range,vibe,session_id").eq("id", first.data.intelPostId).single()).data, "intel row missing");
   assert(intel.tag === "conditions" && intel.wave_size_range === input.waveSizeRange && intel.vibe === input.vibe, JSON.stringify(intel));
+  assert(intel.session_id === first.data.sessionId, `intel/session linkage mismatch: ${JSON.stringify(intel)}`);
   pass(phase, "intel_posts", intel);
   const session = requireValue((await service.from("sessions").select("id,wave_height_ft,source").eq("id", first.data.sessionId).single()).data, "conditions session missing");
   assert(Number(session.wave_height_ft) === 2.5 && session.source === "conditions_report", JSON.stringify(session));
@@ -183,6 +208,51 @@ async function conditionsPhase(a: { client: Client; user: User }, service: Clien
     pass(phase, "forecast feedback context", feedback);
   }
   return { beachId: beach.id, sessionId: requireValue(first.data.sessionId, "conditions core did not create a session") };
+}
+
+async function reportVideoPhase(a: { client: Client; user: User; accessToken: string }, b: { client: Client; user: User; accessToken: string }, service: Client, conditions: { beachId: string; sessionId: string }, storagePaths: string[], onMediaId: (mediaId: string) => void): Promise<void> {
+  const phase = "report-video";
+  const intel = requireValue((await service.from("intel_posts").select("id,session_id").eq("session_id", conditions.sessionId).single()).data, "linked conditions intel row missing");
+  assert(intel.session_id === conditions.sessionId, JSON.stringify(intel));
+  pass(phase, "intel/session linkage row-for-row", intel);
+
+  const path = `${conditions.sessionId}/${a.user.id}/${randomUUID()}.mp4`;
+  const fixture = Buffer.from("\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom", "ascii");
+  const upload = await a.client.storage.from("session-videos").upload(path, fixture, { contentType: "video/mp4", upsert: false });
+  if (upload.error) throw upload.error;
+  storagePaths.push(path);
+  pass(phase, "report session storage upload", `${path} (${fixture.length} bytes)`);
+
+  const { POST } = await import("../../app/api/sessions/[id]/videos/route");
+  const finalize = await POST(new Request(`${url}/api/sessions/${conditions.sessionId}/videos`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${a.accessToken}`, "content-type": "application/json" },
+    body: JSON.stringify({ storagePath: path, durationSec: 12, sizeBytes: fixture.length }),
+  }) as any, { params: { id: conditions.sessionId } } as any);
+  const finalizeText = await finalize.text();
+  assert(finalize.status === 201, `report video finalize returned ${finalize.status}: ${finalizeText}`);
+  const mediaId = requireValue((JSON.parse(finalizeText) as { mediaId?: string }).mediaId, "report video mediaId missing");
+  onMediaId(mediaId);
+  pass(phase, "report video finalized pending", mediaId);
+
+  const { data: bIntel, error: bIntelError } = await b.client.from("intel_posts").select("id,session_id").eq("id", intel.id).single();
+  if (bIntelError) throw bIntelError;
+  assert(bIntel?.session_id === conditions.sessionId, `actor B cannot see report linkage: ${JSON.stringify(bIntel)}`);
+  const { data: pendingForB, error: pendingError } = await b.client.from("session_media").select("id").eq("id", mediaId).maybeSingle();
+  if (pendingError) throw pendingError;
+  assert(!pendingForB, "pending report video is visible to actor B through the intel-side lens");
+  pass(phase, "pending invisible to actor B", "intel linkage visible; pending clip hidden");
+
+  const approved = await service.from("session_media").update({ moderation_status: "approved" }).eq("id", mediaId);
+  if (approved.error) throw approved.error;
+  const { GET } = await import("../../app/api/sessions/[id]/videos/[mediaId]/route");
+  const playback = await GET(new Request(`${url}/api/sessions/${conditions.sessionId}/videos/${mediaId}`, {
+    headers: { authorization: `Bearer ${b.accessToken}` },
+  }) as any, { params: { id: conditions.sessionId, mediaId } } as any);
+  const playbackText = await playback.text();
+  assert(playback.status === 200, `actor B playback returned ${playback.status}: ${playbackText}`);
+  assert(Boolean((JSON.parse(playbackText) as { url?: string }).url), "actor B playback URL is empty");
+  pass(phase, "actor B approved playback", "HTTP 200 signed URL");
 }
 
 async function videoPhase(a: { client: Client; user: User; accessToken: string }, service: Client, beachId: string, storagePaths: string[]): Promise<{ publicSessionId: string; mediaId: string }> {
@@ -280,16 +350,26 @@ async function main(): Promise<void> {
   let actorA: Awaited<ReturnType<typeof createActor>> | null = null;
   let actorB: Awaited<ReturnType<typeof createActor>> | null = null;
   const storagePaths: string[] = [];
+  let reportVideoMediaId: string | null = null;
+  let failure: unknown = null;
   try {
     actorA = await createActor(anon, service, "a");
     actorB = await createActor(anon, service, "b");
     pass("actors", "throwaway auth users", `${actorA.user.id}, ${actorB.user.id}`);
     const conditions = await conditionsPhase(actorA, localService);
+    await reportVideoPhase(actorA, actorB, localService, conditions, storagePaths, (mediaId) => { reportVideoMediaId = mediaId; });
     const video = await videoPhase(actorA, localService, conditions.beachId, storagePaths);
     await visibilityPhase(actorA, actorB, anon, localService, video.publicSessionId, video.mediaId, conditions.beachId);
     await contractsPhase(localService, video.mediaId);
     await sharesPhase(actorA, conditions.sessionId);
+  } catch (error: unknown) {
+    failure = error;
+    fail("fatal", "harness", error);
   } finally {
+    if (failure || failureObserved) {
+      // Capture the database row and storage object before cleanup removes either.
+      printFailureEvidence(reportVideoMediaId, storagePaths);
+    }
     if (storagePaths.length > 0) {
       const removed = await localService.storage.from("session-videos").remove(storagePaths);
       if (removed.error) fail("cleanup", "storage objects", removed.error);

--- a/supabase/migrations/20260811020600_link_intel_posts_to_sessions.sql
+++ b/supabase/migrations/20260811020600_link_intel_posts_to_sessions.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE public.intel_posts
+  ADD COLUMN IF NOT EXISTS session_id uuid NULL
+  REFERENCES public.sessions(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_intel_posts_session_id
+  ON public.intel_posts (session_id);
+
+COMMIT;

--- a/types/database.ts
+++ b/types/database.ts
@@ -184,6 +184,8 @@ export interface ProfileWithStats extends Profile {
 }
 
 export interface IntelPostWithUser extends IntelPost {
+  session_id?: string | null
+  video_media_id?: string | null
   // Additional fields from RPC function get_nearby_intel_posts
   beach_name?: string
   distance_miles?: number


### PR DESCRIPTION
The beach-reporter persona (films every morning, never logs a session) gets clips on their conditions reports. The clip attaches to the report's existing hidden session, so the entire S2 pipeline (moderation, RLS, signed playback, share tier) applies unchanged.

- New additive migration `20260811020600`: `intel_posts.session_id` + index (**apply together with `20260811020500`, before the parity OTA — the native strip queries this column**)
- Report sessions now `is_public` (their intel content already is); v1 response gains additive `sessionId`
- Intel feed renders click-to-load play tiles for approved report clips
- **Harness catch:** cross-user playback 500'd — the route signed through the viewer's RLS-scoped storage client; now user-client visibility check + service-role signing, storage miss → 404
- Data validation extended with a `report-video` phase: **29 PASS / 0 FAIL** executed (+ independent rerun)

Native half (`feat/s2c-report-clip`) merges next: Add-clip in the report sheet + play tiles in the Recent Reports strip, OTA-eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)