### PR TITLE
fix: mirror 020500 session_media columns into session_media_history

### DIFF
--- a/supabase/migrations/20260811020700_add_moderation_status_to_session_media_history.sql
+++ b/supabase/migrations/20260811020700_add_moderation_status_to_session_media_history.sql
@@ -1,0 +1,17 @@
+-- Companion to 20260811020500_create_session_videos.sql.
+-- log_revision() mirrors every live session_media column into
+-- session_media_history; adding moderation_status to the live table without
+-- the history table makes every UPDATE/DELETE revision insert fail (soft
+-- WARNING, history silently stops recording). Apply in the same window as
+-- 20260811020500.
+BEGIN;
+
+ALTER TABLE public.session_media_history
+  ADD COLUMN IF NOT EXISTS moderation_status text,
+  ADD COLUMN IF NOT EXISTS moderation_reason text,
+  ADD COLUMN IF NOT EXISTS thumbnail_path text;
+
+COMMENT ON COLUMN public.session_media_history.moderation_status IS
+  'Mirror of session_media columns added in 20260811020500 for log_revision(); nullable, no default.';
+
+COMMIT;


### PR DESCRIPTION
## What

Companion migration to 20260811020500. `log_revision()` mirrors every live `session_media` column into `session_media_history`; 020500 added `moderation_status`, `moderation_reason`, and `thumbnail_path` to the live table only, so every UPDATE/DELETE revision insert fails with a swallowed `WARNING` and history silently stops recording (caught live during the UGC demo when a cascade delete emitted the warning).

## Verification

- Applied to local Supabase via `supabase migration up`
- Before: `UPDATE session_media` → `WARNING: column "thumbnail_path" of relation "session_media_history" does not exist`, zero history rows
- After: same UPDATE records a revision row with the OLD tuple
- Idempotent (`IF NOT EXISTS`), `BEGIN/COMMIT` wrapped

## Operator note

Ships code-only per the shared prod/dev DB rule. Apply to the shared DB **in the same window as 20260811020500** (which is still pending) — order among the three 202608110205/6/700 files is enforced by timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)