### PR TITLE
feat(seo): server-render crawlable hourly surf forecast table (prod slice)

### DIFF
--- a/__tests__/actions/spot/spot-surf-report-actions.test.ts
+++ b/__tests__/actions/spot/spot-surf-report-actions.test.ts
@@ -394,7 +394,7 @@ describe("spot-surf-report-actions", () => {
       expect(result).toBeNull();
     });
 
-    it("returns isTomorrow: true when falling back to tomorrow forecast", async () => {
+    it("keeps today's hourly rows when the best recommendation falls tomorrow", async () => {
       const { createSupabaseServerClient, createSupabaseServiceRoleClient } = await import(
         "@/lib/supabase/server"
       );
@@ -428,8 +428,8 @@ describe("spot-surf-report-actions", () => {
       ]);
       (getBatchSunTimes as jest.Mock).mockResolvedValue(mockSunTimesCache);
 
-      // Setup mock Supabase response with only tomorrow's forecasts
-      const tomorrowForecasts = [
+      const todayAndTomorrowForecasts = [
+        mockForecasts[0],
         {
           ...mockForecasts[0],
           forecast_at: "2024-01-16T14:00Z",
@@ -444,7 +444,7 @@ describe("spot-surf-report-actions", () => {
                 lt: jest.fn(() => ({
                   order: jest.fn(() => ({
                     limit: jest.fn(async () => ({
-                      data: tomorrowForecasts,
+                      data: todayAndTomorrowForecasts,
                       error: null,
                     })),
                   })),
@@ -471,6 +471,33 @@ describe("spot-surf-report-actions", () => {
       const result = await getSpotSurfReport(mockBeach);
 
       expect(result?.isTomorrow).toBe(true);
+      expect(result?.hourlyForecastDay).toBe("today");
+      expect(result?.hourlyForecasts).toEqual([
+        expect.objectContaining({ forecast_at: "2024-01-15T14:00Z" }),
+      ]);
+      expect(result?.hourlyForecasts).not.toEqual([
+        expect.objectContaining({ forecast_at: "2024-01-16T14:00Z" }),
+      ]);
+    });
+
+    it("keeps today's hourly rows when neither day has a viable window", async () => {
+      await setupBoardAwareScenario();
+      mockSelectBestWindow.mockReturnValue(null);
+      const { getSpotSurfReportPublic } = await import(
+        "@/actions/spot/spot-surf-report-actions"
+      );
+
+      const result = await getSpotSurfReportPublic(mockBeach);
+
+      expect(result?.isTomorrow).toBe(false);
+      expect(result?.hourlyForecastDay).toBe("today");
+      expect(result?.hourlyForecasts).toEqual([
+        expect.objectContaining({ forecast_at: "2024-01-15T14:00Z" }),
+      ]);
+      expect(result?.report.recommendationAvailability).toEqual({
+        state: "available",
+        holdEpoch: "no-positive-surf-call",
+      });
     });
 
     it("passes user preferences to selectBestWindow when user is logged in", async () => {
@@ -889,6 +916,15 @@ describe("spot-surf-report-actions", () => {
       );
       expect(result?.report.userTier).toBeNull();
       expect(result?.report.tiers).toBeNull();
+      expect(result?.hourlyForecasts).toEqual([
+        expect.objectContaining({
+          forecast_at: "2024-01-15T14:00Z",
+          wave_height: "2",
+          wind_speed: "3 mph",
+          wind_direction: "E",
+        }),
+      ]);
+      expect(result?.hourlyForecastDay).toBe("today");
     });
 
     it("passes null userPrefs for anonymous users", async () => {

--- a/__tests__/app/generic-beach-detail-resolution.test.ts
+++ b/__tests__/app/generic-beach-detail-resolution.test.ts
@@ -62,7 +62,16 @@ jest.mock("@/lib/utils/timezone-utils.server", () => ({
 
 // Mock the child components to avoid rendering issues in node environment
 jest.mock("@/app/beach/[slug]/beach-detail-client", () => ({
-  BeachDetailClient: () => null,
+  BeachDetailClient: ({
+    beach,
+    heroHeadingLevel = "h1",
+  }: {
+    beach: Beach;
+    heroHeadingLevel?: "h1" | "h2";
+  }) => {
+    const React = jest.requireActual("react");
+    return React.createElement(heroHeadingLevel, null, beach.name);
+  },
 }));
 
 jest.mock("@/components/spots/spot-surf-report", () => ({
@@ -180,19 +189,85 @@ function makeBeach(overrides: BeachTestOverrides) {
 
 function freshForecastResult() {
   const now = Date.now();
+  const selectedRowTime = new Date(now).toISOString();
+  const windowStart = new Date(now - 60 * 60 * 1000).toISOString();
+  const windowEnd = new Date(now + 60 * 60 * 1000).toISOString();
   return {
     report: {
       waveHeight: "2-3 ft",
       updatedAt: new Date(now - 60 * 60 * 1000).toISOString(),
+      bestWindowStart: windowStart,
+      bestWindowEnd: windowEnd,
+      verdict: "YES",
+      score: 84,
+      forecastConfidence: 92,
     },
     isTomorrow: false,
     forecastContext: {
-      selectedRowTime: new Date(now + 60 * 60 * 1000).toISOString(),
+      selectedRowTime,
       waveHeight: "2-3 ft",
       sourceDataUpdatedAt: new Date(now - 60 * 60 * 1000).toISOString(),
       primaryDataSource: "NOAA_NWS",
+      displayWindowStart: windowStart,
+      displayWindowEnd: windowEnd,
+      timezone: "America/Los_Angeles",
     },
+    hourlyForecasts: [
+      {
+        forecast_at: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        wave_height: "2 ft",
+        swell_1_height: "2 ft",
+        swell_1_period: "17s",
+        swell_1_direction: "SW",
+        swell_2_height: null,
+        swell_2_period: null,
+        swell_2_direction: null,
+        wind_speed: "4 mph",
+        wind_direction: "N",
+        tide_height: "3.0 ft",
+        tide_status: "Rising",
+        confidence_score: 91,
+      },
+      {
+        forecast_at: selectedRowTime,
+        wave_height: "3 ft",
+        swell_1_height: "2 ft",
+        swell_1_period: "17s",
+        swell_1_direction: "SW",
+        swell_2_height: null,
+        swell_2_period: null,
+        swell_2_direction: null,
+        wind_speed: "4 mph",
+        wind_direction: "N",
+        tide_height: "3.2 ft",
+        tide_status: "Rising",
+        confidence_score: 92,
+      },
+      {
+        forecast_at: new Date(now + 2 * 60 * 60 * 1000).toISOString(),
+        wave_height: "2-3 ft",
+        swell_1_height: "2 ft",
+        swell_1_period: "16s",
+        swell_1_direction: "SW",
+        swell_2_height: null,
+        swell_2_period: null,
+        swell_2_direction: null,
+        wind_speed: "6 mph",
+        wind_direction: "W",
+        tide_height: "3.4 ft",
+        tide_status: "Rising",
+        confidence_score: 90,
+      },
+    ],
+    hourlyForecastDay: "today" as const,
   };
+}
+
+function getHeadingTexts(html: string, level: 1 | 2): string[] {
+  const pattern = new RegExp(`<h${level}\\b[^>]*>([\\s\\S]*?)<\\/h${level}>`, "gi");
+  return Array.from(html.matchAll(pattern), (match) =>
+    match[1].replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim(),
+  ).filter(Boolean);
 }
 
 describe("GenericBeachDetailPage slug resolution", () => {
@@ -273,6 +348,60 @@ describe("GenericBeachDetailPage slug resolution", () => {
     expect(html).not.toContain("Lower Trestles tide chart");
     expect(html).not.toContain("Lower Trestles water temperature");
     expect(html).not.toContain('aria-label="Lower Trestles related surf guides"');
+  });
+
+  it("renders the forecast answer and hourly rows in initial HTML", async () => {
+    (getBeachesBySlug as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [
+        makeBeach({
+          name: "Del Mar",
+          slug: "del-mar",
+          city: "Del Mar",
+        }),
+      ],
+    });
+    (getSpotSurfReportPublic as jest.Mock).mockResolvedValueOnce(freshForecastResult());
+
+    const page = await GenericBeachDetailPage({
+      params: Promise.resolve({
+        intent: "ca",
+        city: "del-mar",
+        beachSlug: "del-mar",
+      }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(getHeadingTexts(html, 1)).toEqual(["Del Mar Surf Forecast"]);
+    expect(getHeadingTexts(html, 2)).toContain("Del Mar");
+    expect(getHeadingTexts(html, 2)).toContain("Del Mar Hourly Surf Forecast");
+    expect(html).toContain('data-testid="public-forecast-hourly"');
+    expect((html.match(/data-testid="public-forecast-hour"/g) ?? [])).toHaveLength(3);
+    expect(html.match(/84\/100/g)).toHaveLength(1);
+    expect(html).toContain("Best window");
+    expect(html).toContain("17s SW");
+    expect(html).toContain("3.2 ft · Rising");
+    expect(html).toContain("92%");
+  });
+
+  it("keeps the surf-forecast H1 when live forecast details are unavailable", async () => {
+    (getBeachesBySlug as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeBeach({ name: "Del Mar", slug: "del-mar", city: "Del Mar" })],
+    });
+
+    const page = await GenericBeachDetailPage({
+      params: Promise.resolve({
+        intent: "ca",
+        city: "del-mar",
+        beachSlug: "del-mar",
+      }),
+    });
+    const html = renderToStaticMarkup(page);
+
+    expect(getHeadingTexts(html, 1)).toEqual(["Del Mar Surf Forecast"]);
+    expect(getHeadingTexts(html, 2)).toContain("Del Mar");
+    expect(html).toContain("Current forecast details are temporarily unavailable");
   });
 
   it("redirects stale city slugs to the canonical beach URL", async () => {

--- a/__tests__/app/major-event-hold-dynamic-pages.test.ts
+++ b/__tests__/app/major-event-hold-dynamic-pages.test.ts
@@ -11,6 +11,11 @@ const PUBLIC_SEO_PAGES = [
   "app/mexico/[region]/[city]/[beachSlug]/water-temp/page.tsx",
 ];
 
+const CANONICAL_BEACH_DETAIL_PAGES = [
+  "app/[intent]/[city]/[beachSlug]/page.tsx",
+  "app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx",
+];
+
 describe("major-event hold-sensitive pages", () => {
   it.each(PUBLIC_SEO_PAGES)(
     "keeps %s on ISR for crawler performance",
@@ -33,4 +38,17 @@ describe("major-event hold-sensitive pages", () => {
     expect(source).toContain("getSpotSurfReportPublic(beach)");
     expect(source).not.toContain("getSpotSurfReport(beach)");
   });
+
+  it.each(CANONICAL_BEACH_DETAIL_PAGES)(
+    "keeps one stable surf-forecast H1 and a secondary visual hero in %s",
+    (page) => {
+      const source = readFileSync(page, "utf8");
+
+      expect(source).toContain('<PublicForecastAnswer');
+      expect(source).toContain('headingLevel="h1"');
+      expect(source).toContain('heroHeadingLevel="h2"');
+      expect(source).toContain('<PublicForecastHourly');
+      expect(source).toContain('forecastDay={hourlyForecastDay}');
+    },
+  );
 });

--- a/__tests__/components/beach-detail/public-forecast-answer.test.tsx
+++ b/__tests__/components/beach-detail/public-forecast-answer.test.tsx
@@ -59,26 +59,33 @@ describe("PublicForecastAnswer", () => {
         report={null}
         context={context}
         isTomorrow
+        headingLevel="h1"
       />,
     );
 
     expect(screen.getByTestId("public-forecast-answer")).toBeInTheDocument();
     expect(screen.getByText("Tomorrow's surf forecast")).toBeInTheDocument();
-    expect(screen.getByText(/Oceanside Harbor surf forecast for/)).toBeInTheDocument();
+    expect(screen.getByText(/Oceanside Harbor Surf Forecast for/)).toBeInTheDocument();
     expect(screen.getByText("2-3 ft")).toBeInTheDocument();
     expect(screen.getByText(/NOAA NWS, NOAA CO-OPS/)).toBeInTheDocument();
   });
 
-  it("does not render without a selected forecast row", () => {
+  it("keeps the exact-query heading when forecast details are unavailable", () => {
     render(
       <PublicForecastAnswer
         beach={beach}
         report={null}
         context={null}
         isTomorrow={false}
+        headingLevel="h1"
       />,
     );
 
-    expect(screen.queryByTestId("public-forecast-answer")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", {
+      level: 1,
+      name: "Oceanside Harbor Surf Forecast",
+    })).toBeInTheDocument();
+    expect(screen.getByText(/temporarily unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText(/Forecast valid at/)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/beach-detail/public-forecast-hourly.test.tsx
+++ b/__tests__/components/beach-detail/public-forecast-hourly.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+
+const report = {
+  verdict: "YES",
+  score: 84,
+  bestWindowStart: "2026-08-15T14:00:00.000Z",
+  bestWindowEnd: "2026-08-15T16:00:00.000Z",
+} as SurfCallResult;
+
+const context = {
+  timezone: "America/Los_Angeles",
+  selectedRowTime: "2026-08-15T15:00:00.000Z",
+  displayWindowStart: "2026-08-15T14:00:00.000Z",
+  displayWindowEnd: "2026-08-15T16:00:00.000Z",
+} as ForecastRecommendationContext;
+
+const forecastHours = [
+  {
+    forecast_at: "2026-08-15T13:00:00.000Z",
+    wave_height: "2 ft",
+    swell_1_height: "2 ft",
+    swell_1_period: "17s",
+    swell_1_direction: "SW",
+    swell_2_height: null,
+    swell_2_period: null,
+    swell_2_direction: null,
+    wind_speed: "4 mph",
+    wind_direction: "N",
+    tide_height: "3.0 ft",
+    tide_status: "Rising",
+    confidence_score: 91,
+  },
+  {
+    forecast_at: "2026-08-15T15:00:00.000Z",
+    wave_height: "3 ft",
+    swell_1_height: "2 ft",
+    swell_1_period: "17s",
+    swell_1_direction: "SW",
+    swell_2_height: null,
+    swell_2_period: null,
+    swell_2_direction: null,
+    wind_speed: "4 mph",
+    wind_direction: "N",
+    tide_height: "3.2 ft",
+    tide_status: "Rising",
+    confidence_score: 92,
+  },
+];
+
+describe("PublicForecastHourly", () => {
+  it("marks matching rows without presenting the window score as an hourly score", () => {
+    render(
+      <PublicForecastHourly
+        beachName="Del Mar"
+        forecastHours={forecastHours}
+        report={report}
+        context={context}
+        isTomorrow={false}
+        forecastDay="today"
+      />,
+    );
+
+    expect(document.body).not.toHaveTextContent("84/100");
+    expect(screen.getByRole("columnheader", { name: "Quiver recommendation" })).toBeInTheDocument();
+
+    const rows = screen.getAllByTestId("public-forecast-hour");
+    expect(within(rows[0]).queryByText("Best window")).not.toBeInTheDocument();
+    expect(within(rows[1]).getByText("Best window")).toBeInTheDocument();
+  });
+
+  it("keeps today's rows separate from a tomorrow recommendation", () => {
+    render(
+      <PublicForecastHourly
+        beachName="Del Mar"
+        forecastHours={forecastHours}
+        report={report}
+        context={context}
+        isTomorrow
+        forecastDay="today"
+      />,
+    );
+
+    expect(screen.getByText("Today by time")).toBeInTheDocument();
+    expect(screen.queryByText("Best window")).not.toBeInTheDocument();
+  });
+});

--- a/actions/spot/spot-surf-report-actions.ts
+++ b/actions/spot/spot-surf-report-actions.ts
@@ -36,13 +36,42 @@ export interface SpotSurfReportResult {
   report: MajorEventHoldSurfCallResult;
   isTomorrow: boolean;
   forecastContext: ForecastRecommendationContext | null;
+  /** Only produced by the cached spot report; `/api/surf/call` omits it. */
+  hourlyForecasts?: PublicForecastHour[];
+  hourlyForecastDay?: PublicForecastDay;
 }
 
 interface CachedSpotSurfReportResult {
   report: SurfCallResult;
   isTomorrow: boolean;
   forecastContext: ForecastRecommendationContext | null;
+  hourlyForecasts: PublicForecastHour[];
+  hourlyForecastDay: PublicForecastDay;
 }
+
+export type PublicForecastDay = 'today' | 'tomorrow';
+
+/** Fields projected into the crawlable hourly table (keeps the cached payload small). */
+const PUBLIC_FORECAST_HOUR_FIELDS = [
+  'forecast_at',
+  'wave_height',
+  'swell_1_height',
+  'swell_1_period',
+  'swell_1_direction',
+  'swell_2_height',
+  'swell_2_period',
+  'swell_2_direction',
+  'wind_speed',
+  'wind_direction',
+  'tide_height',
+  'tide_status',
+  'confidence_score',
+] as const;
+
+export type PublicForecastHour = Pick<
+  EnhancedForecastEntity,
+  (typeof PUBLIC_FORECAST_HOUR_FIELDS)[number]
+>;
 
 export interface SpotSurfReportAuthContext {
   user: User;
@@ -444,6 +473,12 @@ function canonicalizeBeachForSurfCall(beach: Beach): Beach {
   } as unknown as Beach;
 }
 
+function toPublicForecastHour(forecast: EnhancedForecastEntity): PublicForecastHour {
+  return Object.fromEntries(
+    PUBLIC_FORECAST_HOUR_FIELDS.map(field => [field, forecast[field] ?? null]),
+  ) as PublicForecastHour;
+}
+
 /**
  * Cached surf report computation.
  *
@@ -515,6 +550,8 @@ const getCachedSurfReport = unstable_cache(
         report: buildReport(null, [], beach, {}, resolvedSkill),
         isTomorrow: false,
         forecastContext: null,
+        hourlyForecasts: [],
+        hourlyForecastDay: 'today',
       };
     }
 
@@ -523,6 +560,8 @@ const getCachedSurfReport = unstable_cache(
         report: buildReport(null, [], beach, {}, resolvedSkill),
         isTomorrow: false,
         forecastContext: null,
+        hourlyForecasts: [],
+        hourlyForecastDay: 'today',
       };
     }
 
@@ -534,6 +573,9 @@ const getCachedSurfReport = unstable_cache(
     // 4. Filter to today first; fall back to tomorrow if no viable window today
     const todayForecasts = forecasts.filter(f => extractForecastDate(f.forecast_at, beachTz) === todayStr);
     const tomorrowForecasts = forecasts.filter(f => extractForecastDate(f.forecast_at, beachTz) === tomorrowStr);
+    const hasTodayForecasts = todayForecasts.length > 0;
+    const publicHourlyForecasts = hasTodayForecasts ? todayForecasts : tomorrowForecasts;
+    const hourlyForecastDay: PublicForecastDay = hasTodayForecasts ? 'today' : 'tomorrow';
     const rideabilityBand = boardClass
       ? getRideabilityBand(resolvedSkillForBoard!.skill, boardClass)
       : null;
@@ -566,6 +608,8 @@ const getCachedSurfReport = unstable_cache(
           report: buildReport(adjustedWindow, todayForecasts, beach, { isTomorrow: false, boardNote }, resolvedSkill),
           isTomorrow: false,
           forecastContext,
+          hourlyForecasts: publicHourlyForecasts.map(toPublicForecastHour),
+          hourlyForecastDay,
         };
       }
     }
@@ -598,6 +642,8 @@ const getCachedSurfReport = unstable_cache(
           report: buildReport(adjustedWindow, tomorrowForecasts, beach, { isTomorrow: true, boardNote }, resolvedSkill),
           isTomorrow: true,
           forecastContext,
+          hourlyForecasts: publicHourlyForecasts.map(toPublicForecastHour),
+          hourlyForecastDay,
         };
       }
       return {
@@ -609,6 +655,24 @@ const getCachedSurfReport = unstable_cache(
           window: null,
           timezone: beachTz,
         }),
+        hourlyForecasts: publicHourlyForecasts.map(toPublicForecastHour),
+        hourlyForecastDay,
+      };
+    }
+
+    // Keep today's physical forecast crawlable even when no recommendation window exists.
+    if (todayForecasts.length > 0) {
+      return {
+        report: buildReport(null, todayForecasts, beach, { isTomorrow: false }, resolvedSkill),
+        isTomorrow: false,
+        forecastContext: buildForecastRecommendationContext({
+          beach,
+          forecasts: todayForecasts,
+          window: null,
+          timezone: beachTz,
+        }),
+        hourlyForecasts: publicHourlyForecasts.map(toPublicForecastHour),
+        hourlyForecastDay,
       };
     }
 
@@ -617,6 +681,8 @@ const getCachedSurfReport = unstable_cache(
       report: buildReport(null, [], beach, {}, resolvedSkill),
       isTomorrow: false,
       forecastContext: null,
+      hourlyForecasts: [],
+      hourlyForecastDay: 'today',
     };
   },
   ['spot-surf-report'],

--- a/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
@@ -2,6 +2,7 @@ import { BeachPageStructuredData } from "@/components/seo/structured-data";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
+import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
 import { WebPageSchema } from "@/components/seo/web-page-schema";
 import type { Metadata } from "next";
 import { buildDynamicBeachMetadata, buildPageMetadata } from "@/lib/seo/meta";
@@ -184,6 +185,8 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
     const surfCallReport = surfReportResult?.report ?? null;
     const surfCallIsTomorrow = surfReportResult?.isTomorrow ?? false;
     const forecastContext = surfReportResult?.forecastContext ?? null;
+    const hourlyForecasts = surfReportResult?.hourlyForecasts ?? [];
+    const hourlyForecastDay = surfReportResult?.hourlyForecastDay ?? "today";
 
     return (
       <>
@@ -222,6 +225,7 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
           report={surfCallReport}
           context={forecastContext}
           isTomorrow={surfCallIsTomorrow}
+          headingLevel="h1"
         />
 
         <BeachDetailClient
@@ -230,7 +234,17 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
           beachTimezone={beachTimezone}
           surfCallReport={surfCallReport}
           surfCallIsTomorrow={surfCallIsTomorrow}
+          heroHeadingLevel="h2"
           freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
+        />
+
+        <PublicForecastHourly
+          beachName={publicBeach.name}
+          forecastHours={hourlyForecasts}
+          report={surfCallReport}
+          context={forecastContext}
+          isTomorrow={surfCallIsTomorrow}
+          forecastDay={hourlyForecastDay}
         />
       </>
     );

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -3,6 +3,7 @@ import { BeachPageStructuredData } from "@/components/seo/structured-data";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
+import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
 import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spots";
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
@@ -187,6 +188,8 @@ export default async function GenericBeachDetailPage(props: PageProps) {
     const surfCallReport = surfReportResult?.report || null;
     const surfCallIsTomorrow = surfReportResult?.isTomorrow ?? false;
     const forecastContext = surfReportResult?.forecastContext ?? null;
+    const hourlyForecasts = surfReportResult?.hourlyForecasts ?? [];
+    const hourlyForecastDay = surfReportResult?.hourlyForecastDay ?? "today";
     const publicBeach = sanitizeBeachEditorialContent(beach);
 
     // Validate that the beach's state matches the URL state parameter
@@ -276,6 +279,7 @@ export default async function GenericBeachDetailPage(props: PageProps) {
           report={surfCallReport}
           context={forecastContext}
           isTomorrow={surfCallIsTomorrow}
+          headingLevel="h1"
         />
 
         {/* VideoObject + BroadcastEvent for live cam — earns LIVE badge in SERPs */}
@@ -297,6 +301,7 @@ export default async function GenericBeachDetailPage(props: PageProps) {
           amenities={amenitiesResult}
           waterQuality={waterQualityResult}
           beachPhoto={beachPhoto}
+          heroHeadingLevel="h2"
           freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
           beforeTabsContent={
             <div className="hidden md:block">
@@ -326,6 +331,15 @@ export default async function GenericBeachDetailPage(props: PageProps) {
               </Suspense>
             </div>
           }
+        />
+
+        <PublicForecastHourly
+          beachName={publicBeach.name}
+          forecastHours={hourlyForecasts}
+          report={surfCallReport}
+          context={forecastContext}
+          isTomorrow={surfCallIsTomorrow}
+          forecastDay={hourlyForecastDay}
         />
 
         <StickySignupBar

--- a/components/beach-detail.tsx
+++ b/components/beach-detail.tsx
@@ -1208,7 +1208,14 @@ function BeachDetailContent({
 // Wrap BeachDetailContent in Suspense to support useSearchParams() during static generation
 export function BeachDetail(props: BeachDetailProps) {
   return (
-    <Suspense fallback={<FullPageLoader text="Loading beach details..." />}>
+    <Suspense
+      fallback={(
+        <div
+          aria-hidden="true"
+          className="min-h-[50vh] animate-pulse bg-muted/20"
+        />
+      )}
+    >
       <BeachDetailContent {...props} />
     </Suspense>
   );

--- a/components/beach-detail/public-forecast-answer.tsx
+++ b/components/beach-detail/public-forecast-answer.tsx
@@ -9,6 +9,7 @@ interface PublicForecastAnswerProps {
   report: SurfCallResult | null;
   context: ForecastRecommendationContext | null;
   isTomorrow: boolean;
+  headingLevel: "h1" | "h2";
 }
 
 function formatForecastDate(
@@ -73,6 +74,7 @@ export function PublicForecastAnswer({
   report,
   context,
   isTomorrow,
+  headingLevel,
 }: PublicForecastAnswerProps) {
   const timezone =
     context?.timezone ??
@@ -110,8 +112,6 @@ export function PublicForecastAnswer({
   const isStale = sourceDataUpdatedAt
     ? isDataStale(sourceDataUpdatedAt, primaryDataSource)
     : false;
-  if (!context?.selectedRowTime || !context.waveHeight) return null;
-
   const titleDate = forecastDate ? ` for ${forecastDate}` : "";
   const validAt = context?.selectedRowTime
     ? formatBeachDateTime(context.selectedRowTime, timezone, "EEE h:mm a")
@@ -122,6 +122,8 @@ export function PublicForecastAnswer({
   const computedAt = report?.updatedAt
     ? formatBeachDateTime(report.updatedAt, timezone, "EEE h:mm a")
     : null;
+  const HeadingTag = headingLevel;
+  const hasForecastDetails = Boolean(context?.selectedRowTime && waveHeight);
 
   return (
     <section
@@ -133,21 +135,27 @@ export function PublicForecastAnswer({
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
           {isTomorrow ? "Tomorrow's surf forecast" : "Surf forecast"}
         </p>
-        <h2 id="public-forecast-answer-heading" className="mt-2 text-xl font-semibold text-foreground">
-          {beach.name} surf forecast{titleDate}
-        </h2>
+        <HeadingTag id="public-forecast-answer-heading" className="mt-2 text-xl font-semibold text-foreground">
+          {beach.name} Surf Forecast{titleDate}
+        </HeadingTag>
 
-        <dl className="mt-4 grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
-          {waveHeight && <div><dt className="font-medium text-muted-foreground">Surf</dt><dd>{waveHeight}</dd></div>}
-          {bestWindow && <div><dt className="font-medium text-muted-foreground">Best window</dt><dd>{bestWindow}</dd></div>}
-          {report?.verdict && <div><dt className="font-medium text-muted-foreground">Verdict</dt><dd>{report.verdict}</dd></div>}
-          {report?.score != null && <div><dt className="font-medium text-muted-foreground">Score</dt><dd>{report.score}/100</dd></div>}
-          {report?.forecastConfidence != null && <div><dt className="font-medium text-muted-foreground">Confidence</dt><dd>{report.forecastConfidence}/100</dd></div>}
-          {primarySwell && <div><dt className="font-medium text-muted-foreground">Primary swell</dt><dd>{primarySwell}</dd></div>}
-          {secondarySwell && <div><dt className="font-medium text-muted-foreground">Secondary swell</dt><dd>{secondarySwell}</dd></div>}
-          {wind && <div><dt className="font-medium text-muted-foreground">Wind</dt><dd>{wind}</dd></div>}
-          {tide && <div><dt className="font-medium text-muted-foreground">Tide</dt><dd>{tide}</dd></div>}
-        </dl>
+        {hasForecastDetails ? (
+          <dl className="mt-4 grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+            {waveHeight && <div><dt className="font-medium text-muted-foreground">Surf</dt><dd>{waveHeight}</dd></div>}
+            {bestWindow && <div><dt className="font-medium text-muted-foreground">Best window</dt><dd>{bestWindow}</dd></div>}
+            {report?.verdict && <div><dt className="font-medium text-muted-foreground">Verdict</dt><dd>{report.verdict}</dd></div>}
+            {report?.score != null && <div><dt className="font-medium text-muted-foreground">Score</dt><dd>{report.score}/100</dd></div>}
+            {report?.forecastConfidence != null && <div><dt className="font-medium text-muted-foreground">Confidence</dt><dd>{report.forecastConfidence}/100</dd></div>}
+            {primarySwell && <div><dt className="font-medium text-muted-foreground">Primary swell</dt><dd>{primarySwell}</dd></div>}
+            {secondarySwell && <div><dt className="font-medium text-muted-foreground">Secondary swell</dt><dd>{secondarySwell}</dd></div>}
+            {wind && <div><dt className="font-medium text-muted-foreground">Wind</dt><dd>{wind}</dd></div>}
+            {tide && <div><dt className="font-medium text-muted-foreground">Tide</dt><dd>{tide}</dd></div>}
+          </dl>
+        ) : (
+          <p className="mt-4 text-sm leading-6 text-muted-foreground">
+            Current forecast details are temporarily unavailable. Check back for the next Quiver surf call and hourly conditions.
+          </p>
+        )}
 
         {report?.whySentence && (
           <p className="mt-5 text-sm leading-6 text-foreground">
@@ -155,17 +163,17 @@ export function PublicForecastAnswer({
           </p>
         )}
 
-        <div className="mt-5 border-t border-border/60 pt-3 text-xs leading-5 text-muted-foreground">
-          <p>
-            Forecast valid at {validAt ?? "the selected forecast time"} ({timezone}).
+        {(validAt || sourceUpdatedAt || computedAt) && <div className="mt-5 border-t border-border/60 pt-3 text-xs leading-5 text-muted-foreground">
+          {validAt && <p>
+            Forecast valid at {validAt} ({timezone}).
             {isStale ? " Source data is stale; conditions may have changed." : ""}
-          </p>
+          </p>}
           {sourceUpdatedAt && <p>Source data updated: {sourceUpdatedAt}.</p>}
           {computedAt && <p>Quiver computed this answer: {computedAt}.</p>}
           {context?.contributingSources && context.contributingSources.length > 0 && (
             <p>Contributing sources: {context.contributingSources.map(sourceLabel).join(", ")}.</p>
           )}
-        </div>
+        </div>}
       </div>
     </section>
   );

--- a/components/beach-detail/public-forecast-hourly.tsx
+++ b/components/beach-detail/public-forecast-hourly.tsx
@@ -1,0 +1,139 @@
+import type {
+  PublicForecastDay,
+  PublicForecastHour,
+} from "@/actions/spot/spot-surf-report-actions";
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+import { formatTimeInTimezone } from "@/lib/utils/date-time";
+
+interface PublicForecastHourlyProps {
+  beachName: string;
+  forecastHours: PublicForecastHour[];
+  report: SurfCallResult | null;
+  context: ForecastRecommendationContext | null;
+  isTomorrow: boolean;
+  forecastDay: PublicForecastDay;
+}
+
+function join(parts: (string | null | undefined)[], separator = " "): string {
+  return parts.filter(Boolean).join(separator) || "—";
+}
+
+function swellLabel(hour: PublicForecastHour): string {
+  const secondary = [
+    hour.swell_2_height,
+    hour.swell_2_period ? `@ ${hour.swell_2_period}` : null,
+    hour.swell_2_direction,
+  ].filter(Boolean);
+
+  return join([
+    hour.swell_1_height,
+    hour.swell_1_period ? `@ ${hour.swell_1_period}` : null,
+    hour.swell_1_direction,
+    secondary.length > 0 ? `(${secondary.join(" ")})` : null,
+  ]);
+}
+
+function isWithinCallWindow(
+  forecastAt: string,
+  report: SurfCallResult | null,
+  context: ForecastRecommendationContext | null,
+): boolean {
+  const startMs = Date.parse(
+    context?.displayWindowStart ?? report?.bestWindowStart ?? "",
+  );
+  const endMs = Date.parse(
+    context?.displayWindowEnd ?? report?.bestWindowEnd ?? "",
+  );
+  if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
+
+  const forecastMs = Date.parse(forecastAt);
+  return forecastMs >= startMs && forecastMs <= endMs;
+}
+
+export function PublicForecastHourly({
+  beachName,
+  forecastHours,
+  report,
+  context,
+  isTomorrow,
+  forecastDay,
+}: PublicForecastHourlyProps) {
+  if (forecastHours.length === 0) return null;
+
+  const timezone = context?.timezone ?? "UTC";
+  const dayLabel = forecastDay === "tomorrow" ? "Tomorrow" : "Today";
+
+  return (
+    <section
+      aria-labelledby="public-forecast-hourly-heading"
+      data-testid="public-forecast-hourly"
+      className="mx-auto max-w-5xl px-4 pt-5 sm:px-6 lg:px-8"
+    >
+      <div className="rounded-2xl border border-border/70 bg-card p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {dayLabel} by time
+        </p>
+        <h2
+          id="public-forecast-hourly-heading"
+          className="mt-2 text-xl font-semibold text-foreground"
+        >
+          {beachName} Hourly Surf Forecast
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Forecast times are shown in {timezone}.
+        </p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[760px] border-collapse text-left text-sm">
+            <caption className="sr-only">
+              {beachName} {dayLabel.toLowerCase()} hourly surf forecast with
+              surf height, Quiver recommendation, swell, wind, tide, and confidence.
+            </caption>
+            <thead>
+              <tr className="border-b border-border text-xs uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="px-3 py-2 font-medium">Time</th>
+                <th scope="col" className="px-3 py-2 font-medium">Surf height</th>
+                <th scope="col" className="px-3 py-2 font-medium">Quiver recommendation</th>
+                <th scope="col" className="px-3 py-2 font-medium">Swell</th>
+                <th scope="col" className="px-3 py-2 font-medium">Wind</th>
+                <th scope="col" className="px-3 py-2 font-medium">Tide</th>
+                <th scope="col" className="px-3 py-2 font-medium">Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {forecastHours.map((hour) => {
+                const inCallWindow =
+                  forecastDay === (isTomorrow ? "tomorrow" : "today") &&
+                  isWithinCallWindow(hour.forecast_at, report, context);
+
+                return (
+                  <tr
+                    key={hour.forecast_at}
+                    data-testid="public-forecast-hour"
+                    className="border-b border-border/60 last:border-0"
+                  >
+                    <th scope="row" className="whitespace-nowrap px-3 py-3 font-medium text-foreground">
+                      {formatTimeInTimezone(hour.forecast_at, timezone)}
+                    </th>
+                    <td className="px-3 py-3">{hour.wave_height || "—"}</td>
+                    <td className="px-3 py-3">
+                      {inCallWindow ? "Best window" : "—"}
+                    </td>
+                    <td className="px-3 py-3">{swellLabel(hour)}</td>
+                    <td className="px-3 py-3">{join([hour.wind_speed, hour.wind_direction])}</td>
+                    <td className="px-3 py-3">{join([hour.tide_height, hour.tide_status], " · ")}</td>
+                    <td className="px-3 py-3">
+                      {hour.confidence_score == null
+                        ? "—"
+                        : `${Math.round(hour.confidence_score)}%`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -38,7 +38,7 @@ export const TEST_BEACHES = isDevEnvironment ? {
     slug: 'blacks',
     city: 'San Diego',
     state: 'CA',
-    name: 'Blacks'
+    name: 'Blacks Beach'
   },
   birdrock: {
     id: 'ca2b1d6f-2428-4273-ab02-7555eeec4323',
@@ -59,9 +59,9 @@ export const TEST_BEACHES = isDevEnvironment ? {
   blacks: {
     id: 'blacks',
     slug: 'blacks',
-    city: 'La Jolla',
+    city: 'San Diego',
     state: 'CA',
-    name: 'Blacks'
+    name: 'Blacks Beach'
   },
   birdrock: {
     id: 'bird-rock',

--- a/e2e/guest-route-html-contracts.spec.ts
+++ b/e2e/guest-route-html-contracts.spec.ts
@@ -7,6 +7,7 @@
 
 import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
 import { TEST_BEACHES } from './fixtures/test-data';
+import { buildBeachUrl } from '@/lib/utils/beach-url-utils';
 
 const WAVE_HEIGHT_PATTERN = /\d+(\.\d+)?(-\d+(\.\d+)?)?\s*ft/i;
 
@@ -191,6 +192,33 @@ test.describe('Route HTML Contracts', () => {
       expect(ogImage).toContain(`slug=${beach.slug}`);
 
       expectBeachMetaDescription(description, beach.name);
+    });
+
+    test('/[state]/[city]/[beachSlug] keeps one exact-query H1 in initial HTML', async ({
+      request,
+    }) => {
+      const beach = TEST_BEACHES.blacks;
+      const html = await getHtml(request, buildBeachUrl(beach));
+      const h1Headings = getHeadingTexts(html, 1);
+
+      expect(h1Headings).toHaveLength(1);
+      expect(h1Headings[0]).toMatch(new RegExp(`^${beach.name} Surf Forecast(?: for .+)?$`));
+      expect(getHeadingTexts(html, 2)).toContain(beach.name);
+      expect(html).not.toContain('Loading beach details');
+    });
+
+    test('/[state]/[city]/[beachSlug] exposes hourly rows in initial HTML @requires-data', async ({
+      request,
+    }) => {
+      const beach = TEST_BEACHES.blacks;
+      const html = await getHtml(request, buildBeachUrl(beach));
+
+      expect(getHeadingTexts(html, 2)).toContain(`${beach.name} Hourly Surf Forecast`);
+      expect(html).toContain('data-testid="public-forecast-hourly"');
+      expect((html.match(/data-testid="public-forecast-hour"/g) ?? []).length).toBeGreaterThan(1);
+      expect(html).toMatch(/Surf height/);
+      expect(html).toMatch(/Quiver recommendation/);
+      expect(html).toMatch(/Confidence/);
     });
   });
 


### PR DESCRIPTION
Prod slice of PR #553 (merged to `main` as `6620788f2`). `prod` is 233 commits behind `main`, so this is a targeted slice rather than a full merge.

## What ships

- Stable `[Beach] Surf Forecast` H1 on beach detail pages in every forecast/data state.
- Server-rendered hourly table (surf height, swell, wind, tide, confidence) below the interactive detail experience.
- Today's hourly rows stay crawlable when the best recommendation is tomorrow, and when no viable window exists.
- Window-level score appears only in the answer card; hourly rows just identify the best window.
- The crawler-visible `Loading beach details...` Suspense fallback becomes an aria-hidden skeleton.
- Canonical Blacks Beach E2E fixture corrected (`La Jolla` → `San Diego`, `Blacks` → `Blacks Beach`).

## Slice scope

13 files, +594/−34 — cherry-pick of `ffc6cca6a` onto `origin/prod`, no drive-by edits.

**One test dropped versus main:** `renders a held beach page with its forecast intact` depends on `CHRONICALLY_IMPACTED_WATER_QUALITY_BEACH_IDS` from `lib/recommendations/major-event-hold/water-quality.ts`, a module `prod` does not have. That constant belongs to the water-quality-holds feature, which is a separate promotion — pulling it in would have widened this slice well past its blast radius. The two tests that cover *this* feature (stable H1, hourly rows in initial HTML) are both included.

## Verification (local, against prod's own dependency tree)

Ran with a real `yarn install --frozen-lockfile` in a dedicated worktree off `origin/prod`, not a borrowed `node_modules`:

- `yarn typecheck` — **0 errors**
- `VERCEL_ENV=production yarn build` — passed
- Feature Jest suites — 51 tests, 5 suites, all passing
- Scoped ESLint on all touched files — clean
- Cherry-pick conflicts — 1, in a test file, purely additive; resolved by taking the feature side

**Import closure:** clean. **Route closure:** both new/changed components emit no internal links (`href`/`push`), so there is no unreachable-route risk of the PR #330 kind.

**No feature flag.** This is unconditional SSR markup, so rollback is a revert of the deploy, not a flag flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)