### PR TITLE
test(e2e): realign guest-landing smoke specs with the shipped landing

### DIFF
--- a/e2e/guest-landing-media-budget.spec.ts
+++ b/e2e/guest-landing-media-budget.spec.ts
@@ -8,11 +8,17 @@ import {
 
 const HERO_POSTER_PATH = "/images/hero/quiver-landing-hero-poster.jpg";
 const HERO_VIDEO_PATH = "/videos/quiver-landing-hero-720.mp4";
+const WALKTHROUGH_VIDEO_PATH = "/videos/buoy-loop.mp4";
 const SCREENSHOT_ROOT = "/images/app-screenshots/";
-const FIRST_LOAD_MEDIA_REQUEST_BUDGET = 5;
+const VIDEO_ROOT = "/videos/";
+// Desktop currently spends 5 (hero poster, hero video, walkthrough video,
+// local-intel screenshot); mobile spends 4. Both landing videos autoplay, so
+// they are first-load cost and must stay counted.
+const LANDING_MEDIA_REQUEST_BUDGET = 6;
 const ALLOWED_FIRST_LOAD_MEDIA = new Set([
   HERO_POSTER_PATH,
   HERO_VIDEO_PATH,
+  WALKTHROUGH_VIDEO_PATH,
   "/images/app-screenshots/local-intel-720.webp",
 ]);
 
@@ -29,9 +35,8 @@ function toLandingMediaPath(requestUrl: string): string | null {
       : url.pathname;
 
   if (!assetPath) return null;
-  if (assetPath === HERO_POSTER_PATH || assetPath === HERO_VIDEO_PATH) {
-    return assetPath;
-  }
+  if (assetPath === HERO_POSTER_PATH) return assetPath;
+  if (assetPath.startsWith(VIDEO_ROOT)) return assetPath;
   if (assetPath.startsWith(SCREENSHOT_ROOT)) return assetPath;
   return null;
 }
@@ -72,17 +77,21 @@ for (const { name, viewport } of MEDIA_VIEWPORTS) {
       });
     });
 
-    test("keeps first-load media within the documented request budget @smoke", async ({
+    test("keeps landing media within the documented request budget @smoke", async ({
       page,
     }) => {
       const mediaRequests = captureLandingMediaRequests(page);
+      const media = page.getByTestId("field-guide-hero-video");
       const response = await page.goto("/", { waitUntil: "load" });
 
       expect(response).not.toBeNull();
       expect(response!.status()).toBe(200);
+      // The hero starts on its own for viewers who allow motion, so there is
+      // no play control and the element is present from first paint.
+      await expect(media.locator("video")).toBeVisible();
       await expect(
-        page.getByTestId("field-guide-hero-video").locator("video"),
-      ).toBeVisible();
+        media.getByRole("button", { name: "Play demo" }),
+      ).toHaveCount(0);
       await expect
         .poll(
           () =>
@@ -93,16 +102,18 @@ for (const { name, viewport } of MEDIA_VIEWPORTS) {
 
       const uniqueMedia = [...new Set(mediaRequests)];
       expect(uniqueMedia).toEqual(
-        expect.arrayContaining([HERO_POSTER_PATH, HERO_VIDEO_PATH]),
+        expect.arrayContaining([
+          HERO_POSTER_PATH,
+          HERO_VIDEO_PATH,
+          WALKTHROUGH_VIDEO_PATH,
+        ]),
       );
       expect(
         uniqueMedia.every((assetPath) =>
           ALLOWED_FIRST_LOAD_MEDIA.has(assetPath),
         ),
       ).toBe(true);
-      expect(mediaRequests.length).toBeLessThanOrEqual(
-        FIRST_LOAD_MEDIA_REQUEST_BUDGET,
-      );
+      expect(mediaRequests.length).toBeLessThanOrEqual(LANDING_MEDIA_REQUEST_BUDGET);
     });
   });
 }

--- a/e2e/guest-landing.spec.ts
+++ b/e2e/guest-landing.spec.ts
@@ -64,15 +64,15 @@ test.describe('Guest Landing Page', () => {
     // Landing page should have some content
     expect(hasHero || hasMain).toBe(true);
 
-    const spotlight = page.getByTestId('field-guide-spotlight');
-    await expect(spotlight).toBeVisible({ timeout: 5000 });
+    const walkthrough = page.getByTestId('field-guide-walkthrough');
+    await expect(walkthrough).toBeVisible({ timeout: 5000 });
     await expect(
-      spotlight.getByRole('heading', { name: /quiver's swell view is here/i }),
+      walkthrough.getByRole('heading', { name: /turn a forecast into a surf plan/i }),
     ).toBeVisible();
-    await expect(spotlight.getByText('FREE · NEW IN THE APP')).toBeVisible();
+    await expect(walkthrough.getByRole('listitem')).toHaveCount(4);
     await expect(
-      spotlight.getByRole('link', { name: 'Get the app' }),
-    ).toHaveCount(0);
+      walkthrough.getByTestId('field-guide-walkthrough-video').locator('video'),
+    ).toBeVisible();
   });
 
   test('should open auth modal when clicking login', async ({ page }) => {


### PR DESCRIPTION
Unblocks the prod gate. This is test-only — no application code changes.

## Why prod slices have been failing

Prod Gate runs its smoke suite against `https://dev.quiversurf.app`, which serves **`main`**, while the specs come from the PR branch. Two landing changes on main never reached prod's copies of these specs, so the gate has been asserting against UI that no longer exists:

| Change on main | Prod's spec still expected |
|---|---|
| `6199a5175` (2026-08-13) removed `FieldGuideSpotlight` | `field-guide-spotlight` visible |
| `a734b1a41` made the hero and walkthrough videos autoplay | a `Play demo` click before any `<video>` |

Every Prod Gate run through 2026-08-11 was green; both slices since (`codex/prod-wq-holds-20260814` and `#554`) went red on exactly these assertions. Main Gate runs no Playwright at all, which is why main never caught it.

## What this syncs from main

- Target `field-guide-walkthrough` instead of the removed `field-guide-spotlight`.
- Expect both videos playing on arrival rather than clicking `Play demo`.
- **Count every request under `/videos/`**, not just the hero by exact path. The tracker previously matched the hero video by literal path, so the second autoplaying landing video would have loaded completely unmeasured. Budget is 6; measured desktop spends 5, mobile 4.

## Verification

Run against `dev.quiversurf.app` — the same target CI uses — on the re-synced branch: **3 passed**.

## Follow-ups, not in this PR

- `#554` (SEO hourly table) needs `prod` merged into it after this lands. It branched before the fix and still carries the stale spec, and CI runs the suite from the PR branch.
- Worth addressing separately: Prod Gate smoke-tests `dev` (main's deploy), so it never exercises the prod code in a prod PR, and Main Gate runs no smoke at all. That combination is what let a landing change block prod promotion for three days with nothing red on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)