### PR TITLE
docs(soul): restore two rules dropped in the CLAUDE.md consolidation

### DIFF
--- a/soul.md
+++ b/soul.md
@@ -173,6 +173,8 @@ Behavior changes require corresponding test review and, where needed, test updat
 - Run `yarn deadcode` when adding or removing components, hooks, libraries, or CLI entry points, and do not introduce new unused files or exports.
 - Prefer stable user-facing selectors, explicit waits tied to real state, isolated test data, and assertions that fail when behavior breaks.
 - Diagnose failures as product bugs, test bugs, timing issues, missing setup, or environment problems. Fix actionable failures and rerun the focused check.
+- E2E specs must call `setupErrorDetection(page)` in `beforeEach` and `assertNoErrors(page, errorCapture)` in `afterEach`, assert real HTTP status codes (400/401/403/404/405), and treat a 500 as a bug. Use `throw new Error('Not implemented: <reason>')` rather than `test.skip()`, and annotate any `waitForTimeout` with an eslint-disable and a reason.
+- Define the target pattern for SEO and metadata work before editing `lib/seo/meta.ts` or related files. No trial-and-error across commits.
 - Do not add wall-clock micro-benchmarks that are expected to be stable on shared CI.
 - CI configuration and current CI results are authoritative; do not rely on a dated documentation claim about whether a workflow is active or green.
 


### PR DESCRIPTION
Follow-on from repointing the guardrails lesson anchors after `quiver/CLAUDE.md` became a pointer to `soul.md`.

Verifying each anchor meant checking the lesson's actual subject appears under the heading it now cites, rather than matching heading names. Eight did. Two did not — the consolidation **dropped** them rather than moving them:

- **L-020** — E2E requirements: `setupErrorDetection`/`assertNoErrors`, real HTTP status codes with 500 always a bug, `throw` over `test.skip()`, annotated `waitForTimeout`. Absent from `soul.md` entirely.
- **L-021** — define the SEO/meta target pattern before editing `lib/seo/meta.ts`. `soul.md` only routed SEO to `product-marketing-context.md`, which doesn't carry the no-trial-and-error rule.

Both restored under **Testing and validation**.

Worth noting: the prose guard only checks that an anchor *resolves*. It would have passed with these two pointing at a section that no longer stated the rule — green guard, missing rules. If it compared each lesson's `summary` against the section text, this class of loss would be caught automatically.

Docs-only; no monitored paths, so no Vercel build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)