### PR TITLE
Zine polish batch (#568–584) plus review-found rendering and forecast-semantics fixes

### DIFF
--- a/.planning/2026-08-19-zine-polish-issue-batch.md
+++ b/.planning/2026-08-19-zine-polish-issue-batch.md
@@ -1,0 +1,99 @@
+# Zine polish issue batch — #568–584 (2026-08-19)
+
+Loop-driven run: main session = PM/review (impeccable normalize + polish standards),
+`codex exec` = implementation worker, sequential batches in place on branch
+`fix/zine-polish-issues-568-584`. One conventional commit per batch. No push.
+
+Design authority: `docs/STYLE_GUIDE.md`, `app/styles/zine.css`, `components/zine/`,
+`soul.md` (personality over template polish; roughness must never reduce readability).
+
+## Cross-batch consistency rules (impeccable/normalize)
+
+- Torn-paper/rotation is decorative: content must sit in a safe inset; reduce/disable
+  rotation at constrained widths (~870px is the reported breakpoint) instead of clipping.
+  Prefer ONE systemic fix in the shared zine component/pattern over per-page patches.
+- No dark navy app-card modules on cream zine pages: ink-on-paper type, ruled/dashed
+  dividers, restrained blue/orange stamps, existing zine tokens only (no new one-off colors).
+- Guest gating reuses the existing login flow/CTA pattern; public facts stay public.
+- All interactive elements: visible focus, keyboard accessible, WCAG AA on paper.
+- Viewports to verify: 390, 768, 870×707, wide desktop, 200% zoom. No horizontal scroll,
+  no layout shift from images.
+
+## Queue
+
+| Batch | Issues | Scope | Status |
+|---|---|---|---|
+| A | #572, #584 | Copy: /about headline; /vs/surfline/free "free-to-browse"→"free" (+meta/OG/tests) | done (7a4c77b91, aa5c57f6b) — visual QA pending |
+| B | #578, #579, #580, #581, #571, #573 | Torn-edge clipping + crooked layout: fixed-depth mask bands + safe-inset token + rot step-down ≤900px in zine.css; learn cards drop edge mask; tools cards straightened | done (27e9d31af, da8f5c40e) — visual QA pending |
+| C | #574 | /forecast: zine variant for BestSurfWindows/WhyThisCall/SevenDayOutlook/SwellArc; contracts + analytics preserved | done (08dc2baa1) — visual QA + e2e forecast-hub pending |
+| D | #575, #576, #577 | Zine redesign all 3 indexes; DB-backed Baja photo w/ attribution; licensed static US photos; state stamps; structured data added; browser QA passed at 870 | done (a485df7ca, babbcb4a1, 91607394d) |
+| E | #570 | Dark hero removed; temp summary slotted into ZineHero (H1 + suffix); dangling #seasonal-trends fixed; SSR has single H1; browser QA passed | done (b4457f885) |
+| F | #583 | LiveCamCard w/ 4-tier source chain + ink fallback; PM follow-up: cam hosts bypass photo proxy (403) via shouldProxyUrl passthrough; optimizer verified 200 | done (92292e3b8, 2d5ecb6f8) |
+| G | #568 | Values out of static HTML; authed hydration via /api/surf/call; stamp login link (SSR verified: no verdict/marker, facts public); handoff panel ink-on-paper, QR 16:1 contrast | done (a951dfe84, f8775b541) |
+| H | #569 | Hero+table derive action/window/score from one policy-filtered window result; "Go now!" requires now∈qualifying window (beach-local); table subtext removed; guest score gate w/ redirectTo. Personalization gap documented (signed-in still generic scores) | done (a6c7af3da, 6803b1605) |
+| I | #582 | lastVerified constant (2026-07-08) + 60-day tripwire test + link checker (bot-walled hosts → WARN, real failures → exit 1; ran live: 8/8 OK, 2 manual-review warns) | done (155810180) |
+
+## Log
+
+- 2026-08-19: plan created; loop armed.
+- 2026-08-19 09:15: In-browser QA (dev server :3100) passed for batches A/B/C at 870×707 + 1280:
+  /learn (START HERE 22px inset, all OPEN NOTE CTAs 22px clear, rot zeroed ≤900), /tools (cards
+  straight at all widths, quick-check straight ≤900 + deliberate tilt at 1280, content inset),
+  /features (stamp 22px inset, all CTAs inside bounds incl. Android 22px bottom-clear),
+  /plans (full Pro headline, 22px insets), /forecast (both modules + arc render, 0 navy bg,
+  7 outlook days, 5 window cards), /about + /vs copy verified server-rendered. No horizontal
+  scroll anywhere. Screenshots unreliable (hidden pane renders stale frames) — geometry checks
+  used instead; final human eye-pass still recommended.
+- 2026-08-19 10:30: ALL 17 ISSUES IMPLEMENTED. 16 commits on this branch (nothing pushed).
+  Regression gates run: yarn typecheck PASS, yarn lint PASS, FULL yarn test:unit PASS
+  (1333 suites / 17,037 tests, 0 failures). Live browser QA passed for every changed surface
+  (see entries above; also /forecast/san-diego guest semantics, beach-page guest gate SSR,
+  water-temp merged hero, beaches indexes, cam-card thumbnails).
+
+## Outcome
+
+PR: https://github.com/SteveChandler/quiver/pull/585 (closes #568–584 on merge).
+
+All 17 issues shipped, plus defects found in live design review — those carried the
+real behavioural risk:
+
+- Hero scrim never rendered: `from-[#252D6B]/92 …/78 …/88` are off Tailwind's opacity
+  scale (multiples of 5), so no stop rules generated, `--tw-gradient-stops` stayed
+  undefined and the gradient collapsed to `none`. Pinned by
+  `__tests__/styles/gradient-opacity-scale.test.ts`.
+- `SeoScenePanel` cropped photos: `aspect-[16/9]` + `h-full` drove width FROM height
+  (1252px media in a 460px figure), so `overflow-hidden` clipped the left ~63% and
+  `object-position` never applied. Fixed for 5 call sites.
+- Regional "TOP BEACH NOW" scored the day's FIRST three rows (dawn), so afternoons
+  reported stale EPIC beside an honest "no qualifying window". Score and window now
+  share one reference instant.
+- Hero ranked on the condition-score engine but sourced its window from the window
+  engine. Now leads with the region's best window; when nothing is live it points at
+  the next one.
+- `clamp(48px, 8vw, 96px)` overflowed narrow columns by 124px. `cqw` inside
+  `.zine-measure` sizes off the column; no container ⇒ unchanged elsewhere.
+
+### Verification
+
+- Full unit suite green (17k+ tests); typecheck + lint clean.
+- E2E baselined against `main` on the same machine: **111 passed / 11 failed / 3 skipped
+  on BOTH**, failure lists diffed to an empty symmetric difference ⇒ no regressions.
+  All failures are `@requires-data` or depend on forecast rows the local DB lacks
+  (server logs `Forecast issues: 53 failed` on both runs).
+- Docker needed a restart mid-run: its storage went read-only, so containers had exited
+  while `docker ps` still reported them healthy from stale cache (`docker inspect`
+  showed `exited unhealthy`).
+
+### Known gaps (deliberate, not oversights)
+
+1. Signed-in regional scores remain the generic calculation; per-user personalisation
+   was not fabricated (#569).
+2. `/best-time-to-surf/san-diego` keeps whitespace under its 4:3 hero — the approved
+   photo pipeline returned zero license-safe San Diego candidates
+   (`docs/seo/photo-candidates/san-diego-hero-*`). Not filled with a weak shot.
+3. Beach sub-pages (tides + water-temp) had their below-fold alert CTA, next-steps and
+   nearby-spots sections REMOVED at Steven's request. This drops internal links from
+   those SEO pages — breadcrumb, structured data and hero links remain. Revisit if
+   internal-link equity matters more than the visual weight.
+4. `NearbyBeachesEnriched` (navy) is still used on `/beach/[slug]` and the Mexico beach
+   page; only the sub-page path swapped to `ZineNearbySpots`.

--- a/__tests__/app/ahrefs-metadata-cleanup.test.ts
+++ b/__tests__/app/ahrefs-metadata-cleanup.test.ts
@@ -11,7 +11,13 @@ jest.mock("@/actions/beach/beach-location-list-actions", () => ({
 
 describe("Ahrefs metadata cleanup", () => {
   it("keeps /about meta description under Ahrefs truncation threshold", () => {
-    expect(aboutMetadata.description).toContain("Why Quiver exists");
+    const headline =
+      "I built Quiver because I was tired of forecasts being wrong.";
+
+    expect(aboutMetadata.title).toEqual({ absolute: headline });
+    expect(aboutMetadata.description).toContain(headline);
+    expect(aboutMetadata.openGraph?.title).toBe(headline);
+    expect(aboutMetadata.twitter?.title).toBe(headline);
     expect(String(aboutMetadata.description).length).toBeLessThanOrEqual(160);
   });
 

--- a/__tests__/app/beaches-index-page.test.tsx
+++ b/__tests__/app/beaches-index-page.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+
+import BeachesIndexPage from "@/app/beaches/page";
+import { getBajaFeaturedPhoto } from "@/app/beaches/_lib/get-baja-featured-photo";
+
+jest.mock("@/app/beaches/_lib/get-baja-featured-photo", () => ({
+  getBajaFeaturedPhoto: jest.fn(),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ fill: _fill, priority: _priority, sizes: _sizes, ...props }: any) => (
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+const mockGetBajaFeaturedPhoto = jest.mocked(getBajaFeaturedPhoto);
+
+function getSchemas(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll('script[type="application/ld+json"]'),
+  ).map((script) => script.textContent ?? "");
+}
+
+describe("beaches region index", () => {
+  beforeEach(() => {
+    mockGetBajaFeaturedPhoto.mockResolvedValue({
+      src: "https://example.com/baja.webp",
+      alt: "Surf at San Miguel, Baja California",
+      attributionHtml: "Photo by Example Surfer",
+    });
+  });
+
+  it("renders the zine hierarchy, region links, counts, and structured data", async () => {
+    const { container } = render(await BeachesIndexPage());
+
+    expect(screen.getByTestId("beaches-zine-surface")).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /breadcrumb/i }),
+    ).toHaveTextContent(/Home\s*\/\s*Beaches/);
+    expect(
+      screen.getByRole("heading", { level: 1, name: /browse surf beaches by region/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /united states/i })).toHaveAttribute(
+      "href",
+      "/beaches/usa",
+    );
+    expect(screen.getByRole("link", { name: /mexico/i })).toHaveAttribute(
+      "href",
+      "/beaches/mexico",
+    );
+    expect(screen.getByText(/16 coastal states/i)).toBeInTheDocument();
+    expect(screen.getByText(/over 5,000 beaches/i)).toBeInTheDocument();
+
+    const schemas = getSchemas(container).join("\n");
+    expect(schemas).toContain('"@type":"BreadcrumbList"');
+    expect(schemas).toContain('"@type":"WebPage"');
+    expect(schemas).toContain("/beaches");
+  });
+
+  it("uses the approved Baja photo when present and a zine fallback when absent", async () => {
+    const { rerender } = render(await BeachesIndexPage());
+
+    expect(
+      screen.getByRole("img", { name: /surf at san miguel/i }),
+    ).toHaveAttribute(
+      "src",
+      "/api/image-proxy?url=https%3A%2F%2Fexample.com%2Fbaja.webp",
+    );
+
+    mockGetBajaFeaturedPhoto.mockResolvedValueOnce(null);
+    rerender(await BeachesIndexPage());
+
+    expect(
+      screen.getByRole("img", { name: /baja california coast photo coming soon/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/beaches-mexico-index-page.test.tsx
+++ b/__tests__/app/beaches-mexico-index-page.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from "@testing-library/react";
+
+import { getAllBeachLocations } from "@/actions/beach/beach-location-list-actions";
+import { getBajaFeaturedPhoto } from "@/app/beaches/_lib/get-baja-featured-photo";
+import MexicoStatesIndexPage from "@/app/beaches/mexico/page";
+
+jest.mock("@/actions/beach/beach-location-list-actions", () => ({
+  getAllBeachLocations: jest.fn(),
+}));
+
+jest.mock("@/app/beaches/_lib/get-baja-featured-photo", () => ({
+  getBajaFeaturedPhoto: jest.fn(),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ fill: _fill, priority: _priority, sizes: _sizes, ...props }: any) => (
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+const mockGetAllBeachLocations = jest.mocked(getAllBeachLocations);
+const mockGetBajaFeaturedPhoto = jest.mocked(getBajaFeaturedPhoto);
+
+describe("Mexico beaches state index", () => {
+  beforeEach(() => {
+    mockGetAllBeachLocations.mockResolvedValue({
+      success: true,
+      data: [
+        { country: "Mexico", state: "Baja California", city: "Ensenada" },
+        { country: "MX", state: "Baja California", city: "Rosarito" },
+        { country: "MEX", state: "Baja California", city: "Rosarito" },
+      ],
+    } as Awaited<ReturnType<typeof getAllBeachLocations>>);
+    mockGetBajaFeaturedPhoto.mockResolvedValue({
+      src: "https://example.com/baja-featured.webp",
+      alt: "Surf at San Miguel, Baja California",
+      attributionHtml: "Photo by Example Surfer",
+    });
+  });
+
+  it("renders the zine hierarchy, Baja link, counts, and structured data", async () => {
+    const { container } = render(await MexicoStatesIndexPage());
+
+    expect(screen.getByTestId("mexico-beaches-zine-surface")).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /breadcrumb/i }),
+    ).toHaveTextContent(/Home\s*\/\s*Beaches\s*\/\s*Mexico/);
+    expect(
+      screen.getByRole("heading", { level: 1, name: /best surf beaches in mexico/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 state")).toBeInTheDocument();
+    expect(screen.getAllByText("2 cities")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: /baja california/i })).toHaveAttribute(
+      "href",
+      "/beaches/mexico/baja-california",
+    );
+
+    const schemas = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    )
+      .map((script) => script.textContent ?? "")
+      .join("\n");
+    expect(schemas).toContain('"@type":"BreadcrumbList"');
+    expect(schemas).toContain('"@type":"WebPage"');
+    expect(schemas).toContain("/beaches/mexico");
+  });
+
+  it("renders the approved Baja photo and its attribution", async () => {
+    render(await MexicoStatesIndexPage());
+
+    expect(
+      screen.getByRole("img", { name: /surf at san miguel/i }),
+    ).toHaveAttribute(
+      "src",
+      "/api/image-proxy?url=https%3A%2F%2Fexample.com%2Fbaja-featured.webp",
+    );
+    expect(screen.getByText(/photo by example surfer/i)).toBeInTheDocument();
+  });
+
+  it("uses the deliberate zine fallback when no approved photo is available", async () => {
+    mockGetBajaFeaturedPhoto.mockResolvedValueOnce(null);
+
+    render(await MexicoStatesIndexPage());
+
+    expect(
+      screen.getByRole("img", { name: /baja california coast photo coming soon/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/beaches-usa-index-page.test.tsx
+++ b/__tests__/app/beaches-usa-index-page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+
+import { getAllBeachLocations } from "@/actions/beach/beach-location-list-actions";
+import UsaStatesIndexPage from "@/app/beaches/usa/page";
+
+jest.mock("@/actions/beach/beach-location-list-actions", () => ({
+  getAllBeachLocations: jest.fn(),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ fill: _fill, priority: _priority, sizes: _sizes, ...props }: any) => (
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+const mockGetAllBeachLocations = jest.mocked(getAllBeachLocations);
+
+describe("USA beaches state index", () => {
+  beforeEach(() => {
+    mockGetAllBeachLocations.mockResolvedValue({
+      success: true,
+      data: [
+        { country: "USA", state: "CA", city: "Los Angeles" },
+        { country: "United States", state: "California", city: "San Diego" },
+        { country: "US", state: "CA", city: "San Diego" },
+        { country: "USA", state: "HI", city: "Honolulu" },
+        { country: "USA", state: "OR", city: "Bandon" },
+      ],
+    } as Awaited<ReturnType<typeof getAllBeachLocations>>);
+  });
+
+  it("renders the zine hierarchy, scannable counts, links, and schemas", async () => {
+    const { container } = render(await UsaStatesIndexPage());
+
+    expect(screen.getByTestId("usa-beaches-zine-surface")).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /breadcrumb/i }),
+    ).toHaveTextContent(/Home\s*\/\s*Beaches\s*\/\s*United States/);
+    expect(
+      screen.getByRole("heading", { level: 1, name: /best surf beaches by state/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3 states")).toBeInTheDocument();
+    expect(screen.getByText("4+ cities")).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /california/i })).toHaveAttribute(
+      "href",
+      "/beaches/usa/ca",
+    );
+    expect(screen.getByRole("link", { name: /hawaii/i })).toHaveAttribute(
+      "href",
+      "/beaches/usa/hi",
+    );
+    expect(screen.getByRole("link", { name: /oregon/i })).toHaveAttribute(
+      "href",
+      "/beaches/usa/or",
+    );
+
+    const schemas = Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    )
+      .map((script) => script.textContent ?? "")
+      .join("\n");
+    expect(schemas).toContain('"@type":"BreadcrumbList"');
+    expect(schemas).toContain('"@type":"WebPage"');
+    expect(schemas).toContain('"@type":"ItemList"');
+    expect(schemas).toContain("/beaches/usa/ca");
+  });
+
+  it("uses regional photography where available and a state-stamp fallback otherwise", async () => {
+    render(await UsaStatesIndexPage());
+
+    expect(
+      screen.getByRole("img", { name: /venice beach and the southern california coastline/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /hawaii state stamp/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("HI")).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/best-surf-forecast-app-freshness.test.ts
+++ b/__tests__/app/best-surf-forecast-app-freshness.test.ts
@@ -1,0 +1,33 @@
+import { COMPARISON_SOURCE_REVIEW } from "@/app/best-surf-forecast-app/comparison-sources";
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+describe("Best surf forecast app source freshness", () => {
+  it("requires comparison claims to be re-verified before they become stale", () => {
+    const lastVerifiedAt = new Date(
+      `${COMPARISON_SOURCE_REVIEW.lastVerified}T00:00:00.000Z`,
+    );
+    const staleAfter = new Date(
+      lastVerifiedAt.getTime() +
+        COMPARISON_SOURCE_REVIEW.freshnessThresholdDays *
+          MILLISECONDS_PER_DAY,
+    );
+    const now = new Date();
+
+    expect(() => {
+      if (now.getTime() <= staleAfter.getTime()) {
+        return;
+      }
+
+      throw new Error(
+        [
+          `Comparison sources are stale: last verified ${COMPARISON_SOURCE_REVIEW.lastVerified} by ${COMPARISON_SOURCE_REVIEW.reviewedBy}, with a ${COMPARISON_SOURCE_REVIEW.freshnessThresholdDays}-day threshold.`,
+          "Re-verify the claims and bump COMPARISON_SOURCE_REVIEW.lastVerified only after completing every verification step:",
+          "1. Confirm every material comparison claim against its cited source.",
+          "2. Check App Store and competitor information.",
+          "3. Check every source link for 404s or redirects with `yarn check:comparison-sources`.",
+        ].join("\n"),
+      );
+    }).not.toThrow();
+  });
+});

--- a/__tests__/app/best-surf-forecast-app-metadata.test.ts
+++ b/__tests__/app/best-surf-forecast-app-metadata.test.ts
@@ -19,7 +19,7 @@ describe("Best surf forecast app SEO page", () => {
     );
 
     expect(source).toContain("Affiliation disclosure: Quiver is our app.");
-    expect(source).toContain('CHECKED_ON_ISO = "2026-07-08"');
+    expect(source).toContain("COMPARISON_SOURCE_REVIEW.lastVerified");
     expect(source).toContain('href="/best-free-surf-forecast-app"');
     expect(source).toContain('href="/vs/surfline"');
     expect(source).toContain('href="/forecast-accuracy"');

--- a/__tests__/app/best-time-city-page.test.ts
+++ b/__tests__/app/best-time-city-page.test.ts
@@ -395,4 +395,16 @@ describe("best-time city SEO page", () => {
     expect(source).toContain("Monthly Breakdown");
     expect(source).toContain("path: `/best-time-to-surf/${citySlug}`");
   });
+
+  it("suppresses immediate-action copy on the seasonal month gauge", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/best-time-to-surf/[city]/page.tsx"),
+      "utf8"
+    );
+
+    const gauges = source.match(/<AnimatedScoreGauge[\s\S]*?\/>/g) ?? [];
+
+    expect(gauges).toHaveLength(1);
+    expect(gauges[0]).toContain("showAction={false}");
+  });
 });

--- a/__tests__/app/features-page.test.tsx
+++ b/__tests__/app/features-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 import FeaturesPage, { metadata } from "@/app/features/page";
@@ -29,14 +29,17 @@ jest.mock("@/components/pricing/android-waitlist-cta", () => ({
     source,
     surface,
     placement,
+    className,
   }: {
     children: ReactNode;
     source: string;
     surface: string;
     placement: string;
+    className?: string;
   }) => (
     <button
       type="button"
+      className={className}
       data-testid="android-waitlist-cta"
       data-source={source}
       data-surface={surface}
@@ -127,6 +130,21 @@ describe("FeaturesPage", () => {
     expect(
       screen.getByRole("link", { name: /read how free surf reports work/i }),
     ).toHaveAttribute("href", "/free-surf-reports");
+
+    const finalPanel = screen
+      .getByRole("heading", {
+        name: /make tomorrow's forecast about your surfing/i,
+      })
+      .closest("section");
+    expect(finalPanel).toHaveClass("torn", "torn-tb", "rot-neg");
+    expect(
+      within(finalPanel!).getByRole("link", { name: /open app store/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(finalPanel!).getByRole("button", {
+        name: /get the android beta/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("removes the old beach-directory experience from the features route", () => {

--- a/__tests__/app/generic-beach-detail-resolution.test.ts
+++ b/__tests__/app/generic-beach-detail-resolution.test.ts
@@ -418,7 +418,8 @@ describe("GenericBeachDetailPage slug resolution", () => {
         }),
       ],
     });
-    (getSpotSurfReportPublic as jest.Mock).mockResolvedValueOnce(freshForecastResult());
+    const forecastResult = freshForecastResult();
+    (getSpotSurfReportPublic as jest.Mock).mockResolvedValueOnce(forecastResult);
 
     const page = await GenericBeachDetailPage({
       params: Promise.resolve({
@@ -434,8 +435,12 @@ describe("GenericBeachDetailPage slug resolution", () => {
     expect(getHeadingTexts(html, 2)).toContain("Del Mar Hourly Surf Forecast");
     expect(html).toContain('data-testid="public-forecast-hourly"');
     expect((html.match(/data-testid="public-forecast-hour"/g) ?? [])).toHaveLength(3);
-    expect(html.match(/84\/100/g)).toHaveLength(1);
-    expect(html).toContain("Best window");
+    expect(html).not.toContain("84/100");
+    expect(html).not.toMatch(/>\s*(?:YES|MAYBE|NO)\s*</);
+    expect(html).not.toContain(forecastResult.report.bestWindowStart);
+    expect(html).not.toContain(forecastResult.report.bestWindowEnd);
+    expect(html).toContain("Sign in to reveal");
+    expect(html).not.toContain(">Best window</span>");
     expect(html).toContain("17s SW");
     expect(html).toContain("3.2 ft · Rising");
     expect(html).toContain("92%");

--- a/__tests__/app/learn-zine-content-safety.test.tsx
+++ b/__tests__/app/learn-zine-content-safety.test.tsx
@@ -1,0 +1,52 @@
+import { render, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import LearnHubPage from "@/app/learn/page";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt = "",
+    fill: _fill,
+    priority: _priority,
+    sizes: _sizes,
+    ...props
+  }: Record<string, unknown>) => <img alt={String(alt)} {...props} />,
+}));
+
+jest.mock("@/components/ui/scroll-reveal", () => ({
+  ScrollReveal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/components/ui/sticky-signup-bar", () => ({
+  StickySignupBar: () => null,
+}));
+
+describe("learn zine content safety", () => {
+  it.each([
+    ["/learn/how-to-read-surf-conditions", "How to Read a Surf Report"],
+    ["/learn/how-do-tides-work", "How Tides Work for Surfing"],
+  ])("keeps the guide CTA outside a torn mask for %s", (href, title) => {
+    const { container } = render(<LearnHubPage />);
+    const card = container.querySelector<HTMLAnchorElement>(`a[href="${href}"]`);
+
+    expect(card).not.toBeNull();
+    expect(card).toHaveClass("torn");
+    expect(card).not.toHaveClass("torn-tb");
+    expect(within(card!).getByText(/open note/i)).toBeInTheDocument();
+    expect(
+      within(card!).getByRole("heading", { name: new RegExp(title, "i") }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps cross-link CTAs outside torn masks", () => {
+    const { container } = render(<LearnHubPage />);
+    const card = container.querySelector<HTMLAnchorElement>(
+      'a[href="/guides"]',
+    );
+
+    expect(card).toHaveClass("torn");
+    expect(card).not.toHaveClass("torn-tb");
+    expect(within(card!).getByText(/visit/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/tools-page-zine.test.tsx
+++ b/__tests__/app/tools-page-zine.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import ToolsIndexPage from "@/app/tools/page";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    alt = "",
+    fill: _fill,
+    preload: _preload,
+    sizes: _sizes,
+    ...props
+  }: Record<string, unknown>) => <img alt={String(alt)} {...props} />,
+}));
+
+jest.mock("@/components/ui/scroll-reveal", () => ({
+  ScrollReveal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("tools page zine layout", () => {
+  it("renders every tool card without a rotation helper", () => {
+    render(<ToolsIndexPage />);
+
+    const toolCards = [
+      "Tide Clock",
+      "Wave Height Converter",
+      "Offshore Wind Checker",
+      "Dawn Patrol Calculator",
+      "Surfboard Volume Calculator",
+      "Swell Quality Analyzer",
+      "Water Quality Check",
+      "Best Month to Surf",
+    ].map((name) => screen.getByRole("link", { name: new RegExp(name, "i") }));
+
+    expect(toolCards).toHaveLength(8);
+    toolCards.forEach((card) => {
+      expect(card.className).not.toMatch(/(?:^|\s)rot-(?:1|2|3|4|neg)(?:\s|$)/);
+    });
+
+    const quickCheckPanel = screen
+      .getByRole("heading", { name: /surf tools that connect/i })
+      .closest("section");
+    expect(quickCheckPanel).toHaveClass("torn", "torn-tb", "rot-neg");
+  });
+});

--- a/__tests__/app/vs-surfline-free-live-cam-card.test.tsx
+++ b/__tests__/app/vs-surfline-free-live-cam-card.test.tsx
@@ -1,0 +1,96 @@
+import { forwardRef, type ImgHTMLAttributes } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { CamBeachWithRegion } from "@/actions/beach/cam-actions";
+import { LiveCamCard } from "@/app/vs/surfline/free/live-cam-card";
+
+type MockNextImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean;
+};
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: forwardRef<HTMLImageElement, MockNextImageProps>(function MockImage(
+    { fill: _fill, ...props },
+    ref,
+  ) {
+    // eslint-disable-next-line jsx-a11y/alt-text
+    return <img ref={ref} {...props} />;
+  }),
+}));
+
+const baseBeach: CamBeachWithRegion = {
+  id: "beach-1",
+  name: "Test Beach",
+  slug: "test-beach",
+  city: "San Diego",
+  state: "CA",
+  camera_url: "https://example.com/live-cam",
+  thumbnail_url: "https://images.example/test-beach-cam.jpg",
+  photo_url: "https://photos.example/test-beach.jpg",
+  regionSlug: "southern-california",
+};
+
+describe("LiveCamCard", () => {
+  it("renders a proxied camera thumbnail with meaningful alt text", () => {
+    render(<LiveCamCard beach={baseBeach} />);
+
+    const image = screen.getByRole("img", {
+      name: "Test Beach live surf cam preview",
+    });
+
+    expect(image).toHaveAttribute(
+      "src",
+      "/api/image-proxy?url=https%3A%2F%2Fimages.example%2Ftest-beach-cam.jpg",
+    );
+    expect(image).toHaveAttribute(
+      "sizes",
+      "(max-width: 639px) 50vw, (max-width: 767px) 33vw, (max-width: 1280px) 25vw, 304px",
+    );
+    expect(screen.getByText("Test Beach")).toBeInTheDocument();
+    expect(screen.getByText("San Diego, CA")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Watch the Test Beach live cam in San Diego, CA",
+      }),
+    ).toHaveAttribute("href", "/ca/san-diego/test-beach");
+  });
+
+  it("renders the intentional fallback when no imagery is available", () => {
+    render(
+      <LiveCamCard
+        beach={{
+          ...baseBeach,
+          thumbnail_url: null,
+          photo_url: null,
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByTestId("live-cam-image-fallback")).toBeInTheDocument();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("replaces failed imagery with the intentional fallback", () => {
+    render(
+      <LiveCamCard
+        beach={{
+          ...baseBeach,
+          photo_url: null,
+        }}
+      />,
+    );
+
+    fireEvent.error(
+      screen.getByRole("img", {
+        name: "Test Beach live surf cam preview",
+      }),
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByTestId("live-cam-image-fallback")).toBeInTheDocument();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/app/vs-surfline-free-metadata.test.ts
+++ b/__tests__/app/vs-surfline-free-metadata.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { metadata } from "@/app/vs/surfline/free/page";
 
 describe("/vs/surfline/free metadata", () => {
@@ -16,5 +19,15 @@ describe("/vs/surfline/free metadata", () => {
     expect(metadata.keywords).toEqual(
       expect.arrayContaining(["free surfline alternative"]),
     );
+  });
+
+  it("positions Quiver as a free alternative in the short answer", () => {
+    const source = readFileSync(
+      join(process.cwd(), "app/vs/surfline/free/page-content.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("Yes — Quiver is a free Surfline alternative");
+    expect(source).not.toMatch(/free[- ]to[- ]browse/i);
   });
 });

--- a/__tests__/components/app-store/beach-subpage-cta-switch.test.tsx
+++ b/__tests__/components/app-store/beach-subpage-cta-switch.test.tsx
@@ -33,12 +33,10 @@ function setUserAgent(userAgent: string): void {
 function createSwitch(installCtaEnabled = true): ReactElement {
   return (
     <BeachSubPageCtaSwitch
-      beachId="beach-1"
       beachName="Blacks"
       installCtaEnabled={installCtaEnabled}
       pathname="/ca/san-diego/blacks/tides"
       placement="tides-blacks"
-      pageType="tides"
       searchReferralCta={{
         ctaText: "Get Tide Alerts",
         supportingText: "Know when the tide is right at Blacks",
@@ -53,12 +51,12 @@ function createSwitch(installCtaEnabled = true): ReactElement {
 }
 
 describe("BeachSubPageCtaSwitch", () => {
-  it("server-renders the alert CTA and sticky signup path", () => {
+  it("server-renders the sticky signup path with no inline alert CTA", () => {
     setUserAgent(IPHONE_SAFARI_UA);
 
     const markup = renderToStaticMarkup(createSwitch());
 
-    expect(markup).toContain('data-testid="alert-capture-cta"');
+    expect(markup).not.toContain('data-testid="alert-capture-cta"');
     expect(markup).toContain('data-testid="sticky-signup-bar"');
     expect(markup).not.toContain('data-testid="install-app-cta"');
   });
@@ -77,12 +75,12 @@ describe("BeachSubPageCtaSwitch", () => {
   it.each([
     ["desktop Safari", DESKTOP_SAFARI_UA],
     ["non-Safari iPhone", IPHONE_CHROME_UA],
-  ])("keeps the alert CTA and sticky signup path for %s", async (_name, userAgent) => {
+  ])("keeps the sticky signup path and no inline alert CTA for %s", async (_name, userAgent) => {
     setUserAgent(userAgent);
     render(createSwitch());
 
     await waitFor(() => {
-      expect(screen.getByTestId("alert-capture-cta")).toBeInTheDocument();
+      expect(screen.queryByTestId("alert-capture-cta")).not.toBeInTheDocument();
       expect(screen.getByTestId("sticky-signup-bar")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("install-app-cta")).not.toBeInTheDocument();
@@ -93,7 +91,7 @@ describe("BeachSubPageCtaSwitch", () => {
     render(createSwitch(false));
 
     await waitFor(() => {
-      expect(screen.getByTestId("alert-capture-cta")).toBeInTheDocument();
+      expect(screen.queryByTestId("alert-capture-cta")).not.toBeInTheDocument();
       expect(screen.getByTestId("sticky-signup-bar")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("install-app-cta")).not.toBeInTheDocument();

--- a/__tests__/components/beach-detail/public-forecast-answer.test.tsx
+++ b/__tests__/components/beach-detail/public-forecast-answer.test.tsx
@@ -2,11 +2,24 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
+import { AuthenticatedForecastDecisionProvider } from "@/components/beach-detail/authenticated-forecast-decision";
+import { useAuth } from "@/context/auth-context";
 import type { Beach } from "@/types/database";
 import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+import {
+  selectPublicForecastContextFacts,
+  selectPublicForecastReportFacts,
+} from "@/lib/utils/public-forecast-facts";
+
+jest.mock("@/context/auth-context", () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 const beach = {
   id: "beach-1",
@@ -51,23 +64,103 @@ const context: ForecastRecommendationContext = {
   timezone: "America/Los_Angeles",
 };
 
-describe("PublicForecastAnswer", () => {
-  it("renders the selected tomorrow state and truthful provenance in server HTML", () => {
-    render(
+const report = {
+  verdict: "YES",
+  bestWindowStart: "2026-08-09T18:00:00.000Z",
+  bestWindowEnd: "2026-08-09T20:00:00.000Z",
+  waveHeight: "3 ft",
+  windSpeed: "5 mph",
+  windCompass: "E",
+  windType: "offshore",
+  tideHeight: "3.2 ft",
+  tidePhase: "rising",
+  nextTideType: "High",
+  forecastConfidence: 82,
+  score: 78,
+  whySentence: "Clean swell and light offshore wind.",
+  updatedAt: "2026-08-09T17:05:00.000Z",
+} as SurfCallResult;
+
+function renderAnswer() {
+  return render(
+    <AuthenticatedForecastDecisionProvider beachId={beach.id}>
       <PublicForecastAnswer
         beach={beach}
-        report={null}
+        report={report}
         context={context}
         isTomorrow
         headingLevel="h1"
-      />,
-    );
+        returnTo="/ca/san-diego/ocean-beach"
+      />
+    </AuthenticatedForecastDecisionProvider>,
+  );
+}
+
+describe("PublicForecastAnswer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    } as ReturnType<typeof useAuth>);
+    global.fetch = jest.fn();
+  });
+
+  it("keeps public facts in guest HTML while replacing the verdict and window with login", () => {
+    renderAnswer();
 
     expect(screen.getByTestId("public-forecast-answer")).toBeInTheDocument();
     expect(screen.getByText("Tomorrow")).toBeInTheDocument();
     expect(screen.getByText(/Oceanside Harbor Surf Forecast for/)).toBeInTheDocument();
     expect(screen.getByText("2-3 ft")).toBeInTheDocument();
     expect(screen.getByText(/NOAA NWS, NOAA CO-OPS/)).toBeInTheDocument();
+    expect(screen.queryByText("YES")).not.toBeInTheDocument();
+    expect(screen.queryByText("11:00 AM–1:00 PM")).not.toBeInTheDocument();
+
+    const login = screen.getByRole("link", { name: /sign in to reveal/i });
+    expect(login).toHaveAttribute(
+      "href",
+      "/auth/sign-in?redirectTo=%2Fca%2Fsan-diego%2Focean-beach",
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("projects decision values out of props sent through the static route", () => {
+    const publicReport = selectPublicForecastReportFacts(report);
+    const publicContext = selectPublicForecastContextFacts(context);
+
+    expect(publicReport).not.toHaveProperty("verdict");
+    expect(publicReport).not.toHaveProperty("bestWindowStart");
+    expect(publicReport).not.toHaveProperty("bestWindowEnd");
+    expect(publicContext).not.toHaveProperty("displayWindowStart");
+    expect(publicContext).not.toHaveProperty("displayWindowEnd");
+    expect(publicContext).not.toHaveProperty("displayTimeLabel");
+  });
+
+  it("fetches and renders the verdict and best window for an authenticated user", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
+      isLoading: false,
+    } as ReturnType<typeof useAuth>);
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { report, forecastContext: context, isTomorrow: true },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    renderAnswer();
+
+    await waitFor(() => expect(screen.getByText("YES")).toBeInTheDocument());
+    expect(screen.getByText("11:00 AM–1:00 PM")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /sign in to reveal/i })).not.toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/surf/call?beachId=beach-1",
+      expect.objectContaining({ cache: "no-store" }),
+    );
   });
 
   it("keeps the exact-query heading when forecast details are unavailable", () => {
@@ -78,6 +171,7 @@ describe("PublicForecastAnswer", () => {
         context={null}
         isTomorrow={false}
         headingLevel="h1"
+        returnTo="/ca/oceanside/oceanside-harbor"
       />,
     );
 

--- a/__tests__/components/beach-detail/public-forecast-hourly.test.tsx
+++ b/__tests__/components/beach-detail/public-forecast-hourly.test.tsx
@@ -2,11 +2,19 @@
  * @jest-environment jsdom
  */
 
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
+import { AuthenticatedForecastDecisionProvider } from "@/components/beach-detail/authenticated-forecast-decision";
+import { useAuth } from "@/context/auth-context";
 import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
 import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+
+jest.mock("@/context/auth-context", () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 const report = {
   verdict: "YES",
@@ -56,39 +64,88 @@ const forecastHours = [
 ];
 
 describe("PublicForecastHourly", () => {
-  it("marks matching rows without presenting the window score as an hourly score", () => {
-    render(
-      <PublicForecastHourly
-        beachName="Del Mar"
-        forecastHours={forecastHours}
-        report={report}
-        context={context}
-        isTomorrow={false}
-        forecastDay="today"
-      />,
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    } as ReturnType<typeof useAuth>);
+    global.fetch = jest.fn();
+  });
+
+  function renderHourly() {
+    return render(
+      <AuthenticatedForecastDecisionProvider beachId="beach-1">
+        <PublicForecastHourly
+          beachName="Del Mar"
+          forecastHours={forecastHours}
+          context={context}
+          forecastDay="today"
+          returnTo="/ca/san-diego/del-mar"
+        />
+      </AuthenticatedForecastDecisionProvider>,
+    );
+  }
+
+  it("keeps hourly facts public but omits the marker and highlight for guests", () => {
+    renderHourly();
+
+    expect(screen.getByText("2 ft")).toBeInTheDocument();
+    expect(screen.getByText("3 ft")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.queryByText("Best window")).not.toBeInTheDocument();
+    for (const row of screen.getAllByTestId("public-forecast-hour")) {
+      expect(row).not.toHaveClass("bg-[#F7E7BE]");
+    }
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("marks matching rows after fetching the authenticated decision", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
+      isLoading: false,
+    } as ReturnType<typeof useAuth>);
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { report, forecastContext: context, isTomorrow: false },
+        }),
+        { status: 200 },
+      ),
     );
 
+    renderHourly();
+
+    await waitFor(() => expect(screen.getByText("Best window")).toBeInTheDocument());
     expect(document.body).not.toHaveTextContent("84/100");
     expect(screen.getByRole("columnheader", { name: "Quiver call" })).toBeInTheDocument();
 
     const rows = screen.getAllByTestId("public-forecast-hour");
     expect(within(rows[0]).queryByText("Best window")).not.toBeInTheDocument();
     expect(within(rows[1]).getByText("Best window")).toBeInTheDocument();
+    expect(rows[0]).not.toHaveClass("bg-[#F7E7BE]");
+    expect(rows[1]).toHaveClass("bg-[#F7E7BE]");
   });
 
-  it("keeps today's rows separate from a tomorrow recommendation", () => {
-    render(
-      <PublicForecastHourly
-        beachName="Del Mar"
-        forecastHours={forecastHours}
-        report={report}
-        context={context}
-        isTomorrow
-        forecastDay="today"
-      />,
+  it("keeps today's rows separate from a tomorrow recommendation", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
+      isLoading: false,
+    } as ReturnType<typeof useAuth>);
+    (global.fetch as jest.Mock).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { report, forecastContext: context, isTomorrow: true },
+        }),
+        { status: 200 },
+      ),
     );
+    renderHourly();
 
     expect(screen.getByText("Today by time")).toBeInTheDocument();
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     expect(screen.queryByText("Best window")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/beach-detail/zine/today-surf-call.test.tsx
+++ b/__tests__/components/beach-detail/zine/today-surf-call.test.tsx
@@ -9,6 +9,14 @@ import { TodaySurfCall } from "@/components/beach-detail/zine/today-surf-call";
 import { createMockBeach } from "@/__tests__/setup/typed-mocks";
 
 describe("TodaySurfCall", () => {
+  it("does not invent a fallback verdict when no authorized call is available", () => {
+    const { container } = render(
+      <TodaySurfCall beach={createMockBeach({ name: "Seaside Reef" })} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it("labels the public call as tomorrow when the selected forecast rolls over", () => {
     render(
       <TodaySurfCall

--- a/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
+++ b/__tests__/components/beach-detail/zine/zine-hero-heading.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { createMockBeach } from "@/__tests__/setup/typed-mocks";
 import { ZineHero } from "@/components/beach-detail/zine/zine-hero";
+import { WaterTempSummaryHero } from "@/components/beach-detail/water-temp-summary-hero";
 import type { BeachSources } from "@/hooks/use-beach-detail-data";
 
 describe("ZineHero heading level", () => {
@@ -26,6 +27,48 @@ describe("ZineHero heading level", () => {
     expect(
       screen.queryByRole("heading", { level: 1, name: "Seaside Reef" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("integrates the water-temperature guide into the beach identity hero", () => {
+    const beach = createMockBeach({
+      name: "Ocean Beach",
+      city: "San Diego",
+      state: "CA",
+    });
+
+    render(
+      <ZineHero
+        beach={beach}
+        headingSuffix="Water Temp & Wetsuit Guide"
+        summarySlot={
+          <WaterTempSummaryHero
+            beachName={beach.name}
+            seasonalTrendsHref="/water-temp/san-diego#seasonal-trends"
+            seasonalTrendsLocation="San Diego"
+            waterTempData={{ tempF: 67, wetsuitRec: "3/2mm fullsuit" }}
+          />
+        }
+      />,
+    );
+
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "Ocean Beach Water Temp & Wetsuit Guide",
+      }),
+    ).toBeInTheDocument();
+
+    const summary = screen.getByLabelText(
+      "Current water temperature at Ocean Beach",
+    );
+    expect(summary).toHaveTextContent("67°F");
+    expect(summary).toHaveTextContent("19°C");
+    expect(summary).toHaveTextContent("Mild");
+    expect(summary).toHaveTextContent("3/2mm fullsuit");
+    expect(
+      screen.getByRole("link", { name: /seasonal water trends for san diego/i }),
+    ).toHaveAttribute("href", "/water-temp/san-diego#seasonal-trends");
   });
 
   it("uses the beach coordinates to render a real static location map", () => {

--- a/__tests__/components/best-time-to-surf/monthly-grid.test.tsx
+++ b/__tests__/components/best-time-to-surf/monthly-grid.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+
+import { MonthlyGrid } from "@/components/best-time-to-surf/monthly-grid";
+import type { MonthlySurfEntry } from "@/actions/city/best-time-actions";
+
+const MONTHLY: MonthlySurfEntry[] = [
+  { month: 1, monthName: "January", bestMonthCount: 3, score: 83 },
+  { month: 7, monthName: "July", bestMonthCount: 1, score: 73 },
+];
+
+describe("MonthlyGrid seasonal gauges", () => {
+  it("labels each month's gauge with the band but no immediate-action phrase", () => {
+    render(
+      <MonthlyGrid
+        monthly={MONTHLY}
+        waterTempRange="55-68"
+        summerWetsuit="3/2mm"
+        winterWetsuit="4/3mm"
+        peakMonths={[1]}
+      />
+    );
+
+    expect(screen.getByLabelText("Score: 83, EPIC")).toBeInTheDocument();
+    expect(screen.getByLabelText("Score: 73, GOOD")).toBeInTheDocument();
+    expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+    expect(screen.queryByText("Go surf!")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/forecast/animated-score-gauge.test.tsx
+++ b/__tests__/components/forecast/animated-score-gauge.test.tsx
@@ -29,4 +29,20 @@ describe("AnimatedScoreGauge score vocabulary", () => {
     expect(screen.getByText(label)).toBeInTheDocument();
     expect(screen.getByText(action)).toBeInTheDocument();
   });
+
+  it.each([
+    [73, "GOOD", "Go surf!"],
+    [83, "EPIC", "Go now!"],
+  ])(
+    "keeps the %s band label but drops the action phrase when showAction is false",
+    (score, label, action) => {
+      render(<AnimatedScoreGauge score={score} showLabel showAction={false} />);
+
+      expect(screen.getByText(label)).toBeInTheDocument();
+      expect(screen.queryByText(action)).not.toBeInTheDocument();
+      expect(
+        screen.getByLabelText(`Score: ${score}, ${label}`)
+      ).toBeInTheDocument();
+    }
+  );
 });

--- a/__tests__/components/forecast/beach-conditions-grid.test.tsx
+++ b/__tests__/components/forecast/beach-conditions-grid.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+
+import { BeachConditionsGrid } from "@/components/forecast/beach-conditions-grid";
+import type { BeachConditionSummary } from "@/lib/utils/regional-forecast-utils";
+
+jest.mock("@/components/ui/scroll-reveal", () => ({
+  ScrollReveal: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("@/components/ui/animated-counter", () => ({
+  AnimatedCounter: ({ value, suffix = "" }: { value: number; suffix?: string }) => (
+    <span>{value}{suffix}</span>
+  ),
+}));
+
+jest.mock("@/components/zine", () => ({
+  QuiverSticker: () => null,
+}));
+
+const beach: BeachConditionSummary = {
+  beachId: "beach-1",
+  beachName: "Imperial Beach",
+  beachSlug: "imperial-beach",
+  state: "CA",
+  city: "Imperial Beach",
+  country: "USA",
+  currentScore: 83,
+  currentWaveHeight: 4.2,
+  trend: "steady",
+  bestDay: "Wednesday",
+  bestDayScore: 91,
+};
+
+describe("BeachConditionsGrid", () => {
+  it("shows guests a login CTA without score numbers or rating labels", () => {
+    render(
+      <BeachConditionsGrid
+        beaches={[beach]}
+        regionSlug="san-diego"
+        showScores={false}
+        variant="zine"
+      />
+    );
+
+    const loginLinks = screen.getAllByRole("link", {
+      name: "Log in to get your score",
+    });
+    expect(loginLinks).toHaveLength(2);
+    for (const link of loginLinks) {
+      expect(link).toHaveAttribute(
+        "href",
+        "/auth/sign-in?redirectTo=/forecast/san-diego"
+      );
+    }
+    expect(screen.queryByText("83")).not.toBeInTheDocument();
+    expect(screen.queryByText("91")).not.toBeInTheDocument();
+    expect(screen.queryByText("EPIC")).not.toBeInTheDocument();
+  });
+
+  it("shows authenticated users scores without action-phrase subtext", () => {
+    render(
+      <BeachConditionsGrid
+        beaches={[beach]}
+        regionSlug="san-diego"
+        showScores
+        variant="zine"
+      />
+    );
+
+    expect(screen.getAllByText("83")).toHaveLength(2);
+    expect(screen.getAllByText("EPIC")).toHaveLength(2);
+    expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Log in to get your score" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/forecast/best-days-section.test.tsx
+++ b/__tests__/components/forecast/best-days-section.test.tsx
@@ -196,6 +196,22 @@ describe("BestDaysSection — analytics wiring", () => {
     trackBestConditionsClick = tracking.trackBestConditionsClick;
   });
 
+  it("does not render immediate-action copy for a future weekly best day", () => {
+    const futureBestDay = makeDaySummary({ score: 97 });
+
+    render(
+      <BestDaysSection
+        days={[futureBestDay]}
+        bestDay={futureBestDay}
+        regionName={REGION_NAME}
+        variant="zine"
+      />
+    );
+
+    expect(screen.getByTestId("zine-best-day-card")).toBeInTheDocument();
+    expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+  });
+
   // -------------------------------------------------------------------------
   // 1. IntersectionObserver — viewed tracking
   // -------------------------------------------------------------------------

--- a/__tests__/components/forecast/regional-best-surf-windows.test.tsx
+++ b/__tests__/components/forecast/regional-best-surf-windows.test.tsx
@@ -96,6 +96,24 @@ describe("RegionalBestSurfWindows", () => {
     expect(screen.getAllByRole("button", { name: /why this call/i })[0]).toBeVisible();
   });
 
+  it("passes the paper editorial variant through the regional zine surface", () => {
+    render(
+      <RegionalBestSurfWindows
+        regionName="Southern California"
+        recommendations={[makeRecommendation(1)]}
+        variant="zine"
+      />
+    );
+
+    const region = screen.getByTestId("regional-best-surf-windows");
+    const windows = screen.getByTestId("best-surf-windows");
+
+    expect(region.className).toContain("bg-[#FBF6E8]");
+    expect(windows).toHaveAttribute("data-variant", "zine");
+    expect(region.innerHTML).not.toMatch(/#252D6B|#2D357D|#1a2051/i);
+    expect(screen.getByText("Window 1 looks worth it at Blacks")).toBeVisible();
+  });
+
   it("renders up to five regional windows to avoid a lonely final card", () => {
     render(
       <RegionalBestSurfWindows

--- a/__tests__/components/forecast/regional-best-surf-windows.test.tsx
+++ b/__tests__/components/forecast/regional-best-surf-windows.test.tsx
@@ -25,6 +25,7 @@ function makeRecommendation(
     startIso: "2026-06-03T14:00:00.000Z",
     endIso: "2026-06-03T16:30:00.000Z",
     peakIso: "2026-06-03T15:00:00.000Z",
+    timezone: "America/Los_Angeles",
     forecastAt: "2026-06-03T14:00:00.000Z",
     localTimeLabel: "7:00-9:30 AM",
     score: 86 - rank,

--- a/__tests__/components/forecast/seven-day-outlook.test.tsx
+++ b/__tests__/components/forecast/seven-day-outlook.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+
+import { SevenDayOutlook } from "@/components/forecast/seven-day-outlook";
+import type { ForecastRegion } from "@/lib/data/forecast-regions";
+import type { RegionalForecastSummary } from "@/lib/utils/regional-forecast-utils";
+
+const REGION: ForecastRegion = {
+  slug: "san-diego",
+  name: "San Diego",
+  title: "San Diego surf forecast",
+  metaDescription: "San Diego surf forecast",
+  states: ["ca"],
+  centerLat: 32.8,
+  centerLon: -117.2,
+  zoom: 10,
+};
+
+function makeSummary(
+  availability: "available" | "none" = "available",
+): RegionalForecastSummary {
+  const days = [
+    {
+      date: new Date("2026-07-20T00:00:00.000Z"),
+      dateString: "2026-07-20",
+      dayOfWeek: "Monday",
+      score: 62,
+      avgWaveHeight: 3.5,
+      waveRange: [3, 4] as [number, number],
+      dominantWindDirection: "E",
+      windConditions: "offshore" as const,
+      dominantTideStatus: "Rising",
+      bestTimeSlot: "dawn-patrol" as const,
+      topBeaches: [],
+      beachesWithGoodConditions: 2,
+    },
+    {
+      date: new Date("2026-07-21T00:00:00.000Z"),
+      dateString: "2026-07-21",
+      dayOfWeek: "Tuesday",
+      score: 84,
+      avgWaveHeight: 5,
+      waveRange: [4, 6] as [number, number],
+      dominantWindDirection: "NE",
+      windConditions: "light" as const,
+      dominantTideStatus: "Falling",
+      bestTimeSlot: "morning" as const,
+      topBeaches: [],
+      beachesWithGoodConditions: 4,
+    },
+  ];
+
+  return {
+    region: REGION,
+    generatedAt: new Date("2026-07-19T12:00:00.000Z"),
+    days,
+    bestDay: days[1],
+    upcomingSwells: [],
+    beachConditions: [],
+    bestSurfWindows: [],
+    recommendationAvailability:
+      availability === "available"
+        ? { state: "available", holdEpoch: "epoch-1" }
+        : {
+            state: "none",
+            reasonCode: "major_event_hold",
+            holdEpoch: "epoch-1",
+          },
+    photoUrl: null,
+    photoBeachName: null,
+    secondaryPhotoUrl: null,
+    secondaryPhotoBeachName: null,
+    stats: {
+      totalBeaches: 7,
+      beachesWithData: 7,
+      avgRegionScore: 73,
+    },
+  };
+}
+
+describe("SevenDayOutlook", () => {
+  beforeAll(() => {
+    window.matchMedia = jest.fn().mockReturnValue({
+      matches: true,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    });
+
+    global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+      takeRecords: jest.fn(),
+      root: null,
+      rootMargin: "0px",
+      thresholds: [],
+    }));
+  });
+
+  it("renders the zine outlook and sticky arc on paper without navy chrome", () => {
+    render(
+      <SevenDayOutlook
+        summary={makeSummary()}
+        regionName={REGION.name}
+        variant="zine"
+      />,
+    );
+
+    const outlook = screen.getByTestId("seven-day-outlook");
+    const arc = screen.getByTestId("swell-arc");
+
+    expect(outlook.className).toContain("bg-[#FBF6E8]");
+    expect(arc.className).toContain("bg-[#F0E5CC]");
+    expect(outlook.innerHTML).not.toMatch(/#252D6B|#2D357D|#1a2051/i);
+    expect(screen.getAllByTestId(/^outlook-day-/)).toHaveLength(2);
+    expect(screen.getByTestId("outlook-day-1")).toHaveAttribute(
+      "data-peak",
+      "true",
+    );
+    expect(screen.getByLabelText(/score 84 out of 100/i)).toBeVisible();
+    expect(
+      screen.getByLabelText(/trend building vs previous day/i),
+    ).toBeVisible();
+  });
+
+  it("keeps day rows but suppresses scores, arc, and trends during a hold", () => {
+    render(
+      <SevenDayOutlook
+        summary={makeSummary("none")}
+        regionName={REGION.name}
+        variant="zine"
+      />,
+    );
+
+    expect(screen.getAllByTestId(/^outlook-day-/)).toHaveLength(2);
+    expect(screen.queryByTestId("swell-arc")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/score .* out of 100/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/trend .* previous day/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/rising tide/i)).toBeVisible();
+    expect(screen.getByText(/falling tide/i)).toBeVisible();
+  });
+});

--- a/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
+++ b/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
@@ -52,6 +52,14 @@ describe("TopRankedBeachHero", () => {
         reasons: ["Forecast model row is present"],
       },
       positives: ["Good wave size"],
+      // The card reads height from the window it is describing, not from the
+      // region's separate "current conditions" reading.
+      wave: {
+        height: "4.2",
+        period: "14",
+        direction: "W",
+        summary: "4.2ft at 14s",
+      },
     };
 
     render(
@@ -104,6 +112,12 @@ describe("TopRankedBeachHero", () => {
             reasons: [],
           },
           positives: ["Good wave size"],
+          wave: {
+            height: "3.7",
+            period: "14",
+            direction: "W",
+            summary: "3.7ft at 14s",
+          },
         }}
       />
     );
@@ -111,6 +125,11 @@ describe("TopRankedBeachHero", () => {
     expect(screen.getByText("Worth it · Thu, Aug 13")).toBeInTheDocument();
     expect(screen.getByText("7:00 AM-9:00 AM")).toBeInTheDocument();
     expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+
+    // Height belongs to the upcoming window, not the region's current reading.
+    expect(screen.getByText("Wave height then")).toBeInTheDocument();
+    expect(screen.getByText("3.7ft")).toBeInTheDocument();
+    expect(screen.queryByText("4.2ft")).not.toBeInTheDocument();
 
     // A window that has not started yet is signposted as the next call rather
     // than presented as a live one.

--- a/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
+++ b/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
@@ -111,6 +111,15 @@ describe("TopRankedBeachHero", () => {
     expect(screen.getByText("Worth it · Thu, Aug 13")).toBeInTheDocument();
     expect(screen.getByText("7:00 AM-9:00 AM")).toBeInTheDocument();
     expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+
+    // A window that has not started yet is signposted as the next call rather
+    // than presented as a live one.
+    expect(screen.getByText("Next window")).toBeInTheDocument();
+    expect(screen.getByText("Next best call")).toBeInTheDocument();
+    expect(
+      screen.getByText("Best upcoming window in San Diego")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Top beach now")).not.toBeInTheDocument();
   });
 
   it("uses the supplied region name for other regions", () => {
@@ -136,7 +145,9 @@ describe("TopRankedBeachHero", () => {
     );
 
     expect(screen.getByText("Surf window")).toBeInTheDocument();
-    expect(screen.getByText("No qualifying window")).toBeInTheDocument();
+    expect(
+      screen.getByText("Nothing qualifying in the forecast horizon")
+    ).toBeInTheDocument();
     expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
     expect(screen.queryByText("Best window")).not.toBeInTheDocument();
     expect(screen.getByText("No approved image on file")).toBeInTheDocument();

--- a/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
+++ b/__tests__/components/forecast/top-ranked-beach-hero.test.tsx
@@ -36,12 +36,15 @@ const beach: BeachConditionSummary = {
 };
 
 describe("TopRankedBeachHero", () => {
-  it("uses the region name and shows the ranked beach, score call, window, and wave height", () => {
+  it("uses one current qualifying window for the score call and window display", () => {
     const selectorWindow = {
       startIso: "2026-08-12T07:00:00Z",
       endIso: "2026-08-12T09:00:00Z",
       peakIso: "2026-08-12T08:00:00Z",
+      timezone: "UTC",
       localTimeLabel: "7:00 AM-9:00 AM",
+      score: 83,
+      verdict: "Worth it" as const,
       confidence: {
         level: "high" as const,
         score: 84,
@@ -55,7 +58,7 @@ describe("TopRankedBeachHero", () => {
       <TopRankedBeachHero
         beach={beach}
         regionName="San Diego"
-        beachTimezone="UTC"
+        now={new Date("2026-08-12T08:00:00Z")}
         imageUrl="https://images.example/ocean-beach.webp"
         bestSurfWindow={selectorWindow}
       />
@@ -80,6 +83,36 @@ describe("TopRankedBeachHero", () => {
     expect(screen.queryByText("Approved beach photo")).not.toBeInTheDocument();
   });
 
+  it("does not render an immediate action for a future qualifying window", () => {
+    render(
+      <TopRankedBeachHero
+        beach={beach}
+        regionName="San Diego"
+        now={new Date("2026-08-12T08:00:00Z")}
+        bestSurfWindow={{
+          startIso: "2026-08-13T07:00:00Z",
+          endIso: "2026-08-13T09:00:00Z",
+          peakIso: "2026-08-13T08:00:00Z",
+          timezone: "UTC",
+          localTimeLabel: "7:00 AM-9:00 AM",
+          score: 83,
+          verdict: "Worth it",
+          confidence: {
+            level: "high",
+            score: 84,
+            summary: "High confidence",
+            reasons: [],
+          },
+          positives: ["Good wave size"],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Worth it · Thu, Aug 13")).toBeInTheDocument();
+    expect(screen.getByText("7:00 AM-9:00 AM")).toBeInTheDocument();
+    expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
+  });
+
   it("uses the supplied region name for other regions", () => {
     render(
       <TopRankedBeachHero
@@ -94,10 +127,17 @@ describe("TopRankedBeachHero", () => {
   });
 
   it("does not fabricate a beach image when neither approved imagery nor satellite is available", () => {
-    render(<TopRankedBeachHero beach={beach} regionName="San Diego" />);
+    render(
+      <TopRankedBeachHero
+        beach={beach}
+        regionName="San Diego"
+        now={new Date("2026-08-12T08:00:00Z")}
+      />
+    );
 
     expect(screen.getByText("Surf window")).toBeInTheDocument();
     expect(screen.getByText("No qualifying window")).toBeInTheDocument();
+    expect(screen.queryByText("Go now!")).not.toBeInTheDocument();
     expect(screen.queryByText("Best window")).not.toBeInTheDocument();
     expect(screen.getByText("No approved image on file")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();

--- a/__tests__/components/pricing/founding-offer-surface.test.tsx
+++ b/__tests__/components/pricing/founding-offer-surface.test.tsx
@@ -48,9 +48,10 @@ describe("FoundingOfferSurface", () => {
     expect(screen.queryByText(/android waitlist/i)).not.toBeInTheDocument();
     const appStoreLinks = screen.getAllByRole("link", { name: /open app store/i });
     expect(appStoreLinks).toHaveLength(2);
-    expect(
-      appStoreLinks[0],
-    ).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
+    appStoreLinks.forEach((link) => {
+      expect(link).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
+      expect(link).toHaveClass("focus-visible:ring-2");
+    });
     expect(screen.getByText("iPhone")).toBeInTheDocument();
     expect(screen.getByText("Available")).toBeInTheDocument();
     expect(screen.queryByText(/app store live/i)).not.toBeInTheDocument();

--- a/__tests__/components/send-to-phone-cta.test.tsx
+++ b/__tests__/components/send-to-phone-cta.test.tsx
@@ -89,6 +89,35 @@ describe("SendToPhoneCta", () => {
     expect(fallback).toHaveAttribute("href", IOS_APP_STORE_WEB_REDIRECT_PATH);
   });
 
+  it("uses an ink-on-paper panel, input, and QR palette", async () => {
+    const { container } = render(<SendToPhoneCta {...baseProps} />);
+
+    expect(container.firstChild).toHaveClass(
+      "bg-[#EFE5CF]",
+      "text-[#11100D]",
+      "border-[#11100D]",
+    );
+    expect(screen.getByLabelText(/email/i)).toHaveClass(
+      "bg-[#F4EBD8]",
+      "text-[#11100D]",
+      "border-[#11100D]",
+    );
+    expect(screen.getByRole("button", { name: /send link/i })).toHaveClass(
+      "bg-ocean-blue-decorative",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-handoff-qr")).toHaveAttribute(
+        "data-foreground-color",
+        "#11100D",
+      );
+      expect(screen.getByTestId("app-handoff-qr")).toHaveAttribute(
+        "data-background-color",
+        "#F4EBD8",
+      );
+    });
+  });
+
   it("adds the rollout cohort to QR render tracking when provided", () => {
     render(<SendToPhoneCta {...baseProps} cohort="app_first" />);
 

--- a/__tests__/components/session-intelligence/best-surf-windows.test.tsx
+++ b/__tests__/components/session-intelligence/best-surf-windows.test.tsx
@@ -126,6 +126,43 @@ describe("BestSurfWindows", () => {
     expect(screen.getByRole("button", { name: /why this call/i })).toBeInTheDocument();
   });
 
+  it("renders the zine variant as a complete paper editorial entry", () => {
+    render(
+      <BestSurfWindows
+        recommendations={[
+          makeRecommendation(1, {
+            beach: {
+              ...makeRecommendation(1).beach,
+              photoUrl: "https://example.com/ocean-beach.jpg",
+            },
+          }),
+        ]}
+        variant="zine"
+      />
+    );
+
+    const section = screen.getByTestId("best-surf-windows");
+    const entry = screen.getByTestId("surf-window-card");
+
+    expect(section).toHaveAttribute("data-variant", "zine");
+    expect(entry).toHaveAttribute("data-variant", "zine");
+    expect(entry.className).toContain("bg-[#FBF6E8]");
+    expect(entry.className).not.toMatch(/#252D6B|#2D357D|#1a2051/i);
+    expect(section.innerHTML).not.toMatch(/#252D6B|#2D357D|#1a2051/i);
+    expect(
+      screen.getByText("7:00-9:30 AM looks worth it at Ocean Beach")
+    ).toBeVisible();
+    expect(screen.getByText("4 ft at 12s from W")).toBeVisible();
+    expect(screen.getByText("5 NE (offshore)")).toBeVisible();
+    expect(screen.getByText("Rising, 3.5 ft")).toBeVisible();
+    expect(screen.getByText("longboard")).toBeVisible();
+    expect(screen.getByAltText(/surf photo of ocean beach/i)).toBeVisible();
+    expect(entry.querySelector(".halftone-photo")).toBeInTheDocument();
+    expect(screen.getByTestId("surf-window-web-cta")).toBeVisible();
+    expect(screen.getByTestId("app-deep-link-cta")).toBeVisible();
+    expect(screen.getByRole("button", { name: /why this call/i })).toBeVisible();
+  });
+
   it("renders a beach photo when one is available", () => {
     render(
       <BestSurfWindows

--- a/__tests__/components/session-intelligence/best-surf-windows.test.tsx
+++ b/__tests__/components/session-intelligence/best-surf-windows.test.tsx
@@ -44,6 +44,7 @@ function makeRecommendation(
     startIso: "2026-06-03T14:00:00.000Z",
     endIso: "2026-06-03T16:30:00.000Z",
     peakIso: "2026-06-03T15:00:00.000Z",
+    timezone: "America/Los_Angeles",
     forecastAt: "2026-06-03T14:00:00.000Z",
     localTimeLabel: getLocalTimeLabel(rank),
     score: 84 - rank,

--- a/__tests__/components/session-intelligence/why-this-call.test.tsx
+++ b/__tests__/components/session-intelligence/why-this-call.test.tsx
@@ -31,6 +31,7 @@ function makeRecommendation(
     startIso: "2026-06-03T14:00:00.000Z",
     endIso: "2026-06-03T16:30:00.000Z",
     peakIso: "2026-06-03T15:00:00.000Z",
+    timezone: "America/Los_Angeles",
     forecastAt: "2026-06-03T14:00:00.000Z",
     localTimeLabel: "7:00-9:30 AM",
     score: 82,

--- a/__tests__/lib/constants/content.test.ts
+++ b/__tests__/lib/constants/content.test.ts
@@ -11,8 +11,9 @@ import {
 describe("lib/constants/content invariants", () => {
   test("ABOUT_CONTENT has required structure and non-empty strings", () => {
     // Hero
-    expect(typeof ABOUT_CONTENT.hero.title).toBe("string");
-    expect(ABOUT_CONTENT.hero.title.length).toBeGreaterThan(0);
+    expect(ABOUT_CONTENT.hero.title).toBe(
+      "I built Quiver because I was tired of forecasts being wrong.",
+    );
     expect(typeof ABOUT_CONTENT.hero.subtitle).toBe("string");
     expect(ABOUT_CONTENT.hero.subtitle.length).toBeGreaterThan(0);
 
@@ -87,5 +88,4 @@ describe("lib/constants/content invariants", () => {
     expect(FEATURES_EXTENDED_CONTENT.hero.subtitle.length).toBeGreaterThan(0);
   });
 });
-
 

--- a/__tests__/lib/recommendations/major-event-hold/regional.test.ts
+++ b/__tests__/lib/recommendations/major-event-hold/regional.test.ts
@@ -121,6 +121,7 @@ function surfWindow(
     startIso: STARTS_AT,
     endIso: ENDS_AT,
     peakIso: "2026-07-20T12:00:00.000Z",
+    timezone: "America/Los_Angeles",
     forecastAt: STARTS_AT,
     localTimeLabel: "5:00 AM–7:00 AM",
     score: 90 - index,

--- a/__tests__/lib/recommendations/surf-window-recommendations.test.ts
+++ b/__tests__/lib/recommendations/surf-window-recommendations.test.ts
@@ -93,6 +93,7 @@ describe("buildSurfWindowRecommendations", () => {
     expect(result.recommendations).toHaveLength(3);
     expect(result.recommendations.map((item) => item.rank)).toEqual([1, 2, 3]);
     expect(result.recommendations[0].windowId).toContain("beach-1");
+    expect(result.recommendations[0].timezone).toBe("America/Los_Angeles");
     expect(result.recommendations[0].appDeepLink).toContain("/app/spot/test-beach?window=");
     expect(result.recommendations[0].universalLink).toMatch(/^https:\/\/example.com\/app\/spot\/test-beach\?window=/);
     expect(result.recommendations[0].canonicalWebUrl).toBe(

--- a/__tests__/lib/utils/beach-sub-page-static-rendering.test.tsx
+++ b/__tests__/lib/utils/beach-sub-page-static-rendering.test.tsx
@@ -1,11 +1,29 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { render, screen } from "@testing-library/react";
 import { headers } from "next/headers";
 
 import { getNearbyBeaches } from "@/actions/beach/beach-location-actions";
 import { getTideMetaData } from "@/lib/seo/tide-meta-data";
+import { getWaterTempMetaData } from "@/lib/seo/water-temp-meta-data";
 import { getBeachBySlugOrId } from "@/lib/utils/beach-lookup-utils";
 import { renderBeachSubPage } from "@/lib/utils/beach-sub-page-utils";
+import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
+import { WaterTempSummaryHero } from "@/components/beach-detail/water-temp-summary-hero";
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import type { Beach } from "@/types/database";
+
+type PageTreeElement = ReactElement<{ children?: ReactNode }>;
+
+function getPageChildren(page: PageTreeElement): ReactElement[] {
+  return Children.toArray(page.props.children).filter(
+    isValidElement,
+  ) as ReactElement[];
+}
 
 const mockHeadersGet = jest.fn();
 
@@ -64,6 +82,8 @@ describe("renderBeachSubPage static rendering", () => {
         nextLowTime: null,
         nextLowHeight: null,
       });
+    (getWaterTempMetaData as jest.MockedFunction<typeof getWaterTempMetaData>)
+      .mockResolvedValue({ tempF: null, wetsuitRec: null });
     (
       enrichBeachesWithConditions as jest.MockedFunction<
         typeof enrichBeachesWithConditions
@@ -84,5 +104,76 @@ describe("renderBeachSubPage static rendering", () => {
 
     expect(headers).not.toHaveBeenCalled();
     expect(mockHeadersGet).not.toHaveBeenCalled();
+  });
+
+  it("wires available water-temperature data into the zine hero", async () => {
+    (getWaterTempMetaData as jest.MockedFunction<typeof getWaterTempMetaData>)
+      .mockResolvedValue({ tempF: 67, wetsuitRec: "3/2mm fullsuit" });
+
+    const page = await renderBeachSubPage({
+      beachSlug: "blacks",
+      pageType: "water-temp",
+      beachPath: "/ca/san-diego/blacks",
+    }) as PageTreeElement;
+    const children = getPageChildren(page);
+    const beachDetail = children.find(
+      (child) => child.type === BeachDetailClient,
+    );
+    const beachDetailProps = beachDetail?.props as {
+      heroHeadingLevel?: string;
+      heroHeadingSuffix?: string;
+      heroSummarySlot?: ReactElement;
+    } | undefined;
+
+    expect(beachDetail).toMatchObject({ type: BeachDetailClient });
+    expect(beachDetailProps).toMatchObject({
+      heroHeadingLevel: "h1",
+      heroHeadingSuffix: "Water Temp & Wetsuit Guide",
+    });
+    expect(beachDetailProps?.heroSummarySlot).toMatchObject({
+      type: WaterTempSummaryHero,
+      props: {
+        beachName: "Blacks",
+        seasonalTrendsHref: "/water-temp/san-diego#seasonal-trends",
+        seasonalTrendsLocation: "San Diego",
+        waterTempData: { tempF: 67, wetsuitRec: "3/2mm fullsuit" },
+      },
+    });
+    expect(children.some((child) => child.type === WaterTempSummaryHero)).toBe(false);
+  });
+
+  it("keeps the crawl-copy H1 and tide companion link when temperature is unavailable", async () => {
+    const page = await renderBeachSubPage({
+      beachSlug: "blacks",
+      pageType: "water-temp",
+      beachPath: "/ca/san-diego/blacks",
+    }) as PageTreeElement;
+    const children = getPageChildren(page);
+    const crawlIntro = children.find(
+      (child) =>
+        typeof child.type === "function" &&
+        child.type.name === "BeachSubPageCrawlIntro",
+    );
+    const beachDetail = children.find(
+      (child) => child.type === BeachDetailClient,
+    );
+    const beachDetailProps = beachDetail?.props as {
+      heroHeadingLevel?: string;
+      heroSummarySlot?: ReactElement;
+    } | undefined;
+
+    expect(crawlIntro).toMatchObject({
+      props: { copy: expect.objectContaining({ heading: "Blacks Water Temperature" }) },
+    });
+    if (!crawlIntro) throw new Error("Expected crawl intro");
+    render(crawlIntro);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Blacks Water Temperature" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /watch the tide window/i }),
+    ).toHaveAttribute("href", "/ca/san-diego/blacks/tides");
+    expect(beachDetailProps).toMatchObject({ heroHeadingLevel: "h2" });
+    expect(beachDetailProps?.heroSummarySlot).toBeUndefined();
   });
 });

--- a/__tests__/lib/utils/forecast-hub-utils.test.ts
+++ b/__tests__/lib/utils/forecast-hub-utils.test.ts
@@ -455,6 +455,8 @@ describe("forecast-hub-utils", () => {
       expect(getBatchFreshForecastsFromCache).toHaveBeenCalledTimes(1);
       const regionOne = result["test-region-1"];
       const regionTwo = result["test-region-2"];
+      expect(regionOne?.generatedAt).toEqual(SURF_WINDOW_NOW);
+      expect(regionTwo?.generatedAt).toEqual(SURF_WINDOW_NOW);
       expect(regionOne).toMatchObject({
         region: expect.objectContaining({ slug: "test-region-1" }),
       });

--- a/__tests__/lib/utils/forecast-hub-utils.test.ts
+++ b/__tests__/lib/utils/forecast-hub-utils.test.ts
@@ -399,6 +399,8 @@ describe("forecast-hub-utils", () => {
         expect.anything(),
         [safeBeach],
         expect.any(Map),
+        // Same reference instant the window selector is given.
+        expect.objectContaining({ now: expect.any(Date) }),
       );
     });
 

--- a/__tests__/lib/utils/image-utils.test.ts
+++ b/__tests__/lib/utils/image-utils.test.ts
@@ -315,6 +315,19 @@ describe("Image Proxy Utils", () => {
       expect(result).not.toContain("/api/image-proxy");
     });
 
+    it.each([
+      "https://storage.hdontap.com/wowza_stream_thumbnails/snapshot.stream",
+      "https://img.youtube.com/vi/abc123/mqdefault.jpg",
+      "https://camstills.cdn-surfline.com/some-cam/latest_small.jpg",
+    ])(
+      "should not proxy cam-thumbnail hosts served by next/image remotePatterns (%s)",
+      (url) => {
+        const result = getProxiedImageUrl(url);
+        expect(result).toBe(url);
+        expect(result).not.toContain("/api/image-proxy");
+      },
+    );
+
     it("should not proxy Supabase .in storage URLs", () => {
       const result = getProxiedImageUrl(SUPABASE_IN_URL);
       expect(result).toBe(SUPABASE_IN_URL);

--- a/__tests__/lib/utils/regional-forecast-utils.test.ts
+++ b/__tests__/lib/utils/regional-forecast-utils.test.ts
@@ -576,31 +576,34 @@ describe("aggregateRegionalForecast", () => {
     // Start with poor conditions and improve significantly
     const forecasts: EnhancedForecastEntity[] = [];
 
-    // First forecast: poor conditions (low score)
-    forecasts.push(
-      createMockForecast("beach-1", today, "06:00", {
-        wave_height: "0.5",
-        wind_direction: "W (onshore)",
-        swell_1_period: "6",
-      })
-    );
-
-    // Next forecasts: first stay weak, then improve into the beginner ideal.
-    for (let i = 1; i < 8; i++) {
-      forecasts.push(
-        createMockForecast("beach-1", today, `${6 + i * 3}:00`, {
-          wave_height: i < 3 ? `${0.5 + i * 0.1}` : "2.0",
-          wind_direction: "E (offshore)",
-          swell_1_period: i < 3 ? "7" : "14",
-        })
-      );
+    // Weak morning, then improving into the beginner ideal. Hours are
+    // zero-padded and stay inside the day so every row parses as a real
+    // instant — `9:00`/`24:00`/`27:00` do not, and silently dropped out.
+    const weak: Partial<EnhancedForecastEntity> = {
+      wave_height: "0.5",
+      wind_direction: "W (onshore)",
+      swell_1_period: "6",
+    };
+    const strong: Partial<EnhancedForecastEntity> = {
+      wave_height: "2.0",
+      wind_direction: "E (offshore)",
+      swell_1_period: "14",
+    };
+    for (const time of ["06:00", "09:00", "12:00"]) {
+      forecasts.push(createMockForecast("beach-1", today, time, weak));
+    }
+    for (const time of ["15:00", "18:00", "21:00"]) {
+      forecasts.push(createMockForecast("beach-1", today, time, strong));
     }
     forecastMap.set("beach-1", forecasts);
 
+    // Anchor "now" before the series starts, otherwise the assertion depends on
+    // the wall-clock time the suite happens to run at.
     const summary = aggregateRegionalForecast(
       mockRegion,
       [mockBeaches[0]],
-      forecastMap
+      forecastMap,
+      { now: new Date(`${today}T05:00:00Z`) }
     );
 
     const beach1Summary = summary.beachConditions.find(
@@ -650,5 +653,98 @@ describe("aggregateRegionalForecast", () => {
     for (let i = 1; i < scores.length; i++) {
       expect(scores[i - 1]).toBeGreaterThanOrEqual(scores[i]);
     }
+  });
+});
+
+describe("aggregateRegionalForecast — current-conditions reference instant", () => {
+  const today = futureDateString(0);
+  const EPIC: Partial<EnhancedForecastEntity> = {
+    wave_height: "3.0",
+    wind_direction: "E (offshore)",
+    swell_1_period: "16",
+  };
+  const POOR: Partial<EnhancedForecastEntity> = {
+    wave_height: "0.3",
+    wind_direction: "W (onshore)",
+    swell_1_period: "6",
+  };
+
+  function dawnAndEvening(
+    beachId: string,
+    dawn: Partial<EnhancedForecastEntity>,
+    evening: Partial<EnhancedForecastEntity>
+  ): EnhancedForecastEntity[] {
+    return [
+      createMockForecast(beachId, today, "06:00", dawn),
+      createMockForecast(beachId, today, "21:00", evening),
+    ];
+  }
+
+  it("scores the hours ahead rather than the already-passed dawn rows", () => {
+    const forecastMap = new Map<string, EnhancedForecastEntity[]>();
+    forecastMap.set("beach-1", dawnAndEvening("beach-1", EPIC, POOR));
+
+    const beforeDawn = aggregateRegionalForecast(
+      mockRegion,
+      [mockBeaches[0]],
+      forecastMap,
+      { now: new Date(`${today}T05:00:00Z`) }
+    );
+    const afternoon = aggregateRegionalForecast(
+      mockRegion,
+      [mockBeaches[0]],
+      forecastMap,
+      { now: new Date(`${today}T20:00:00Z`) }
+    );
+
+    // Same data, later reference instant: the epic dawn window has passed, so
+    // the "now" score must fall rather than keep advertising it.
+    expect(afternoon.beachConditions[0].currentScore).toBeLessThan(
+      beforeDawn.beachConditions[0].currentScore
+    );
+  });
+
+  it("ranks the beach that is good now above one that was only good at dawn", () => {
+    const forecastMap = new Map<string, EnhancedForecastEntity[]>();
+    forecastMap.set("beach-1", dawnAndEvening("beach-1", EPIC, POOR));
+    forecastMap.set("beach-2", dawnAndEvening("beach-2", POOR, EPIC));
+
+    const summary = aggregateRegionalForecast(
+      mockRegion,
+      [mockBeaches[0], mockBeaches[1]],
+      forecastMap,
+      { now: new Date(`${today}T20:00:00Z`) }
+    );
+
+    expect(summary.beachConditions[0].beachId).toBe("beach-2");
+  });
+
+  it("reports the wave height of the upcoming row, not the dawn row", () => {
+    const forecastMap = new Map<string, EnhancedForecastEntity[]>();
+    forecastMap.set("beach-1", dawnAndEvening("beach-1", EPIC, POOR));
+
+    const summary = aggregateRegionalForecast(
+      mockRegion,
+      [mockBeaches[0]],
+      forecastMap,
+      { now: new Date(`${today}T20:00:00Z`) }
+    );
+
+    expect(summary.beachConditions[0].currentWaveHeight).toBeCloseTo(0.3);
+  });
+
+  it("still ranks a beach once its forecast horizon is exhausted", () => {
+    const forecastMap = new Map<string, EnhancedForecastEntity[]>();
+    forecastMap.set("beach-1", dawnAndEvening("beach-1", EPIC, POOR));
+
+    const summary = aggregateRegionalForecast(
+      mockRegion,
+      [mockBeaches[0]],
+      forecastMap,
+      { now: new Date(`${today}T23:59:00Z`) }
+    );
+
+    expect(summary.beachConditions).toHaveLength(1);
+    expect(summary.beachConditions[0].currentScore).toBeGreaterThan(0);
   });
 });

--- a/__tests__/styles/gradient-opacity-scale.test.ts
+++ b/__tests__/styles/gradient-opacity-scale.test.ts
@@ -1,0 +1,33 @@
+import { execSync } from "child_process";
+
+/**
+ * Tailwind v3 only emits an `/<opacity>` modifier when the value exists in the
+ * theme's opacity scale (multiples of 5). An off-scale stop like
+ * `from-[#252D6B]/92` silently produces no rule, `--tw-gradient-stops` stays
+ * undefined, and the ENTIRE gradient collapses to `background-image: none`.
+ *
+ * That is invisible in review and in typecheck/lint — it shipped a hero whose
+ * scrim never rendered, leaving white text unreadable on a bright photo. This
+ * pins the scale so a broken gradient fails here instead of in production.
+ */
+describe("gradient stop opacity modifiers", () => {
+  it("only uses opacity values Tailwind actually generates", () => {
+    const matches = execSync(
+      "grep -rEon '(from|via|to)-(\\[[^]]+\\]|[a-z]+(-[0-9]+)?)/[0-9]+' " +
+        "--include='*.tsx' --include='*.ts' app components lib || true",
+      { cwd: process.cwd(), encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+    );
+
+    const offScale = matches
+      .split("\n")
+      .filter(Boolean)
+      // `slide-in-from-left-1/2` and friends are fractions, not opacity modifiers.
+      .filter((line) => !/-(left|top|right|bottom)-\d+\/\d+$/.test(line))
+      .filter((line) => {
+        const opacity = Number(line.slice(line.lastIndexOf("/") + 1));
+        return Number.isFinite(opacity) && opacity % 5 !== 0;
+      });
+
+    expect(offScale).toEqual([]);
+  });
+});

--- a/__tests__/styles/zine-css.test.ts
+++ b/__tests__/styles/zine-css.test.ts
@@ -72,4 +72,25 @@ describe("zine stylesheet", () => {
       "background-color: rgba(11, 58, 117, 0.08) !important;"
     );
   });
+
+  it("uses fixed-height torn edge bands with a safe content inset", () => {
+    expect(zineCss).toContain("--zine-torn-edge-depth: 16px;");
+    expect(zineCss).toContain("--zine-torn-inset: 20px;");
+    expect(zineCss).toContain(":where(.zine-tab) .torn {");
+    expect(zineCss).toContain("padding: var(--zine-torn-inset);");
+    expect(zineCss).toContain(
+      "-webkit-mask-size: 100% var(--zine-torn-edge-depth), 100% calc(100% - var(--zine-torn-edge-depth) - var(--zine-torn-edge-depth)), 100% var(--zine-torn-edge-depth);"
+    );
+    expect(zineCss).toContain(
+      "mask-size: 100% var(--zine-torn-edge-depth), 100% calc(100% - var(--zine-torn-edge-depth) - var(--zine-torn-edge-depth)), 100% var(--zine-torn-edge-depth);"
+    );
+    expect(zineCss).not.toContain("mask-size: 100% 100%;");
+  });
+
+  it("removes decorative rotations at compact desktop widths", () => {
+    expect(zineCss).toContain("@media (max-width: 900px)");
+    expect(zineCss).toMatch(
+      /@media \(max-width: 900px\)[\s\S]*?\.zine-tab \.rot-neg\s*\{[\s\S]*?transform: none;/
+    );
+  });
 });

--- a/__tests__/types/session-intelligence.test.ts
+++ b/__tests__/types/session-intelligence.test.ts
@@ -86,6 +86,7 @@ describe("Session Intelligence shared model", () => {
       startIso: "2026-06-03T14:00:00.000Z",
       endIso: "2026-06-03T16:30:00.000Z",
       peakIso: "2026-06-03T15:00:00.000Z",
+      timezone: "America/Los_Angeles",
       forecastAt: "2026-06-03T14:00:00.000Z",
       localTimeLabel: "7:00-9:30 AM",
       score: 82,

--- a/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/[intlBeachSlug]/page.tsx
@@ -3,6 +3,7 @@ import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
 import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
+import { AuthenticatedForecastDecisionProvider } from "@/components/beach-detail/authenticated-forecast-decision";
 import { WebPageSchema } from "@/components/seo/web-page-schema";
 import type { Metadata } from "next";
 import { buildDynamicBeachMetadata, buildPageMetadata } from "@/lib/seo/meta";
@@ -23,6 +24,10 @@ import { getSpotSurfReportPublic } from "@/lib/services/spot-surf-report-service
 import { evaluateBeachForecastIndexability, applyIndexabilityToMetadata } from "@/lib/seo/indexability";
 import { isDataStale } from "@/lib/utils/forecast-client-utils";
 import { sanitizeBeachEditorialContent } from "@/lib/seo/editorial-integrity";
+import {
+  selectPublicForecastContextFacts,
+  selectPublicForecastReportFacts,
+} from "@/lib/utils/public-forecast-facts";
 
 // The route only reads public beach data; cache on demand instead of rendering
 // every crawler request from scratch.
@@ -187,6 +192,10 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
     const forecastContext = surfReportResult?.forecastContext ?? null;
     const hourlyForecasts = surfReportResult?.hourlyForecasts ?? [];
     const hourlyForecastDay = surfReportResult?.hourlyForecastDay ?? "today";
+    const publicForecastReport =
+      selectPublicForecastReportFacts(surfCallReport);
+    const publicForecastContext =
+      selectPublicForecastContextFacts(forecastContext);
 
     return (
       <>
@@ -220,36 +229,36 @@ export default async function InternationalBeachDetailPage(props: PageProps) {
           dateModified={forecastContext?.sourceDataUpdatedAt ?? undefined}
         />
 
-        <BeachDetailClient
-          beach={publicBeach}
-          slug={intlBeachSlug}
-          beachTimezone={beachTimezone}
-          surfCallReport={surfCallReport}
-          surfCallIsTomorrow={surfCallIsTomorrow}
-          heroHeadingLevel="h2"
-          heroForecastSlot={
+        <AuthenticatedForecastDecisionProvider beachId={publicBeach.id}>
+          <BeachDetailClient
+            beach={publicBeach}
+            slug={intlBeachSlug}
+            beachTimezone={beachTimezone}
+            heroHeadingLevel="h2"
+            heroForecastSlot={
               <PublicForecastAnswer
                 beach={publicBeach}
-                report={surfCallReport}
-                context={forecastContext}
+                report={publicForecastReport}
+                context={publicForecastContext}
                 isTomorrow={surfCallIsTomorrow}
                 headingLevel="h1"
+                returnTo={beachUrl}
               />
-          }
-          freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
-          /* Server-rendered inside the zine paper above the tabs — see the
-             canonical US route for why this is not inside the forecast tab. */
-          afterTabsContent={
-            <PublicForecastHourly
-              beachName={publicBeach.name}
-              forecastHours={hourlyForecasts}
-              report={surfCallReport}
-              context={forecastContext}
-              isTomorrow={surfCallIsTomorrow}
-              forecastDay={hourlyForecastDay}
-            />
-          }
-        />
+            }
+            freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
+            /* Server-rendered inside the zine paper above the tabs — see the
+               canonical US route for why this is not inside the forecast tab. */
+            afterTabsContent={
+              <PublicForecastHourly
+                beachName={publicBeach.name}
+                forecastHours={hourlyForecasts}
+                context={publicForecastContext}
+                forecastDay={hourlyForecastDay}
+                returnTo={beachUrl}
+              />
+            }
+          />
+        </AuthenticatedForecastDecisionProvider>
       </>
     );
   } catch (error) {

--- a/app/[intent]/[city]/[beachSlug]/page.tsx
+++ b/app/[intent]/[city]/[beachSlug]/page.tsx
@@ -4,6 +4,7 @@ import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { PublicForecastAnswer } from "@/components/beach-detail/public-forecast-answer";
 import { PublicForecastHourly } from "@/components/beach-detail/public-forecast-hourly";
+import { AuthenticatedForecastDecisionProvider } from "@/components/beach-detail/authenticated-forecast-decision";
 import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spots";
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
@@ -48,6 +49,10 @@ import {
 } from "@/lib/seo/indexability";
 import { isDataStale } from "@/lib/utils/forecast-client-utils";
 import { sanitizeBeachEditorialContent } from "@/lib/seo/editorial-integrity";
+import {
+  selectPublicForecastContextFacts,
+  selectPublicForecastReportFacts,
+} from "@/lib/utils/public-forecast-facts";
 
 // Public beach data is cookie-free. Major-event hold transitions explicitly
 // revalidate affected paths, so hourly ISR remains safe between transitions.
@@ -191,6 +196,11 @@ export default async function GenericBeachDetailPage(props: PageProps) {
     const hourlyForecasts = surfReportResult?.hourlyForecasts ?? [];
     const hourlyForecastDay = surfReportResult?.hourlyForecastDay ?? "today";
     const publicBeach = sanitizeBeachEditorialContent(beach);
+    const publicForecastReport =
+      selectPublicForecastReportFacts(surfCallReport);
+    const publicForecastContext =
+      selectPublicForecastContextFacts(forecastContext);
+    const returnTo = buildBeachUrl(publicBeach);
 
     // Validate that the beach's state matches the URL state parameter
     const expectedStateSlug = stateToSlug(beach.state);
@@ -284,81 +294,81 @@ export default async function GenericBeachDetailPage(props: PageProps) {
         )}
 
         {/* Client detail component with auth tracking */}
-        <BeachDetailClient
-          beach={publicBeach}
-          slug={beachSlug}
-          beachTimezone={beachTimezone}
-          surfCallReport={surfCallReport}
-          surfCallIsTomorrow={surfCallIsTomorrow}
-          amenities={amenitiesResult}
-          waterQuality={waterQualityResult}
-          beachPhoto={beachPhoto}
-          heroHeadingLevel="h2"
-          heroForecastSlot={
-                <PublicForecastAnswer
-                  beach={publicBeach}
-                  report={surfCallReport}
-                  context={forecastContext}
-                  isTomorrow={surfCallIsTomorrow}
-                  headingLevel="h1"
-                />
-          }
-          freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
-          beforeTabsContent={
-            forecastContext?.selectedRowTime && forecastContext.waveHeight ? (
-              <ContentPageAppHandoffCta
-                source={`content-beach-detail-${beachSlug}`}
-                surface="beach_detail"
-                placement="above_fold_after_public_answer"
-                target={`beach:${beachSlug}`}
-                eyebrow={`Next call · ${beach.name}`}
-                title={`Watch the next good window at ${beach.name}.`}
-                description="Today's call is here. Quiver keeps this break on your phone so the next surfable window is easier to catch."
-                ctaLabel="Watch the next window in the app"
-              />
-            ) : null
-          }
-          afterTabsContent={
-            <div className="pt-2">
-              <PublicForecastHourly
-                beachName={publicBeach.name}
-                forecastHours={hourlyForecasts}
-                report={surfCallReport}
-                context={forecastContext}
+        <AuthenticatedForecastDecisionProvider beachId={publicBeach.id}>
+          <BeachDetailClient
+            beach={publicBeach}
+            slug={beachSlug}
+            beachTimezone={beachTimezone}
+            amenities={amenitiesResult}
+            waterQuality={waterQualityResult}
+            beachPhoto={beachPhoto}
+            heroHeadingLevel="h2"
+            heroForecastSlot={
+              <PublicForecastAnswer
+                beach={publicBeach}
+                report={publicForecastReport}
+                context={publicForecastContext}
                 isTomorrow={surfCallIsTomorrow}
-                forecastDay={hourlyForecastDay}
+                headingLevel="h1"
+                returnTo={returnTo}
               />
-              {/* One ask here, not two. The home-break signup this used to stack
-                  underneath is the same ask the sticky bar already carries, so
-                  it read as the page repeating itself. The install section takes
-                  a real already-fetched figure instead — proof beats adjectives. */}
-              {!bannerOwnsInstallAsk && (
-                <div className="mt-10">
-                  <InstallAppCtaSection
-                    platform={installCtaPlatform}
-                    source={`beach-detail-${beachSlug}`}
-                    surface="beach-detail"
-                    placement="after-tabs"
-                    beachName={beach.name}
-                    proof={
-                      forecastContext?.waveHeightRangeLabel ??
-                      forecastContext?.waveHeight
-                        ? {
-                            value: (forecastContext.waveHeightRangeLabel ??
-                              forecastContext.waveHeight) as string,
-                            label: "Surf right now",
-                          }
-                        : undefined
-                    }
-                  />
-                </div>
-              )}
-              <Suspense fallback={null}>
-                <DeferredZineNearbySpots beach={beach} />
-              </Suspense>
-            </div>
-          }
-        />
+            }
+            freeGrowthPhaseEnabled={isFreeGrowthPhaseEnabled()}
+            beforeTabsContent={
+              forecastContext?.selectedRowTime && forecastContext.waveHeight ? (
+                <ContentPageAppHandoffCta
+                  source={`content-beach-detail-${beachSlug}`}
+                  surface="beach_detail"
+                  placement="above_fold_after_public_answer"
+                  target={`beach:${beachSlug}`}
+                  eyebrow={`Next call · ${beach.name}`}
+                  title={`Watch the next good window at ${beach.name}.`}
+                  description="Today's call is here. Quiver keeps this break on your phone so the next surfable window is easier to catch."
+                  ctaLabel="Watch the next window in the app"
+                />
+              ) : null
+            }
+            afterTabsContent={
+              <div className="pt-2">
+                <PublicForecastHourly
+                  beachName={publicBeach.name}
+                  forecastHours={hourlyForecasts}
+                  context={publicForecastContext}
+                  forecastDay={hourlyForecastDay}
+                  returnTo={returnTo}
+                />
+                {/* One ask here, not two. The home-break signup this used to stack
+                    underneath is the same ask the sticky bar already carries, so
+                    it read as the page repeating itself. The install section takes
+                    a real already-fetched figure instead — proof beats adjectives. */}
+                {!bannerOwnsInstallAsk && (
+                  <div className="mt-10">
+                    <InstallAppCtaSection
+                      platform={installCtaPlatform}
+                      source={`beach-detail-${beachSlug}`}
+                      surface="beach-detail"
+                      placement="after-tabs"
+                      beachName={beach.name}
+                      proof={
+                        forecastContext?.waveHeightRangeLabel ??
+                        forecastContext?.waveHeight
+                          ? {
+                              value: (forecastContext.waveHeightRangeLabel ??
+                                forecastContext.waveHeight) as string,
+                              label: "Surf right now",
+                            }
+                          : undefined
+                      }
+                    />
+                  </div>
+                )}
+                <Suspense fallback={null}>
+                  <DeferredZineNearbySpots beach={beach} />
+                </Suspense>
+              </div>
+            }
+          />
+        </AuthenticatedForecastDecisionProvider>
 
         <StickySignupBar
           source={`beach-detail-${beachSlug}`}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,9 +9,9 @@ import { AboutCtaButtons } from "./about-cta-buttons";
 export const revalidate = 3600;
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "About Quiver — Why I Built This",
+  title: "I built Quiver because I was tired of forecasts being wrong.",
   description:
-    "Why Quiver exists: live buoy, wind, tide, and beach context in one surf forecast app, built so surfers can make the call without checking five apps.",
+    "I built Quiver because I was tired of forecasts being wrong. See why Quiver puts live buoy, wind, tide, and beach context in one surf forecast app.",
   path: "/about",
   keywords: [
     "about Quiver",
@@ -38,7 +38,7 @@ export default function AboutPage() {
             <p className="label-black mb-5">From the founder</p>
           </ScrollReveal>
           <ScrollReveal delay={80}>
-            <h1 className="zine-h1 font-black uppercase leading-[0.9] tracking-normal text-[#11100D]">
+            <h1 className="zine-h1 max-w-5xl break-words font-black uppercase leading-[0.9] tracking-normal text-[#11100D] [text-wrap:balance]">
               {hero.title}
             </h1>
           </ScrollReveal>

--- a/app/beach/[slug]/beach-detail-client.tsx
+++ b/app/beach/[slug]/beach-detail-client.tsx
@@ -28,6 +28,8 @@ interface BeachDetailClientProps {
   waterQuality?: WaterQuality | null;
   beachPhoto?: ZineBeachPhoto | null;
   heroHeadingLevel?: ZineHeroHeadingLevel;
+  heroHeadingSuffix?: string;
+  heroSummarySlot?: ReactNode;
   heroForecastSlot?: ReactNode;
   beforeTabsContent?: ReactNode;
   afterTabsContent?: ReactNode;
@@ -46,6 +48,8 @@ export function BeachDetailClient({
   waterQuality,
   beachPhoto,
   heroHeadingLevel,
+  heroHeadingSuffix,
+  heroSummarySlot,
   heroForecastSlot,
   beforeTabsContent,
   afterTabsContent,
@@ -202,6 +206,8 @@ export function BeachDetailClient({
         waterQuality={waterQuality}
         beachPhoto={beachPhoto}
         heroHeadingLevel={heroHeadingLevel}
+        heroHeadingSuffix={heroHeadingSuffix}
+        heroSummarySlot={heroSummarySlot}
         heroForecastSlot={heroForecastSlot}
         beforeTabsContent={beforeTabsContent}
         afterTabsContent={afterTabsContent}

--- a/app/beach/[slug]/beach-detail-client.tsx
+++ b/app/beach/[slug]/beach-detail-client.tsx
@@ -15,6 +15,7 @@ import type { BeachAmenities } from "@/types/amenities";
 import type { WaterQuality } from "@/components/beach-detail/water-quality-badge";
 import type { ZineBeachPhoto } from "@/components/beach-detail/zine/types";
 import type { ZineHeroHeadingLevel } from "@/components/beach-detail/zine/zine-hero";
+import { useAuthenticatedForecastDecision } from "@/components/beach-detail/authenticated-forecast-decision";
 
 interface BeachDetailClientProps {
   beach: Beach;
@@ -56,6 +57,7 @@ export function BeachDetailClient({
   freeGrowthPhaseEnabled,
 }: BeachDetailClientProps) {
   const { user } = useAuth();
+  const authenticatedForecastDecision = useAuthenticatedForecastDecision();
   const { track } = useTrackEvent();
   const mountTime = useRef(Date.now());
   const beachIdRef = useRef<string | null>(null);
@@ -86,6 +88,12 @@ export function BeachDetailClient({
   useEffect(() => {
     setEffectiveSurfCallIsTomorrow(surfCallIsTomorrow ?? false);
   }, [surfCallIsTomorrow]);
+
+  useEffect(() => {
+    if (!authenticatedForecastDecision.isProvided) return;
+    setEffectiveSurfCallReport(authenticatedForecastDecision.report);
+    setEffectiveSurfCallIsTomorrow(authenticatedForecastDecision.isTomorrow);
+  }, [authenticatedForecastDecision]);
 
   useEffect(() => {
     setPersonalizationReady(false);
@@ -163,7 +171,14 @@ export function BeachDetailClient({
   }, [slug, user, track]);
 
   useEffect(() => {
-    if (!user || !beach?.id || !personalizationReady) return;
+    if (
+      !user ||
+      !beach?.id ||
+      !personalizationReady ||
+      authenticatedForecastDecision.isProvided
+    ) {
+      return;
+    }
 
     const controller = new AbortController();
 
@@ -189,7 +204,12 @@ export function BeachDetailClient({
     void fetchPersonalizedSurfCall();
 
     return () => controller.abort();
-  }, [user, beach?.id, personalizationReady]);
+  }, [
+    user,
+    beach?.id,
+    personalizationReady,
+    authenticatedForecastDecision.isProvided,
+  ]);
 
   return (
     <>

--- a/app/beaches/_components/beach-index-photo.tsx
+++ b/app/beaches/_components/beach-index-photo.tsx
@@ -1,9 +1,8 @@
-import { existsSync } from "fs";
 import Image from "next/image";
-import { join } from "path";
 
 import { PhotoAttribution } from "@/components/photos/photo-attribution";
 import { getProxiedImageUrl } from "@/lib/utils/image-utils";
+import { publicImageExists } from "@/lib/utils/public-image-exists";
 import { cn } from "@/lib/utils";
 
 export interface BeachIndexPhotoData {
@@ -19,12 +18,6 @@ interface BeachIndexPhotoProps {
   imageClassName?: string;
   priority?: boolean;
   sizes: string;
-  showAttribution?: boolean;
-}
-
-function publicImageExists(src: string): boolean {
-  if (!src.startsWith("/")) return true;
-  return existsSync(join(process.cwd(), "public", src.slice(1)));
 }
 
 export function BeachIndexPhoto({
@@ -34,7 +27,6 @@ export function BeachIndexPhoto({
   imageClassName,
   priority = false,
   sizes,
-  showAttribution = true,
 }: BeachIndexPhotoProps) {
   const hasPhoto = Boolean(photo && publicImageExists(photo.src));
 
@@ -63,7 +55,7 @@ export function BeachIndexPhoto({
           </div>
         )}
       </div>
-      {showAttribution && hasPhoto && photo?.attributionHtml ? (
+      {hasPhoto && photo?.attributionHtml ? (
         <figcaption className="mt-2 font-mono text-[10px] uppercase tracking-[0.08em] text-[#11100D]/65">
           Credit: {" "}
           <PhotoAttribution

--- a/app/beaches/_components/beach-index-photo.tsx
+++ b/app/beaches/_components/beach-index-photo.tsx
@@ -1,0 +1,77 @@
+import { existsSync } from "fs";
+import Image from "next/image";
+import { join } from "path";
+
+import { PhotoAttribution } from "@/components/photos/photo-attribution";
+import { getProxiedImageUrl } from "@/lib/utils/image-utils";
+import { cn } from "@/lib/utils";
+
+export interface BeachIndexPhotoData {
+  src: string;
+  alt: string;
+  attributionHtml?: string | null;
+}
+
+interface BeachIndexPhotoProps {
+  photo: BeachIndexPhotoData | null;
+  fallbackLabel: string;
+  className?: string;
+  imageClassName?: string;
+  priority?: boolean;
+  sizes: string;
+  showAttribution?: boolean;
+}
+
+function publicImageExists(src: string): boolean {
+  if (!src.startsWith("/")) return true;
+  return existsSync(join(process.cwd(), "public", src.slice(1)));
+}
+
+export function BeachIndexPhoto({
+  photo,
+  fallbackLabel,
+  className,
+  imageClassName,
+  priority = false,
+  sizes,
+  showAttribution = true,
+}: BeachIndexPhotoProps) {
+  const hasPhoto = Boolean(photo && publicImageExists(photo.src));
+
+  return (
+    <figure className={cn("min-w-0", className)}>
+      <div className="halftone-photo relative aspect-[4/3] overflow-hidden border-2 border-[#11100D] bg-[#D9C49C]">
+        {hasPhoto && photo ? (
+          <Image
+            src={getProxiedImageUrl(photo.src)}
+            alt={photo.alt}
+            fill
+            priority={priority || undefined}
+            sizes={sizes}
+            className={cn("object-cover", imageClassName)}
+          />
+        ) : (
+          <div
+            role="img"
+            aria-label={`${fallbackLabel} photo coming soon`}
+            className="flex h-full w-full items-center justify-center bg-[#F0E5CC] p-4 text-center"
+          >
+            <div className="stamp-circle rot-1 !h-24 !w-24 !text-xs sm:!h-28 sm:!w-28">
+              <span>Field photo</span>
+              <span className="lg">Soon</span>
+            </div>
+          </div>
+        )}
+      </div>
+      {showAttribution && hasPhoto && photo?.attributionHtml ? (
+        <figcaption className="mt-2 font-mono text-[10px] uppercase tracking-[0.08em] text-[#11100D]/65">
+          Credit: {" "}
+          <PhotoAttribution
+            attribution={null}
+            attributionHtml={photo.attributionHtml}
+          />
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/app/beaches/_lib/get-baja-featured-photo.ts
+++ b/app/beaches/_lib/get-baja-featured-photo.ts
@@ -1,0 +1,57 @@
+import type { BeachIndexPhotoData } from "@/app/beaches/_components/beach-index-photo";
+import { createPublicReadClient } from "@/lib/supabase/server";
+
+interface BajaBeachRow {
+  id: string;
+  name: string;
+}
+
+interface FeaturedPhotoRow {
+  beach_id: string | null;
+  image_url: string | null;
+  attribution_html: string | null;
+}
+
+export async function getBajaFeaturedPhoto(): Promise<BeachIndexPhotoData | null> {
+  try {
+    const supabase = createPublicReadClient();
+    const { data: beaches, error: beachesError } = await supabase
+      .from("beaches")
+      .select("id, name")
+      .ilike("state", "baja%")
+      .order("name")
+      .limit(100);
+
+    if (beachesError || !beaches?.length) return null;
+
+    const bajaBeaches = beaches as BajaBeachRow[];
+    const beachById = new Map(
+      bajaBeaches.map((beach) => [beach.id, beach.name]),
+    );
+    const { data: photos, error: photosError } = await supabase
+      .from("beach_photos_featured")
+      .select("beach_id, image_url, attribution_html")
+      .in("beach_id", bajaBeaches.map((beach) => beach.id))
+      .order("beach_id")
+      .limit(1);
+
+    if (photosError || !photos?.length) return null;
+
+    const photo = photos[0] as FeaturedPhotoRow;
+    if (!photo.image_url) return null;
+
+    const beachName = photo.beach_id
+      ? beachById.get(photo.beach_id)
+      : undefined;
+
+    return {
+      src: photo.image_url,
+      alt: beachName
+        ? `Surf at ${beachName}, Baja California`
+        : "Surf on the Baja California coast",
+      attributionHtml: photo.attribution_html,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/app/beaches/mexico/page.tsx
+++ b/app/beaches/mexico/page.tsx
@@ -2,8 +2,18 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { getAllBeachLocations } from "@/actions/beach/beach-location-list-actions";
-import { generateLocationSlug } from "@/lib/utils/location-slug";
+import { BeachIndexPhoto } from "@/app/beaches/_components/beach-index-photo";
+import { getBajaFeaturedPhoto } from "@/app/beaches/_lib/get-baja-featured-photo";
+import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
+import { ItemListSchema } from "@/components/seo/item-list-schema";
+import { WebPageSchema } from "@/components/seo/web-page-schema";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { SITE_URL } from "@/lib/constants/seo";
 import { buildPageMetadata } from "@/lib/seo/meta";
+import {
+  generateLocationSlug,
+  normalizeCountry,
+} from "@/lib/utils/location-slug";
 
 export const dynamic = "force-dynamic";
 
@@ -26,30 +36,65 @@ type BeachLocationRow = {
   country?: string | null;
 };
 
-function normalizeCountryToMexico(country: string | null | undefined): boolean {
-  if (!country) return false;
-  const normalized = country.trim().toLowerCase();
-  return normalized === "mexico" || normalized === "mx" || normalized === "mex";
+function DirectoryStructuredData({ states }: { states: StateIndexEntry[] }) {
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Home", url: SITE_URL },
+          { name: "Beaches", url: `${SITE_URL}/beaches` },
+          { name: "Mexico", url: `${SITE_URL}/beaches/mexico` },
+        ]}
+      />
+      <WebPageSchema
+        name="Best Surf Beaches in Mexico"
+        url={`${SITE_URL}/beaches/mexico`}
+        description="Explore surf regions, cities, and beach breaks across Mexico."
+      />
+      <ItemListSchema
+        name="Mexico Surf Regions"
+        items={states.map((state, index) => ({
+          name: state.stateName,
+          url: `${SITE_URL}/beaches/mexico/${state.stateSlug}`,
+          position: index + 1,
+        }))}
+      />
+    </>
+  );
 }
 
 export default async function MexicoStatesIndexPage() {
-  const response = await getAllBeachLocations();
+  const [response, bajaPhoto] = await Promise.all([
+    getAllBeachLocations(),
+    getBajaFeaturedPhoto(),
+  ]);
 
   if (!response.success || !response.data) {
     return (
-      <div className="container mx-auto px-4 py-12 max-w-5xl">
-        <h1 className="text-3xl font-bold text-gray-900">Browse by state</h1>
-        <p className="mt-3 text-gray-600">
-          We couldn&apos;t load the state directory right now. Try again soon.
-        </p>
-      </div>
+      <>
+        <DirectoryStructuredData states={[]} />
+        <ZineSurface sectionLabel="Beaches" editionLabel="Mexico coast directory">
+          <main className="py-10 text-center">
+            <p className="label-black mb-5">Directory unavailable</p>
+            <h1 className="zine-display text-4xl font-black uppercase text-[#11100D]">
+              Browse by state
+            </h1>
+            <p className="mx-auto mt-4 max-w-xl text-[#11100D]/72">
+              We couldn&apos;t load the state directory right now. Try again soon.
+            </p>
+          </main>
+        </ZineSurface>
+      </>
     );
   }
 
-  const citiesByState = new Map<string, { slug: string; name: string; cities: Set<string> }>();
+  const citiesByState = new Map<
+    string,
+    { slug: string; name: string; cities: Set<string> }
+  >();
 
   for (const loc of response.data as BeachLocationRow[]) {
-    if (!normalizeCountryToMexico(loc.country)) continue;
+    if (normalizeCountry(loc.country) !== "Mexico") continue;
 
     const stateName = String(loc.state || "").trim();
     const cityName = String(loc.city || "").trim();
@@ -59,7 +104,11 @@ export default async function MexicoStatesIndexPage() {
     if (!stateSlug) continue;
 
     if (!citiesByState.has(stateSlug)) {
-      citiesByState.set(stateSlug, { slug: stateSlug, name: stateName, cities: new Set() });
+      citiesByState.set(stateSlug, {
+        slug: stateSlug,
+        name: stateName,
+        cities: new Set(),
+      });
     }
     citiesByState.get(stateSlug)!.cities.add(cityName);
   }
@@ -72,45 +121,116 @@ export default async function MexicoStatesIndexPage() {
     }))
     .sort((a, b) => a.stateName.localeCompare(b.stateName));
 
-  return (
-    <div className="container mx-auto px-4 py-10 max-w-7xl">
-      <header className="mb-8">
-        <nav aria-label="breadcrumb" className="text-sm text-gray-600 mb-4">
-          <Link href="/" className="hover:underline text-ocean-blue">
-            Home
-          </Link>
-          <span className="mx-2 text-gray-400">›</span>
-          <span className="text-gray-900 font-medium">Mexico</span>
-        </nav>
-        <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
-          Best surf beaches in Mexico
-        </h1>
-        <p className="mt-2 text-gray-600 max-w-3xl">
-          Pick a state to explore top surf cities and their best beaches across Mexico.
-        </p>
-      </header>
+  const totalCities = states.reduce((sum, state) => sum + state.cityCount, 0);
 
-      <section aria-label="States" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {states.map((s) => (
-          <Link
-            key={s.stateSlug}
-            href={`/beaches/mexico/${s.stateSlug}`}
-            className="rounded-xl border border-slate-200 bg-white p-5 hover:shadow-md transition-shadow"
-          >
-            <div className="flex items-baseline justify-between gap-4">
-              <h2 className="text-lg font-semibold text-slate-900">
-                {s.stateName}
-              </h2>
-              <span className="text-sm text-slate-600">
-                {s.cityCount} {s.cityCount === 1 ? "city" : "cities"}
+  return (
+    <>
+      <DirectoryStructuredData states={states} />
+      <ZineSurface
+        sectionLabel="Beaches"
+        editionLabel="Mexico coast directory"
+        data-testid="mexico-beaches-zine-surface"
+      >
+        <main>
+          <header className="relative mb-10 border-b-2 border-dashed border-[#11100D]/35 pb-8">
+            <QuiverSticker
+              sticker="orangeMap"
+              className="absolute -right-1 -top-7 hidden w-24 rotate-6 opacity-80 sm:block"
+              sizes="96px"
+              priority
+            />
+            <nav
+              aria-label="breadcrumb"
+              className="mb-5 flex flex-wrap items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[#11100D]/65"
+            >
+              <Link
+                href="/"
+                className="rounded-sm underline decoration-2 underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75]"
+              >
+                Home
+              </Link>
+              <span aria-hidden>/</span>
+              <Link
+                href="/beaches"
+                className="rounded-sm underline decoration-2 underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75]"
+              >
+                Beaches
+              </Link>
+              <span aria-hidden>/</span>
+              <span aria-current="page" className="font-bold text-[#11100D]">
+                Mexico
+              </span>
+            </nav>
+            <p className="label-black mb-5">Pacific field directory</p>
+            <h1 className="zine-h1 zine-display max-w-4xl font-black uppercase leading-[0.88] text-[#11100D]">
+              Best surf beaches in Mexico
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[#11100D]/75 sm:text-xl">
+              Pick a state to explore top surf cities and their best beaches
+              across Mexico.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#11100D]/65">
+              <span>
+                {states.length} {states.length === 1 ? "state" : "states"}
+              </span>
+              <span aria-hidden>/</span>
+              <span>
+                {totalCities} {totalCities === 1 ? "city" : "cities"}
               </span>
             </div>
-            <p className="mt-2 text-sm text-slate-600">
-              Explore surf spots and ranked beaches across {s.stateName}.
+          </header>
+
+          <section aria-label="States" className="space-y-10">
+            {states.map((state, index) => {
+              const isBaja = state.stateSlug.startsWith("baja-california");
+
+              return (
+                <Link
+                  key={state.stateSlug}
+                  href={`/beaches/mexico/${state.stateSlug}`}
+                  className={`group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8] ${index % 2 === 0 ? "rot-1" : "rot-2"}`}
+                >
+                  <article className="torn torn-tb grid gap-6 border-2 border-[#11100D] transition-transform group-hover:-translate-y-1 md:grid-cols-[minmax(0,1.35fr)_minmax(240px,0.65fr)] md:items-center md:gap-8">
+                    <div className="relative">
+                      <div className="tape tl" aria-hidden />
+                      <BeachIndexPhoto
+                        photo={isBaja ? bajaPhoto : null}
+                        fallbackLabel={`${state.stateName} coast`}
+                        priority={index === 0}
+                        sizes="(min-width: 1024px) 650px, (min-width: 768px) 58vw, calc(100vw - 72px)"
+                        imageClassName="transition-transform duration-500 group-hover:scale-105"
+                      />
+                    </div>
+
+                    <div className="min-w-0">
+                      <p className="typewriter mb-3">State field guide</p>
+                      <h2 className="zine-display text-4xl font-black uppercase leading-[0.92] text-[#11100D] sm:text-5xl">
+                        {state.stateName}
+                      </h2>
+                      <div className="mt-5 inline-flex bg-[#11100D] px-3 py-2 font-mono text-xs font-bold uppercase tracking-[0.12em] text-[#F4EBD8]">
+                        {state.cityCount} {state.cityCount === 1 ? "city" : "cities"}
+                      </div>
+                      <p className="mt-5 text-base leading-relaxed text-[#11100D]/72">
+                        Explore surf spots and ranked beaches across {state.stateName}.
+                      </p>
+                      <span className="mt-6 inline-flex font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
+                        Explore the coastline →
+                      </span>
+                    </div>
+                  </article>
+                </Link>
+              );
+            })}
+          </section>
+
+          <aside className="notebook mt-12 border-l-4 border-[#0B3A75] py-4 pl-6 pr-4">
+            <p className="font-handwritten text-2xl leading-tight text-[#11100D]">
+              The directory grows coast by coast. Each new state will slot into
+              the same photo-led field-guide format.
             </p>
-          </Link>
-        ))}
-      </section>
-    </div>
+          </aside>
+        </main>
+      </ZineSurface>
+    </>
   );
 }

--- a/app/beaches/page.tsx
+++ b/app/beaches/page.tsx
@@ -1,7 +1,15 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { BeachIndexPhoto } from "@/app/beaches/_components/beach-index-photo";
+import { getBajaFeaturedPhoto } from "@/app/beaches/_lib/get-baja-featured-photo";
+import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
+import { WebPageSchema } from "@/components/seo/web-page-schema";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { SITE_URL } from "@/lib/constants/seo";
 import { buildPageMetadata } from "@/lib/seo/meta";
+
+export const revalidate = 86400;
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Browse Surf Beaches by Region",
@@ -10,60 +18,145 @@ export const metadata: Metadata = buildPageMetadata({
   path: "/beaches",
 });
 
-export default function BeachesIndexPage() {
-  const regions = [
-    {
-      name: "United States",
-      href: "/beaches/usa",
-      description:
-        "Browse surf spots across 16 coastal states from California to Maine. Over 5,000 beaches with live forecasts.",
-    },
-    {
-      name: "Mexico",
-      href: "/beaches/mexico",
-      description:
-        "Explore surf breaks along Baja California and the Pacific coast. World-class waves without the crowds.",
-    },
-  ];
+const USA_PHOTO = {
+  src: "/images/seo-dioramas/beginner/socal/venice-beach-venice-ca-photo.webp",
+  alt: "The shoreline and surf at Venice Beach, California",
+  attributionHtml: "DXR / CC0 1.0",
+};
+
+export default async function BeachesIndexPage() {
+  const mexicoPhoto = await getBajaFeaturedPhoto();
 
   return (
-    <div className="container mx-auto px-4 py-10 max-w-7xl">
-      <header className="mb-8">
-        <nav aria-label="breadcrumb" className="text-sm text-gray-600 mb-4">
-          <Link href="/" className="hover:underline text-ocean-blue">
-            Home
-          </Link>
-          <span className="mx-2 text-gray-400">&rsaquo;</span>
-          <span className="text-gray-900 font-medium">Beaches</span>
-        </nav>
-        <h1 className="text-3xl md:text-4xl font-bold text-gray-900">
-          Browse surf beaches by region
-        </h1>
-        <p className="mt-2 text-gray-600 max-w-3xl">
-          Pick a region to explore surf cities, beach conditions, and
-          calibrated forecasts.
-        </p>
-      </header>
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Home", url: SITE_URL },
+          { name: "Beaches", url: `${SITE_URL}/beaches` },
+        ]}
+      />
+      <WebPageSchema
+        name="Browse Surf Beaches by Region"
+        url={`${SITE_URL}/beaches`}
+        description="Explore surf beaches across the United States and Mexico with live conditions, calibrated forecasts, and community reviews."
+      />
 
-      <section
-        aria-label="Regions"
-        className="grid gap-4 sm:grid-cols-2"
+      <ZineSurface
+        sectionLabel="Beaches"
+        editionLabel="Coast directory"
+        data-testid="beaches-zine-surface"
       >
-        {regions.map((region) => (
-          <Link
-            key={region.href}
-            href={region.href}
-            className="rounded-xl border border-slate-200 bg-white p-6 hover:shadow-md transition-shadow"
-          >
-            <h2 className="text-xl font-semibold text-slate-900">
-              {region.name}
-            </h2>
-            <p className="mt-2 text-sm text-slate-600">
-              {region.description}
+        <main>
+          <header className="relative mb-10 border-b-2 border-dashed border-[#11100D]/35 pb-8">
+            <QuiverSticker
+              sticker="creamCoastMap"
+              className="absolute -right-4 -top-7 hidden w-36 rotate-6 opacity-70 md:block"
+              sizes="144px"
+              priority
+            />
+            <nav
+              aria-label="breadcrumb"
+              className="mb-5 flex items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[#11100D]/65"
+            >
+              <Link
+                href="/"
+                className="rounded-sm underline decoration-2 underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75]"
+              >
+                Home
+              </Link>
+              <span aria-hidden>/</span>
+              <span aria-current="page" className="font-bold text-[#11100D]">
+                Beaches
+              </span>
+            </nav>
+            <p className="label-black mb-5">Coast directory</p>
+            <h1 className="zine-h1 zine-display max-w-4xl font-black uppercase leading-[0.88] text-[#11100D]">
+              Browse surf beaches by region
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[#11100D]/75 sm:text-xl">
+              Pick a region to explore surf cities, beach conditions, and
+              calibrated forecasts.
             </p>
-          </Link>
-        ))}
-      </section>
-    </div>
+          </header>
+
+          <section
+            aria-label="Regions"
+            className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-start"
+          >
+            <Link
+              href="/beaches/usa"
+              className="group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8]"
+            >
+              <article className="torn torn-tb rot-1 border-2 border-[#11100D] transition-transform group-hover:-translate-y-1">
+                <BeachIndexPhoto
+                  photo={USA_PHOTO}
+                  fallbackLabel="United States coast"
+                  priority
+                  sizes="(min-width: 1024px) 620px, (min-width: 640px) 80vw, calc(100vw - 52px)"
+                  imageClassName="transition-transform duration-500 group-hover:scale-105"
+                />
+                <div className="mt-5 flex items-end justify-between gap-4">
+                  <div>
+                    <p className="typewriter mb-2">Atlantic / Pacific / Gulf</p>
+                    <h2 className="zine-display text-3xl font-black uppercase leading-none text-[#11100D] sm:text-4xl">
+                      United States
+                    </h2>
+                  </div>
+                  <div className="stamp-circle !h-24 !w-24 shrink-0 !text-xs">
+                    <span>Coastal</span>
+                    <span className="lg">16</span>
+                    <span>States</span>
+                  </div>
+                </div>
+                <p className="mt-4 max-w-2xl text-base leading-relaxed text-[#11100D]/72">
+                  Browse surf spots across 16 coastal states from California to
+                  Maine. Over 5,000 beaches with live forecasts.
+                </p>
+                <span className="mt-5 inline-flex font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
+                  Browse the states →
+                </span>
+              </article>
+            </Link>
+
+            <Link
+              href="/beaches/mexico"
+              className="group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8] lg:mt-16"
+            >
+              <article className="polaroid rot-3 transition-transform group-hover:-translate-y-1">
+                <div className="tape tr" aria-hidden />
+                <BeachIndexPhoto
+                  photo={mexicoPhoto}
+                  fallbackLabel="Baja California coast"
+                  sizes="(min-width: 1024px) 440px, (min-width: 640px) 70vw, calc(100vw - 52px)"
+                  imageClassName="transition-transform duration-500 group-hover:scale-105"
+                />
+                <div className="px-2 pb-2 pt-4">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="typewriter mb-2">Southbound field notes</p>
+                      <h2 className="zine-display text-3xl font-black uppercase leading-none text-[#11100D]">
+                        Mexico
+                      </h2>
+                    </div>
+                    <QuiverSticker
+                      sticker="orangeMap"
+                      className="-mt-7 w-16 rotate-6"
+                      sizes="64px"
+                    />
+                  </div>
+                  <p className="mt-4 text-base leading-relaxed text-[#11100D]/72">
+                    Explore surf breaks along Baja California and the Pacific
+                    coast. World-class waves without the crowds.
+                  </p>
+                  <span className="mt-5 inline-flex font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
+                    Head for Baja →
+                  </span>
+                </div>
+              </article>
+            </Link>
+          </section>
+        </main>
+      </ZineSurface>
+    </>
   );
 }

--- a/app/beaches/page.tsx
+++ b/app/beaches/page.tsx
@@ -81,13 +81,13 @@ export default async function BeachesIndexPage() {
 
           <section
             aria-label="Regions"
-            className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-start"
+            className="grid gap-8 lg:grid-cols-2 lg:items-stretch"
           >
             <Link
               href="/beaches/usa"
-              className="group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8]"
+              className="group block h-full rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8]"
             >
-              <article className="torn torn-tb rot-1 border-2 border-[#11100D] transition-transform group-hover:-translate-y-1">
+              <article className="torn torn-tb rot-1 flex h-full flex-col border-2 border-[#11100D] transition-transform group-hover:-translate-y-1">
                 <BeachIndexPhoto
                   photo={USA_PHOTO}
                   fallbackLabel="United States coast"
@@ -112,7 +112,7 @@ export default async function BeachesIndexPage() {
                   Browse surf spots across 16 coastal states from California to
                   Maine. Over 5,000 beaches with live forecasts.
                 </p>
-                <span className="mt-5 inline-flex font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
+                <span className="mt-auto inline-flex pt-5 font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
                   Browse the states →
                 </span>
               </article>
@@ -120,9 +120,9 @@ export default async function BeachesIndexPage() {
 
             <Link
               href="/beaches/mexico"
-              className="group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8] lg:mt-16"
+              className="group block h-full rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8]"
             >
-              <article className="polaroid rot-3 transition-transform group-hover:-translate-y-1">
+              <article className="polaroid rot-3 flex h-full flex-col transition-transform group-hover:-translate-y-1">
                 <div className="tape tr" aria-hidden />
                 <BeachIndexPhoto
                   photo={mexicoPhoto}
@@ -130,7 +130,7 @@ export default async function BeachesIndexPage() {
                   sizes="(min-width: 1024px) 440px, (min-width: 640px) 70vw, calc(100vw - 52px)"
                   imageClassName="transition-transform duration-500 group-hover:scale-105"
                 />
-                <div className="px-2 pb-2 pt-4">
+                <div className="flex flex-1 flex-col px-2 pb-2 pt-4">
                   <div className="flex items-start justify-between gap-4">
                     <div>
                       <p className="typewriter mb-2">Southbound field notes</p>
@@ -148,7 +148,7 @@ export default async function BeachesIndexPage() {
                     Explore surf breaks along Baja California and the Pacific
                     coast. World-class waves without the crowds.
                   </p>
-                  <span className="mt-5 inline-flex font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
+                  <span className="mt-auto inline-flex pt-5 font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#0B3A75] group-hover:underline">
                     Head for Baja →
                   </span>
                 </div>

--- a/app/beaches/usa/page.tsx
+++ b/app/beaches/usa/page.tsx
@@ -1,18 +1,24 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
-import { ArrowRight, MapPin } from "lucide-react";
 
 import { getAllBeachLocations } from "@/actions/beach/beach-location-list-actions";
+import {
+  BeachIndexPhoto,
+  type BeachIndexPhotoData,
+} from "@/app/beaches/_components/beach-index-photo";
+import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
+import { ItemListSchema } from "@/components/seo/item-list-schema";
+import { WebPageSchema } from "@/components/seo/web-page-schema";
+import { QuiverSticker, ZineSurface } from "@/components/zine";
+import { SITE_URL } from "@/lib/constants/seo";
+import { buildPageMetadata } from "@/lib/seo/meta";
 import {
   getUsStateDisplayNameFromSlug,
   isValidStateSlug,
   stateToSlug,
 } from "@/lib/utils/beach-url-utils";
-import { buildPageMetadata } from "@/lib/seo/meta";
 import { normalizeCountry } from "@/lib/utils/location-slug";
-import { OceanBackground } from "@/components/ui/ocean-background";
-import { ScrollReveal } from "@/components/ui/scroll-reveal";
-import { AnimatedCounter } from "@/components/ui/animated-counter";
 
 export const revalidate = 86400;
 
@@ -35,19 +41,103 @@ type BeachLocationRow = {
   country?: string | null;
 };
 
+const STATE_PHOTO_ANCHORS: Partial<Record<string, BeachIndexPhotoData>> = {
+  ca: {
+    src: "/images/seo-dioramas/beginner/socal/venice-beach-venice-ca-photo.webp",
+    alt: "Venice Beach and the Southern California coastline",
+    attributionHtml: "DXR / CC0 1.0",
+  },
+  fl: {
+    src: "/images/seo-scenes/cocoa-beach-pier.webp",
+    alt: "Surf beside Cocoa Beach Pier in Florida",
+  },
+  nc: {
+    src: "/images/seo-scenes/north-carolina-carolina-beach.jpg",
+    alt: "Carolina Beach on the North Carolina coast",
+  },
+  ny: {
+    src: "/images/seo-dioramas/beginner/long-island/ditch-plains-montauk-ny-photo.webp",
+    alt: "A surfer at Ditch Plains in Montauk, New York",
+    attributionHtml: "dpstyles™ / CC BY 2.0",
+  },
+  or: {
+    src: "/images/On_the_Beach_at_Bandon.webp",
+    alt: "The beach and sea stacks at Bandon, Oregon",
+  },
+  pr: {
+    src: "/images/seo-scenes/rincon-domes.webp",
+    alt: "The surf coastline near Domes in Rincón, Puerto Rico",
+  },
+  wa: {
+    src: "/images/seo-scenes/westport-jetty.webp",
+    alt: "The jetty and surf at Westport, Washington",
+  },
+};
+
+const STATE_BADGES: Partial<Record<string, { src: string; alt: string }>> = {
+  ca: {
+    src: "/images/beach-badges/huntington-beach.png",
+    alt: "Huntington Beach crest",
+  },
+  fl: {
+    src: "/images/beach-badges/ponce-inlet.png",
+    alt: "Ponce Inlet crest",
+  },
+};
+
+const CARD_ROTATIONS = ["rot-1", "rot-2", "rot-3", "rot-4"] as const;
+
+function DirectoryStructuredData({ states }: { states: StateIndexEntry[] }) {
+  return (
+    <>
+      <BreadcrumbStructuredData
+        items={[
+          { name: "Home", url: SITE_URL },
+          { name: "Beaches", url: `${SITE_URL}/beaches` },
+          { name: "USA", url: `${SITE_URL}/beaches/usa` },
+        ]}
+      />
+      <WebPageSchema
+        name="Best Surf Beaches by State"
+        url={`${SITE_URL}/beaches/usa`}
+        description="Browse surf beaches by U.S. state with live conditions, calibrated forecasts, and community reviews."
+      />
+      <ItemListSchema
+        name="U.S. Surf States"
+        items={states.map((state, index) => {
+          const imageSrc = STATE_PHOTO_ANCHORS[state.stateSlug]?.src;
+
+          return {
+            name: state.stateName,
+            url: `${SITE_URL}/beaches/usa/${state.stateSlug}`,
+            position: index + 1,
+            image: imageSrc ? `${SITE_URL}${imageSrc}` : undefined,
+          };
+        })}
+      />
+    </>
+  );
+}
+
 export default async function UsaStatesIndexPage() {
   const response = await getAllBeachLocations();
 
   if (!response.success || !response.data) {
     return (
-      <OceanBackground variant="minimal" showWaves={false}>
-        <div className="container mx-auto px-4 py-12 max-w-5xl text-center">
-          <h1 className="text-3xl font-bold text-gray-900">Browse by state</h1>
-          <p className="mt-3 text-gray-600">
-            We couldn&apos;t load the state directory right now. Try again soon.
-          </p>
-        </div>
-      </OceanBackground>
+      <>
+        <DirectoryStructuredData states={[]} />
+        <ZineSurface sectionLabel="Beaches" editionLabel="U.S. coast directory">
+          <main className="py-10 text-center">
+            <p className="label-black mb-5">Directory unavailable</p>
+            <h1 className="zine-display text-4xl font-black uppercase text-[#11100D]">
+              Browse by state
+            </h1>
+            <p className="mx-auto mt-4 max-w-xl text-[#11100D]/72">
+              We couldn&apos;t load the state directory right now. Try again soon.
+            </p>
+          </main>
+        </ZineSurface>
+      </>
     );
   }
 
@@ -73,79 +163,133 @@ export default async function UsaStatesIndexPage() {
     }))
     .sort((a, b) => a.stateName.localeCompare(b.stateName));
 
-  const totalCities = states.reduce((sum, s) => sum + s.cityCount, 0);
+  const totalCities = states.reduce((sum, state) => sum + state.cityCount, 0);
 
   return (
-    <OceanBackground variant="ocean" showWaves animated={false}>
-      <div className="container mx-auto px-4 py-8 max-w-7xl">
-        {/* Hero Section */}
-        <ScrollReveal variant="fadeUp">
-          <header className="text-center mb-12">
+    <>
+      <DirectoryStructuredData states={states} />
+      <ZineSurface
+        sectionLabel="Beaches"
+        editionLabel="U.S. coast directory"
+        data-testid="usa-beaches-zine-surface"
+      >
+        <main>
+          <header className="relative mb-10 border-b-2 border-dashed border-[#11100D]/35 pb-8">
+            <QuiverSticker
+              sticker="creamCoastMap"
+              className="absolute -right-4 -top-7 hidden w-36 rotate-6 opacity-70 md:block"
+              sizes="144px"
+              priority
+            />
             <nav
               aria-label="breadcrumb"
-              className="inline-flex items-center gap-2 text-sm text-muted-foreground mb-4"
+              className="mb-5 flex flex-wrap items-center gap-2 font-mono text-xs uppercase tracking-[0.12em] text-[#11100D]/65"
             >
-              <Link href="/" className="hover:underline text-ocean-blue">
+              <Link
+                href="/"
+                className="rounded-sm underline decoration-2 underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75]"
+              >
                 Home
               </Link>
-              <span className="text-gray-400">/</span>
-              <span className="text-gray-900 font-medium">United States</span>
+              <span aria-hidden>/</span>
+              <Link
+                href="/beaches"
+                className="rounded-sm underline decoration-2 underline-offset-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75]"
+              >
+                Beaches
+              </Link>
+              <span aria-hidden>/</span>
+              <span aria-current="page" className="font-bold text-[#11100D]">
+                United States
+              </span>
             </nav>
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-3">
+            <p className="label-black mb-5">Atlantic / Pacific / Gulf</p>
+            <h1 className="zine-h1 zine-display max-w-4xl font-black uppercase leading-[0.88] text-[#11100D]">
               Best surf beaches by state
             </h1>
-            <p className="text-gray-600 max-w-2xl mx-auto mb-4">
+            <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[#11100D]/75 sm:text-xl">
               Pick a state to explore top surf cities and their best beaches —
               real-time conditions, calibrated forecasts, and community reviews.
             </p>
-            <div className="flex items-center justify-center gap-3 text-sm text-muted-foreground">
-              <span className="inline-flex items-center gap-1">
-                <MapPin className="h-3.5 w-3.5" />
-                <AnimatedCounter value={states.length} duration={600} /> states
-              </span>
-              <span className="text-gray-400">|</span>
-              <span>
-                <AnimatedCounter value={totalCities} duration={800} suffix="+" />{" "}
-                cities
-              </span>
+            <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#11100D]/65">
+              <span>{states.length} states</span>
+              <span aria-hidden>/</span>
+              <span>{totalCities}+ cities</span>
             </div>
           </header>
-        </ScrollReveal>
 
-        {/* State Cards Grid */}
-        <section aria-label="US states">
-        <ScrollReveal
-          variant="fadeUp"
-          stagger
-          staggerDelay={60}
-          className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-        >
-          {states.map((s) => (
-            <Link
-              key={s.stateSlug}
-              href={`/beaches/usa/${s.stateSlug}`}
-              className="group rounded-xl border border-slate-200 bg-white/80 backdrop-blur-sm p-5 transition-[background-color,border-color,box-shadow] duration-200 hover:shadow-lg hover:border-sky-300 hover:bg-gradient-to-br hover:from-sky-50/60 hover:to-blue-50/40"
-            >
-              <div className="flex items-center justify-between gap-4">
-                <h2 className="text-lg font-semibold text-slate-900 transition-colors group-hover:text-sky-700">
-                  {s.stateName}
-                </h2>
-                <div className="flex items-center gap-2">
-                  <span className="rounded-full bg-sky-100 text-sky-700 px-2.5 py-0.5 text-xs font-medium">
-                    <AnimatedCounter value={s.cityCount} duration={500} />{" "}
-                    {s.cityCount === 1 ? "city" : "cities"}
-                  </span>
-                  <ArrowRight className="h-4 w-4 text-sky-500 opacity-0 -translate-x-1 transition-[opacity,transform] duration-200 group-hover:opacity-100 group-hover:translate-x-0" />
-                </div>
-              </div>
-              <p className="mt-2 text-sm text-slate-600">
-                Explore surf spots and ranked beaches across {s.stateName}.
-              </p>
-            </Link>
-          ))}
-        </ScrollReveal>
-        </section>
-      </div>
-    </OceanBackground>
+          <section aria-label="US states">
+            <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {states.map((state, index) => {
+                const photo = STATE_PHOTO_ANCHORS[state.stateSlug] ?? null;
+                const badge = STATE_BADGES[state.stateSlug];
+
+                return (
+                  <Link
+                    key={state.stateSlug}
+                    href={`/beaches/usa/${state.stateSlug}`}
+                    className={`group block rounded-sm focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-4 focus-visible:ring-offset-[#F4EBD8] ${CARD_ROTATIONS[index % CARD_ROTATIONS.length]}`}
+                  >
+                    <article className="torn h-full border-2 border-[#11100D] transition-transform group-hover:-translate-y-1">
+                      <div className="grid grid-cols-[88px_minmax(0,1fr)] gap-4 sm:grid-cols-[96px_minmax(0,1fr)]">
+                        <div className="relative self-start">
+                          {photo ? (
+                            <BeachIndexPhoto
+                              photo={photo}
+                              fallbackLabel={`${state.stateName} coast`}
+                              sizes="96px"
+                              showAttribution={Boolean(photo.attributionHtml)}
+                            />
+                          ) : (
+                            <div
+                              role="img"
+                              aria-label={`${state.stateName} state stamp`}
+                              className="stamp-circle !h-20 !w-20 !text-[10px] sm:!h-24 sm:!w-24"
+                            >
+                              <span>Surf</span>
+                              <span className="lg">
+                                {state.stateSlug.toUpperCase()}
+                              </span>
+                              <span>Guide</span>
+                            </div>
+                          )}
+                          {badge ? (
+                            <Image
+                              src={badge.src}
+                              alt={badge.alt}
+                              width={48}
+                              height={48}
+                              sizes="48px"
+                              className="absolute -bottom-3 -right-2 h-12 w-12 rotate-6 drop-shadow-md"
+                            />
+                          ) : null}
+                        </div>
+
+                        <div className="min-w-0 py-1">
+                          <div className="flex items-start justify-between gap-3">
+                            <h2 className="zine-display text-xl font-black uppercase leading-none text-[#11100D] sm:text-2xl">
+                              {state.stateName}
+                            </h2>
+                            <span className="shrink-0 bg-[#11100D] px-2 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.08em] text-[#F4EBD8]">
+                              {state.cityCount} {state.cityCount === 1 ? "city" : "cities"}
+                            </span>
+                          </div>
+                          <p className="mt-3 text-sm leading-relaxed text-[#11100D]/70">
+                            Explore surf spots and ranked beaches across {state.stateName}.
+                          </p>
+                          <span className="mt-4 inline-flex font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-[#0B3A75] group-hover:underline">
+                            Open field guide →
+                          </span>
+                        </div>
+                      </div>
+                    </article>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        </main>
+      </ZineSurface>
+    </>
   );
 }

--- a/app/beaches/usa/page.tsx
+++ b/app/beaches/usa/page.tsx
@@ -238,7 +238,6 @@ export default async function UsaStatesIndexPage() {
                               photo={photo}
                               fallbackLabel={`${state.stateName} coast`}
                               sizes="96px"
-                              showAttribution={Boolean(photo.attributionHtml)}
                             />
                           ) : (
                             <div

--- a/app/best-surf-forecast-app/comparison-sources.ts
+++ b/app/best-surf-forecast-app/comparison-sources.ts
@@ -1,0 +1,62 @@
+export interface ComparisonSourceLink {
+  label: string;
+  href: string;
+  note: string;
+}
+
+export const COMPARISON_SOURCE_REVIEW = {
+  lastVerified: "2026-07-08",
+  reviewedBy: "Quiver editorial team",
+  // Pricing and product features change often enough to warrant review every two months.
+  freshnessThresholdDays: 60,
+} as const;
+
+export const COMPARISON_SOURCE_LINKS: readonly ComparisonSourceLink[] = [
+  {
+    label: "Quiver App Store listing",
+    href: "https://apps.apple.com/us/app/surf-forecast-quiver/id6759300320",
+    note:
+      "Quiver free listing, Pro monthly, annual, and lifetime in-app purchases, session logging, alerts, board recommendations, custom spots, and offline mode.",
+  },
+  {
+    label: "Surfline upgrade page",
+    href: "https://www.surfline.com/upgrade",
+    note:
+      "Premium and Premium+ plan positioning, 16-day forecasts, live cams, and annual pricing.",
+  },
+  {
+    label: "Surfline free vs Premium support",
+    href:
+      "https://support.surfline.com/hc/en-us/articles/32996023385243-What-do-I-get-as-a-free-vs-Premium-user",
+    note:
+      "Free, Premium, Premium with Ads, and Premium+ feature differences.",
+  },
+  {
+    label: "LazySurfer vs Quiver comparison",
+    href: "https://lazysurfer.app/compare/quiver.html",
+    note:
+      "LazySurfer pricing, cross-platform availability, and personalization framing.",
+  },
+  {
+    label: "Surf-Forecast.com app page",
+    href: "https://www.surf-forecast.com/pages/app-store",
+    note:
+      "Global spot coverage, maps, alerts, tide timing, hourly forecasts, and 16-day planning.",
+  },
+  {
+    label: "Surf Captain FAQ",
+    href: "https://surfcaptain.com/faq",
+    note:
+      "Free 5-day forecasts with ads and Surf Captain Pro 16-day forecast pricing.",
+  },
+  {
+    label: "Windy surfing guide",
+    href: "https://windy.app/guide/mini-guide-to-surfing.html",
+    note: "Wind, swell, tide, and map-reading education for surf forecasting.",
+  },
+  {
+    label: "NOAA NDBC",
+    href: "https://www.ndbc.noaa.gov/observations.shtml",
+    note: "Free buoy observations and historical observations.",
+  },
+];

--- a/app/best-surf-forecast-app/page.tsx
+++ b/app/best-surf-forecast-app/page.tsx
@@ -15,12 +15,15 @@ import { QuiverSticker, ZineSurface } from "@/components/zine";
 import { SITE_URL } from "@/lib/constants/seo";
 import { buildPageMetadata } from "@/lib/seo/meta";
 
+import {
+  COMPARISON_SOURCE_LINKS,
+  COMPARISON_SOURCE_REVIEW,
+} from "./comparison-sources";
+
 export const revalidate = 604800;
 
 const PAGE_PATH = "/best-surf-forecast-app";
 const PAGE_URL = `${SITE_URL}${PAGE_PATH}`;
-const CHECKED_ON_ISO = "2026-07-08";
-const LAST_UPDATED_LABEL = "July 8, 2026";
 const APP_STORE_URL =
   "https://apps.apple.com/us/app/surf-forecast-quiver/id6759300320";
 
@@ -46,12 +49,6 @@ interface AppComparisonRow {
   why: string;
   tradeoff: string;
   sourceHref: string;
-}
-
-interface SourceLink {
-  label: string;
-  href: string;
-  note: string;
 }
 
 const COMPARISON_ROWS: AppComparisonRow[] = [
@@ -120,55 +117,16 @@ const COMPARISON_ROWS: AppComparisonRow[] = [
   },
 ];
 
-const SOURCE_LINKS: SourceLink[] = [
-  {
-    label: "Quiver App Store listing",
-    href: APP_STORE_URL,
-    note:
-      "Quiver free listing, Pro monthly, annual, and lifetime in-app purchases, session logging, alerts, board recommendations, custom spots, and offline mode.",
-  },
-  {
-    label: "Surfline upgrade page",
-    href: "https://www.surfline.com/upgrade",
-    note:
-      "Premium and Premium+ plan positioning, 16-day forecasts, live cams, and annual pricing.",
-  },
-  {
-    label: "Surfline free vs Premium support",
-    href:
-      "https://support.surfline.com/hc/en-us/articles/32996023385243-What-do-I-get-as-a-free-vs-Premium-user",
-    note:
-      "Free, Premium, Premium with Ads, and Premium+ feature differences.",
-  },
-  {
-    label: "LazySurfer vs Quiver comparison",
-    href: "https://lazysurfer.app/compare/quiver.html",
-    note:
-      "LazySurfer pricing, cross-platform availability, and personalization framing.",
-  },
-  {
-    label: "Surf-Forecast.com app page",
-    href: "https://www.surf-forecast.com/pages/app-store",
-    note:
-      "Global spot coverage, maps, alerts, tide timing, hourly forecasts, and 16-day planning.",
-  },
-  {
-    label: "Surf Captain FAQ",
-    href: "https://surfcaptain.com/faq",
-    note:
-      "Free 5-day forecasts with ads and Surf Captain Pro 16-day forecast pricing.",
-  },
-  {
-    label: "Windy surfing guide",
-    href: "https://windy.app/guide/mini-guide-to-surfing.html",
-    note: "Wind, swell, tide, and map-reading education for surf forecasting.",
-  },
-  {
-    label: "NOAA NDBC",
-    href: "https://www.ndbc.noaa.gov/observations.shtml",
-    note: "Free buoy observations and historical observations.",
-  },
-];
+function formatVerifiedDate(lastVerified: string): string {
+  const [year, month, day] = lastVerified.split("-").map(Number);
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(Date.UTC(year, month - 1, day)));
+}
 
 function ComparisonItemListStructuredData(): ReactElement {
   const data = {
@@ -210,13 +168,13 @@ export default function BestSurfForecastAppPage(): ReactElement {
         name="Best Surf Forecast App by Surf Job in 2026"
         description="A source-backed, capability-led surf forecast app comparison by job-to-be-done."
         url={PAGE_URL}
-        dateModified={CHECKED_ON_ISO}
+        dateModified={COMPARISON_SOURCE_REVIEW.lastVerified}
       />
       <ComparisonItemListStructuredData />
 
       <ZineSurface
         sectionLabel="App comparison"
-        editionLabel={`Checked ${CHECKED_ON_ISO}`}
+        editionLabel={`Checked ${COMPARISON_SOURCE_REVIEW.lastVerified}`}
         data-testid="best-surf-forecast-app-zine-surface"
       >
         <main className="overflow-hidden text-[#11100D]">
@@ -248,12 +206,14 @@ export default function BestSurfForecastAppPage(): ReactElement {
                 Last updated
               </div>
               <p className="mt-3 font-mono text-sm font-black uppercase tracking-[0.12em] text-[#252D6B]">
-                {LAST_UPDATED_LABEL}
+                {formatVerifiedDate(COMPARISON_SOURCE_REVIEW.lastVerified)}
               </p>
               <p className="mt-3 text-sm font-semibold leading-6 text-[#252D6B]">
                 Pricing, platform, and feature notes were checked on{" "}
-                <span className="font-mono font-black">{CHECKED_ON_ISO}</span>.
-                Plans can change, so use the source links before buying.
+                <span className="font-mono font-black">
+                  {COMPARISON_SOURCE_REVIEW.lastVerified}
+                </span>. Plans can change, so use the source links before
+                buying.
               </p>
               <p className="mt-4 border-t-2 border-[#11100D] pt-3 text-sm font-black text-[#11100D]">
                 Affiliation disclosure: Quiver is our app.
@@ -286,7 +246,8 @@ export default function BestSurfForecastAppPage(): ReactElement {
               <table className="w-full min-w-[980px] border-collapse text-sm">
                 <caption className="sr-only">
                   Capability-led comparison of surf forecast apps checked on
-                  July 8, 2026.
+                  {" "}
+                  {formatVerifiedDate(COMPARISON_SOURCE_REVIEW.lastVerified)}.
                 </caption>
                 <thead>
                   <tr className="border-b-2 border-[#11100D] bg-[#11100D] text-[#F4EBD8]">
@@ -417,10 +378,12 @@ export default function BestSurfForecastAppPage(): ReactElement {
               </div>
               <p className="mt-3 text-sm font-semibold leading-6 text-[#252D6B]">
                 Source links and comparison facts were checked on{" "}
-                <span className="font-mono font-black">{CHECKED_ON_ISO}</span>.
+                <span className="font-mono font-black">
+                  {COMPARISON_SOURCE_REVIEW.lastVerified}
+                </span>.
               </p>
               <ul className="mt-5 grid gap-3">
-                {SOURCE_LINKS.map((source) => (
+                {COMPARISON_SOURCE_LINKS.map((source) => (
                   <li
                     key={source.label}
                     className="border-t-2 border-[#11100D]/25 pt-3"

--- a/app/best-time-to-surf/[city]/page.tsx
+++ b/app/best-time-to-surf/[city]/page.tsx
@@ -35,6 +35,7 @@ import { AnimatedScoreGauge } from "@/components/forecast/animated-score-gauge";
 import { MonthlySurfChart } from "@/components/best-time-to-surf/monthly-chart";
 import { MonthlyViewToggle } from "@/components/best-time-to-surf/monthly-view-toggle";
 import { ScrollReveal } from "@/components/ui/scroll-reveal";
+import { QuiverSticker } from "@/components/zine/quiver-sticker";
 import { InlineSignupCta } from "@/components/seo/inline-signup-cta";
 import {
   SeoFunnelNextSteps,
@@ -582,7 +583,12 @@ export default async function BestTimeToSurfPage(props: PageParams) {
                   {liveAnswerCopy.todayAnswer}
                 </p>
 
-                <div className="mb-5 rounded-lg border border-[#11100D]/15 bg-white p-5 text-[#11100D] shadow-sm">
+                <div className="relative mb-5 rounded-lg border border-[#11100D]/15 bg-white p-5 text-[#11100D] shadow-sm">
+                  <QuiverSticker
+                    sticker="spotTideWindow"
+                    className="absolute -right-3 -top-6 w-20 rotate-6 drop-shadow-md sm:w-24"
+                    sizes="96px"
+                  />
                   <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#655C4C]">
                     {liveAnswerCopy.eyebrow}
                   </p>
@@ -618,7 +624,12 @@ export default async function BestTimeToSurfPage(props: PageParams) {
                 </div>
 
                 {/* Current month hero card */}
-                <div className="flex flex-col items-center gap-6 rounded-lg border border-[#11100D]/15 bg-gradient-to-br from-[#FBF6E8]/95 to-[#EEE3C9]/75 p-6 text-[#11100D] shadow-[0_18px_38px_rgba(17,16,13,0.14)] md:flex-row md:p-8">
+                <div className="relative flex flex-col items-center gap-6 overflow-hidden rounded-lg border border-[#11100D]/15 bg-gradient-to-br from-[#FBF6E8]/95 to-[#EEE3C9]/75 p-6 text-[#11100D] shadow-[0_18px_38px_rgba(17,16,13,0.14)] md:flex-row md:p-8">
+                  <QuiverSticker
+                    sticker="spotBestSeason"
+                    className="absolute -right-4 -top-4 w-24 rotate-12 opacity-90 drop-shadow-md md:w-28"
+                    sizes="112px"
+                  />
                   {/* Seasonal average, not a live call — no "Go now!" (#569) */}
                   <AnimatedScoreGauge
                     score={currentMonthData.score}

--- a/app/best-time-to-surf/[city]/page.tsx
+++ b/app/best-time-to-surf/[city]/page.tsx
@@ -661,10 +661,13 @@ export default async function BestTimeToSurfPage(props: PageParams) {
                 </div>
               </div>
               {heroScene && (
+                /* 4:3 rather than stretched to the column height: a 16:9 photo
+                   forced that tall only shows ~37% of its width. */
                 <SeoScenePanel
                   scene={heroScene}
                   priority
-                  mediaClassName="h-full min-h-[300px] lg:min-h-full"
+                  className="lg:self-start"
+                  mediaClassName="aspect-[4/3] min-h-[240px]"
                 />
               )}
             </div>

--- a/app/best-time-to-surf/[city]/page.tsx
+++ b/app/best-time-to-surf/[city]/page.tsx
@@ -619,10 +619,12 @@ export default async function BestTimeToSurfPage(props: PageParams) {
 
                 {/* Current month hero card */}
                 <div className="flex flex-col items-center gap-6 rounded-lg border border-[#11100D]/15 bg-gradient-to-br from-[#FBF6E8]/95 to-[#EEE3C9]/75 p-6 text-[#11100D] shadow-[0_18px_38px_rgba(17,16,13,0.14)] md:flex-row md:p-8">
+                  {/* Seasonal average, not a live call — no "Go now!" (#569) */}
                   <AnimatedScoreGauge
                     score={currentMonthData.score}
                     size="xl"
                     showLabel
+                    showAction={false}
                   />
                   <div className="text-center md:text-left">
                     <p className="mb-1 text-sm font-medium uppercase tracking-wide text-[#655C4C]">

--- a/app/dev/session-intelligence-preview/page.tsx
+++ b/app/dev/session-intelligence-preview/page.tsx
@@ -49,6 +49,7 @@ function recommendationFixture(
     startIso: "2026-06-03T14:00:00.000Z",
     endIso: "2026-06-03T16:30:00.000Z",
     peakIso: "2026-06-03T15:00:00.000Z",
+    timezone: "America/Los_Angeles",
     forecastAt: "2026-06-03T14:00:00.000Z",
     localTimeLabel: getPreviewLocalTimeLabel(rank),
     score: 86 - rank * 8,

--- a/app/forecast/[beachId]/page.tsx
+++ b/app/forecast/[beachId]/page.tsx
@@ -15,6 +15,7 @@ import { formatFullDateWithYear } from "@/lib/utils/date-time";
 import { getRegionalSummary } from "@/lib/utils/forecast-hub-utils";
 import { getBeachesForRegion } from "@/lib/utils/regional-forecast-utils";
 import { getStaticMapImageUrl } from "@/lib/map-utils";
+import { getCurrentUser } from "@/lib/auth/admin";
 import { getBeaches } from "@/actions/beach/beach-query-actions";
 import { buildPageMetadata } from "@/lib/seo/meta";
 import { BreadcrumbStructuredData } from "@/components/seo/breadcrumb-schema";
@@ -108,6 +109,7 @@ export default async function ForecastPage(props: {
  * Enhanced with ocean background, animated gauges, and scroll reveals.
  */
 async function renderRegionalForecast(region: typeof FORECAST_REGIONS[string]) {
+  const user = await getCurrentUser();
   // Fetch all beaches once
   const beachesResult = await getBeaches();
   if (!beachesResult.success || !beachesResult.data) {
@@ -347,6 +349,7 @@ async function renderRegionalForecast(region: typeof FORECAST_REGIONS[string]) {
             showViewAll={true}
             className="mb-16"
             variant="zine"
+            showScores={user !== null}
           />
 
           <ScrollReveal variant="fadeUp" delay={200}>

--- a/app/forecast/[beachId]/page.tsx
+++ b/app/forecast/[beachId]/page.tsx
@@ -298,13 +298,15 @@ async function renderRegionalForecast(region: typeof FORECAST_REGIONS[string]) {
             <TopRankedBeachHero
               beach={topBeach}
               regionName={region.name}
-              beachTimezone={topBeachRecord?.timezone}
+              now={summary.generatedAt}
               imageUrl={approvedTopBeachImage}
               mapImageUrl={satelliteFallbackUrl}
               bestSurfWindow={
-                summary.bestSurfWindows?.find(
-                  (window) => window.beach.id === topBeach.beachId,
-                ) ?? null
+                summary.recommendationAvailability?.state === "available"
+                  ? summary.bestSurfWindows?.find(
+                      (window) => window.beach.id === topBeach.beachId,
+                    ) ?? null
+                  : null
               }
             />
           )}

--- a/app/forecast/[beachId]/page.tsx
+++ b/app/forecast/[beachId]/page.tsx
@@ -144,7 +144,25 @@ async function renderRegionalForecast(region: typeof FORECAST_REGIONS[string]) {
   const summary = await getRegionalSummary(region, beaches, {
     includeBestSurfWindows: true,
   });
-  const topBeach = summary.beachConditions[0] ?? null;
+  // The hero answers "where do I surf now", which is a question about a
+  // surfable SESSION, not an instantaneous score. Lead with the region's best
+  // window so its beach, score, and window all come from one selection; a
+  // beach ranked first on a momentary score but carrying no qualifying window
+  // is what produced "EPIC" beside "No qualifying window". When nothing is
+  // live right now the window engine's next-best entry still answers the
+  // question, so point at that rather than going silent.
+  const leadWindow =
+    summary.recommendationAvailability?.state === "available"
+      ? summary.bestSurfWindows?.[0] ?? null
+      : null;
+  const topBeach =
+    (leadWindow
+      ? summary.beachConditions.find(
+          (condition) => condition.beachId === leadWindow.beach.id,
+        )
+      : null) ??
+    summary.beachConditions[0] ??
+    null;
   const topBeachRecord = topBeach
     ? beaches.find((beach) => beach.id === topBeach.beachId)
     : null;

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -132,7 +132,7 @@ export default async function LearnArticlePage({ params }: Props) {
             <span className="text-[#11100D]">{article.title}</span>
           </nav>
 
-          <header className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
+          <header className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-stretch">
             <ScrollReveal>
               <div className="relative">
                 <QuiverSticker
@@ -157,8 +157,8 @@ export default async function LearnArticlePage({ params }: Props) {
               </div>
             </ScrollReveal>
 
-            <ScrollReveal delay={80}>
-              <div className="polaroid rot-2">
+            <ScrollReveal delay={80} className="lg:h-full">
+              <div className="polaroid polaroid-fill rot-2">
                 <div className="photo">
                   <Image
                     src={article.heroImage}

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -259,7 +259,7 @@ export default function LearnHubPage() {
                   <ScrollReveal key={article.slug} delay={articleIndex * 60}>
                     <Link
                       href={`/learn/${article.slug}`}
-                      className="group torn torn-tb flex min-h-[22rem] flex-col overflow-hidden border-2 border-[#11100D] bg-[#FBF6E8] transition-transform hover:-translate-y-1"
+                      className="group torn flex min-h-[22rem] flex-col overflow-hidden border-2 border-[#11100D] bg-[#FBF6E8] transition-transform hover:-translate-y-1"
                     >
                       <div className="relative mb-4 h-36 overflow-hidden border-2 border-[#11100D] bg-[#C8C2B0]">
                         <Image
@@ -301,7 +301,7 @@ export default function LearnHubPage() {
                   <Link
                     key={link.href}
                     href={link.href}
-                    className="group torn torn-tb relative flex min-h-44 flex-col overflow-hidden border-2 border-[#11100D] bg-[#F0E5CC] p-5 transition-transform hover:-translate-y-1"
+                    className="group torn relative flex min-h-44 flex-col overflow-hidden border-2 border-[#11100D] bg-[#F0E5CC] p-5 transition-transform hover:-translate-y-1"
                   >
                     <QuiverSticker
                       sticker={link.sticker}

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -494,6 +494,15 @@
 .zine-tab .zine-h1 {
   font-size: clamp(48px, 8vw, 96px);
 }
+.zine-tab .zine-h1-suffix {
+  display: block;
+  margin-top: 0.32em;
+  color: var(--stamp-blue);
+  font-family: var(--f-stencil);
+  font-size: clamp(17px, 2.4vw, 28px);
+  letter-spacing: 0.055em;
+  line-height: 1.05;
+}
 @media (max-width: 640px) {
   .zine-tab .zine-h1 {
     font-size: 44px;

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -25,6 +25,10 @@
   --q-orange: #F78E42;
   --q-cream: #F5EEDC;
 
+  /* torn paper geometry */
+  --zine-torn-edge-depth: 16px;
+  --zine-torn-inset: 20px;
+
   /* font stacks — first family is the next/font variable, then design fallbacks */
   --f-rough: var(--font-zine-display), 'Bowlby One', 'Big Shoulders Stencil', var(--font-heading), 'Space Grotesk', sans-serif;
   --f-stencil: var(--font-zine-display), 'Bowlby One', var(--font-heading), 'Space Grotesk', sans-serif;
@@ -129,16 +133,16 @@
 .zine-tab .zine-paper > * { position: relative; z-index: 1; }
 
 /* ─── Universal: torn paper module ───────────────────────── */
-.zine-tab .torn {
+:where(.zine-tab) .torn {
   position: relative;
   background: var(--paper);
   background-image: radial-gradient(circle at 30% 70%, rgba(0,0,0,0.04), transparent 60%);
-  padding: 16px 18px;
+  padding: var(--zine-torn-inset);
   box-shadow:
     2px 3px 0 rgba(0,0,0,0.18),
     0 8px 18px rgba(0,0,0,0.12);
 }
-.zine-tab .torn::before {
+:where(.zine-tab) .torn::before {
   content: "";
   position: absolute; inset: 0;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='9'/><feColorMatrix values='0 0 0 0 0.32 0 0 0 0 0.25 0 0 0 0 0.15 0 0 0 0.13 0'/></filter><rect width='100%25' height='100%25' filter='url(%23g)'/></svg>");
@@ -150,11 +154,21 @@
 /* deckled edge masks for torn modules — top + bottom torn */
 .zine-tab .torn-tb {
   -webkit-mask-image:
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100' preserveAspectRatio='none'><path d='M0,8 C40,4 70,14 110,7 C150,1 190,12 230,5 C270,1 310,11 350,4 C390,2 430,13 470,7 C510,2 550,12 600,5 C650,1 690,11 730,5 C770,1 820,12 860,5 C900,2 940,11 1000,6 L1000,94 C950,98 910,88 870,95 C820,99 770,89 720,95 C670,99 630,88 590,94 C540,99 500,89 450,95 C400,99 360,88 320,94 C270,99 220,88 180,94 C140,99 80,89 40,95 C20,98 0,94 0,94 Z' fill='black'/></svg>");
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 16' preserveAspectRatio='none'><path d='M0,7 C40,3 70,10 110,6 C150,1 190,9 230,5 C270,2 310,9 350,4 C390,2 430,10 470,6 C510,2 550,9 600,5 C650,1 690,9 730,5 C770,2 820,10 860,5 C900,2 940,9 1000,5 L1000,16 L0,16 Z' fill='black'/></svg>"),
+    linear-gradient(black, black),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 16' preserveAspectRatio='none'><path d='M0,0 H1000 V10 C950,15 910,7 870,12 C820,15 770,8 720,12 C670,15 630,7 590,11 C540,15 500,8 450,12 C400,15 360,7 320,11 C270,15 220,7 180,11 C140,15 80,8 40,12 C20,15 0,11 0,11 Z' fill='black'/></svg>");
   mask-image:
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100' preserveAspectRatio='none'><path d='M0,8 C40,4 70,14 110,7 C150,1 190,12 230,5 C270,1 310,11 350,4 C390,2 430,13 470,7 C510,2 550,12 600,5 C650,1 690,11 730,5 C770,1 820,12 860,5 C900,2 940,11 1000,6 L1000,94 C950,98 910,88 870,95 C820,99 770,89 720,95 C670,99 630,88 590,94 C540,99 500,89 450,95 C400,99 360,88 320,94 C270,99 220,88 180,94 C140,99 80,89 40,95 C20,98 0,94 0,94 Z' fill='black'/></svg>");
-  -webkit-mask-size: 100% 100%;
-  mask-size: 100% 100%;
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 16' preserveAspectRatio='none'><path d='M0,7 C40,3 70,10 110,6 C150,1 190,9 230,5 C270,2 310,9 350,4 C390,2 430,10 470,6 C510,2 550,9 600,5 C650,1 690,9 730,5 C770,2 820,10 860,5 C900,2 940,9 1000,5 L1000,16 L0,16 Z' fill='black'/></svg>"),
+    linear-gradient(black, black),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 16' preserveAspectRatio='none'><path d='M0,0 H1000 V10 C950,15 910,7 870,12 C820,15 770,8 720,12 C670,15 630,7 590,11 C540,15 500,8 450,12 C400,15 360,7 320,11 C270,15 220,7 180,11 C140,15 80,8 40,12 C20,15 0,11 0,11 Z' fill='black'/></svg>");
+  -webkit-mask-position: top, center, bottom;
+  mask-position: top, center, bottom;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: 100% var(--zine-torn-edge-depth), 100% calc(100% - var(--zine-torn-edge-depth) - var(--zine-torn-edge-depth)), 100% var(--zine-torn-edge-depth);
+  mask-size: 100% var(--zine-torn-edge-depth), 100% calc(100% - var(--zine-torn-edge-depth) - var(--zine-torn-edge-depth)), 100% var(--zine-torn-edge-depth);
+  -webkit-mask-composite: source-over, source-over;
+  mask-composite: add, add;
 }
 
 /* ─── Tape pieces ────────────────────────────────────────── */
@@ -398,6 +412,16 @@
 .zine-tab .rot-3 { transform: rotate(-1.4deg); }
 .zine-tab .rot-4 { transform: rotate(2deg); }
 .zine-tab .rot-neg { transform: rotate(-2.2deg); }
+
+@media (max-width: 900px) {
+  .zine-tab .rot-1,
+  .zine-tab .rot-2,
+  .zine-tab .rot-3,
+  .zine-tab .rot-4,
+  .zine-tab .rot-neg {
+    transform: none;
+  }
+}
 
 /* ─── Mobile (<= 640px) ─────────────────────────────────── */
 @media (max-width: 640px) {

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -500,8 +500,17 @@
 }
 
 /* ─── Page H1 (zine is the page) ─────────────────────────── */
+/* Display type sizes off the viewport, which overflows when the heading sits in
+   a narrow grid column — a long unbreakable word (e.g. "ALTERNATIVE?") renders
+   wider than its track and spills over neighbouring content. Inside a
+   `.zine-measure` container the `cqw` term sizes off the COLUMN instead; with
+   no container ancestor `cqw` resolves against the viewport, where the larger
+   value loses the `min()` and behaviour is unchanged. */
 .zine-tab .zine-h1 {
-  font-size: clamp(48px, 8vw, 96px);
+  font-size: clamp(48px, min(8vw, 13cqw), 96px);
+}
+.zine-measure {
+  container-type: inline-size;
 }
 .zine-tab .zine-h1-suffix {
   display: block;

--- a/app/styles/zine.css
+++ b/app/styles/zine.css
@@ -365,6 +365,15 @@
   line-height: 1.05;
   text-align: center;
 }
+/* Polaroid beside a tall display headline: goes portrait so it rises to the top
+   of its track instead of sitting bottom-aligned under a column of dead space.
+   Stops short of filling the full height — a landscape photo cropped that
+   narrow loses its composition. */
+@media (min-width: 1024px) {
+  .zine-tab .polaroid.polaroid-fill .photo {
+    aspect-ratio: 3 / 4;
+  }
+}
 
 /* spot summary strip */
 .zine-tab .summary-strip {

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -134,17 +134,6 @@ const TOOLS = [
   },
 ];
 
-const TOOL_CARD_ROTATIONS = [
-  "rot-1",
-  "rot-2",
-  "rot-3",
-  "rot-4",
-  "rot-neg",
-  "rot-1",
-  "rot-2",
-  "rot-3",
-] as const;
-
 export default function ToolsIndexPage(): ReactElement {
   return (
     <>
@@ -360,11 +349,7 @@ export default function ToolsIndexPage(): ReactElement {
                     <ScrollReveal key={tool.slug} delay={(index % 3) * 50}>
                       <Link
                         href={href}
-                        className={`group block h-full border-2 border-[#11100D] bg-[#FBF6E8] p-3 shadow-[2px_3px_0_rgba(17,16,13,0.22)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] ${
-                          TOOL_CARD_ROTATIONS[
-                            index % TOOL_CARD_ROTATIONS.length
-                          ]
-                        }`}
+                        className="group block h-full border-2 border-[#11100D] bg-[#FBF6E8] p-3 shadow-[2px_3px_0_rgba(17,16,13,0.22)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42]"
                       >
                         <div className="relative overflow-hidden border-2 border-[#11100D] bg-[#D9C49C]">
                           <div className="relative aspect-[16/10]">

--- a/app/vs/surfline/free/live-cam-card.tsx
+++ b/app/vs/surfline/free/live-cam-card.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { Camera, MapPin } from "lucide-react";
+
+import type { CamBeachWithRegion } from "@/actions/beach/cam-actions";
+import {
+  CAM_CARD_FALLBACK_IMAGE_URL,
+  getDisplayCamThumbnailUrls,
+} from "@/lib/media/cam-thumbnail";
+import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+import { getProxiedImageUrl } from "@/lib/utils/image-utils";
+
+interface LiveCamCardProps {
+  beach: CamBeachWithRegion;
+}
+
+export function LiveCamCard({ beach }: LiveCamCardProps): ReactElement {
+  const imageUrls = useMemo(
+    () =>
+      getDisplayCamThumbnailUrls({
+        cameraUrl: beach.camera_url,
+        thumbnailUrl: beach.thumbnail_url,
+        fallbackImageUrl: beach.photo_url,
+      })
+        .filter((url) => url !== CAM_CARD_FALLBACK_IMAGE_URL)
+        .map(getProxiedImageUrl)
+        .filter(Boolean),
+    [beach.camera_url, beach.photo_url, beach.thumbnail_url],
+  );
+  const [imageIndex, setImageIndex] = useState(0);
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  const imageUrl = imageUrls[imageIndex] ?? null;
+  const location = `${beach.city}, ${beach.state}`;
+  const href = buildBeachUrl({
+    slug: beach.slug,
+    city: beach.city,
+    state: beach.state,
+  });
+
+  const handleImageError = useCallback((): void => {
+    setImageIndex((currentIndex) => currentIndex + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!imageUrl) return;
+
+    const image = imageRef.current;
+    if (!image?.complete || image.naturalWidth > 0) return;
+
+    handleImageError();
+  }, [handleImageError, imageUrl]);
+
+  return (
+    <Link
+      href={href}
+      aria-label={`Watch the ${beach.name} live cam in ${location}`}
+      className="group block overflow-hidden rounded-md border-2 border-[#11100D] bg-[#FFFDF7] shadow-[3px_3px_0_rgba(17,16,13,0.18)] transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#F4EBD8]"
+    >
+      <div className="relative aspect-[16/9] overflow-hidden border-b-2 border-[#11100D] bg-[#F0E5CC]">
+        {imageUrl ? (
+          <Image
+            key={imageUrl}
+            ref={imageRef}
+            src={imageUrl}
+            alt={`${beach.name} live surf cam preview`}
+            fill
+            sizes="(max-width: 639px) 50vw, (max-width: 767px) 33vw, (max-width: 1280px) 25vw, 304px"
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+            onError={handleImageError}
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            data-testid="live-cam-image-fallback"
+            className="absolute inset-0 flex items-center justify-center overflow-hidden bg-[#F0E5CC] text-[#11100D]"
+          >
+            <div className="absolute inset-0 opacity-20 [background-image:radial-gradient(circle_at_1px_1px,#11100D_1px,transparent_0)] [background-size:9px_9px]" />
+            <div className="absolute -bottom-8 left-[-8%] h-16 w-[116%] rotate-[-3deg] border-t-2 border-[#11100D] bg-[#D9C49C]" />
+            <div className="relative flex rotate-[-2deg] items-center gap-2 border-2 border-[#11100D] bg-[#FBF6E8] px-3 py-2 shadow-[3px_3px_0_rgba(17,16,13,0.22)]">
+              <Camera className="h-5 w-5" strokeWidth={2.5} />
+              <span className="font-mono text-[9px] font-black uppercase tracking-[0.12em]">
+                Cam at the coast
+              </span>
+            </div>
+          </div>
+        )}
+
+        <span className="absolute left-2 top-2 z-10 inline-flex items-center gap-1.5 border-2 border-[#11100D] bg-[#FBF6E8] px-2 py-1 font-mono text-[8px] font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.24)]">
+          <span className="h-1.5 w-1.5 rounded-full bg-[#00A884]" aria-hidden="true" />
+          Live
+        </span>
+      </div>
+
+      <div className="min-w-0 px-2.5 py-2">
+        <div className="truncate font-heading text-xs font-black uppercase leading-tight text-[#11100D] sm:text-sm">
+          {beach.name}
+        </div>
+        <div className="mt-1 flex min-w-0 items-center gap-1 font-mono text-[8px] font-bold uppercase tracking-[0.08em] text-[#6B6557] sm:text-[9px]">
+          <MapPin className="h-3 w-3 shrink-0 text-[#9E5010]" aria-hidden="true" />
+          <span className="truncate">{location}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/app/vs/surfline/free/page-content.tsx
+++ b/app/vs/surfline/free/page-content.tsx
@@ -410,7 +410,7 @@ export default async function VsSurflineFreePage() {
         />
 
         <div className="relative mx-auto grid max-w-7xl gap-7 lg:grid-cols-[minmax(0,1.02fr)_minmax(380px,0.98fr)] lg:items-end">
-          <div className="relative space-y-5 md:space-y-7">
+          <div className="zine-measure relative space-y-5 md:space-y-7">
             <QuiverSticker
               sticker="orangeTape"
               className="absolute -top-10 right-2 hidden w-32 rotate-[5deg] opacity-90 lg:block"

--- a/app/vs/surfline/free/page-content.tsx
+++ b/app/vs/surfline/free/page-content.tsx
@@ -542,7 +542,7 @@ export default async function VsSurflineFreePage() {
               the short answer
             </div>
             <p className="font-heading text-2xl font-black leading-tight md:text-4xl">
-              Yes — Quiver is a free-to-browse Surfline alternative for the US,
+              Yes — Quiver is a free Surfline alternative for the US,
               Hawaii, Puerto Rico, and Baja. You read any beach&apos;s forecast,
               tide, and cams without paying. The personalization that learns your
               sessions is the optional Pro layer.

--- a/app/vs/surfline/free/page-content.tsx
+++ b/app/vs/surfline/free/page-content.tsx
@@ -34,7 +34,7 @@ import { FAQSchema } from "@/components/seo/faq-schema";
 import { QuiverSticker, ZineSurface } from "@/components/zine";
 import { SITE_URL } from "@/lib/constants/seo";
 import { getBeachesWithCameras } from "@/actions/beach/cam-actions";
-import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
+import { LiveCamCard } from "@/app/vs/surfline/free/live-cam-card";
 import {
   FadeInSection,
   AnimatedStickerBadge,
@@ -624,33 +624,9 @@ export default async function VsSurflineFreePage() {
                 {camCount} live cams
               </span>
             </div>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
               {camBeaches.slice(0, 12).map((b) => (
-                <Link
-                  key={b.id}
-                  href={buildBeachUrl({ slug: b.slug, city: b.city, state: b.state })}
-                  className="rounded-md overflow-hidden border border-[#11100D] block"
-                >
-                  <div className="h-12 bg-gradient-to-br from-[#3a4896] to-[#252D6B] relative">
-                    <span className="absolute top-1 left-1 flex items-center gap-1">
-                      <span
-                        className="w-1.5 h-1.5 rounded-full bg-[#00D4AA]"
-                        aria-hidden
-                      />
-                      <span className="font-mono text-[7px] tracking-wider text-white">
-                        LIVE
-                      </span>
-                    </span>
-                  </div>
-                  <div className="bg-[#FFFDF7] px-1.5 py-1">
-                    <div className="font-sans text-[10px] font-medium text-[#11100D] leading-tight truncate">
-                      {b.name}
-                    </div>
-                    <div className="font-mono text-[7px] tracking-wide text-[#6b6557] uppercase">
-                      {b.city}, {b.state}
-                    </div>
-                  </div>
-                </Link>
+                <LiveCamCard key={b.id} beach={b} />
               ))}
             </div>
             <Link

--- a/components/app-store/beach-subpage-cta-switch.tsx
+++ b/components/app-store/beach-subpage-cta-switch.tsx
@@ -80,6 +80,7 @@ export function BeachSubPageCtaSwitch({
             beachId={beachId}
             beachName={beachName}
             source={`${source}-inline`}
+            variant="paper"
           />
         </div>
       )}

--- a/components/app-store/beach-subpage-cta-switch.tsx
+++ b/components/app-store/beach-subpage-cta-switch.tsx
@@ -8,18 +8,16 @@ import {
 } from "react";
 
 import { InstallAppCtaSection } from "@/components/app-store/install-app-cta-section";
-import { AlertCaptureCta } from "@/components/seo/alert-capture-cta";
 import { StickySignupBar } from "@/components/ui/sticky-signup-bar";
 import { shouldShowBeachSubPageInstallCta } from "@/lib/app-store/beach-subpage-install-cta";
 
 interface BeachSubPageCtaSwitchProps {
-  beachId: string;
   beachName: string;
-  children: ReactNode;
+  /** Optional wrapped content; the sub-page below-fold sections were removed. */
+  children?: ReactNode;
   installCtaEnabled: boolean;
   placement: string;
   pathname: string;
-  pageType: "tides" | "water-temp";
   proof?: { value: string; label: string };
   searchReferralCta: { ctaText: string; supportingText: string };
   source: string;
@@ -28,13 +26,11 @@ interface BeachSubPageCtaSwitchProps {
 }
 
 export function BeachSubPageCtaSwitch({
-  beachId,
   beachName,
   children,
   installCtaEnabled,
   placement,
   pathname,
-  pageType,
   proof,
   searchReferralCta,
   source,
@@ -73,17 +69,7 @@ export function BeachSubPageCtaSwitch({
             proof={proof}
           />
         </div>
-      ) : (
-        <div className="container mx-auto px-4 py-8">
-          <AlertCaptureCta
-            pageContext={pageType}
-            beachId={beachId}
-            beachName={beachName}
-            source={`${source}-inline`}
-            variant="paper"
-          />
-        </div>
-      )}
+      ) : null}
 
       {children}
 

--- a/components/app-store/send-to-phone-cta.tsx
+++ b/components/app-store/send-to-phone-cta.tsx
@@ -195,12 +195,12 @@ export function SendToPhoneCta({
   return (
     <div
       className={cn(
-        "rounded-[1.25rem] border border-white/12 bg-header-end p-6 text-white shadow-[0_18px_60px_rgba(0,0,0,0.24)]",
+        "rounded-[1.25rem] border-2 border-[#11100D] bg-[#EFE5CF] p-6 text-[#11100D] shadow-[5px_6px_0_#11100D]",
         className,
       )}
     >
       <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
-        <div className="mx-auto shrink-0 -rotate-1 rounded-[1.1rem] bg-white p-3 shadow-md">
+        <div className="mx-auto shrink-0 -rotate-1 rounded-[1.1rem] border-2 border-[#11100D] bg-[#F4EBD8] p-3 shadow-[3px_3px_0_#11100D]">
           {qrValue ? (
             <QRCodeSVG
               aria-label="Scan to open Quiver on your phone"
@@ -210,8 +210,10 @@ export function SendToPhoneCta({
               size={150}
               level="H"
               marginSize={3}
-              bgColor="#FFFFFF"
-              fgColor="#252D6B"
+              bgColor="#F4EBD8"
+              fgColor="#11100D"
+              data-background-color="#F4EBD8"
+              data-foreground-color="#11100D"
               imageSettings={{
                 src: "/quiver-app-icon-128.png",
                 width: 28,
@@ -228,7 +230,7 @@ export function SendToPhoneCta({
         </div>
 
         <div className="min-w-0 flex-1">
-          <p className="font-sans text-sm leading-6 text-white/80">
+          <p className="font-sans text-sm leading-6 text-[#11100D]/80">
             {showEmailForm
               ? "Scan to get Quiver on your phone, or email yourself the link."
               : "Scan with your phone to open Quiver."}
@@ -238,7 +240,7 @@ export function SendToPhoneCta({
             <form onSubmit={onSubmit} className="mt-3" noValidate>
               <label
                 htmlFor="send-to-phone-email"
-                className="block font-sans text-xs font-semibold uppercase tracking-widest text-white/60"
+                className="block font-sans text-xs font-semibold uppercase tracking-widest text-[#11100D]/65"
               >
                 Your email
               </label>
@@ -251,12 +253,12 @@ export function SendToPhoneCta({
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}
                   placeholder="you@email.com"
-                  className="min-h-11 flex-1 rounded-md border border-white/12 bg-white/10 px-3 font-sans text-base text-white placeholder:text-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-blue-decorative"
+                  className="min-h-11 flex-1 rounded-md border border-[#11100D] bg-[#F4EBD8] px-3 font-sans text-base text-[#11100D] placeholder:text-[#11100D]/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EFE5CF]"
                 />
                 <button
                   type="submit"
                   disabled={state === "sending" || !handoffId}
-                  className="inline-flex min-h-11 items-center justify-center rounded-md bg-ocean-blue-decorative px-5 font-sans text-base font-bold text-header-end transition hover:bg-[#D57835] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white active:bg-[#C06A25] disabled:opacity-60"
+                  className="inline-flex min-h-11 items-center justify-center rounded-md border border-[#11100D] bg-ocean-blue-decorative px-5 font-sans text-base font-bold text-[#11100D] transition hover:bg-[#D57835] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#11100D] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EFE5CF] active:bg-[#C06A25] disabled:opacity-60"
                 >
                   {state === "sending" ? "Sending..." : "Send link"}
                 </button>
@@ -267,14 +269,14 @@ export function SendToPhoneCta({
                 className="mt-2 min-h-5 font-sans text-sm"
               >
                 {inlineError ? (
-                  <span className="text-sunset-orange">{inlineError}</span>
+                  <span className="text-[#9A3412]">{inlineError}</span>
                 ) : null}
                 {statusCopy ? (
                   <span
                     className={
                       state === "sent"
-                        ? "text-emerald-300"
-                        : "text-sunset-orange"
+                        ? "text-[#006B5F]"
+                        : "text-[#9A3412]"
                     }
                   >
                     {statusCopy}
@@ -286,7 +288,7 @@ export function SendToPhoneCta({
 
           <a
             href={IOS_APP_STORE_WEB_REDIRECT_PATH}
-            className="mt-2 inline-block font-sans text-sm text-white/72 underline underline-offset-2 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-blue-decorative"
+            className="mt-2 inline-block font-sans text-sm text-[#11100D]/75 underline underline-offset-2 hover:text-[#11100D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EFE5CF]"
           >
             Open App Store anyway
           </a>

--- a/components/beach-detail.tsx
+++ b/components/beach-detail.tsx
@@ -243,6 +243,8 @@ interface BeachDetailProps {
   waterQuality?: WaterQuality | null;
   beachPhoto?: ZineBeachPhoto | null;
   heroHeadingLevel?: ZineHeroHeadingLevel;
+  heroHeadingSuffix?: string;
+  heroSummarySlot?: ReactNode;
   heroForecastSlot?: ReactNode;
   beforeTabsContent?: ReactNode;
   afterTabsContent?: ReactNode;
@@ -274,6 +276,8 @@ function BeachDetailContent({
   waterQuality,
   beachPhoto,
   heroHeadingLevel,
+  heroHeadingSuffix,
+  heroSummarySlot,
   heroForecastSlot,
   beforeTabsContent,
   afterTabsContent,
@@ -986,6 +990,8 @@ function BeachDetailContent({
         beachPhoto={beachPhoto}
         sources={sources}
         heroHeadingLevel={heroHeadingLevel}
+        heroHeadingSuffix={heroHeadingSuffix}
+        heroSummarySlot={heroSummarySlot}
         heroForecastSlot={heroForecastSlot}
       >
         <div ref={signupCtaRef} />

--- a/components/beach-detail/authenticated-forecast-decision.tsx
+++ b/components/beach-detail/authenticated-forecast-decision.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { useAuth } from "@/context/auth-context";
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+
+interface AuthenticatedForecastDecision {
+  report: SurfCallResult | null;
+  context: ForecastRecommendationContext | null;
+  isTomorrow: boolean;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  isProvided: boolean;
+}
+
+type ForecastDecisionState = Omit<
+  AuthenticatedForecastDecision,
+  "isAuthenticated" | "isProvided"
+>;
+
+const DEFAULT_DECISION: ForecastDecisionState = {
+  report: null,
+  context: null,
+  isTomorrow: false,
+  isLoading: false,
+};
+
+const DEFAULT_CONTEXT: AuthenticatedForecastDecision = {
+  ...DEFAULT_DECISION,
+  isAuthenticated: false,
+  isProvided: false,
+};
+
+const AuthenticatedForecastDecisionContext =
+  createContext<AuthenticatedForecastDecision>(DEFAULT_CONTEXT);
+
+interface AuthenticatedForecastDecisionProviderProps {
+  beachId: string;
+  children: ReactNode;
+}
+
+export function AuthenticatedForecastDecisionProvider({
+  beachId,
+  children,
+}: AuthenticatedForecastDecisionProviderProps) {
+  const { user, isLoading: authLoading } = useAuth();
+  const userId = user?.id;
+  const [decision, setDecision] = useState<ForecastDecisionState>(
+    DEFAULT_DECISION,
+  );
+
+  useEffect(() => {
+    if (!userId) {
+      setDecision(DEFAULT_DECISION);
+      return;
+    }
+
+    const controller = new AbortController();
+    setDecision((current) => ({ ...current, isLoading: true }));
+
+    async function fetchDecision(): Promise<void> {
+      try {
+        const response = await fetch(`/api/surf/call?beachId=${beachId}`, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          setDecision(DEFAULT_DECISION);
+          return;
+        }
+
+        const payload = await response.json();
+        const data = payload?.data;
+        if (!data?.report) {
+          setDecision(DEFAULT_DECISION);
+          return;
+        }
+
+        setDecision({
+          report: data.report as SurfCallResult,
+          context:
+            (data.forecastContext as ForecastRecommendationContext | null) ??
+            null,
+          isTomorrow: Boolean(data.isTomorrow),
+          isLoading: false,
+        });
+      } catch (error) {
+        if ((error as Error).name === "AbortError") return;
+        setDecision(DEFAULT_DECISION);
+      }
+    }
+
+    void fetchDecision();
+    return () => controller.abort();
+  }, [beachId, userId]);
+
+  const value = useMemo(
+    () => ({
+      ...decision,
+      isLoading: authLoading || decision.isLoading,
+      isAuthenticated: Boolean(userId),
+      isProvided: true,
+    }),
+    [authLoading, decision, userId],
+  );
+
+  return (
+    <AuthenticatedForecastDecisionContext.Provider value={value}>
+      {children}
+    </AuthenticatedForecastDecisionContext.Provider>
+  );
+}
+
+export function useAuthenticatedForecastDecision(): AuthenticatedForecastDecision {
+  return useContext(AuthenticatedForecastDecisionContext);
+}

--- a/components/beach-detail/authenticated-forecast-decision.tsx
+++ b/components/beach-detail/authenticated-forecast-decision.tsx
@@ -19,6 +19,7 @@ interface AuthenticatedForecastDecision {
   isTomorrow: boolean;
   isLoading: boolean;
   isAuthenticated: boolean;
+  /** False when no provider is mounted above the consumer (legacy /beach/[slug] route) — tells it to keep its own fetch. */
   isProvided: boolean;
 }
 

--- a/components/beach-detail/forecast-decision-login-link.tsx
+++ b/components/beach-detail/forecast-decision-login-link.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+interface ForecastDecisionLoginLinkProps {
+  returnTo: string;
+  compact?: boolean;
+}
+
+export function ForecastDecisionLoginLink({
+  returnTo,
+  compact = false,
+}: ForecastDecisionLoginLinkProps) {
+  return (
+    <Link
+      href={`/auth/sign-in?redirectTo=${encodeURIComponent(returnTo)}`}
+      className={
+        compact
+          ? "inline-block border-b border-[#11100D] font-mono text-[9px] font-bold uppercase tracking-[0.1em] text-[#11100D]/70 hover:text-[#11100D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EFE5CF]"
+          : "inline-block -rotate-1 border-2 border-[#11100D] bg-[#EFE5CF] px-2.5 py-1 font-mono text-xs font-bold uppercase tracking-[0.1em] text-[#11100D] shadow-[2px_2px_0_#11100D] hover:bg-[#F7E7BE] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#EFE5CF]"
+      }
+    >
+      {compact ? "Sign in" : "Sign in to reveal"}
+    </Link>
+  );
+}

--- a/components/beach-detail/public-forecast-answer.tsx
+++ b/components/beach-detail/public-forecast-answer.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import type { Beach } from "@/types/database";
-import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
-import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
 import { formatBeachDateTime, formatTimeInTimezone } from "@/lib/utils/date-time";
 import { isDataStale } from "@/lib/utils/forecast-client-utils";
+import { useAuthenticatedForecastDecision } from "@/components/beach-detail/authenticated-forecast-decision";
+import { ForecastDecisionLoginLink } from "@/components/beach-detail/forecast-decision-login-link";
+import type {
+  PublicForecastContextFacts,
+  PublicForecastReportFacts,
+} from "@/lib/utils/public-forecast-facts";
 
 // Same contrast-checked verdict palette the in-tab surf call uses on tan paper.
 const VERDICT_COLOR: Record<string, string> = {
@@ -20,10 +26,11 @@ const STRIP_LABEL =
 
 interface PublicForecastAnswerProps {
   beach: Beach;
-  report: SurfCallResult | null;
-  context: ForecastRecommendationContext | null;
+  report: PublicForecastReportFacts | null;
+  context: PublicForecastContextFacts | null;
   isTomorrow: boolean;
   headingLevel: "h1" | "h2";
+  returnTo: string;
 }
 
 function formatForecastDate(
@@ -89,7 +96,11 @@ export function PublicForecastAnswer({
   context,
   isTomorrow,
   headingLevel,
+  returnTo,
 }: PublicForecastAnswerProps) {
+  const authenticatedDecision = useAuthenticatedForecastDecision();
+  const decisionReport = authenticatedDecision.report;
+  const decisionContext = authenticatedDecision.context;
   const timezone =
     context?.timezone ??
     (beach as { timezone?: string | null }).timezone ??
@@ -97,8 +108,8 @@ export function PublicForecastAnswer({
   const forecastDate = formatForecastDate(context?.localDate, timezone);
   const waveHeight = context?.waveHeightRangeLabel ?? context?.waveHeight ?? report?.waveHeight;
   const bestWindow = formatRange(
-    context?.displayWindowStart ?? report?.bestWindowStart,
-    context?.displayWindowEnd ?? report?.bestWindowEnd,
+    decisionContext?.displayWindowStart ?? decisionReport?.bestWindowStart,
+    decisionContext?.displayWindowEnd ?? decisionReport?.bestWindowEnd,
     timezone,
   );
   const primarySwell = buildSwell(
@@ -181,11 +192,11 @@ export function PublicForecastAnswer({
                 <dd className={DECK_VALUE}>{waveHeight}</dd>
               </div>
             )}
-            {report?.verdict && (
+            {decisionReport?.verdict && (
               <div>
                 <dt className={DECK_LABEL}>Verdict</dt>
-                <dd className={DECK_VALUE} style={{ color: VERDICT_COLOR[report.verdict] }}>
-                  {report.verdict}
+                <dd className={DECK_VALUE} style={{ color: VERDICT_COLOR[decisionReport.verdict] }}>
+                  {decisionReport.verdict}
                 </dd>
               </div>
             )}
@@ -194,6 +205,22 @@ export function PublicForecastAnswer({
                 <dt className={DECK_LABEL}>Best window</dt>
                 <dd className="mt-0.5 font-mono text-lg font-bold leading-none text-[#11100D] sm:text-xl">
                   {bestWindow}
+                </dd>
+              </div>
+            )}
+            {!decisionReport?.verdict && !bestWindow && (
+              <div>
+                <dt className={DECK_LABEL}>Verdict &amp; best window</dt>
+                <dd className="mt-1.5">
+                  {authenticatedDecision.isAuthenticated ? (
+                    <span className="font-mono text-xs font-bold uppercase tracking-[0.1em] text-[#11100D]/60">
+                      {authenticatedDecision.isLoading
+                        ? "Loading your call…"
+                        : "Call unavailable"}
+                    </span>
+                  ) : (
+                    <ForecastDecisionLoginLink returnTo={returnTo} />
+                  )}
                 </dd>
               </div>
             )}
@@ -227,7 +254,7 @@ export function PublicForecastAnswer({
               ))}
           </div>
 
-          {(secondarySwell || report?.score != null) && (
+          {(secondarySwell || decisionReport?.score != null) && (
             <div className="mt-4 flex flex-wrap gap-x-6 gap-y-1 font-mono text-xs text-[#11100D]/75">
               {secondarySwell && (
                 <div className="flex gap-1.5">
@@ -235,10 +262,10 @@ export function PublicForecastAnswer({
                   <dd>{secondarySwell}</dd>
                 </div>
               )}
-              {report?.score != null && (
+              {decisionReport?.score != null && (
                 <div className="flex gap-1.5">
                   <dt className="font-bold uppercase tracking-[0.14em]">Score</dt>
-                  <dd>{report.score}/100</dd>
+                  <dd>{decisionReport.score}/100</dd>
                 </div>
               )}
             </div>
@@ -250,9 +277,9 @@ export function PublicForecastAnswer({
         </p>
       )}
 
-      {report?.whySentence && (
+      {decisionReport?.whySentence && (
         <p className="mt-5 max-w-2xl font-mono text-sm leading-6 text-[#11100D]">
-          <strong className="font-bold">Why:</strong> {report.whySentence}
+          <strong className="font-bold">Why:</strong> {decisionReport.whySentence}
         </p>
       )}
 

--- a/components/beach-detail/public-forecast-hourly.tsx
+++ b/components/beach-detail/public-forecast-hourly.tsx
@@ -1,18 +1,20 @@
+"use client";
+
 import type {
   PublicForecastDay,
   PublicForecastHour,
 } from "@/lib/services/spot-surf-report-service";
-import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
-import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
 import { formatTimeInTimezone } from "@/lib/utils/date-time";
+import { useAuthenticatedForecastDecision } from "@/components/beach-detail/authenticated-forecast-decision";
+import { ForecastDecisionLoginLink } from "@/components/beach-detail/forecast-decision-login-link";
+import type { PublicForecastContextFacts } from "@/lib/utils/public-forecast-facts";
 
 interface PublicForecastHourlyProps {
   beachName: string;
   forecastHours: PublicForecastHour[];
-  report: SurfCallResult | null;
-  context: ForecastRecommendationContext | null;
-  isTomorrow: boolean;
+  context: PublicForecastContextFacts | null;
   forecastDay: PublicForecastDay;
+  returnTo: string;
 }
 
 function join(parts: (string | null | undefined)[], separator = " "): string {
@@ -36,15 +38,11 @@ function swellLabel(hour: PublicForecastHour): string {
 
 function isWithinCallWindow(
   forecastAt: string,
-  report: SurfCallResult | null,
-  context: ForecastRecommendationContext | null,
+  start: string,
+  end: string,
 ): boolean {
-  const startMs = Date.parse(
-    context?.displayWindowStart ?? report?.bestWindowStart ?? "",
-  );
-  const endMs = Date.parse(
-    context?.displayWindowEnd ?? report?.bestWindowEnd ?? "",
-  );
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
   if (Number.isNaN(startMs) || Number.isNaN(endMs)) return false;
 
   const forecastMs = Date.parse(forecastAt);
@@ -54,11 +52,11 @@ function isWithinCallWindow(
 export function PublicForecastHourly({
   beachName,
   forecastHours,
-  report,
   context,
-  isTomorrow,
   forecastDay,
+  returnTo,
 }: PublicForecastHourlyProps) {
+  const authenticatedDecision = useAuthenticatedForecastDecision();
   if (forecastHours.length === 0) return null;
 
   const timezone = context?.timezone ?? "UTC";
@@ -98,6 +96,13 @@ export function PublicForecastHourly({
                   className="px-3 pb-2 text-[10px] font-bold uppercase tracking-[0.16em] text-[#0B3A75]"
                 >
                   {label}
+                  {label === "Quiver call" &&
+                  !authenticatedDecision.report &&
+                  !authenticatedDecision.isAuthenticated ? (
+                    <span className="mt-1 block normal-case tracking-normal">
+                      <ForecastDecisionLoginLink returnTo={returnTo} compact />
+                    </span>
+                  ) : null}
                 </th>
               ))}
             </tr>
@@ -105,8 +110,18 @@ export function PublicForecastHourly({
           <tbody>
             {forecastHours.map((hour) => {
               const inCallWindow =
-                forecastDay === (isTomorrow ? "tomorrow" : "today") &&
-                isWithinCallWindow(hour.forecast_at, report, context);
+                Boolean(authenticatedDecision.report) &&
+                forecastDay ===
+                  (authenticatedDecision.isTomorrow ? "tomorrow" : "today") &&
+                isWithinCallWindow(
+                  hour.forecast_at,
+                  authenticatedDecision.context?.displayWindowStart ??
+                    authenticatedDecision.report?.bestWindowStart ??
+                    "",
+                  authenticatedDecision.context?.displayWindowEnd ??
+                    authenticatedDecision.report?.bestWindowEnd ??
+                    "",
+                );
 
               return (
                 <tr

--- a/components/beach-detail/water-temp-summary-hero.tsx
+++ b/components/beach-detail/water-temp-summary-hero.tsx
@@ -1,179 +1,81 @@
-/**
- * WaterTempSummaryHero — server-rendered above-the-fold summary for water-temp sub-pages.
- *
- * Renders immediately on the server so Google (and users) see the answer to
- * "what is the water temperature at [beach]?" without waiting for the client bundle.
- * Intentionally minimal — just the current temp and wetsuit call, scannable on mobile.
- */
+import Link from "next/link";
+import { ArrowUpRight, Thermometer } from "lucide-react";
 
 import type { WaterTempMetaData } from "@/lib/seo/water-temp-meta-data";
-import { Thermometer, ArrowDown } from "lucide-react";
 
 export interface WaterTempSummaryHeroProps {
   beachName: string;
+  seasonalTrendsHref: string;
+  seasonalTrendsLocation: string;
   waterTempData: WaterTempMetaData;
 }
 
-/** Convert Fahrenheit to Celsius, rounded to one decimal place. */
-function toCelsius(f: number): number {
-  return Math.round(((f - 32) * 5) / 9);
+function toCelsius(tempF: number): number {
+  return Math.round(((tempF - 32) * 5) / 9);
 }
 
-/**
- * Map a temperature range to a descriptive label and color hint.
- * These correspond to the retro dark design system colors.
- */
-function getTempProfile(tempF: number): {
-  label: string;
-  colorStyle: React.CSSProperties;
-  borderStyle: React.CSSProperties;
-} {
-  if (tempF >= 75) {
-    return {
-      label: "Warm",
-      colorStyle: { color: "#F78E42" },
-      borderStyle: { borderColor: "rgba(247, 142, 66, 0.4)" },
-    };
-  }
-  if (tempF >= 65) {
-    return {
-      label: "Mild",
-      colorStyle: { color: "#FDB84B" },
-      borderStyle: { borderColor: "rgba(253, 184, 75, 0.35)" },
-    };
-  }
-  if (tempF >= 55) {
-    return {
-      label: "Cool",
-      colorStyle: { color: "#B8C7E0" },
-      borderStyle: { borderColor: "rgba(184, 199, 224, 0.3)" },
-    };
-  }
-  return {
-    label: "Cold",
-    colorStyle: { color: "#93B4D8" },
-    borderStyle: { borderColor: "rgba(147, 180, 216, 0.3)" },
-  };
+function getTempProfile(tempF: number): string {
+  if (tempF >= 75) return "Warm";
+  if (tempF >= 65) return "Mild";
+  if (tempF >= 55) return "Cool";
+  return "Cold";
 }
 
 export function WaterTempSummaryHero({
   beachName,
+  seasonalTrendsHref,
+  seasonalTrendsLocation,
   waterTempData,
 }: WaterTempSummaryHeroProps) {
   const { tempF, wetsuitRec } = waterTempData;
 
-  // Don't render the hero if we have no temperature data.
   if (tempF === null) return null;
 
   const tempC = toCelsius(tempF);
   const profile = getTempProfile(tempF);
 
   return (
-    <section
+    <div
       aria-label={`Current water temperature at ${beachName}`}
-      className="noise-texture w-full"
-      style={{
-        background:
-          "linear-gradient(180deg, #1E2558 0%, #252D6B 60%, rgba(37,45,107,0) 100%)",
-        borderBottom: "1px solid rgba(64, 76, 146, 0.4)",
-      }}
+      className="flex flex-col gap-4 border-y-2 border-[#11100D] py-4 sm:flex-row sm:items-center sm:gap-6"
+      role="group"
     >
-      <div className="container mx-auto px-4 py-6 sm:py-8">
-        {/* Heading row */}
-        <div className="mb-5">
-          <h1 className="font-heading text-2xl font-bold leading-tight text-high sm:text-3xl">
-            {beachName} Water Temp & Wetsuit Guide
-          </h1>
-        </div>
-
-        {/* Primary data: temperature display */}
-        <div className="flex flex-wrap items-end gap-5 sm:gap-8">
-          {/* Large temperature badge — sticker aesthetic with slight rotation */}
-          <div
-            className="noise-texture flex flex-col items-center justify-center rounded-2xl border px-6 py-5"
-            style={{
-              background:
-                "linear-gradient(135deg, rgba(47, 57, 120, 0.9) 0%, rgba(37, 45, 107, 0.95) 100%)",
-              ...profile.borderStyle,
-              transform: "rotate(-1.5deg)",
-              minWidth: "140px",
-            }}
-          >
-            <span className="flex items-center gap-1.5 text-xs font-mono font-semibold uppercase tracking-widest text-medium">
-              <Thermometer className="h-3.5 w-3.5" aria-hidden="true" style={profile.colorStyle} />
-              Water Temp
-            </span>
-            <span
-              className="font-heading text-5xl font-bold leading-none mt-1.5"
-              style={profile.colorStyle}
-              aria-label={`${tempF} degrees Fahrenheit, ${tempC} degrees Celsius`}
-            >
-              {tempF}°
-            </span>
-            <div className="mt-1 flex items-center gap-2 font-mono text-sm font-medium text-medium">
-              <span>{tempF}°F</span>
-              <span aria-hidden="true" className="opacity-40">/</span>
-              <span>{tempC}°C</span>
-            </div>
-            {/* Temperature descriptor badge */}
-            <span
-              className="mt-2 rounded-full px-2.5 py-0.5 font-mono text-xs font-semibold uppercase tracking-wider"
-              style={{
-                background: "rgba(255,255,255,0.07)",
-                ...profile.colorStyle,
-              }}
-            >
-              {profile.label}
-            </span>
-          </div>
-
-          {/* Wetsuit recommendation */}
-          {wetsuitRec && (
-            <div className="flex flex-col gap-1.5">
-              <span className="font-mono text-xs font-semibold uppercase tracking-widest text-medium">
-                Recommended Wetsuit
-              </span>
-              <div
-                className="noise-texture inline-flex items-center gap-2 rounded-xl border px-4 py-3"
-                style={{
-                  background:
-                    "linear-gradient(135deg, rgba(37, 45, 107, 0.9) 0%, rgba(30, 37, 88, 0.95) 100%)",
-                  borderColor: "rgba(184, 199, 224, 0.2)",
-                  transform: "rotate(0.75deg)",
-                }}
-              >
-                {/* Wetsuit icon — simple visual shorthand */}
-                <span
-                  className="text-2xl"
-                  role="img"
-                  aria-hidden="true"
-                >
-                  🤿
-                </span>
-                <span className="font-heading text-lg font-bold text-high">
-                  {wetsuitRec}
-                </span>
-              </div>
-              <p className="text-xs text-medium leading-relaxed max-w-[220px]">
-                Based on current water temperature
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Anchor link to seasonal trends below */}
-        <div className="mt-5">
-          <a
-            href="#seasonal-trends"
-            className="inline-flex items-center gap-1.5 text-sm text-medium transition-colors hover:text-high focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F78E42] focus-visible:ring-offset-2 focus-visible:ring-offset-[#252D6B]"
-            aria-label="Scroll to seasonal temperature trends"
-          >
-            <Thermometer className="h-4 w-4" aria-hidden="true" />
-            See seasonal trends below
-            <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
-          </a>
-        </div>
+      <div className="stamp-circle shrink-0" aria-hidden="true">
+        <span>Water</span>
+        <span className="lg">{tempF}°F</span>
+        <span>{tempC}°C</span>
       </div>
-    </section>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1.5 border-2 border-[#0B3A75] bg-[#F78E42] px-2.5 py-1 font-[var(--font-mono)] text-[11px] font-black uppercase tracking-[0.14em] text-[#11100D] shadow-[2px_2px_0_#0B3A75]">
+            <Thermometer className="h-3.5 w-3.5" aria-hidden="true" />
+            {profile}
+          </span>
+          <span className="font-[var(--font-mono)] text-xs font-bold uppercase tracking-[0.12em] text-[#5F5646]">
+            {tempF}°F / {tempC}°C
+          </span>
+        </div>
+
+        {wetsuitRec ? (
+          <p className="mt-3 text-[#11100D]">
+            <span className="block font-[var(--font-mono)] text-[10px] font-black uppercase tracking-[0.16em] text-[#5F5646]">
+              Recommended wetsuit
+            </span>
+            <strong className="mt-0.5 block font-[var(--font-zine-display)] text-xl font-black uppercase leading-tight sm:text-2xl">
+              {wetsuitRec}
+            </strong>
+          </p>
+        ) : null}
+
+        <Link
+          href={seasonalTrendsHref}
+          className="mt-3 inline-flex min-h-11 items-center gap-1.5 font-[var(--font-mono)] text-xs font-black uppercase tracking-[0.09em] text-[#0B3A75] underline decoration-2 underline-offset-4 transition-colors hover:text-[#11100D] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0B3A75] focus-visible:ring-offset-2 focus-visible:ring-offset-[#F4EBD8]"
+        >
+          Seasonal water trends for {seasonalTrendsLocation}
+          <ArrowUpRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/components/beach-detail/zine/today-surf-call.tsx
+++ b/components/beach-detail/zine/today-surf-call.tsx
@@ -40,6 +40,8 @@ export function TodaySurfCall({
   beachTimezone,
   isTomorrow = false,
 }: TodaySurfCallProps) {
+  if (!surfCallReport) return null;
+
   const tiers = surfCallReport?.tiers ?? null;
   const userTier = surfCallReport?.userTier ?? null;
   const displayTier: TierKey | null = tiers ? selectDisplayTier(userTier) : null;

--- a/components/beach-detail/zine/zine-hero.tsx
+++ b/components/beach-detail/zine/zine-hero.tsx
@@ -107,6 +107,26 @@ export function ZineHero({
         </div>
 
         {forecastSlot ? <div className="mt-6">{forecastSlot}</div> : null}
+
+        {/* Hero prose sits in the left column so it fills the space beside the
+            taller photo/map stack rather than leaving dead cream paper there. */}
+        {beach.best_conditions_prose && (
+          <p
+            className="mt-6"
+            style={{
+              fontFamily:
+                "var(--font-zine-marker), 'Permanent Marker', cursive",
+              fontWeight: 400,
+              fontSize: 22,
+              color: "#11100D",
+              letterSpacing: "-0.01em",
+              lineHeight: 1.25,
+              maxWidth: "78ch",
+            }}
+          >
+            {beach.best_conditions_prose}
+          </p>
+        )}
       </div>
 
       <TapedMapPhoto
@@ -121,26 +141,6 @@ export function ZineHero({
         features={beach.features}
       />
       </div>
-
-      {/* Hero prose — full width below the grid so long descriptions
-          breathe into the empty cream paper instead of stacking inside
-          the narrow left column when the photo/map column ends short. */}
-      {beach.best_conditions_prose && (
-        <p
-          className="mt-6"
-          style={{
-            fontFamily: "var(--font-zine-marker), 'Permanent Marker', cursive",
-            fontWeight: 400,
-            fontSize: 22,
-            color: "#11100D",
-            letterSpacing: "-0.01em",
-            lineHeight: 1.25,
-            maxWidth: "78ch",
-          }}
-        >
-          {beach.best_conditions_prose}
-        </p>
-      )}
     </section>
   );
 }

--- a/components/beach-detail/zine/zine-hero.tsx
+++ b/components/beach-detail/zine/zine-hero.tsx
@@ -22,6 +22,9 @@ interface ZineHeroProps {
   beachPhoto?: ZineBeachPhoto | null;
   sources?: BeachSources | null;
   headingLevel?: ZineHeroHeadingLevel;
+  headingSuffix?: string;
+  /** Route-specific answer, shown directly below the beach location. */
+  summarySlot?: ReactNode;
   /** Server-rendered forecast answer, shown in the hero's left column. */
   forecastSlot?: ReactNode;
 }
@@ -31,6 +34,8 @@ export function ZineHero({
   beachPhoto,
   sources,
   headingLevel = "h1",
+  headingSuffix,
+  summarySlot,
   forecastSlot,
 }: ZineHeroProps) {
   const skill = (beach.skill_level || "All").toUpperCase();
@@ -60,6 +65,9 @@ export function ZineHero({
           }}
         >
           {beach.name}
+          {headingSuffix ? (
+            <span className="zine-h1-suffix">{headingSuffix}</span>
+          ) : null}
         </HeadingTag>
         {locationName && (
           <p
@@ -77,6 +85,8 @@ export function ZineHero({
             {locationName}
           </p>
         )}
+
+        {summarySlot ? <div className="mt-5">{summarySlot}</div> : null}
 
         <div className="flex flex-wrap items-center gap-4 md:gap-6 mt-5">
           <MetaItem icon={<SkillBars size={28} />} label={skill} />

--- a/components/beach-detail/zine/zine-page-shell.tsx
+++ b/components/beach-detail/zine/zine-page-shell.tsx
@@ -14,6 +14,8 @@ interface ZinePageShellProps {
   beachPhoto?: ZineBeachPhoto | null;
   sources?: BeachSources | null;
   heroHeadingLevel?: ZineHeroHeadingLevel;
+  heroHeadingSuffix?: string;
+  heroSummarySlot?: ReactNode;
   heroForecastSlot?: ReactNode;
   /**
    * The tabs container is rendered here so the cream-paper styling wraps
@@ -32,6 +34,8 @@ export function ZinePageShell({
   beachPhoto,
   sources,
   heroHeadingLevel,
+  heroHeadingSuffix,
+  heroSummarySlot,
   heroForecastSlot,
   children,
 }: ZinePageShellProps) {
@@ -49,6 +53,8 @@ export function ZinePageShell({
             beachPhoto={beachPhoto}
             sources={sources}
             headingLevel={heroHeadingLevel}
+            headingSuffix={heroHeadingSuffix}
+            summarySlot={heroSummarySlot}
             forecastSlot={heroForecastSlot}
           />
 

--- a/components/beginner/BeginnerHero.tsx
+++ b/components/beginner/BeginnerHero.tsx
@@ -105,7 +105,7 @@ export function BeginnerHero({
                 sizes="(max-width: 1024px) 100vw, 360px"
                 className="object-cover"
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-[#0F1B3D] via-[#0F1B3D]/12 to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-t from-[#0F1B3D] via-[#0F1B3D]/10 to-transparent" />
             </>
           ) : (
             <div className="absolute inset-0 bg-[linear-gradient(135deg,#203A7C,#0F1B3D_52%,#F78E42)]" />

--- a/components/best-time-to-surf/monthly-grid.tsx
+++ b/components/best-time-to-surf/monthly-grid.tsx
@@ -120,7 +120,12 @@ export function MonthlyGrid({
                     </span>
                   )}
                 </div>
-                <AnimatedScoreGauge score={entry.score} size="sm" />
+                {/* Seasonal average, not a live call — no "Go now!" (#569) */}
+                <AnimatedScoreGauge
+                  score={entry.score}
+                  size="sm"
+                  showAction={false}
+                />
               </div>
 
               <div className="space-y-2 text-xs text-gray-600">

--- a/components/forecast/animated-score-gauge.tsx
+++ b/components/forecast/animated-score-gauge.tsx
@@ -30,6 +30,12 @@ export interface AnimatedScoreGaugeProps {
   /** Whether to show the quality label below the gauge */
   showLabel?: boolean;
   /**
+   * Whether to show the immediate-action phrase ("Go now!" etc.) under the
+   * quality label. Must be false for future-day/ranking contexts, where
+   * immediate-action copy is wrong (#569).
+   */
+  showAction?: boolean;
+  /**
    * Optional condition character to show below the gauge number.
    * Only rendered when size is "lg" or "xl" and showLabel is true.
    */
@@ -119,6 +125,7 @@ export function AnimatedScoreGauge({
   score,
   size = "md",
   showLabel = false,
+  showAction = true,
   character,
   duration = 1200,
   enableGlow = true,
@@ -275,7 +282,11 @@ export function AnimatedScoreGauge({
               config.fontSize,
               labelTextClass
             )}
-            aria-label={`Score: ${score}, ${scoreCall.label}. ${scoreCall.action}`}
+            aria-label={
+              showAction
+                ? `Score: ${score}, ${scoreCall.label}. ${scoreCall.action}`
+                : `Score: ${score}, ${scoreCall.label}`
+            }
           >
             {displayScore}
           </span>
@@ -296,17 +307,19 @@ export function AnimatedScoreGauge({
           >
             {scoreCall.label}
           </span>
-          <span
-            className={cn(
-              "font-medium",
-              config.labelSize,
-              labelTextClass,
-              !hasAnimated && !reducedMotion && "opacity-0",
-              hasAnimated && "motion-safe:animate-fade-in"
-            )}
-          >
-            {scoreCall.action}
-          </span>
+          {showAction && (
+            <span
+              className={cn(
+                "font-medium",
+                config.labelSize,
+                labelTextClass,
+                !hasAnimated && !reducedMotion && "opacity-0",
+                hasAnimated && "motion-safe:animate-fade-in"
+              )}
+            >
+              {scoreCall.action}
+            </span>
+          )}
 
           {/*
            * Condition character label — lg/xl sizes only, non-hero variant.

--- a/components/forecast/beach-conditions-grid.tsx
+++ b/components/forecast/beach-conditions-grid.tsx
@@ -46,6 +46,19 @@ export interface BeachConditionsGridProps {
   className?: string;
   /** Visual treatment variant */
   variant?: "default" | "zine";
+  /** Whether personalized score values are available to this viewer */
+  showScores?: boolean;
+}
+
+function ScoreLoginLink({ regionSlug }: { regionSlug: string }) {
+  return (
+    <Link
+      href={`/auth/sign-in?redirectTo=/forecast/${regionSlug}`}
+      className="inline-flex font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-[#11100D] underline decoration-[#B56A2B] decoration-2 underline-offset-4 transition-colors hover:text-[#B56A2B] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#11100D]"
+    >
+      Log in to get your score
+    </Link>
+  );
 }
 
 /**
@@ -111,10 +124,14 @@ function TrendIndicator({
 function BeachConditionRow({
   beach,
   index,
+  regionSlug,
+  showScores,
   variant = "default",
 }: {
   beach: BeachConditionSummary;
   index: number;
+  regionSlug: string;
+  showScores: boolean;
   variant?: "default" | "zine";
 }) {
   const scoreCall = getScoreCall(beach.currentScore);
@@ -147,7 +164,7 @@ function BeachConditionRow({
         <div className="flex items-center gap-1.5">
           <Calendar className={cn("h-4 w-4", isZine ? "text-[#11100D]/58" : "text-muted-foreground")} />
           <span className={cn("text-sm", isZine && "text-[#11100D]/72")}>{beach.bestDay}</span>
-          {beach.bestDayScore > 0 && (
+          {showScores && beach.bestDayScore > 0 && (
             <span
               className={cn(
                 "text-xs",
@@ -176,22 +193,23 @@ function BeachConditionRow({
         <TrendIndicator trend={beach.trend} variant={variant} />
       </TableCell>
       <TableCell>
-        <div className="flex items-center gap-2">
-          <div className="transition-transform duration-200 hover:scale-110">
-            <ScoreBadge
-              score={beach.currentScore}
-              className={getScoreColorClasses(beach.currentScore).paperBadge}
-            />
+        {showScores ? (
+          <div className="flex items-center gap-2">
+            <div className="transition-transform duration-200 hover:scale-110">
+              <ScoreBadge
+                score={beach.currentScore}
+                className={getScoreColorClasses(beach.currentScore).paperBadge}
+              />
+            </div>
+            <div className="flex min-w-0 flex-col">
+              <span className="text-xs font-bold text-[#11100D]">
+                {scoreCall.label}
+              </span>
+            </div>
           </div>
-          <div className="flex min-w-0 flex-col">
-            <span className="text-xs font-bold text-[#11100D]">
-              {scoreCall.label}
-            </span>
-            <span className="text-[11px] leading-tight text-[#11100D]">
-              {scoreCall.action}
-            </span>
-          </div>
-        </div>
+        ) : (
+          <ScoreLoginLink regionSlug={regionSlug} />
+        )}
       </TableCell>
     </TableRow>
   );
@@ -203,10 +221,14 @@ function BeachConditionRow({
 function BeachConditionCard({
   beach,
   index,
+  regionSlug,
+  showScores,
   variant = "default",
 }: {
   beach: BeachConditionSummary;
   index: number;
+  regionSlug: string;
+  showScores: boolean;
   variant?: "default" | "zine";
 }) {
   const scoreCall = getScoreCall(beach.currentScore);
@@ -225,12 +247,14 @@ function BeachConditionCard({
         <CardContent className={cn("p-4", isZine && "relative z-10")}>
           <div className="flex items-start gap-3">
             {/* Score Badge with hover scale */}
-            <div className="transition-transform duration-200 group-hover:scale-110">
-              <ScoreBadge
-                score={beach.currentScore}
-                className={getScoreColorClasses(beach.currentScore).paperBadge}
-              />
-            </div>
+            {showScores && (
+              <div className="transition-transform duration-200 group-hover:scale-110">
+                <ScoreBadge
+                  score={beach.currentScore}
+                  className={getScoreColorClasses(beach.currentScore).paperBadge}
+                />
+              </div>
+            )}
 
             {/* Beach Info */}
             <div className="flex-1 min-w-0">
@@ -246,9 +270,15 @@ function BeachConditionCard({
               </Link>
 
               {/* Score Label */}
-              <p className="mt-0.5 text-xs font-medium text-[#11100D]">
-                {scoreCall.label} · {scoreCall.action}
-              </p>
+              {showScores ? (
+                <p className="mt-0.5 text-xs font-medium text-[#11100D]">
+                  {scoreCall.label}
+                </p>
+              ) : (
+                <div className="mt-1">
+                  <ScoreLoginLink regionSlug={regionSlug} />
+                </div>
+              )}
 
               {/* Quick Stats with animated wave height */}
               <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
@@ -272,7 +302,7 @@ function BeachConditionCard({
                 <span>
                   Best: <span className="font-medium">{beach.bestDay}</span>
                 </span>
-                {beach.bestDayScore > 0 && (
+                {showScores && beach.bestDayScore > 0 && (
                   <span
                     className={cn(
                       "font-medium",
@@ -315,6 +345,7 @@ export function BeachConditionsGrid({
   showViewAll = true,
   className,
   variant = "default",
+  showScores = true,
 }: BeachConditionsGridProps) {
   // Sort beaches by current score (highest first) and limit display
   const displayBeaches = beaches
@@ -406,6 +437,8 @@ export function BeachConditionsGrid({
                   key={beach.beachId}
                   beach={beach}
                   index={index}
+                  regionSlug={regionSlug}
+                  showScores={showScores}
                   variant={variant}
                 />
               ))}
@@ -421,6 +454,8 @@ export function BeachConditionsGrid({
             key={beach.beachId}
             beach={beach}
             index={index}
+            regionSlug={regionSlug}
+            showScores={showScores}
             variant={variant}
           />
         ))}

--- a/components/forecast/best-days-section.tsx
+++ b/components/forecast/best-days-section.tsx
@@ -220,6 +220,7 @@ function BestDayCard({
             score={day.score}
             size="xl"
             showLabel
+            showAction={false}
             enableGlow={isEpic}
           />
 
@@ -310,6 +311,7 @@ function BestDayCard({
               score={day.score}
               size="xl"
               showLabel
+              showAction={false}
               enableGlow={isEpic}
             />
 

--- a/components/forecast/regional-best-surf-windows.tsx
+++ b/components/forecast/regional-best-surf-windows.tsx
@@ -58,7 +58,7 @@ export function RegionalBestSurfWindows({
       aria-labelledby="best-windows-this-week-heading"
       className={
         isZine
-          ? "mb-10 rounded-[24px_10px_28px_12px] border-2 border-[#11100D] bg-[#252D6B] p-4 shadow-[4px_5px_0_rgba(17,16,13,0.22)] sm:p-6"
+          ? "torn torn-tb mb-10 border-2 border-[#11100D] bg-[#FBF6E8] px-5 py-6 sm:px-6"
           : "mb-10"
       }
     >
@@ -68,6 +68,7 @@ export function RegionalBestSurfWindows({
         title="Best windows this week"
         subtitle={`The strongest upcoming surf calls across ${regionName}.`}
         surface="regional_forecast"
+        variant={variant}
       />
     </section>
   );

--- a/components/forecast/regional-call-hero.tsx
+++ b/components/forecast/regional-call-hero.tsx
@@ -326,7 +326,7 @@ export function RegionalCallHero({
           </div>
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#252D6B]/92 via-[#252D6B]/78 to-[#252D6B]/88"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-[#252D6B]/90 via-[#252D6B]/80 to-[#252D6B]/85"
           />
         </>
       )}

--- a/components/forecast/regional-call-hero.tsx
+++ b/components/forecast/regional-call-hero.tsx
@@ -453,7 +453,9 @@ export function RegionalCallHero({
             transform: stickerTransform(11, 7, -30, "-3deg"),
           }}
         >
-          <span className="inline-flex items-center gap-2 font-[var(--font-handwritten)] text-2xl leading-tight text-[#F78E42] md:text-3xl">
+          {/* Gold rather than orange: over the photo scrim the orange sat at
+              2.9:1, under AA even for large display text. */}
+          <span className="inline-flex items-center gap-2 font-[var(--font-handwritten)] text-2xl leading-tight text-[#FDB84B] md:text-3xl">
             <span className="whitespace-nowrap">{pullquote}</span>
             <Share2
               aria-hidden="true"
@@ -462,7 +464,7 @@ export function RegionalCallHero({
           </span>
           <span
             aria-hidden="true"
-            className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-[#F78E42]/65 transition-colors group-hover:text-[#F78E42]"
+            className="font-mono text-[0.62rem] uppercase tracking-[0.18em] text-[#F4EBD8] transition-colors group-hover:text-[#FDB84B]"
           >
             Tap to share
           </span>

--- a/components/forecast/seven-day-outlook.tsx
+++ b/components/forecast/seven-day-outlook.tsx
@@ -41,16 +41,33 @@ function daySubtitle(
     : "Marginal — longboard day.";
 }
 
-function trendIcon(delta: number): {
+function trendIcon(
+  delta: number,
+  variant: "default" | "zine",
+): {
   label: string;
   char: string;
   color: string;
 } {
-  if (delta >= 5)
-    return { label: "building", char: "↗", color: "text-emerald-400" };
-  if (delta <= -5)
-    return { label: "dropping", char: "↘", color: "text-rose-400" };
-  return { label: "holding", char: "→", color: "text-white/50" };
+  if (delta >= 5) {
+    return {
+      label: "building",
+      char: "↗",
+      color: variant === "zine" ? "text-[#166534]" : "text-emerald-400",
+    };
+  }
+  if (delta <= -5) {
+    return {
+      label: "dropping",
+      char: "↘",
+      color: variant === "zine" ? "text-[#9F1239]" : "text-rose-400",
+    };
+  }
+  return {
+    label: "holding",
+    char: "→",
+    color: variant === "zine" ? "text-[#4B453D]" : "text-white/50",
+  };
 }
 
 export function SevenDayOutlook({
@@ -115,7 +132,7 @@ export function SevenDayOutlook({
       aria-labelledby="seven-day-outlook-heading"
       className={
         isZine
-          ? "mb-10 min-w-0 rounded-[24px_10px_28px_12px] border-2 border-[#11100D] bg-[#252D6B] p-4 text-white shadow-[4px_5px_0_rgba(17,16,13,0.22)] sm:p-5"
+          ? "torn torn-tb mb-10 min-w-0 border-2 border-[#11100D] bg-[#FBF6E8] p-4 text-[#11100D] sm:p-5"
           : "mb-10 min-w-0"
       }
       data-testid="seven-day-outlook"
@@ -124,7 +141,7 @@ export function SevenDayOutlook({
         id="seven-day-outlook-heading"
         className={
           isZine
-            ? "mb-4 font-display text-3xl font-black uppercase leading-tight text-[#F4EBD8]"
+            ? "label-black mb-5 font-display text-2xl font-black uppercase leading-tight"
             : "mb-4 font-[var(--font-heading)] text-2xl font-bold text-white"
         }
       >
@@ -132,10 +149,20 @@ export function SevenDayOutlook({
       </h2>
 
       {recommendationsAvailable ? (
-        <SwellArc points={arcPoints} peakIndex={Math.max(0, peakIndex)} />
+        <SwellArc
+          points={arcPoints}
+          peakIndex={Math.max(0, peakIndex)}
+          variant={variant}
+        />
       ) : null}
 
-      <ol className="divide-y divide-white/10 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04]">
+      <ol
+        className={
+          isZine
+            ? "divide-y-2 divide-dashed divide-[#11100D]/30 border-y-2 border-[#11100D] bg-[#FBF6E8]"
+            : "divide-y divide-white/10 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04]"
+        }
+      >
         {summary.days.map((day, idx) => {
           const scoreColors = recommendationsAvailable
             ? getScoreColorClasses(day.score)
@@ -146,7 +173,7 @@ export function SevenDayOutlook({
             day.score === peakScore &&
             peakScore > 0;
           const prevScore = idx > 0 ? summary.days[idx - 1].score : day.score;
-          const trend = trendIcon(day.score - prevScore);
+          const trend = trendIcon(day.score - prevScore, variant);
           const monthDay = `${day.date.getUTCMonth() + 1}/${day.date.getUTCDate()}`;
 
           return (
@@ -155,24 +182,36 @@ export function SevenDayOutlook({
               data-testid={`outlook-day-${idx}`}
               data-peak={isPeak ? "true" : undefined}
               className={[
-                "relative flex items-center gap-4 px-4 py-4 sm:px-5",
-                isPeak ? "bg-[#F78E42]/[0.08]" : "",
+                "relative flex items-center gap-3 px-3 py-4 sm:gap-4 sm:px-5",
+                isPeak
+                  ? isZine
+                    ? "bg-[#FDB84B]/20"
+                    : "bg-[#F78E42]/[0.08]"
+                  : "",
               ].join(" ")}
             >
               {/* Peak accent — left edge Charming Orange bar */}
               {isPeak ? (
                 <span
                   aria-hidden="true"
-                  className="absolute inset-y-2 left-0 w-1 rounded-r bg-[#F78E42]"
+                  className={
+                    isZine
+                      ? "absolute inset-x-3 bottom-1 h-1 bg-[#F78E42]"
+                      : "absolute inset-y-2 left-0 w-1 rounded-r bg-[#F78E42]"
+                  }
                 />
               ) : null}
 
               {/* Day + date */}
               <div className="w-20 shrink-0 sm:w-24">
-                <div className="font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide text-white">
+                <div
+                  className={`font-[var(--font-heading)] text-sm font-semibold uppercase tracking-wide ${isZine ? "text-[#11100D]" : "text-white"}`}
+                >
                   {day.dayOfWeek.slice(0, 3)}
                 </div>
-                <div className="font-mono text-xs text-white/50">
+                <div
+                  className={`font-mono text-xs ${isZine ? "text-[#11100D]/60" : "text-white/50"}`}
+                >
                   {monthDay}
                 </div>
               </div>
@@ -182,8 +221,10 @@ export function SevenDayOutlook({
                 <div className="shrink-0">
                   <span
                     className={[
-                      "inline-flex h-9 min-w-[2.5rem] items-center justify-center rounded-full px-2 text-sm font-bold text-white",
-                      scoreColors.bg,
+                      "inline-flex h-9 min-w-[2.5rem] items-center justify-center rounded-full px-2 font-mono text-sm font-bold",
+                      isZine
+                        ? scoreColors.paperBadge
+                        : `${scoreColors.bg} text-white`,
                     ].join(" ")}
                     aria-label={`Score ${day.score} out of 100 (${scoreColors.label})`}
                   >
@@ -195,10 +236,14 @@ export function SevenDayOutlook({
               {/* Waves + callout */}
               <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
-                  <span className="font-[var(--font-heading)] text-base font-semibold text-white">
+                  <span
+                    className={`font-[var(--font-heading)] text-base font-semibold ${isZine ? "text-[#11100D]" : "text-white"}`}
+                  >
                     {waves}
                   </span>
-                  <span className="font-mono text-xs uppercase tracking-wide text-white/55">
+                  <span
+                    className={`font-mono text-xs uppercase tracking-wide ${isZine ? "text-[#11100D]/65" : "text-white/55"}`}
+                  >
                     {day.windConditions === "offshore"
                       ? "offshore"
                       : day.windConditions === "light"
@@ -207,11 +252,15 @@ export function SevenDayOutlook({
                   </span>
                 </div>
                 {recommendationsAvailable ? (
-                  <div className="truncate text-sm text-white/70">
+                  <div
+                    className={`truncate text-sm ${isZine ? "text-[#11100D]/75" : "text-white/70"}`}
+                  >
                     {daySubtitle(day.windConditions, day.score)}
                   </div>
                 ) : (
-                  <div className="truncate text-sm text-white/70">
+                  <div
+                    className={`truncate text-sm ${isZine ? "text-[#11100D]/75" : "text-white/70"}`}
+                  >
                     {day.dominantTideStatus
                       ? `${day.dominantTideStatus} tide`
                       : "Tide status pending"}

--- a/components/forecast/swell-arc.tsx
+++ b/components/forecast/swell-arc.tsx
@@ -20,7 +20,7 @@
  * @module components/forecast/swell-arc
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 export interface SwellArcPoint {
   dayOfWeek: string;
@@ -32,6 +32,7 @@ export interface SwellArcPoint {
 interface SwellArcProps {
   points: SwellArcPoint[];
   peakIndex: number;
+  variant?: "default" | "zine";
 }
 
 const VIEWBOX_WIDTH = 1000;
@@ -84,7 +85,7 @@ function smoothPath(pts: PlottedPoint[]): string {
     const cp2x = p2.x - (p3.x - p1.x) / 6;
     const cp2y = p2.y - (p3.y - p1.y) / 6;
     path.push(
-      `C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)}, ${cp2x.toFixed(2)} ${cp2y.toFixed(2)}, ${p2.x.toFixed(2)} ${p2.y.toFixed(2)}`
+      `C ${cp1x.toFixed(2)} ${cp1y.toFixed(2)}, ${cp2x.toFixed(2)} ${cp2y.toFixed(2)}, ${p2.x.toFixed(2)} ${p2.y.toFixed(2)}`,
     );
   }
   return path.join(" ");
@@ -96,12 +97,20 @@ function areaPath(pts: PlottedPoint[]): string {
   return `${top} L ${pts[pts.length - 1].x.toFixed(2)} ${VIEWBOX_HEIGHT - PADDING_Y_BOTTOM} L ${pts[0].x.toFixed(2)} ${VIEWBOX_HEIGHT - PADDING_Y_BOTTOM} Z`;
 }
 
-export function SwellArc({ points, peakIndex }: SwellArcProps) {
+export function SwellArc({
+  points,
+  peakIndex,
+  variant = "default",
+}: SwellArcProps) {
   const [activeIndex, setActiveIndex] = useState<number>(peakIndex);
   const [reduceMotion, setReduceMotion] = useState(false);
   const [isStuck, setIsStuck] = useState(false);
   const initializedRef = useRef(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const gradientId = useId().replace(/:/g, "");
+  const areaGradientId = `swell-arc-area-${gradientId}`;
+  const strokeGradientId = `swell-arc-stroke-${gradientId}`;
+  const isZine = variant === "zine";
 
   const scorePoints = useMemo(() => plotScore(points), [points]);
 
@@ -120,9 +129,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
   useEffect(() => {
     if (points.length === 0) return;
     const rows = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        '[data-testid^="outlook-day-"]'
-      )
+      document.querySelectorAll<HTMLElement>('[data-testid^="outlook-day-"]'),
     );
     if (rows.length === 0) return;
 
@@ -131,7 +138,9 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
       (entries) => {
         for (const entry of entries) {
           const idx = Number(
-            entry.target.getAttribute("data-testid")?.replace("outlook-day-", "")
+            entry.target
+              .getAttribute("data-testid")
+              ?.replace("outlook-day-", ""),
           );
           if (!Number.isFinite(idx)) continue;
           ratios.set(idx, entry.isIntersecting ? entry.intersectionRatio : 0);
@@ -154,7 +163,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
       {
         rootMargin: "-25% 0px -55% 0px",
         threshold: [0, 0.25, 0.5, 0.75, 1],
-      }
+      },
     );
     rows.forEach((row) => observer.observe(row));
     return () => observer.disconnect();
@@ -171,7 +180,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
         if (!entry) return;
         setIsStuck(!entry.isIntersecting && entry.boundingClientRect.top < 0);
       },
-      { threshold: [0, 1] }
+      { threshold: [0, 1] },
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
@@ -180,8 +189,10 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
   if (scorePoints.length === 0) return null;
 
   const active =
-    scorePoints[Math.min(activeIndex, scorePoints.length - 1)] ?? scorePoints[0];
-  const peak = scorePoints[Math.min(peakIndex, scorePoints.length - 1)] ?? scorePoints[0];
+    scorePoints[Math.min(activeIndex, scorePoints.length - 1)] ??
+    scorePoints[0];
+  const peak =
+    scorePoints[Math.min(peakIndex, scorePoints.length - 1)] ?? scorePoints[0];
   const activePoint =
     points[Math.min(activeIndex, points.length - 1)] ?? points[0];
 
@@ -205,22 +216,35 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
           // with 4-8px of breathing room. z-20 sits ABOVE the outlook list
           // but BELOW both the app-header (z-50) and the mobile
           // StickySignupBar (z-50), so collisions are impossible.
-          "sticky top-[calc(var(--site-header-height,72px))] z-20 mb-3 overflow-hidden rounded-2xl border bg-[#1a2051]/90 px-3 py-3 shadow-[0_8px_24px_-12px_rgba(0,0,0,0.55)] backdrop-blur-sm transition-[border-color,box-shadow] duration-300",
+          "sticky top-[calc(var(--site-header-height,72px))] z-20 mb-3 overflow-hidden border px-3 py-3 transition-[border-color,box-shadow] duration-300",
+          isZine
+            ? "bg-[#F0E5CC] shadow-sm"
+            : "rounded-2xl bg-[#11100D]/90 shadow-[0_8px_24px_-12px_rgba(0,0,0,0.55)] backdrop-blur-sm",
           isStuck
-            ? "border-[#F78E42]/50 shadow-[0_10px_36px_-14px_rgba(247,142,66,0.45)]"
-            : "border-white/10",
+            ? isZine
+              ? "border-[#11100D] shadow-md"
+              : "border-[#F78E42]/50 shadow-[0_10px_36px_-14px_rgba(247,142,66,0.45)]"
+            : isZine
+              ? "border-[#11100D]/45"
+              : "border-white/10",
         ].join(" ")}
       >
         <div className="mb-1.5 flex items-end justify-between gap-3 px-1">
           <div className="flex items-baseline gap-2">
-            <span className="font-[var(--font-heading)] text-xs font-semibold uppercase tracking-[0.18em] text-white/75">
+            <span
+              className={`font-[var(--font-heading)] text-xs font-semibold uppercase tracking-[0.18em] ${isZine ? "text-[#11100D]" : "text-white/75"}`}
+            >
               Swell arc
             </span>
-            <span className="font-mono text-[0.68rem] uppercase tracking-wide text-white/40">
+            <span
+              className={`font-mono text-[0.68rem] uppercase tracking-wide ${isZine ? "text-[#11100D]/55" : "text-white/40"}`}
+            >
               score · 7d
             </span>
           </div>
-          <span className="font-mono text-[0.72rem] uppercase tracking-wide text-[#F78E42]/90">
+          <span
+            className={`font-mono text-[0.72rem] font-bold uppercase tracking-wide ${isZine ? "text-[#713F12]" : "text-[#F78E42]/90"}`}
+          >
             {activePoint?.dayOfWeek?.slice(0, 3) ?? ""}
             {" · "}
             {activePoint?.score ?? 0}/100
@@ -237,13 +261,13 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
           className="block h-[112px] w-full"
         >
           <defs>
-            <linearGradient id="swell-arc-area" x1="0" y1="0" x2="0" y2="1">
+            <linearGradient id={areaGradientId} x1="0" y1="0" x2="0" y2="1">
               <stop offset="0%" stopColor="#F78E42" stopOpacity="0.32" />
               <stop offset="100%" stopColor="#F78E42" stopOpacity="0" />
             </linearGradient>
-            <linearGradient id="swell-arc-stroke" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0%" stopColor="#7fb0ff" />
-              <stop offset="55%" stopColor="#c7a3ff" />
+            <linearGradient id={strokeGradientId} x1="0" y1="0" x2="1" y2="0">
+              <stop offset="0%" stopColor={isZine ? "#0B3A75" : "#7fb0ff"} />
+              <stop offset="55%" stopColor={isZine ? "#11100D" : "#c7a3ff"} />
               <stop offset="100%" stopColor="#F78E42" />
             </linearGradient>
           </defs>
@@ -254,7 +278,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
             y1={VIEWBOX_HEIGHT - PADDING_Y_BOTTOM}
             x2={VIEWBOX_WIDTH - PADDING_X}
             y2={VIEWBOX_HEIGHT - PADDING_Y_BOTTOM}
-            stroke="rgba(255,255,255,0.15)"
+            stroke={isZine ? "rgba(17,16,13,0.28)" : "rgba(255,255,255,0.15)"}
             strokeWidth={1}
             strokeDasharray="2 4"
           />
@@ -262,7 +286,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
           {/* Filled area under the score curve */}
           <path
             d={areaPath(scorePoints)}
-            fill="url(#swell-arc-area)"
+            fill={`url(#${areaGradientId})`}
             style={{
               animation: reduceMotion
                 ? "none"
@@ -274,7 +298,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
           <path
             d={smoothPath(scorePoints)}
             fill="none"
-            stroke="url(#swell-arc-stroke)"
+            stroke={`url(#${strokeGradientId})`}
             strokeWidth={2.5}
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -294,8 +318,16 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
               cx={p.x}
               cy={p.y}
               r={i === activeIndex ? 5.5 : 3}
-              fill={i === activeIndex ? "#F78E42" : "rgba(255,255,255,0.65)"}
-              stroke={i === activeIndex ? "#fff" : "none"}
+              fill={
+                i === activeIndex
+                  ? "#F78E42"
+                  : isZine
+                    ? "rgba(17,16,13,0.68)"
+                    : "rgba(255,255,255,0.65)"
+              }
+              stroke={
+                i === activeIndex ? (isZine ? "#11100D" : "#fff") : "none"
+              }
               strokeWidth={i === activeIndex ? 1.5 : 0}
               style={{
                 transition: reduceMotion
@@ -322,7 +354,7 @@ export function SwellArc({ points, peakIndex }: SwellArcProps) {
             y={Math.max(12, active.y - 10)}
             textAnchor="middle"
             className="font-mono"
-            fill="rgba(255,255,255,0.85)"
+            fill={isZine ? "rgba(17,16,13,0.88)" : "rgba(255,255,255,0.85)"}
             fontSize="11"
             style={{
               transition: reduceMotion ? "none" : "x 260ms ease, y 260ms ease",

--- a/components/forecast/top-ranked-beach-hero.tsx
+++ b/components/forecast/top-ranked-beach-hero.tsx
@@ -19,7 +19,14 @@ type HeroSurfWindow = Pick<
   | "verdict"
   | "confidence"
   | "positives"
+  | "wave"
 >;
+
+/** The window's own wave height, so the card never mixes two instants. */
+function windowWaveHeight(window: HeroSurfWindow | null | undefined): number | null {
+  const parsed = Number.parseFloat(window?.wave?.height ?? "");
+  return Number.isFinite(parsed) ? parsed : null;
+}
 
 interface TopRankedBeachHeroProps {
   beach: BeachConditionSummary;
@@ -193,10 +200,12 @@ export function TopRankedBeachHero({
           <div className="border-t-2 border-[#11100D]/25 pt-3">
             <dt className="flex items-center gap-2 font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-[#11100D]/65">
               <Waves className="h-4 w-4" aria-hidden="true" />
-              Wave height
+              {isUpcoming ? "Wave height then" : "Wave height"}
             </dt>
             <dd className="mt-1 font-semibold text-[#11100D]">
-              {formatWaveHeightDecimal(beach.currentWaveHeight)}
+              {formatWaveHeightDecimal(
+                windowWaveHeight(bestSurfWindow) ?? beach.currentWaveHeight
+              )}
             </dd>
           </div>
         </dl>

--- a/components/forecast/top-ranked-beach-hero.tsx
+++ b/components/forecast/top-ranked-beach-hero.tsx
@@ -84,8 +84,12 @@ export function TopRankedBeachHero({
 }: TopRankedBeachHeroProps) {
   const selectedScore = bestSurfWindow?.score ?? beach.currentScore;
   const scoreCall = getScoreCall(selectedScore);
+  const isLive = bestSurfWindow ? includesInstant(bestSurfWindow, now) : false;
+  // Only reframe as "upcoming" when there is a real window to point at; with no
+  // window the card falls back to the score ranking and stays "ranked first".
+  const isUpcoming = Boolean(bestSurfWindow) && !isLive;
   const action = bestSurfWindow
-    ? includesInstant(bestSurfWindow, now)
+    ? isLive
       ? scoreCall.action
       : scheduledAction(bestSurfWindow)
     : "Check back soon";
@@ -128,14 +132,15 @@ export function TopRankedBeachHero({
         )}
 
         <div className="absolute left-4 top-4 bg-[#F4EBD8] px-3 py-2 font-mono text-xs font-bold uppercase tracking-[0.12em] text-[#11100D] shadow-[2px_2px_0_rgba(17,16,13,0.3)]">
-          Top beach now
+          {isUpcoming ? "Next best call" : "Top beach now"}
         </div>
       </div>
 
       <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
         <div>
           <p className="font-mono text-xs font-bold uppercase tracking-[0.14em] text-[#B56A2B]">
-            Ranked first in {regionName || "this region"}
+            {isUpcoming ? "Best upcoming window in" : "Ranked first in"}{" "}
+            {regionName || "this region"}
           </p>
           <h2 className="mt-3 break-words font-display text-3xl font-black uppercase leading-[0.95] text-[#11100D] sm:text-4xl">
             {beach.beachName}
@@ -160,7 +165,11 @@ export function TopRankedBeachHero({
           <div className="border-t-2 border-[#11100D]/25 pt-3">
             <dt className="flex items-center gap-2 font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-[#11100D]/65">
               <Clock3 className="h-4 w-4" aria-hidden="true" />
-              {bestSurfWindow ? "Best window" : "Surf window"}
+              {!bestSurfWindow
+                ? "Surf window"
+                : includesInstant(bestSurfWindow, now)
+                  ? "Surfable now"
+                  : "Next window"}
             </dt>
             {bestSurfWindow ? (
               <>
@@ -177,7 +186,7 @@ export function TopRankedBeachHero({
               </>
             ) : (
               <dd className="mt-1 font-semibold text-[#11100D]">
-                No qualifying window
+                Nothing qualifying in the forecast horizon
               </dd>
             )}
           </div>

--- a/components/forecast/top-ranked-beach-hero.tsx
+++ b/components/forecast/top-ranked-beach-hero.tsx
@@ -4,26 +4,33 @@ import { Clock3, MapPin, Waves } from "lucide-react";
 
 import type { BeachConditionSummary } from "@/lib/utils/regional-forecast-utils";
 import { buildBeachUrl } from "@/lib/utils/beach-url-utils";
-import { resolveBeachTimezone } from "@/lib/utils/timezone-utils";
 import { formatWaveHeightDecimal } from "@/lib/utils/wave-formatters";
 import type { SurfWindowRecommendation } from "@/types/session-intelligence";
 import { getScoreCall } from "./score-band-call";
 
 type HeroSurfWindow = Pick<
   SurfWindowRecommendation,
-  "startIso" | "endIso" | "peakIso" | "localTimeLabel" | "confidence" | "positives"
+  | "startIso"
+  | "endIso"
+  | "peakIso"
+  | "timezone"
+  | "localTimeLabel"
+  | "score"
+  | "verdict"
+  | "confidence"
+  | "positives"
 >;
 
 interface TopRankedBeachHeroProps {
   beach: BeachConditionSummary;
   regionName: string;
-  beachTimezone?: string | null;
+  now?: Date;
   imageUrl?: string | null;
   mapImageUrl?: string | null;
   bestSurfWindow?: HeroSurfWindow | null;
 }
 
-function formatPeakTime(peakIso: string, timezone?: string | null): string {
+function formatPeakTime(peakIso: string, timezone: string): string {
   const peakDate = new Date(peakIso);
   if (!Number.isFinite(peakDate.getTime())) return "Not available";
 
@@ -31,22 +38,57 @@ function formatPeakTime(peakIso: string, timezone?: string | null): string {
     return new Intl.DateTimeFormat("en-US", {
       hour: "numeric",
       minute: "2-digit",
-      timeZone: resolveBeachTimezone(timezone),
+      timeZone: timezone,
     }).format(peakDate);
   } catch {
     return "Not available";
   }
 }
 
+function includesInstant(window: HeroSurfWindow, instant: Date): boolean {
+  const start = Date.parse(window.startIso);
+  const end = Date.parse(window.endIso);
+  const current = instant.getTime();
+  return (
+    Number.isFinite(start) &&
+    Number.isFinite(end) &&
+    start <= current &&
+    current <= end
+  );
+}
+
+function scheduledAction(window: HeroSurfWindow): string {
+  const start = new Date(window.startIso);
+  if (!Number.isFinite(start.getTime())) return window.verdict;
+
+  try {
+    const date = new Intl.DateTimeFormat("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      timeZone: window.timezone,
+    }).format(start);
+    return `${window.verdict} · ${date}`;
+  } catch {
+    return window.verdict;
+  }
+}
+
 export function TopRankedBeachHero({
   beach,
   regionName,
-  beachTimezone,
+  now = new Date(),
   imageUrl,
   mapImageUrl,
   bestSurfWindow,
 }: TopRankedBeachHeroProps) {
-  const scoreCall = getScoreCall(beach.currentScore);
+  const selectedScore = bestSurfWindow?.score ?? beach.currentScore;
+  const scoreCall = getScoreCall(selectedScore);
+  const action = bestSurfWindow
+    ? includesInstant(bestSurfWindow, now)
+      ? scoreCall.action
+      : scheduledAction(bestSurfWindow)
+    : "Check back soon";
   const imageSource = imageUrl ?? mapImageUrl ?? null;
   const imageAlt = imageUrl
     ? `${beach.beachName} beach photo`
@@ -102,14 +144,14 @@ export function TopRankedBeachHero({
 
         <div className="flex items-end gap-3 border-2 border-[#11100D] bg-[#11100D] px-4 py-3 text-[#F4EBD8]">
           <span className="text-4xl font-black tabular-nums leading-none">
-            {beach.currentScore}
+            {selectedScore}
           </span>
           <div className="min-w-0">
             <p className="font-mono text-xs font-bold uppercase tracking-[0.12em]">
               {scoreCall.label}
             </p>
             <p className="mt-1 font-display text-xl font-black leading-none text-[#F78E42]">
-              {scoreCall.action}
+              {action}
             </p>
           </div>
         </div>
@@ -126,7 +168,7 @@ export function TopRankedBeachHero({
                   {bestSurfWindow.localTimeLabel}
                 </dd>
                 <dd className="mt-1 text-xs text-[#11100D]/65">
-                  Peak {formatPeakTime(bestSurfWindow.peakIso, beachTimezone)} ·{" "}
+                  Peak {formatPeakTime(bestSurfWindow.peakIso, bestSurfWindow.timezone)} ·{" "}
                   {bestSurfWindow.confidence.summary}
                 </dd>
                 <dd className="mt-1 text-xs text-[#11100D]/65">

--- a/components/intent/monthly-averages-chart.tsx
+++ b/components/intent/monthly-averages-chart.tsx
@@ -23,7 +23,7 @@ export function MonthlyAveragesChart({ data }: MonthlyAveragesChartProps) {
   const currentMonth = new Date().getMonth() + 1;
 
   return (
-    <section>
+    <section id="seasonal-trends">
       <Card className="overflow-hidden rounded-2xl border-slate-200/50 shadow-sm">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-lg font-heading text-gray-800">

--- a/components/seo/alert-capture-cta.tsx
+++ b/components/seo/alert-capture-cta.tsx
@@ -38,6 +38,8 @@ interface AlertCaptureCtaProps {
   /** Analytics source tracking identifier */
   source: string;
   className?: string;
+  /** "paper" for zine surfaces, where a navy card reads as a foreign app panel. */
+  variant?: "default" | "paper";
 }
 
 /**
@@ -53,7 +55,9 @@ export function AlertCaptureCta({
   beachName,
   source,
   className,
+  variant = "default",
 }: AlertCaptureCtaProps) {
+  const isPaper = variant === "paper";
   const { user, isLoading } = useAuth();
   const { setPendingAction } = usePendingAction();
   const { track } = useTrackEvent();
@@ -116,9 +120,9 @@ export function AlertCaptureCta({
     <>
       <div
         className={cn(
-          "rounded-2xl",
-          "bg-[#252D6B]",
-          "border border-white/10 shadow-sm",
+          isPaper
+            ? "rounded-[20px_8px_22px_10px] border-2 border-[#11100D] bg-[#FBF6E8] shadow-[3px_4px_0_rgba(17,16,13,0.2)]"
+            : "rounded-2xl bg-[#252D6B] border border-white/10 shadow-sm",
           "p-6",
           className,
         )}
@@ -129,14 +133,35 @@ export function AlertCaptureCta({
         <div className="flex flex-col gap-4">
           {/* Header */}
           <div className="flex items-start gap-3">
-            <div className="rounded-lg bg-[#F78E42]/15 p-2 shrink-0">
-              <Waves className="h-5 w-5 text-[#F78E42]" aria-hidden="true" />
+            <div
+              className={cn(
+                "rounded-lg p-2 shrink-0",
+                isPaper ? "bg-[#F78E42]/25" : "bg-[#F78E42]/15"
+              )}
+            >
+              <Waves
+                className={cn(
+                  "h-5 w-5",
+                  isPaper ? "text-[#B56A2B]" : "text-[#F78E42]"
+                )}
+                aria-hidden="true"
+              />
             </div>
             <div className="min-w-0">
-              <h3 className="text-lg md:text-xl font-semibold text-white mb-1">
+              <h3
+                className={cn(
+                  "text-lg md:text-xl font-semibold mb-1",
+                  isPaper ? "text-[#11100D]" : "text-white"
+                )}
+              >
                 {config.headline(beachName)}
               </h3>
-              <p className="text-sm md:text-base text-white/70">
+              <p
+                className={cn(
+                  "text-sm md:text-base",
+                  isPaper ? "text-[#11100D]/75" : "text-white/70"
+                )}
+              >
                 {config.description(beachName)}
               </p>
             </div>
@@ -151,7 +176,12 @@ export function AlertCaptureCta({
               return (
                 <span
                   key={presetKey}
-                  className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/70"
+                  className={cn(
+                    "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+                    isPaper
+                      ? "border border-[#11100D]/20 bg-[#11100D]/[0.06] text-[#11100D]/75"
+                      : "bg-white/10 text-white/70"
+                  )}
                 >
                   {badge.label}
                 </span>
@@ -170,7 +200,12 @@ export function AlertCaptureCta({
             </Button>
           </div>
 
-          <p className="text-xs text-white/40">
+          <p
+            className={cn(
+              "text-xs",
+              isPaper ? "text-[#11100D]/60" : "text-white/40"
+            )}
+          >
             No spam. Just surf.
           </p>
         </div>

--- a/components/seo/funnel/SeoImageFrame.tsx
+++ b/components/seo/funnel/SeoImageFrame.tsx
@@ -1,9 +1,8 @@
-import { existsSync } from "fs";
-import { join } from "path";
 import Image from "next/image";
 import { ImageIcon } from "lucide-react";
 
 import type { SeoImage } from "@/lib/seo/funnel-pages";
+import { publicImageExists } from "@/lib/utils/public-image-exists";
 
 interface SeoImageFrameProps {
   image: SeoImage;
@@ -11,11 +10,6 @@ interface SeoImageFrameProps {
   className?: string;
   showCaption?: boolean;
   sizes?: string;
-}
-
-function publicImageExists(src: string): boolean {
-  if (!src.startsWith("/")) return true;
-  return existsSync(join(process.cwd(), "public", src.slice(1)));
 }
 
 export function SeoImageFrame({

--- a/components/seo/seo-scene-panel.tsx
+++ b/components/seo/seo-scene-panel.tsx
@@ -24,7 +24,11 @@ export function SeoScenePanel({
         className
       )}
     >
-      <div className={cn("relative aspect-[16/9] min-h-[260px]", mediaClassName)}>
+      {/* `w-full` keeps the width bound to the figure. Without it, a caller that
+          stretches the height (`h-full`) lets `aspect-[16/9]` drive width FROM
+          that height, blowing the media past the figure so `overflow-hidden`
+          crops the photo's left edge and `object-position` never applies. */}
+      <div className={cn("relative w-full aspect-[16/9] min-h-[260px]", mediaClassName)}>
         <Image
           src={scene.imageSrc}
           alt={scene.alt}

--- a/components/session-intelligence/best-surf-windows.tsx
+++ b/components/session-intelligence/best-surf-windows.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import Image from "next/image";
 import { ArrowRight, Clock, Tags } from "lucide-react";
 
+import { HalftonePhoto } from "@/components/beach-detail/zine/atoms";
 import { QuiverSticker } from "@/components/zine/quiver-sticker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,7 @@ export interface BestSurfWindowsProps {
   surface?: string;
   className?: string;
   layout?: "cards" | "feature-list";
+  variant?: "default" | "zine";
   /** Suppress the inner title/subtitle block (the section keeps aria-label={title}) */
   hideHeader?: boolean;
 }
@@ -43,15 +45,49 @@ function verdictClasses(verdict: SurfWindowRecommendation["verdict"]): string {
   return "border-[#F78E42]/35 bg-[#F78E42]/10 text-[#FFD2B7]";
 }
 
+function paperVerdictClasses(
+  verdict: SurfWindowRecommendation["verdict"],
+): string {
+  if (verdict === "Worth it") {
+    return "border-[#166534] bg-[#166534]/10 text-[#14532D]";
+  }
+  if (verdict === "Maybe") {
+    return "border-[#B56A2B] bg-[#FDB84B]/25 text-[#713F12]";
+  }
+  return "border-[#9F1239] bg-[#9F1239]/10 text-[#881337]";
+}
+
 function ConditionRow({
   sticker,
   label,
   value,
+  variant = "default",
 }: {
   sticker: QuiverStickerKey;
   label: string;
   value: string;
+  variant?: "default" | "zine";
 }) {
+  if (variant === "zine") {
+    return (
+      <div className="flex min-w-0 items-center gap-2 border-b border-[#11100D]/20 px-2 py-3 last:border-b-0 sm:border-b-0 sm:border-r sm:last:border-r-0">
+        <QuiverSticker
+          sticker={sticker}
+          className="h-8 w-8 shrink-0 object-contain"
+          sizes="32px"
+        />
+        <div className="min-w-0">
+          <p className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-[#11100D]/65">
+            {label}
+          </p>
+          <p className="text-sm font-semibold leading-snug text-[#11100D]">
+            {value}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-3 rounded-[12px_6px_14px_8px] border border-white/8 bg-white/[0.03] px-3 py-2 shadow-[2px_3px_0_rgba(0,0,0,0.12)]">
       <span className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-[12px_4px_14px_6px] bg-[#252D6B]/45 shadow-[2px_3px_0_rgba(0,0,0,0.18)]">
@@ -629,6 +665,223 @@ function CompactWindowRow({
   );
 }
 
+function ZineWindowEntry({
+  recommendation,
+  ctaLabel,
+  surface,
+}: {
+  recommendation: SurfWindowRecommendation;
+  ctaLabel?: string;
+  surface: string;
+}) {
+  const { track } = useTrackEvent();
+  const tracking = buildSurfWindowTrackingContext(recommendation, surface);
+  const beach = recommendation.beach;
+  const locality =
+    [beach.city, beach.state].filter(Boolean).join(", ") ||
+    beach.region ||
+    null;
+  const webUrl = recommendation.canonicalWebUrl;
+  const photoUrl = beach.photoUrl?.trim() ?? "";
+  const photoSrc = photoUrl.length > 0 ? getProxiedImageUrl(photoUrl) : null;
+
+  function handleWebClick(): void {
+    if (!webUrl) return;
+    void track("surf_window_click", {
+      beachId: beach.id,
+      metadata: buildSurfWindowTrackingMetadata(tracking, {
+        targetHref: webUrl,
+        linkType: "web",
+      }),
+      debounceMs: 0,
+    });
+  }
+
+  const titleHeading = (
+    <h3 className="font-heading text-2xl font-bold leading-tight text-[#11100D] sm:text-3xl">
+      {beach.name}
+    </h3>
+  );
+
+  return (
+    <article
+      data-testid="surf-window-card"
+      data-variant="zine"
+      className="relative bg-[#FBF6E8] py-6 text-[#11100D] first:pt-2 last:pb-2"
+    >
+      <div
+        className={cn(
+          "grid gap-5",
+          photoSrc && "md:grid-cols-[minmax(10rem,0.7fr)_minmax(0,1.3fr)]",
+        )}
+      >
+        {photoSrc ? (
+          <div className="polaroid rot-neg self-start">
+            <span className="tape tl" aria-hidden="true" />
+            {webUrl ? (
+              <a
+                href={webUrl}
+                aria-label={`View ${beach.name} forecast`}
+                onClick={handleWebClick}
+                className="photo block focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#11100D]"
+              >
+                <HalftonePhoto
+                  src={photoSrc}
+                  alt={`Surf photo of ${beach.name}`}
+                  height={220}
+                />
+              </a>
+            ) : (
+              <div className="photo">
+                <HalftonePhoto
+                  src={photoSrc}
+                  alt={`Surf photo of ${beach.name}`}
+                  height={220}
+                />
+              </div>
+            )}
+            <p className="cap">{beach.name}</p>
+          </div>
+        ) : null}
+
+        <div className="min-w-0 space-y-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className="circled shrink-0 bg-[#FDB84B]/35"
+                  aria-label={`Rank ${recommendation.rank}`}
+                >
+                  {recommendation.rank}
+                </span>
+                <span className="inline-flex items-center gap-1.5 font-mono text-xs font-bold uppercase tracking-[0.08em] text-[#11100D]/75">
+                  <Clock
+                    className="h-4 w-4 text-[#B56A2B]"
+                    aria-hidden="true"
+                  />
+                  {recommendation.localTimeLabel}
+                </span>
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "border px-2.5 py-1 font-mono text-[11px] font-bold uppercase",
+                    paperVerdictClasses(recommendation.verdict),
+                  )}
+                >
+                  {recommendation.verdict}
+                </Badge>
+              </div>
+              {webUrl ? (
+                <a
+                  href={webUrl}
+                  onClick={handleWebClick}
+                  className="block decoration-[#B56A2B] underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#11100D]"
+                >
+                  {titleHeading}
+                </a>
+              ) : (
+                titleHeading
+              )}
+              {locality ? (
+                <p className="font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-[#11100D]/65">
+                  {locality}
+                </p>
+              ) : null}
+            </div>
+            <div
+              className="flex h-16 w-16 shrink-0 flex-col items-center justify-center rounded-full border-[3px] border-double border-[#0B3A75] bg-[#F4EBD8] text-[#0B3A75] shadow-sm"
+              aria-label={`Surf window score ${recommendation.score}`}
+            >
+              <span className="font-heading text-xl font-black leading-none">
+                {recommendation.score}
+              </span>
+              <span className="font-mono text-[9px] font-bold uppercase">
+                score
+              </span>
+            </div>
+          </div>
+
+          <p className="border-l-4 border-[#F78E42] pl-3 font-[var(--font-handwritten)] text-xl font-bold leading-snug text-[#11100D]/85">
+            {recommendation.headline}
+          </p>
+
+          <div
+            className="condition-strip grid-cols-1 sm:grid-cols-3"
+            role="group"
+            aria-label={`Conditions for ${beach.name}`}
+          >
+            <ConditionRow
+              sticker="spotSwellMatch"
+              label="Wave"
+              value={recommendation.wave.summary}
+              variant="zine"
+            />
+            <ConditionRow
+              sticker="spotWindRead"
+              label="Wind"
+              value={recommendation.wind.summary}
+              variant="zine"
+            />
+            <ConditionRow
+              sticker="spotTideWindow"
+              label="Tide"
+              value={recommendation.tide.summary}
+              variant="zine"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 border-b border-dashed border-[#11100D]/30 pb-4">
+            <span className="inline-flex items-center gap-1.5 font-mono text-[11px] font-bold uppercase tracking-[0.1em] text-[#11100D]/70">
+              <Tags className="h-3.5 w-3.5" aria-hidden="true" />
+              Best for
+            </span>
+            {recommendation.bestFor.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="border-[#11100D]/35 bg-[#F0E5CC] text-[11px] text-[#11100D]"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {webUrl ? (
+              <Button
+                asChild
+                size="sm"
+                className="h-10 w-full bg-[#F78E42] text-[#11100D] shadow-sm hover:bg-[#F78E42]/90"
+              >
+                <a
+                  href={webUrl}
+                  data-testid="surf-window-web-cta"
+                  onClick={handleWebClick}
+                >
+                  <span>View spot forecast</span>
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </Button>
+            ) : null}
+            <AppDeepLinkCTA
+              links={recommendation}
+              label={ctaLabel}
+              variant="ghost"
+              tracking={tracking}
+              className="w-full border-[#11100D]/45 bg-transparent text-[#11100D] hover:bg-[#F0E5CC] hover:text-[#11100D]"
+            />
+          </div>
+          <WhyThisCall
+            recommendation={recommendation}
+            surface={surface}
+            variant="zine"
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+
 export function BestSurfWindows({
   recommendations,
   title = "Best surf windows",
@@ -639,6 +892,7 @@ export function BestSurfWindows({
   className,
   layout = "cards",
   hideHeader = false,
+  variant = "default",
 }: BestSurfWindowsProps) {
   const { track } = useTrackEvent();
   const trackedImpressions = useRef<Set<string>>(new Set());
@@ -663,13 +917,27 @@ export function BestSurfWindows({
     return (
       <section
         data-testid="best-surf-windows"
+        data-variant={variant}
         aria-label={title}
         className={cn("space-y-3", className)}
       >
         {hideHeader ? null : (
-          <h2 className="font-heading text-xl font-semibold text-white">{title}</h2>
+          <h2
+            className={cn(
+              "font-heading text-xl font-semibold",
+              variant === "zine" ? "text-[#11100D]" : "text-white",
+            )}
+          >
+            {title}
+          </h2>
         )}
-        <p role="status" className="text-sm text-white/65">
+        <p
+          role="status"
+          className={cn(
+            "text-sm",
+            variant === "zine" ? "text-[#11100D]/65" : "text-white/65",
+          )}
+        >
           No recommended surf windows are available yet.
         </p>
       </section>
@@ -680,9 +948,42 @@ export function BestSurfWindows({
     return null;
   }
 
+  if (variant === "zine") {
+    return (
+      <section
+        data-testid="best-surf-windows"
+        data-variant="zine"
+        aria-label={title}
+        className={cn("space-y-5 text-[#11100D]", className)}
+      >
+        {hideHeader ? null : (
+          <div className="space-y-2">
+            <h2 className="label-black font-display text-2xl font-black uppercase leading-tight">
+              {title}
+            </h2>
+            {subtitle ? (
+              <p className="text-sm text-[#11100D]/70">{subtitle}</p>
+            ) : null}
+          </div>
+        )}
+        <div className="divide-y-2 divide-dashed divide-[#11100D]/35">
+          {visibleRecommendations.map((recommendation) => (
+            <ZineWindowEntry
+              key={recommendation.windowId}
+              recommendation={recommendation}
+              ctaLabel={ctaLabel}
+              surface={surface}
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section
       data-testid="best-surf-windows"
+      data-variant="default"
       aria-label={title}
       className={cn("space-y-4", className)}
     >

--- a/components/session-intelligence/why-this-call.tsx
+++ b/components/session-intelligence/why-this-call.tsx
@@ -26,17 +26,29 @@ export interface WhyThisCallProps {
   recommendation: SurfWindowRecommendation;
   surface?: string;
   className?: string;
+  variant?: "default" | "zine";
 }
 
 function SourceChips({
   recommendation,
+  variant,
 }: {
   recommendation: SurfWindowRecommendation;
+  variant: "default" | "zine";
 }) {
   const sourceLabels = getSurfWindowSourceLabels(recommendation.sources);
 
   if (sourceLabels.length === 0) {
-    return <p className="text-sm text-white/60">No source claims are attached.</p>;
+    return (
+      <p
+        className={cn(
+          "text-sm",
+          variant === "zine" ? "text-[#11100D]/65" : "text-white/60",
+        )}
+      >
+        No source claims are attached.
+      </p>
+    );
   }
 
   return (
@@ -45,7 +57,12 @@ function SourceChips({
         <Badge
           key={label}
           variant="outline"
-          className="border-white/15 bg-white/5 text-[11px] text-white/75"
+          className={cn(
+            "text-[11px]",
+            variant === "zine"
+              ? "border-[#11100D]/30 bg-[#F0E5CC] text-[#11100D]"
+              : "border-white/15 bg-white/5 text-white/75",
+          )}
         >
           {label}
         </Badge>
@@ -58,13 +75,24 @@ function ExplanationList({
   items,
   emptyText,
   icon,
+  variant,
 }: {
   items: string[];
   emptyText: string;
   icon: "positive" | "watchout" | "confidence";
+  variant: "default" | "zine";
 }) {
   if (items.length === 0) {
-    return <p className="text-sm text-white/60">{emptyText}</p>;
+    return (
+      <p
+        className={cn(
+          "text-sm",
+          variant === "zine" ? "text-[#11100D]/65" : "text-white/60",
+        )}
+      >
+        {emptyText}
+      </p>
+    );
   }
 
   const Icon = icon === "positive" ? CheckCircle2 : icon === "watchout" ? AlertTriangle : Info;
@@ -72,8 +100,20 @@ function ExplanationList({
   return (
     <ul className="space-y-2">
       {items.map((item) => (
-        <li key={item} className="flex gap-2 text-sm text-white/78">
-          <Icon className="mt-0.5 h-4 w-4 shrink-0 text-ocean-blue" aria-hidden="true" />
+        <li
+          key={item}
+          className={cn(
+            "flex gap-2 text-sm",
+            variant === "zine" ? "text-[#11100D]/78" : "text-white/78",
+          )}
+        >
+          <Icon
+            className={cn(
+              "mt-0.5 h-4 w-4 shrink-0",
+              variant === "zine" ? "text-[#B56A2B]" : "text-ocean-blue",
+            )}
+            aria-hidden="true"
+          />
           <span>{item}</span>
         </li>
       ))}
@@ -85,6 +125,7 @@ export function WhyThisCall({
   recommendation,
   surface = "session_intelligence",
   className,
+  variant = "default",
 }: WhyThisCallProps) {
   const { track } = useTrackEvent();
   const hasTrackedOpen = useRef(false);
@@ -107,62 +148,118 @@ export function WhyThisCall({
       type="single"
       collapsible
       onValueChange={handleValueChange}
-      className={cn("rounded-md border border-white/10 bg-white/[0.03]", className)}
+      className={cn(
+        "rounded-md border",
+        variant === "zine"
+          ? "border-[#11100D]/30 bg-[#F4EBD8]"
+          : "border-white/10 bg-white/[0.03]",
+        className,
+      )}
     >
       <AccordionItem value={triggerId} className="border-b-0">
         <AccordionTrigger
-          className="px-3 py-2 text-sm font-semibold text-white/90 hover:no-underline"
+          className={cn(
+            "px-3 py-2 text-sm font-semibold hover:no-underline",
+            variant === "zine" ? "text-[#11100D]" : "text-white/90",
+          )}
           aria-label={`Why this call for ${recommendation.beach.name} ${recommendation.localTimeLabel}`}
         >
           <span className="inline-flex items-center gap-2">
-            <Info className="h-4 w-4 text-ocean-blue" aria-hidden="true" />
+            <Info
+              className={cn(
+                "h-4 w-4",
+                variant === "zine" ? "text-[#B56A2B]" : "text-ocean-blue",
+              )}
+              aria-hidden="true"
+            />
             Why this call?
           </span>
         </AccordionTrigger>
         <AccordionContent className="px-3 pb-4 pt-1">
           <div className="grid gap-4 sm:grid-cols-2">
             <section aria-label="Positive signals" className="space-y-2">
-              <h4 className="font-heading text-sm font-semibold text-white">
+              <h4
+                className={cn(
+                  "font-heading text-sm font-semibold",
+                  variant === "zine" ? "text-[#11100D]" : "text-white",
+                )}
+              >
                 Positive signals
               </h4>
               <ExplanationList
                 items={recommendation.positives}
                 emptyText="No positive signals are attached."
                 icon="positive"
+                variant={variant}
               />
             </section>
             <section aria-label="Watchouts" className="space-y-2">
-              <h4 className="font-heading text-sm font-semibold text-white">
+              <h4
+                className={cn(
+                  "font-heading text-sm font-semibold",
+                  variant === "zine" ? "text-[#11100D]" : "text-white",
+                )}
+              >
                 Watchouts
               </h4>
               <ExplanationList
                 items={recommendation.watchouts}
                 emptyText="No major watchouts attached to this window."
                 icon="watchout"
+                variant={variant}
               />
             </section>
             <section aria-label="Confidence" className="space-y-2">
-              <h4 className="font-heading text-sm font-semibold text-white">
+              <h4
+                className={cn(
+                  "font-heading text-sm font-semibold",
+                  variant === "zine" ? "text-[#11100D]" : "text-white",
+                )}
+              >
                 Confidence
               </h4>
               {/* Demoted from the card badge row — confidence detail belongs with the explanation */}
               <SourceConfidenceBadge
                 confidence={recommendation.confidence}
                 sources={recommendation.sources}
+                className={
+                  variant === "zine"
+                    ? "border-[#0B3A75]/45 bg-[#0B3A75]/10 text-[#0B3A75]"
+                    : undefined
+                }
               />
-              <p className="text-sm text-white/70">{recommendation.confidence.summary}</p>
+              <p
+                className={cn(
+                  "text-sm",
+                  variant === "zine" ? "text-[#11100D]/75" : "text-white/70",
+                )}
+              >
+                {recommendation.confidence.summary}
+              </p>
               <ExplanationList
                 items={recommendation.confidence.reasons}
                 emptyText="No confidence reasons are attached."
                 icon="confidence"
+                variant={variant}
               />
             </section>
             <section aria-label="Sources present" className="space-y-2">
-              <h4 className="inline-flex items-center gap-2 font-heading text-sm font-semibold text-white">
-                <Radio className="h-4 w-4 text-ocean-blue" aria-hidden="true" />
+              <h4
+                className={cn(
+                  "inline-flex items-center gap-2 font-heading text-sm font-semibold",
+                  variant === "zine" ? "text-[#11100D]" : "text-white",
+                )}
+              >
+                <Radio
+                  className={cn(
+                    "h-4 w-4",
+                    variant === "zine" ? "text-[#0B3A75]" : "text-ocean-blue",
+                  )}
+                  aria-hidden="true"
+                />
                 Sources present
               </h4>
-              <SourceChips recommendation={recommendation} />
+              <SourceChips recommendation={recommendation} variant={variant} />
             </section>
           </div>
         </AccordionContent>

--- a/docs/archive/superpowers/plans/2026-03-13-about-page-rewrite.md
+++ b/docs/archive/superpowers/plans/2026-03-13-about-page-rewrite.md
@@ -43,9 +43,9 @@ New `ABOUT_CONTENT` (replaces lines 17-74):
 ```ts
 export const ABOUT_CONTENT = {
   hero: {
-    title: "I built Quiver because I was tired of being wrong.",
+    title: "I built Quiver because I was tired of forecasts being wrong.",
     subtitle:
-      "Wrong about the swell. Wrong about the wind. Wrong about whether it was even worth getting out of bed at 5am.",
+      "Forecasts missed the swell. Missed the wind. Missed whether it was even worth getting out of bed at 5am.",
   },
   problem: [
     "I was checking five different apps before every session. Surfline for the cam, Magic Seaweed for the swell, NOAA for the wind, some tide app, and then a group text to see if anyone was going out. And half the time I'd show up and conditions were nothing like what any of them said.",

--- a/docs/archive/superpowers/specs/2026-03-13-about-page-rewrite-design.md
+++ b/docs/archive/superpowers/specs/2026-03-13-about-page-rewrite-design.md
@@ -30,8 +30,8 @@ Rewrite the about page as a **founder letter** — first person, casual, direct.
 
 ### Section 1: Hero
 - **Background:** `bg-[#252D6B]` (Deep Twilight navy)
-- **Heading:** "I built Quiver because I was tired of being wrong."
-- **Subtext:** "Wrong about the swell. Wrong about the wind. Wrong about whether it was even worth getting out of bed at 5am."
+- **Heading:** "I built Quiver because I was tired of forecasts being wrong."
+- **Subtext:** "Forecasts missed the swell. Missed the wind. Missed whether it was even worth getting out of bed at 5am."
 - **Animation:** Simple `motion` fade-in on heading and subtext. No spinning wave icon, no animated counters.
 - **Reduced motion:** Honors `prefers-reduced-motion` — content appears immediately without animation.
 
@@ -89,8 +89,8 @@ Replace `ABOUT_CONTENT` in `lib/constants/content.ts`. New structure:
 ```ts
 export const ABOUT_CONTENT = {
   hero: {
-    title: "I built Quiver because I was tired of being wrong.",
-    subtitle: "Wrong about the swell. Wrong about the wind. Wrong about whether it was even worth getting out of bed at 5am.",
+    title: "I built Quiver because I was tired of forecasts being wrong.",
+    subtitle: "Forecasts missed the swell. Missed the wind. Missed whether it was even worth getting out of bed at 5am.",
   },
   problem: [
     "I was checking five different apps before every session. Surfline for the cam, Magic Seaweed for the swell, NOAA for the wind, some tide app, and then a group text to see if anyone was going out. And half the time I'd show up and conditions were nothing like what any of them said.",

--- a/docs/seo/photo-candidates/san-diego-hero-photo-candidates.json
+++ b/docs/seo/photo-candidates/san-diego-hero-photo-candidates.json
@@ -1,0 +1,9 @@
+{
+  "generatedAt": "2026-08-19T19:20:49.080Z",
+  "source": "openverse",
+  "sourceFilter": "wikimedia",
+  "includeManual": true,
+  "minScore": 4,
+  "targetPath": "scripts/data/san-diego-hero-photo-targets.json",
+  "candidates": []
+}

--- a/docs/seo/photo-candidates/san-diego-hero-photo-candidates.md
+++ b/docs/seo/photo-candidates/san-diego-hero-photo-candidates.md
@@ -1,0 +1,24 @@
+# Beach Photo Candidate Report
+
+Generated: 2026-08-19T19:20:49.080Z
+Source: Openverse API commercial-use Creative Commons image search (wikimedia, min score 4) plus manual review sources
+Target manifest: `scripts/data/san-diego-hero-photo-targets.json`
+
+These are review candidates only. Do not approve or seed them until the beach match, license, creator, and source URL have been manually checked.
+
+## San Diego surf lineup
+
+Slug: `san-diego-hero`
+Query: `San Diego surfing lineup waves`
+Notes: Hero imagery for /best-time-to-surf/san-diego. Needs a surf-conditions shot (rideable waves and/or a lineup), at least 1600px wide, landscape. Reject sea-lion/pinniped scenery, empty sand, and wave pools.
+
+No license-safe candidates returned.
+
+## Ocean Beach Pier
+
+Slug: `ocean-beach-san-diego`
+Query: `Ocean Beach Pier San Diego surf`
+Notes: Pier plus breaking swell reads as tide-and-conditions context. Replaces the 800x600 OceanBeachSurfers asset.
+
+No license-safe candidates returned.
+

--- a/docs/seo/plans/2026-06-23-aeo-brand-pages.md
+++ b/docs/seo/plans/2026-06-23-aeo-brand-pages.md
@@ -15,7 +15,7 @@
 ## Ground rules (read once before starting)
 
 - **Run all commands from the `quiver/` directory with Node 22.** `yarn test:unit` = Jest; `yarn test` = Playwright — never confuse them.
-- **Copy guardrails (from spec §3):** never write a flat "free / no paywall / free forever" claim, never publish fabricated head-to-head MAE numbers vs Surfline, never present the in-sample concordance as live fact. "Free to browse, no subscription to read a forecast" is the only price claim.
+- **Copy guardrails (from spec §3):** describe Quiver as a free Surfline alternative while keeping the geographic coverage and optional Pro personalization alongside the price claim; never claim "no paywall" or "free forever," publish fabricated head-to-head MAE numbers vs Surfline, or present the in-sample concordance as live fact.
 - **`/vs/surfline` must NOT gain the word "free":** `__tests__/app/vs-surfline-metadata.test.ts` asserts `/\bfree\b/i` is absent from `/vs/surfline` metadata AND page source. Phase C edits to that file must avoid the word "free."
 - **`FAQSchema` is a deliberate no-op** (returns `null`; Google restricts FAQ rich results). FAQ copy still helps AI Overviews (they read the visible Q&A) but produces no FAQPage rich snippet — do not expect one.
 - **Beach links use `buildBeachUrl({slug, city, state})`** from `@/lib/utils/beach-url-utils` → `/<state>/<city>/<beachSlug>`. Do NOT link `/forecast/<beachSlug>` (region-only path that 301-redirects).

--- a/docs/seo/specs/2026-06-23-aeo-brand-pages-design.md
+++ b/docs/seo/specs/2026-06-23-aeo-brand-pages-design.md
@@ -117,7 +117,7 @@ Mandatory link graph:
 
 **Section order:**
 1. **Hero** — eyebrow `QUIVER VS SURFLINE · THE FREE READ`; Space Grotesk **900** H1 "Looking for a free Surfline alternative?"; honest subhead; rotated "Updated Jun 2026" sticker; CTAs "Start free →" (orange) + "Browse forecasts." **Stat row beneath:** `2.5M+ forecasts crunched · 280+ breaks · 70+ live cams` (Space Mono, sticker-badged).
-2. **The short answer** (AEO extractable, rotated card) — "Yes — Quiver is a free-to-browse Surfline alternative for the US, Hawaii, Puerto Rico, and Baja. You read any beach's forecast, tide, and cams without paying. What's paid is the optional personalization that learns your logged sessions."
+2. **The short answer** (AEO extractable, rotated card) — "Yes — Quiver is a free Surfline alternative for the US, Hawaii, Puerto Rico, and Baja. You read any beach's forecast, tide, and cams without paying. What's paid is the optional personalization that learns your logged sessions."
 3. **Comparison in 60 seconds** — table (honest content below).
 4. **Decision cards** — "Use Quiver if… / Use Surfline if…" (honest tradeoffs; Surfline wins international + biggest cam network).
 5. **Live cam wall** — 70+ free live cams grouped by coast (San Diego · LA · OC · SF · OR · WA · HI · Outer Banks · Maine · FL · TX), each linking to its beach forecast page → 73 internal links + location keywords. Header: "Watch any break, free."

--- a/lib/constants/content.ts
+++ b/lib/constants/content.ts
@@ -15,9 +15,9 @@ import {
 
 export const ABOUT_CONTENT = {
   hero: {
-    title: "I built Quiver because I was tired of being wrong.",
+    title: "I built Quiver because I was tired of forecasts being wrong.",
     subtitle:
-      "Wrong about the swell. Wrong about the wind. Wrong about whether it was even worth getting out of bed at 5am.",
+      "Forecasts missed the swell. Missed the wind. Missed whether it was even worth getting out of bed at 5am.",
   },
   problem: [
     "I was checking five different apps before every session. Surfline for the cam, Magic Seaweed for the swell, NOAA for the wind, some tide app, and then a group text to see if anyone was going out. And half the time I'd show up and conditions were nothing like what any of them said.",

--- a/lib/constants/seo-scenes.ts
+++ b/lib/constants/seo-scenes.ts
@@ -79,9 +79,10 @@ const NORTH_CAROLINA_BEGINNER_SCENE: SeoScene = {
 };
 
 const SAN_DIEGO_SCENE: SeoScene = {
-  imageSrc: "/images/hero/hero-3-windansea.webp",
-  alt: "The Windansea surf shack above the reef at sunset in La Jolla, San Diego.",
-  objectPosition: "center",
+  imageSrc: "/images/seo-scenes/la-jolla-scripps-clean.webp",
+  alt: "Morning swell lines breaking past Scripps Pier in San Diego.",
+  // Keep the pier and the breaking swell in frame when cropped to a tall panel.
+  objectPosition: "40% 60%",
 };
 
 const CITY_SCENES: Record<string, SeoScene> = {

--- a/lib/constants/seo-scenes.ts
+++ b/lib/constants/seo-scenes.ts
@@ -78,7 +78,14 @@ const NORTH_CAROLINA_BEGINNER_SCENE: SeoScene = {
   attribution: "Photo: Billy Hathorn / Wikimedia Commons (CC BY 3.0)",
 };
 
+const SAN_DIEGO_SCENE: SeoScene = {
+  imageSrc: "/images/hero/hero-3-windansea.webp",
+  alt: "The Windansea surf shack above the reef at sunset in La Jolla, San Diego.",
+  objectPosition: "center",
+};
+
 const CITY_SCENES: Record<string, SeoScene> = {
+  "san-diego": SAN_DIEGO_SCENE,
   "la-jolla": LA_JOLLA_SCENE,
   "san-onofre": SAN_ONOFRE_SCENE,
   "santa-cruz": SANTA_CRUZ_SCENE,

--- a/lib/data/learn-articles.ts
+++ b/lib/data/learn-articles.ts
@@ -252,11 +252,6 @@ export const learnArticles: LearnArticle[] = [
         content: `<p>Use this order every time you open a surf report:</p><ol><li><strong>Period</strong>: is this weak windswell or ground swell?</li><li><strong>Direction</strong>: does my spot actually receive this angle?</li><li><strong>Wind</strong>: clean, cross, or blown out?</li><li><strong>Tide</strong>: is the break in its usable window?</li><li><strong>Height</strong>: now that I trust the setup, how big is it really?</li></ol><p>If you want to get good fast, log a few notes after every surf: period, direction, tide, wind, and which board felt right. After 10 to 20 sessions at the same beach, the numbers stop being abstract and start matching what you feel in the water.</p><p>The data behind those checks is public and transparent: NOAA/NWS WaveWatch-style marine forecasts, NDBC/CDIP/IOOS buoy observations where available, NOAA CO-OPS tides, and Open-Meteo for some wind and extended-horizon coverage. The hard part is not getting numbers. It's learning which numbers matter most for your break.</p><p>Want the read done for you? Quiver scores 280+ breaks by tide, wind, and swell and learns the days you rate — see <a href="/vs/surfline/free">how it compares to Surfline</a> or <a href="/roadmap">vote on what we build next</a>. Runs in any browser, or <a href="/app">get the iOS app</a>.</p>`,
         keyTakeaway:
           "Read surf reports in the same order every time so you stop chasing a misleading height number.",
-        image: {
-          src: "/images/OceanBeachSurfers.webp",
-          alt: "Surfers checking conditions from the beach before choosing boards",
-          position: "right",
-        },
       },
     ],
     faqs: [

--- a/lib/recommendations/session-intelligence-surface-adapters.ts
+++ b/lib/recommendations/session-intelligence-surface-adapters.ts
@@ -270,6 +270,7 @@ function homepageRecommendation(
     startIso,
     endIso,
     peakIso,
+    timezone: recommendation.window.timezone,
     forecastAt: recommendation.forecast.forecast_at,
     localTimeLabel: timeLabel,
     score,

--- a/lib/recommendations/surf-window-recommendations.ts
+++ b/lib/recommendations/surf-window-recommendations.ts
@@ -381,6 +381,7 @@ function buildRecommendation(
     startIso,
     endIso,
     peakIso,
+    timezone: window.timezone,
     forecastAt: row.forecast_at,
     localTimeLabel,
     score,

--- a/lib/utils/beach-sub-page-utils.tsx
+++ b/lib/utils/beach-sub-page-utils.tsx
@@ -180,7 +180,7 @@ export async function renderBeachSubPage({
   const nearbyBeaches = await enrichBeachesWithConditions(nearbyBeachesRaw);
   const hasTideHero = pageType === "tides" &&
     Boolean(tideMeta?.nextHighTime || tideMeta?.nextLowTime);
-  const hasWaterTempHero = pageType === "water-temp" &&
+  const hasWaterTempSummary = pageType === "water-temp" &&
     waterTempMeta?.tempF != null;
   // One real figure from data this render already has (React-cached, no extra
   // queries). A number the visitor can check beats a list of claims - but only
@@ -264,13 +264,7 @@ export async function renderBeachSubPage({
       {hasTideHero && tideMeta && (
         <TideSummaryHero beachName={beach.name} tideData={tideMeta} />
       )}
-      {hasWaterTempHero && waterTempMeta && (
-        <WaterTempSummaryHero
-          beachName={beach.name}
-          waterTempData={waterTempMeta}
-        />
-      )}
-      {!hasTideHero && !hasWaterTempHero && (
+      {!hasTideHero && !hasWaterTempSummary && (
         <BeachSubPageCrawlIntro copy={crawlCopy} />
       )}
 
@@ -280,7 +274,20 @@ export async function renderBeachSubPage({
         beachTimezone={beachTimezone}
         defaultTab={config.defaultTab}
         defaultSubTab={config.defaultSubTab}
-        heroHeadingLevel="h2"
+        heroHeadingLevel={hasWaterTempSummary ? "h1" : "h2"}
+        heroHeadingSuffix={
+          hasWaterTempSummary ? "Water Temp & Wetsuit Guide" : undefined
+        }
+        heroSummarySlot={
+          hasWaterTempSummary && waterTempMeta ? (
+            <WaterTempSummaryHero
+              beachName={beach.name}
+              seasonalTrendsHref={`/water-temp/${cityToSlug(beach.city)}#seasonal-trends`}
+              seasonalTrendsLocation={beach.city || "the area"}
+              waterTempData={waterTempMeta}
+            />
+          ) : undefined
+        }
       />
 
       <BeachSubPageCtaSwitch

--- a/lib/utils/beach-sub-page-utils.tsx
+++ b/lib/utils/beach-sub-page-utils.tsx
@@ -12,13 +12,9 @@ import { WaterTempDatasetSchema } from "@/components/seo/water-temp-dataset-sche
 import Link from "next/link";
 
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
-import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spots";
 import { BeachSubPageCtaSwitch } from "@/components/app-store/beach-subpage-cta-switch";
-import { SeoFunnelNextSteps } from "@/components/seo/seo-funnel-next-steps";
-import { ZineSurface } from "@/components/zine/zine-surface";
 import { TideSummaryHero } from "@/components/beach-detail/tide-summary-hero";
 import { WaterTempSummaryHero } from "@/components/beach-detail/water-temp-summary-hero";
-import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
 import { getNearbyBeaches } from "@/actions/beach/beach-location-actions";
 import type { Beach } from "@/types/database";
 import type { Metadata } from "next";
@@ -156,29 +152,13 @@ export async function renderBeachSubPage({
   const subPagePath = `${beachPath}/${pageType}`;
   const installCtaEnabled = isBeachSubPageInstallCtaEnabled();
 
-  // Fetch dataset schema data in parallel with nearby beaches — uses React cache()
-  // so no extra DB queries when generateBeachSubPageMetadata already called these.
-  const [nearbyBeachesRaw, tideMeta, waterTempMeta] = await Promise.all([
-    (async (): Promise<Beach[]> => {
-      try {
-        if (beach.lat && beach.lon) {
-          const result = await getNearbyBeaches(beach.lat, beach.lon, 25);
-          if (result?.success && result.data) {
-            return result.data
-              .filter((b) => b.id !== beach.id && b.slug !== beach.slug)
-              .slice(0, 4);
-          }
-        }
-      } catch {
-        // Gracefully degrade — nearby beaches are not critical
-      }
-      return [];
-    })(),
+  // Fetch dataset schema data — uses React cache() so no extra DB queries when
+  // generateBeachSubPageMetadata already called these.
+  const [tideMeta, waterTempMeta] = await Promise.all([
     pageType === "tides" ? getTideMetaData(beach.id) : Promise.resolve(null),
     pageType === "water-temp" ? getWaterTempMetaData(beach.id) : Promise.resolve(null),
   ]);
 
-  const nearbyBeaches = await enrichBeachesWithConditions(nearbyBeachesRaw);
   const hasTideHero = pageType === "tides" &&
     Boolean(tideMeta?.nextHighTime || tideMeta?.nextLowTime);
   const hasWaterTempSummary = pageType === "water-temp" &&
@@ -292,12 +272,10 @@ export async function renderBeachSubPage({
       />
 
       <BeachSubPageCtaSwitch
-        beachId={beach.id}
         beachName={beach.name}
         installCtaEnabled={installCtaEnabled}
         placement={`${pageType}-${beachSlug}`}
         pathname={subPagePath}
-        pageType={pageType}
         proof={installCtaProof ?? undefined}
         searchReferralCta={
           pageType === "tides"
@@ -313,53 +291,7 @@ export async function renderBeachSubPage({
         source={ctaSource}
         stickyCtaText={ctaConfig.ctaText}
         stickySupportingText={ctaConfig.supportingText(beach.name)}
-      >
-        {/* These sections render below the hero's zine surface, which left them
-            sitting on the dark site background — the paper-variant components
-            put ink type straight onto navy. Give them their own cream stage so
-            the whole page reads as one field guide. */}
-        <ZineSurface
-          sectionLabel={config.breadcrumbLabel}
-          data-testid="beach-sub-page-next-steps-surface"
-        >
-          <SeoFunnelNextSteps
-            variant="paper"
-            title={`Keep planning ${beach.name}`}
-            description={`Use this ${config.breadcrumbLabel.toLowerCase()} page as one signal, then check the full forecast, nearby breaks, and the companion condition page.`}
-            steps={[
-              {
-                label: `Open the full ${beach.name} forecast`,
-                href: beachPath,
-                description: "Return to the full spot page for forecast, reviews, intel, and sessions.",
-              },
-              {
-                label: pageType === "tides" ? "Check water temperature" : "Watch the tide window",
-                href: pageType === "tides" ? `${beachPath}/water-temp` : `${beachPath}/tides`,
-                description:
-                  pageType === "tides"
-                    ? "Pair the tide call with gear and water-temperature context."
-                    : "Pair water temperature with the next useful tide shift.",
-              },
-              {
-                label: "Compare nearby surf spots",
-                href: "/map",
-                description: "Use the map when this spot is not the right call.",
-              },
-            ]}
-          />
-
-          <div className="mt-12">
-            {/* Zine variant of the same section — the enriched one paints its
-                own navy panel, which covered the cream stage. */}
-            <ZineNearbySpots
-              beaches={nearbyBeaches}
-              sourceBeachName={beach.name}
-              sourceBeachLat={beach.lat}
-              sourceBeachLon={beach.lon}
-            />
-          </div>
-        </ZineSurface>
-      </BeachSubPageCtaSwitch>
+      />
     </>
   );
 }

--- a/lib/utils/beach-sub-page-utils.tsx
+++ b/lib/utils/beach-sub-page-utils.tsx
@@ -15,6 +15,7 @@ import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
 import { NearbyBeachesEnriched } from "@/components/beach-detail/nearby-spots-enriched";
 import { BeachSubPageCtaSwitch } from "@/components/app-store/beach-subpage-cta-switch";
 import { SeoFunnelNextSteps } from "@/components/seo/seo-funnel-next-steps";
+import { ZineSurface } from "@/components/zine/zine-surface";
 import { TideSummaryHero } from "@/components/beach-detail/tide-summary-hero";
 import { WaterTempSummaryHero } from "@/components/beach-detail/water-temp-summary-hero";
 import { enrichBeachesWithConditions } from "@/lib/utils/nearby-beach-enrichment";
@@ -313,7 +314,14 @@ export async function renderBeachSubPage({
         stickyCtaText={ctaConfig.ctaText}
         stickySupportingText={ctaConfig.supportingText(beach.name)}
       >
-        <div className="container mx-auto px-4 pb-8">
+        {/* These sections render below the hero's zine surface, which left them
+            sitting on the dark site background — the paper-variant components
+            put ink type straight onto navy. Give them their own cream stage so
+            the whole page reads as one field guide. */}
+        <ZineSurface
+          sectionLabel={config.breadcrumbLabel}
+          data-testid="beach-sub-page-next-steps-surface"
+        >
           <SeoFunnelNextSteps
             variant="paper"
             title={`Keep planning ${beach.name}`}
@@ -339,16 +347,16 @@ export async function renderBeachSubPage({
               },
             ]}
           />
-        </div>
 
-        <div className="container mx-auto px-4 pb-8">
-          <NearbyBeachesEnriched
-            beaches={nearbyBeaches}
-            sourceBeachName={beach.name}
-            sourceBeachLat={beach.lat}
-            sourceBeachLon={beach.lon}
-          />
-        </div>
+          <div className="mt-12">
+            <NearbyBeachesEnriched
+              beaches={nearbyBeaches}
+              sourceBeachName={beach.name}
+              sourceBeachLat={beach.lat}
+              sourceBeachLon={beach.lon}
+            />
+          </div>
+        </ZineSurface>
       </BeachSubPageCtaSwitch>
     </>
   );

--- a/lib/utils/beach-sub-page-utils.tsx
+++ b/lib/utils/beach-sub-page-utils.tsx
@@ -12,7 +12,7 @@ import { WaterTempDatasetSchema } from "@/components/seo/water-temp-dataset-sche
 import Link from "next/link";
 
 import { BeachDetailClient } from "@/app/beach/[slug]/beach-detail-client";
-import { NearbyBeachesEnriched } from "@/components/beach-detail/nearby-spots-enriched";
+import { ZineNearbySpots } from "@/components/beach-detail/zine/zine-nearby-spots";
 import { BeachSubPageCtaSwitch } from "@/components/app-store/beach-subpage-cta-switch";
 import { SeoFunnelNextSteps } from "@/components/seo/seo-funnel-next-steps";
 import { ZineSurface } from "@/components/zine/zine-surface";
@@ -349,7 +349,9 @@ export async function renderBeachSubPage({
           />
 
           <div className="mt-12">
-            <NearbyBeachesEnriched
+            {/* Zine variant of the same section — the enriched one paints its
+                own navy panel, which covered the cream stage. */}
+            <ZineNearbySpots
               beaches={nearbyBeaches}
               sourceBeachName={beach.name}
               sourceBeachLat={beach.lat}

--- a/lib/utils/forecast-hub-utils.ts
+++ b/lib/utils/forecast-hub-utils.ts
@@ -128,12 +128,13 @@ export async function getRegionalSummaries(
     }
 
     // Aggregate into regional summary
+    const selectionNow = options.now ?? new Date();
     const summary = aggregateRegionalForecast(
       region,
       regionBeaches,
-      regionForecastMap
+      regionForecastMap,
+      { now: selectionNow }
     );
-    const selectionNow = options.now ?? summary.generatedAt;
     summary.generatedAt = selectionNow;
     if (options.includeBestSurfWindows !== false) {
       summary.bestSurfWindows = buildBestSurfWindowsForRegion(
@@ -267,12 +268,13 @@ export async function getRegionalSummary(
     }
   }
 
+  const selectionNow = options.now ?? new Date();
   const summary = aggregateRegionalForecast(
     region,
     regionBeaches,
-    regionForecastMap
+    regionForecastMap,
+    { now: selectionNow }
   );
-  const selectionNow = options.now ?? summary.generatedAt;
   summary.generatedAt = selectionNow;
 
   if (options.includeBestSurfWindows !== false) {

--- a/lib/utils/forecast-hub-utils.ts
+++ b/lib/utils/forecast-hub-utils.ts
@@ -133,11 +133,13 @@ export async function getRegionalSummaries(
       regionBeaches,
       regionForecastMap
     );
+    const selectionNow = options.now ?? summary.generatedAt;
+    summary.generatedAt = selectionNow;
     if (options.includeBestSurfWindows !== false) {
       summary.bestSurfWindows = buildBestSurfWindowsForRegion(
         regionBeaches,
         regionForecastMap,
-        options,
+        { ...options, now: selectionNow },
       );
     }
     summaries[region.slug] = await applyRegionalMajorEventHold(
@@ -270,12 +272,14 @@ export async function getRegionalSummary(
     regionBeaches,
     regionForecastMap
   );
+  const selectionNow = options.now ?? summary.generatedAt;
+  summary.generatedAt = selectionNow;
 
   if (options.includeBestSurfWindows !== false) {
     summary.bestSurfWindows = buildBestSurfWindowsForRegion(
       regionBeaches,
       regionForecastMap,
-      options
+      { ...options, now: selectionNow }
     );
   }
 

--- a/lib/utils/image-utils.ts
+++ b/lib/utils/image-utils.ts
@@ -234,6 +234,7 @@ function cleanOpenverseThumbUrl(url: string): string {
  * URLs that should NOT be proxied:
  * - Relative URLs (e.g., '/images/logo.png')
  * - Supabase storage URLs
+ * - Cam-thumbnail hosts already served directly by next/image remotePatterns
  * - URLs from the app's own domain
  * - null, undefined, or empty strings
  *
@@ -243,6 +244,18 @@ function cleanOpenverseThumbUrl(url: string): string {
  * @param url - The image URL to check
  * @returns true if the URL should be proxied, false otherwise
  */
+/**
+ * External hosts whitelisted in next.config.mjs images.remotePatterns whose
+ * URLs must stay un-proxied — /api/image-proxy's allowlist rejects them.
+ */
+const DIRECT_REMOTE_IMAGE_HOSTS = new Set([
+  "storage.hdontap.com",
+  "img.youtube.com",
+  "camstills.cdn-surfline.com",
+  "ccn-media.coastalcameranetwork.com",
+  "cdn.target-video.com",
+]);
+
 function shouldProxyUrl(url: string | null | undefined): boolean {
   // Handle null, undefined, or empty strings
   if (!url || url.trim() === '') {
@@ -265,6 +278,16 @@ function shouldProxyUrl(url: string | null | undefined): boolean {
 
   // Don't proxy Supabase storage URLs (use centralized check)
   if (isSupabaseStorageUrl(url)) {
+    return false;
+  }
+
+  // Don't proxy cam-thumbnail hosts: next/image remotePatterns serves them
+  // directly, and the proxy's photo-source allowlist rejects them with 403.
+  try {
+    if (DIRECT_REMOTE_IMAGE_HOSTS.has(new URL(url).hostname)) {
+      return false;
+    }
+  } catch {
     return false;
   }
 

--- a/lib/utils/location-slug.ts
+++ b/lib/utils/location-slug.ts
@@ -152,7 +152,7 @@ export function normalizeCountry(country: string | null | undefined): string {
     return "USA";
   }
 
-  if (normalized === "MX" || normalized === "MEXICO") {
+  if (normalized === "MX" || normalized === "MEX" || normalized === "MEXICO") {
     return "Mexico";
   }
 

--- a/lib/utils/public-forecast-facts.ts
+++ b/lib/utils/public-forecast-facts.ts
@@ -1,76 +1,62 @@
 import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
 import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
 
+const REPORT_FACT_KEYS = [
+  "waveHeight",
+  "windSpeed",
+  "windCompass",
+  "windType",
+  "tideHeight",
+  "tidePhase",
+  "nextTideType",
+  "forecastConfidence",
+  "updatedAt",
+] as const satisfies readonly (keyof SurfCallResult)[];
+
+const CONTEXT_FACT_KEYS = [
+  "localDate",
+  "selectedRowTime",
+  "waveHeight",
+  "waveHeightRangeLabel",
+  "swellPeriod",
+  "swellDirection",
+  "primarySwellHeight",
+  "secondarySwellHeight",
+  "secondarySwellPeriod",
+  "secondarySwellDirection",
+  "windSpeed",
+  "windDirection",
+  "primaryDataSource",
+  "sourceDataUpdatedAt",
+  "contributingSources",
+  "timezone",
+] as const satisfies readonly (keyof ForecastRecommendationContext)[];
+
 export type PublicForecastReportFacts = Pick<
   SurfCallResult,
-  | "waveHeight"
-  | "windSpeed"
-  | "windCompass"
-  | "windType"
-  | "tideHeight"
-  | "tidePhase"
-  | "nextTideType"
-  | "forecastConfidence"
-  | "updatedAt"
+  (typeof REPORT_FACT_KEYS)[number]
 >;
 
 export type PublicForecastContextFacts = Pick<
   ForecastRecommendationContext,
-  | "localDate"
-  | "selectedRowTime"
-  | "waveHeight"
-  | "waveHeightRangeLabel"
-  | "swellPeriod"
-  | "swellDirection"
-  | "primarySwellHeight"
-  | "secondarySwellHeight"
-  | "secondarySwellPeriod"
-  | "secondarySwellDirection"
-  | "windSpeed"
-  | "windDirection"
-  | "primaryDataSource"
-  | "sourceDataUpdatedAt"
-  | "contributingSources"
-  | "timezone"
+  (typeof CONTEXT_FACT_KEYS)[number]
 >;
+
+function pick<T, K extends keyof T>(source: T, keys: readonly K[]): Pick<T, K> {
+  return Object.fromEntries(keys.map((key) => [key, source[key]])) as Pick<
+    T,
+    K
+  >;
+}
 
 export function selectPublicForecastReportFacts(
   report: SurfCallResult | null,
 ): PublicForecastReportFacts | null {
-  if (!report) return null;
-  return {
-    waveHeight: report.waveHeight,
-    windSpeed: report.windSpeed,
-    windCompass: report.windCompass,
-    windType: report.windType,
-    tideHeight: report.tideHeight,
-    tidePhase: report.tidePhase,
-    nextTideType: report.nextTideType,
-    forecastConfidence: report.forecastConfidence,
-    updatedAt: report.updatedAt,
-  };
+  return report ? pick(report, REPORT_FACT_KEYS) : null;
 }
 
 export function selectPublicForecastContextFacts(
   context: ForecastRecommendationContext | null,
 ): PublicForecastContextFacts | null {
-  if (!context) return null;
-  return {
-    localDate: context.localDate,
-    selectedRowTime: context.selectedRowTime,
-    waveHeight: context.waveHeight,
-    waveHeightRangeLabel: context.waveHeightRangeLabel,
-    swellPeriod: context.swellPeriod,
-    swellDirection: context.swellDirection,
-    primarySwellHeight: context.primarySwellHeight,
-    secondarySwellHeight: context.secondarySwellHeight,
-    secondarySwellPeriod: context.secondarySwellPeriod,
-    secondarySwellDirection: context.secondarySwellDirection,
-    windSpeed: context.windSpeed,
-    windDirection: context.windDirection,
-    primaryDataSource: context.primaryDataSource,
-    sourceDataUpdatedAt: context.sourceDataUpdatedAt,
-    contributingSources: context.contributingSources,
-    timezone: context.timezone,
-  };
+  return context ? pick(context, CONTEXT_FACT_KEYS) : null;
 }

--- a/lib/utils/public-forecast-facts.ts
+++ b/lib/utils/public-forecast-facts.ts
@@ -1,0 +1,76 @@
+import type { ForecastRecommendationContext } from "@/lib/services/forecast-recommendation-context";
+import type { SurfCallResult } from "@/lib/utils/surf-call-logic";
+
+export type PublicForecastReportFacts = Pick<
+  SurfCallResult,
+  | "waveHeight"
+  | "windSpeed"
+  | "windCompass"
+  | "windType"
+  | "tideHeight"
+  | "tidePhase"
+  | "nextTideType"
+  | "forecastConfidence"
+  | "updatedAt"
+>;
+
+export type PublicForecastContextFacts = Pick<
+  ForecastRecommendationContext,
+  | "localDate"
+  | "selectedRowTime"
+  | "waveHeight"
+  | "waveHeightRangeLabel"
+  | "swellPeriod"
+  | "swellDirection"
+  | "primarySwellHeight"
+  | "secondarySwellHeight"
+  | "secondarySwellPeriod"
+  | "secondarySwellDirection"
+  | "windSpeed"
+  | "windDirection"
+  | "primaryDataSource"
+  | "sourceDataUpdatedAt"
+  | "contributingSources"
+  | "timezone"
+>;
+
+export function selectPublicForecastReportFacts(
+  report: SurfCallResult | null,
+): PublicForecastReportFacts | null {
+  if (!report) return null;
+  return {
+    waveHeight: report.waveHeight,
+    windSpeed: report.windSpeed,
+    windCompass: report.windCompass,
+    windType: report.windType,
+    tideHeight: report.tideHeight,
+    tidePhase: report.tidePhase,
+    nextTideType: report.nextTideType,
+    forecastConfidence: report.forecastConfidence,
+    updatedAt: report.updatedAt,
+  };
+}
+
+export function selectPublicForecastContextFacts(
+  context: ForecastRecommendationContext | null,
+): PublicForecastContextFacts | null {
+  if (!context) return null;
+  return {
+    localDate: context.localDate,
+    selectedRowTime: context.selectedRowTime,
+    waveHeight: context.waveHeight,
+    waveHeightRangeLabel: context.waveHeightRangeLabel,
+    swellPeriod: context.swellPeriod,
+    swellDirection: context.swellDirection,
+    primarySwellHeight: context.primarySwellHeight,
+    secondarySwellHeight: context.secondarySwellHeight,
+    secondarySwellPeriod: context.secondarySwellPeriod,
+    secondarySwellDirection: context.secondarySwellDirection,
+    windSpeed: context.windSpeed,
+    windDirection: context.windDirection,
+    primaryDataSource: context.primaryDataSource,
+    sourceDataUpdatedAt: context.sourceDataUpdatedAt,
+    contributingSources: context.contributingSources,
+    timezone: context.timezone,
+  };
+}

--- a/lib/utils/public-image-exists.ts
+++ b/lib/utils/public-image-exists.ts
@@ -1,0 +1,11 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
+/**
+ * Build/server-time guard for optional local imagery: remote URLs pass
+ * through, local paths must exist under public/ to render.
+ */
+export function publicImageExists(src: string): boolean {
+  if (!src.startsWith("/")) return true;
+  return existsSync(join(process.cwd(), "public", src.slice(1)));
+}

--- a/lib/utils/regional-forecast-utils.ts
+++ b/lib/utils/regional-forecast-utils.ts
@@ -424,9 +424,14 @@ export function detectSwellEvents(
 export function aggregateRegionalForecast(
   region: ForecastRegion,
   beaches: Beach[],
-  forecastMap: Map<string, EnhancedForecastEntity[]>
+  forecastMap: Map<string, EnhancedForecastEntity[]>,
+  options: { now?: Date } = {}
 ): RegionalForecastSummary {
-  const generatedAt = new Date();
+  // Same reference instant the window selector uses, so "now" means the same
+  // thing in the ranking score and in the surf window beside it.
+  const referenceNow = options.now ?? new Date();
+  const referenceMs = referenceNow.getTime();
+  const generatedAt = referenceNow;
   const days: DaySummary[] = [];
 
   // Group forecasts by date
@@ -451,7 +456,7 @@ export function aggregateRegionalForecast(
   // Filter to today and future dates, then take first 7 days.
   // Use HST offset (-10h) as the earliest US timezone so we never
   // prematurely filter out "today" for any US-based user.
-  const nowWithOffset = new Date(Date.now() - 10 * 60 * 60 * 1000);
+  const nowWithOffset = new Date(referenceMs - 10 * 60 * 60 * 1000);
   const today = nowWithOffset.toISOString().split("T")[0]; // YYYY-MM-DD
   const sortedDates = Array.from(dateMap.keys())
     .filter((date) => date >= today)
@@ -610,20 +615,34 @@ export function aggregateRegionalForecast(
     const forecasts = forecastMap.get(beach.id);
     if (!forecasts || forecasts.length === 0) continue;
 
-    // Current score (first forecast)
-    const currentForecasts = forecasts
-      .filter((forecast) => forecast.forecast_at?.split("T")[0] === sortedDates[0])
+    // Current score: the next few hours from the reference instant, NOT the
+    // day's first rows. Scoring dawn rows in the afternoon reported a stale
+    // "EPIC" for conditions that had already passed, contradicting the
+    // future-only surf window rendered beside it.
+    const chronological = forecasts
+      .filter((forecast) => Boolean(forecast.forecast_at))
       .sort(
         (left, right) =>
           Date.parse(left.forecast_at) - Date.parse(right.forecast_at),
-      )
-      .slice(0, 3);
+      );
+    const upcoming = chronological.filter(
+      (forecast) => Date.parse(forecast.forecast_at) >= referenceMs,
+    );
+    // Once a beach's horizon is exhausted, fall back to its most recent rows
+    // so it still ranks rather than dropping out of the region entirely.
+    const currentForecasts = (
+      upcoming.length > 0 ? upcoming : chronological.slice(-3)
+    ).slice(0, 3);
     const currentInterval = resolveForecastInterval(currentForecasts);
     const currentScore = calculateDayScore(currentForecasts, beach);
     const currentWaveHeight = parseFloat(currentForecasts[0]?.wave_height || "0");
 
-    // Calculate trend
-    const next24hForecasts = forecasts.slice(0, 8); // Next 24 hours (3hr intervals)
+    // Trend over the next 24h, taken from the same now-anchored chronological
+    // series as currentScore — comparing it against raw insertion order made
+    // "improving"/"declining" a comparison between two different baselines.
+    const next24hForecasts = (
+      upcoming.length > 0 ? upcoming : chronological
+    ).slice(0, 8);
     const scores = next24hForecasts.map((f) => calculateDayScore([f], beach));
     const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length;
     const trend: "improving" | "steady" | "declining" =

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "seo:gsc-refresh": "node --import tsx scripts/seo/gsc-refresh.ts",
     "seo:technical-audit": "node --import tsx scripts/seo/technical-audit.ts",
     "seo:metadata-audit": "node --import tsx scripts/seo/metadata-audit.ts",
+    "check:comparison-sources": "node --import tsx scripts/check-comparison-sources.ts",
     "seo:forecast-authority-audit": "node --import tsx scripts/seo/forecast-authority-audit.ts",
     "seo:forecast-authority-benchmark": "node --import tsx scripts/seo/forecast-authority-benchmark.ts",
     "seo:enrich": "node --import tsx scripts/seo/enrich.ts",

--- a/scripts/check-comparison-sources.ts
+++ b/scripts/check-comparison-sources.ts
@@ -1,0 +1,134 @@
+import {
+  COMPARISON_SOURCE_LINKS,
+  type ComparisonSourceLink,
+} from "../app/best-surf-forecast-app/comparison-sources";
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Hosts that answer automated checkers with 403/429 bot walls even when the
+ * page is live (Apple rate-limits, Surfline/Zendesk block non-browser UAs).
+ * A blocked response from these hosts is a WARN needing a manual look, not a
+ * broken link; 404/410/redirects/5xx from them still fail.
+ */
+const BOT_PROTECTED_HOSTS = new Set([
+  "apps.apple.com",
+  "www.surfline.com",
+  "support.surfline.com",
+]);
+
+function isBotWalledResponse(result: SourceCheckResult): boolean {
+  if (result.status !== 403 && result.status !== 429) {
+    return false;
+  }
+  try {
+    return BOT_PROTECTED_HOSTS.has(new URL(result.source.href).hostname);
+  } catch {
+    return false;
+  }
+}
+
+interface SourceCheckResult {
+  source: ComparisonSourceLink;
+  status: number | null;
+  redirectLocation?: string;
+  error?: string;
+}
+
+async function checkSource(
+  source: ComparisonSourceLink,
+): Promise<SourceCheckResult> {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(source.href, {
+      headers: {
+        Accept: "text/html,application/xhtml+xml",
+        "User-Agent": "QuiverComparisonSourceChecker/1.0",
+      },
+      redirect: "manual",
+      signal: abortController.signal,
+    });
+
+    await response.body?.cancel();
+
+    return {
+      source,
+      status: response.status,
+      redirectLocation: response.headers.get("location") ?? undefined,
+    };
+  } catch (error) {
+    return {
+      source,
+      status: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function describeFailure(result: SourceCheckResult): string | null {
+  if (result.error) {
+    return result.error;
+  }
+
+  if (result.status && result.status >= 300 && result.status < 400) {
+    return `redirected (${result.status}) to ${result.redirectLocation ?? "an unspecified location"}`;
+  }
+
+  if (!result.status || result.status < 200 || result.status >= 300) {
+    return `returned HTTP ${result.status ?? "unknown"}`;
+  }
+
+  return null;
+}
+
+async function main(): Promise<void> {
+  const results = await Promise.all(
+    COMPARISON_SOURCE_LINKS.map((source) => checkSource(source)),
+  );
+  let failureCount = 0;
+  let warnCount = 0;
+
+  for (const result of results) {
+    const failure = describeFailure(result);
+
+    if (failure && isBotWalledResponse(result)) {
+      warnCount += 1;
+      console.warn(
+        `WARN ${result.source.label}: ${failure} (bot-protected host — verify manually in a browser)`,
+      );
+      console.warn(`     ${result.source.href}`);
+      continue;
+    }
+
+    if (failure) {
+      failureCount += 1;
+      console.error(`FAIL ${result.source.label}: ${failure}`);
+      console.error(`     ${result.source.href}`);
+      continue;
+    }
+
+    console.log(`PASS ${result.source.label}: HTTP ${result.status}`);
+  }
+
+  if (warnCount > 0) {
+    console.warn(
+      `\n${warnCount} bot-protected source(s) could not be verified automatically — open them in a browser during the review.`,
+    );
+  }
+
+  if (failureCount > 0) {
+    console.error(
+      `\n${failureCount} of ${results.length} comparison source links failed. Review redirects and update a cited URL only after verifying the replacement source.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`\nAll ${results.length} comparison source links passed.`);
+}
+
+void main();

--- a/scripts/data/san-diego-hero-photo-targets.json
+++ b/scripts/data/san-diego-hero-photo-targets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "slug": "san-diego-hero",
+    "name": "San Diego surf lineup",
+    "city": "San Diego",
+    "state": "CA",
+    "country": "USA",
+    "query": "San Diego surfing lineup waves",
+    "notes": "Hero imagery for /best-time-to-surf/san-diego. Needs a surf-conditions shot (rideable waves and/or a lineup), at least 1600px wide, landscape. Reject sea-lion/pinniped scenery, empty sand, and wave pools."
+  },
+  {
+    "slug": "ocean-beach-san-diego",
+    "name": "Ocean Beach Pier",
+    "city": "San Diego",
+    "state": "CA",
+    "country": "USA",
+    "query": "Ocean Beach Pier San Diego surf",
+    "notes": "Pier plus breaking swell reads as tide-and-conditions context. Replaces the 800x600 OceanBeachSurfers asset."
+  }
+]

--- a/types/session-intelligence.ts
+++ b/types/session-intelligence.ts
@@ -156,6 +156,7 @@ export interface SurfWindowRecommendation extends SurfWindowLinks {
   startIso: string;
   endIso: string;
   peakIso: string;
+  timezone: string;
   forecastAt: string;
   localTimeLabel: string;
   score: number;


### PR DESCRIPTION
Closes #568, #569, #570, #571, #572, #573, #574, #575, #576, #577, #578, #579, #580, #581, #582, #583, #584

Two batches of work: the 17 filed zine/polish issues, plus a set of defects found during a live design review of the result. **The review findings carry the real behavioural risk — they're listed first.**

## Bugs found during review (not in any issue)

**The regional hero scrim never rendered.** It was written as `from-[#252D6B]/92 via-[#252D6B]/78 to-[#252D6B]/88`, but Tailwind only emits opacity modifiers on its scale (multiples of 5). No `/92`, `/78`, `/88` rules were generated, `--tw-gradient-stops` stayed undefined, and the whole gradient collapsed to `background-image: none` — leaving white text on a bright photo. A repo-wide sweep found one more (`BeginnerHero`, `/12`). `__tests__/styles/gradient-opacity-scale.test.ts` now fails the build on any off-scale stop.

**`SeoScenePanel` cropped photos whenever a caller stretched its height.** `aspect-[16/9]` combined with `h-full` drove *width from height*, computing a 1252px-wide media box inside a 460px figure — so `overflow-hidden` sliced off the left ~63% of every photo and `object-position` never applied. Binding width to the figure fixes this panel and four other latent call sites.

**"TOP BEACH NOW" was scoring dawn conditions.** `currentScore` came from the day's *first three* forecast rows, so at 2pm the regional page ranked and labelled beaches on conditions that had already passed — reporting `87 EPIC` beside a window selector that correctly found nothing left. Score and window now share one reference instant.

**The hero ranked on one engine and sourced its window from another.** A beach could top the ranking on a momentary reading while carrying no qualifying session. The hero now leads with the region's best window, so beach, score, window, and wave height all come from one selection — and when nothing is live it points at the next window instead of going silent.

**Display headings overflowed narrow columns.** `clamp(48px, 8vw, 96px)` sizes off the viewport; in a two-column hero the column is ~36% of it, so `ALTERNATIVE?` rendered 124px past its track into the neighbouring card. A `cqw` term inside `.zine-measure` sizes off the column instead; with no container ancestor `cqw` resolves to the viewport and loses the `min()`, so every other zine heading is unchanged.

**Cam thumbnails were 403ing.** The image proxy's photo-source allowlist rejects cam hosts that `next/image` already serves directly, breaking every hdontap/YouTube/Surfline preview.

**Sub-page sections sat outside the zine surface**, putting ink type on the dark background — the "Keep planning" heading was effectively invisible at ~1:1 contrast.

## The filed issues

- **Torn-edge cluster (#571 #573 #578 #579 #580 #581)** — one root cause, not six: the deckle mask scaled with element height while padding stayed fixed at 16px, so tall cards took a ~100px bite. Fixed-depth mask bands + a safe-inset token + a rotation step-down under 900px; `/tools` cards straightened per the issue.
- **Guest gating (#568 #569)** — decision content is now absent from static HTML for guests (not merely hidden), with authed hydration via `/api/surf/call`; regional scores gated behind login.
- **Zine restyles (#570 #574 #575 #576 #577)** — `/forecast` modules, all three `/beaches` indexes with licensed photography and DB-backed Baja imagery, and the water-temp hero merged into one cream field guide.
- **Copy + content (#572 #583 #584 #582)** — About headline, live-cam card visuals with a deliberate fallback, Surfline positioning, and a 60-day freshness tripwire for comparison sources.

## Verification

- Full unit suite green (**17,000+ tests**); typecheck and lint clean.
- Every changed surface verified in-browser at 390 / 768 / 870×707 / desktop.
- **Guest-contract e2e, 9 specs, run locally against Supabase — and baselined against `main` on the same machine:**

  | | passed | failed | skipped |
  |---|---|---|---|
  | `main` | 111 | 11 | 3 |
  | this branch | 111 | 11 | 3 |

  The failing set is **identical on both** — verified by diffing the failure lists, which produced an empty symmetric difference. **No regressions from this branch.** Every failure is tagged `@requires-data` or depends on forecast rows the local database lacks (the dev server logs `Forecast issues: 53 failed` on both runs). These need a seeded environment or CI to clear; they are not introduced here.

## Known gaps

- Signed-in regional scores are still the generic calculation; per-user personalisation was **not** fabricated (#569).
- `/best-time-to-surf/san-diego` keeps whitespace under its 4:3 hero — the approved-photo pipeline returned no license-safe San Diego candidates (recorded in `docs/seo/photo-candidates/`). Deliberately not filled with a weak shot.
