### PR TITLE
perf: reduce Vercel usage

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -7,7 +7,6 @@ __tests__/
 /.next/
 /reports/
 /.planning/
-/.git/
 /.claude/
 /.agents/
 /.superpowers/

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ npx playwright test --grep auth   # E2E tests matching "auth"
 
 **Web Application:**
 
-- Automatic Preview deployment to Vercel on merge to `main`
+- Automatic Preview deployment for runtime changes merged to `main`; docs- and
+  test-only commits skip the Vercel build
 - Automatic Production deployment from `prod`
 - PR branch previews are opt-in via `preview/<description>` branches
 - URL: [www.quiversurf.app](https://www.quiversurf.app)
@@ -308,7 +309,7 @@ graph LR
     PR -.->|Optional preview/** branch| Preview[Vercel Preview]
     PR -->|Tests Pass| Review[Code Review]
     Review -->|Approved| Main[Merge to Main]
-    Main -->|Auto Deploy| DevPreview[dev.quiversurf.app]
+    Main -->|Runtime changes| DevPreview[dev.quiversurf.app]
     DevPreview -->|Promote via prod| Prod[Production]
     Main -.->|Manual| Mobile[Mobile Build]
     Mobile -.->|Submit| Stores[App Stores]

--- a/__tests__/components/analytics/analytics-loader.vercel-analytics.test.tsx
+++ b/__tests__/components/analytics/analytics-loader.vercel-analytics.test.tsx
@@ -18,7 +18,12 @@ jest.mock("@vercel/analytics/react", () => ({
 }));
 
 jest.mock("@vercel/speed-insights/next", () => ({
-  SpeedInsights: () => <div data-testid="vercel-speed-insights" />,
+  SpeedInsights: ({ sampleRate }: { sampleRate?: number }) => (
+    <div
+      data-testid="vercel-speed-insights"
+      data-sample-rate={sampleRate}
+    />
+  ),
 }));
 
 import { AnalyticsLoader } from "@/components/analytics/analytics-loader";
@@ -29,12 +34,14 @@ describe("AnalyticsLoader (Vercel Web Analytics)", () => {
     expect(screen.getByTestId("vercel-analytics")).toBeInTheDocument();
   });
 
-  it("mounts the Vercel Speed Insights component", () => {
+  it("samples 10% of sessions with Vercel Speed Insights", () => {
     render(<AnalyticsLoader />);
-    expect(screen.getByTestId("vercel-speed-insights")).toBeInTheDocument();
+    expect(screen.getByTestId("vercel-speed-insights")).toHaveAttribute(
+      "data-sample-rate",
+      "0.1",
+    );
   });
 });
-
 
 
 

--- a/__tests__/components/cams/cam-card.test.tsx
+++ b/__tests__/components/cams/cam-card.test.tsx
@@ -85,4 +85,28 @@ describe("CamCard", () => {
       CAM_CARD_FALLBACK_IMAGE_URL,
     );
   });
+
+  it("keeps a space before the arrow in the hover label", () => {
+    render(<CamCard beach={baseBeach} />);
+
+    expect(screen.getByText("Watch live cam →")).toBeInTheDocument();
+  });
+
+  it("keeps a space before the arrow when no preview is available", () => {
+    render(
+      <CamCard
+        beach={{
+          ...baseBeach,
+          camera_url: "https://example.com/some-cam",
+          thumbnail_url: null,
+          photo_url: null,
+        }}
+      />,
+    );
+
+    fireEvent.error(screen.getByAltText("Test Beach live camera"));
+
+    expect(screen.getByText("Preview unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Open cam page →")).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/cams/cam-grid.test.tsx
+++ b/__tests__/components/cams/cam-grid.test.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, type ImgHTMLAttributes } from "react";
+import { render, screen } from "@testing-library/react";
+
+import { CamGrid } from "@/components/cams/cam-grid";
+import type { CamBeachWithRegion } from "@/actions/beach/cam-actions";
+
+type MockNextImageProps = ImgHTMLAttributes<HTMLImageElement> & {
+  fill?: boolean;
+};
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: forwardRef<HTMLImageElement, MockNextImageProps>(function MockImage(
+    { fill: _fill, ...props },
+    ref,
+  ) {
+    // eslint-disable-next-line jsx-a11y/alt-text
+    return <img ref={ref} {...props} />;
+  }),
+}));
+
+function makeBeach(index: number): CamBeachWithRegion {
+  return {
+    id: `beach-${index}`,
+    name: `Test Beach ${index}`,
+    slug: `test-beach-${index}`,
+    city: "San Diego",
+    state: "CA",
+    camera_url: "https://www.youtube.com/watch?v=abc123",
+    thumbnail_url: "https://img.youtube.com/vi/abc123/hqdefault.jpg",
+    photo_url: null,
+    regionSlug: "southern-california",
+  };
+}
+
+describe("CamGrid", () => {
+  it("keeps a space before the arrow in the region link", () => {
+    render(<CamGrid beaches={[makeBeach(1), makeBeach(2)]} groupByRegion />);
+
+    const link = screen.getByRole("link", { name: /view all/i });
+    expect(link).toHaveTextContent("View all 2 cams →");
+    expect(link).toHaveAttribute("href", "/cams/southern-california");
+  });
+
+  it("singularizes the region link for a single cam", () => {
+    render(<CamGrid beaches={[makeBeach(1)]} groupByRegion />);
+
+    expect(
+      screen.getByRole("link", { name: /view all/i }),
+    ).toHaveTextContent("View all 1 cam →");
+  });
+});

--- a/__tests__/config/vercel-config.test.js
+++ b/__tests__/config/vercel-config.test.js
@@ -23,6 +23,10 @@ describe("vercel.json", () => {
   it("skips docs-only commits but builds runtime changes", () => {
     const configPath = path.join(process.cwd(), "vercel.json");
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const vercelIgnore = fs.readFileSync(
+      path.join(process.cwd(), ".vercelignore"),
+      "utf8",
+    );
     const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "vercel-ignore-"));
     const git = (...args) =>
       execFileSync("git", args, { cwd: repoPath, stdio: "ignore" });
@@ -32,6 +36,8 @@ describe("vercel.json", () => {
         env: { ...process.env, ...env },
         shell: true,
       }).status;
+
+    expect(vercelIgnore).not.toMatch(/^\/\.git\/$/m);
 
     try {
       git("init");

--- a/__tests__/config/vercel-config.test.js
+++ b/__tests__/config/vercel-config.test.js
@@ -3,14 +3,84 @@
  */
 
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
+const { execFileSync, spawnSync } = require("node:child_process");
 
 describe("vercel.json", () => {
-  it("does not use an ignored build step", () => {
+  it("keeps staging, production, and explicit preview deployments enabled", () => {
     const configPath = path.join(process.cwd(), "vercel.json");
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
 
-    expect(config).not.toHaveProperty("ignoreCommand");
+    expect(config.git.deploymentEnabled).toEqual({
+      "**": false,
+      main: true,
+      prod: true,
+      "preview/**": true,
+    });
+  });
+
+  it("skips docs-only commits but builds runtime changes", () => {
+    const configPath = path.join(process.cwd(), "vercel.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const repoPath = fs.mkdtempSync(path.join(os.tmpdir(), "vercel-ignore-"));
+    const git = (...args) =>
+      execFileSync("git", args, { cwd: repoPath, stdio: "ignore" });
+    const runIgnoreCommand = (env = {}) =>
+      spawnSync(config.ignoreCommand, {
+        cwd: repoPath,
+        env: { ...process.env, ...env },
+        shell: true,
+      }).status;
+
+    try {
+      git("init");
+      git("config", "user.email", "test@example.com");
+      git("config", "user.name", "Test User");
+
+      fs.writeFileSync(path.join(repoPath, "README.md"), "baseline\n");
+      fs.mkdirSync(path.join(repoPath, "components"));
+      fs.writeFileSync(path.join(repoPath, "components", "example.tsx"), "baseline\n");
+      git("add", ".");
+      git("commit", "-m", "baseline");
+      const baselineSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repoPath,
+        encoding: "utf8",
+      }).trim();
+
+      fs.writeFileSync(path.join(repoPath, "README.md"), "docs update\n");
+      git("add", "README.md");
+      git("commit", "-m", "docs update");
+      expect(runIgnoreCommand()).toBe(0);
+
+      fs.mkdirSync(path.join(repoPath, "__tests__"));
+      fs.writeFileSync(
+        path.join(repoPath, "__tests__", "example.test.ts"),
+        "test update\n",
+      );
+      git("add", "__tests__/example.test.ts");
+      git("commit", "-m", "test update");
+      expect(runIgnoreCommand()).toBe(0);
+
+      fs.writeFileSync(
+        path.join(repoPath, "components", "example.tsx"),
+        "runtime update\n",
+      );
+      git("add", "components/example.tsx");
+      git("commit", "-m", "runtime update");
+      expect(runIgnoreCommand()).toBe(1);
+
+      fs.writeFileSync(path.join(repoPath, "README.md"), "follow-up docs\n");
+      git("add", "README.md");
+      git("commit", "-m", "follow-up docs");
+      expect(runIgnoreCommand()).toBe(0);
+      expect(
+        runIgnoreCommand({ VERCEL_GIT_PREVIOUS_SHA: baselineSha }),
+      ).toBe(1);
+    } finally {
+      fs.rmSync(repoPath, { force: true, recursive: true });
+    }
+
     expect(Array.isArray(config.crons)).toBe(true);
     expect(config.crons).toEqual(
       expect.arrayContaining([

--- a/components/analytics/analytics-loader.tsx
+++ b/components/analytics/analytics-loader.tsx
@@ -91,7 +91,7 @@ export function AnalyticsLoader() {
       <Analytics />
 
       {/* Vercel Speed Insights (Core Web Vitals monitoring) */}
-      <SpeedInsights />
+      <SpeedInsights sampleRate={0.1} />
 
       {/* Google Analytics (GA4) - Load on ALL pages for attribution */}
       {GA_ID && (

--- a/components/cams/cam-card.tsx
+++ b/components/cams/cam-card.tsx
@@ -127,7 +127,9 @@ export function CamCard({ beach }: CamCardProps) {
           </span>
         </div>
         <p className="mt-3 font-mono text-[11px] font-black uppercase tracking-[0.14em] text-[#0B3A75] opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-          {showThumbnail ? "Watch live cam" : "Open cam page"} &rarr;
+          {/* One string expression: SWC eats the leading space of a
+              multi-line JSX text child that contains an HTML entity. */}
+          {`${showThumbnail ? "Watch live cam" : "Open cam page"} →`}
         </p>
       </div>
     </Link>

--- a/components/cams/cam-grid.tsx
+++ b/components/cams/cam-grid.tsx
@@ -48,8 +48,11 @@ export function CamGrid({ beaches, groupByRegion = false }: CamGridProps) {
                 href={`/cams/${region.slug}`}
                 className="font-mono text-xs font-black uppercase tracking-[0.12em] text-[#0B3A75] underline decoration-[#F78E42] decoration-2 underline-offset-4 transition hover:text-[#11100D]"
               >
-                View all {regionBeaches.length}{" "}
-                {regionBeaches.length === 1 ? "cam" : "cams"} &rarr;
+                {/* One string expression: SWC eats the leading space of a
+                    multi-line JSX text child that contains an HTML entity. */}
+                {`View all ${regionBeaches.length} ${
+                  regionBeaches.length === 1 ? "cam" : "cams"
+                } →`}
               </Link>
             </div>
             <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -33,6 +33,8 @@ Vercel automatic Git deployments are intentionally limited in `vercel.json`:
 - `prod` deploys to Production
 - `preview/**` branches deploy when a PR explicitly needs a branch preview
 - Routine `feat/**`, `fix/**`, `chore/**`, and `codex/**` branches do not deploy
+- Commits limited to documentation, planning files, tests, or GitHub workflows skip
+  the Vercel build; any unrecognized path still builds by default
 
 If a PR needs its own Vercel preview, create it from a `preview/<description>`
 branch. Otherwise, rely on local verification and the `main` preview after merge.

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff --quiet \"${VERCEL_GIT_PREVIOUS_SHA:-HEAD^}\" HEAD -- . ':(exclude)*.md' ':(exclude)**/*.md' ':(exclude).github/**' ':(exclude).planning/**' ':(exclude)__tests__/**' ':(exclude)docs/**' ':(exclude)e2e/**' ':(exclude)plans/**'",
   "git": {
     "deploymentEnabled": {
       "**": false,


### PR DESCRIPTION
## Summary
- sample 10% of Vercel Speed Insights sessions
- skip Vercel builds for docs, planning, tests, E2E, and workflow-only changes
- preserve git metadata so the ignored-build step can compare against the last successful deployment
- include the current main cam-label whitespace fix in the normal main-to-prod promotion

## Verification
- focused cost-control tests: 5 passed
- production integration tests: 12 passed
- TypeScript: passed
- full ESLint with zero warnings: passed
- main Vercel preview: Ready and aliased to dev.quiversurf.app

## Risk
The ignored-build command fails safe: unknown paths, missing history, or git diff errors continue the build.