### PR TITLE
fix(map): legible, compact forecast timeline day labels (#510 #511 #513)

### DIFF
--- a/__tests__/components/map/swell-day-timeline.test.tsx
+++ b/__tests__/components/map/swell-day-timeline.test.tsx
@@ -4,6 +4,8 @@ import {
   advancePlaybackPosition,
   compactTimelineDayLabel,
   findAdjacentLocalDayIndex,
+  timelineDayLabelClasses,
+  timelineDayLabelWidthPercent,
   SwellDayTimeline,
   type SwellDayTimelineProps,
 } from "@/components/map/swell-field/swell-day-timeline";
@@ -50,22 +52,86 @@ describe("SwellDayTimeline", () => {
     expect(advancePlaybackPosition(9.9, 100, 10)).toBe(10);
   });
 
-  it("uses readable date numbers for compact ten-day bands", () => {
+  it("falls back to the viewport breakpoint for day labels before the track is measured", () => {
     expect(compactTimelineDayLabel("Sat 8")).toBe("8");
     expect(compactTimelineDayLabel("Mon 17")).toBe("17");
+    expect(timelineDayLabelWidthPercent(0, 1, 12)).toBeCloseTo(16.67, 1);
+    expect(timelineDayLabelClasses(null)).toEqual({
+      full: "hidden truncate sm:inline",
+      compact: "tabular-nums sm:hidden",
+    });
 
     render(<SwellDayTimeline {...createProps()} />);
 
-    expect(screen.getByTestId("timeline-day-Fri-10-compact")).toHaveTextContent("10");
+    expect(screen.getByTestId("timeline-day-Fri-10")).toHaveClass("text-xs");
     expect(screen.getByTestId("timeline-day-Fri-10-compact")).toHaveClass(
       "tabular-nums",
       "sm:hidden",
     );
-    expect(screen.getByTestId("timeline-day-Fri-10")).toHaveClass(
-      "justify-center",
-      "px-0.5",
-      "sm:px-2",
+  });
+
+  it("picks the full or short day label from the measured band width, not the viewport", () => {
+    expect(timelineDayLabelClasses(63)).toEqual({ full: "hidden", compact: "inline tabular-nums" });
+    expect(timelineDayLabelClasses(64)).toEqual({ full: "inline truncate", compact: "hidden tabular-nums" });
+
+    const originalRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = function measure(this: HTMLElement) {
+      const rect = originalRect.call(this);
+      if (this.dataset.testid === "timeline-track") {
+        return { ...rect, width: 600, toJSON: () => ({}) } as DOMRect;
+      }
+      return rect;
+    };
+    try {
+      const hourly = Array.from({ length: 12 }, (_, index) =>
+        new Date(Date.UTC(2026, 6, 10, index)).toISOString(),
+      );
+      render(
+        <SwellDayTimeline
+          {...createProps({
+            timestamps: hourly,
+            timezone: "UTC",
+            daySegments: [
+              // 2/12 of 600px = 100px: wide enough for "Fri 10".
+              { key: "2026-07-10", label: "Fri 10", startIndex: 0, endIndex: 1 },
+              // 1/12 of 600px = 50px: date number only.
+              { key: "2026-07-11", label: "Sat 11", startIndex: 2, endIndex: 2 },
+              { key: "2026-07-12", label: "Sun 12", startIndex: 3, endIndex: 11 },
+            ],
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId("timeline-day-Fri-10-compact")).toHaveClass("hidden");
+      expect(screen.getByTestId("timeline-day-Sat-11-compact")).toHaveClass("inline");
+      expect(screen.getByTestId("timeline-day-Sat-11-compact")).toHaveTextContent("11");
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalRect;
+    }
+  });
+
+  it("labels a midday current-day segment Today without changing its proportional width", () => {
+    const middayTimestamps = Array.from({ length: 24 }, (_, index) =>
+      new Date(Date.UTC(2026, 6, 10, 12 + index)).toISOString(),
     );
+
+    render(
+      <SwellDayTimeline
+        {...createProps({
+          timestamps: middayTimestamps,
+          timezone: "UTC",
+          daySegments: [
+            { key: "2026-07-10", label: "Fri 10", startIndex: 0, endIndex: 11 },
+            { key: "2026-07-11", label: "Sat 11", startIndex: 12, endIndex: 23 },
+          ],
+        })}
+      />,
+    );
+
+    const today = screen.getByTestId("timeline-day-Fri-10");
+    expect(today).toHaveStyle({ width: "50%" });
+    expect(today).toHaveTextContent("Today · 12h left");
+    expect(today).toHaveAttribute("title", "Today · 12h left");
   });
 
   it("exposes the active local forecast time through the native slider", () => {
@@ -73,7 +139,7 @@ describe("SwellDayTimeline", () => {
 
     expect(screen.getByRole("slider", { name: "Forecast time" }))
       .toHaveAttribute("aria-valuetext", "Fri 10 — 2 PM HST");
-    expect(screen.getByTestId("timeline-day-Fri-10")).toHaveTextContent("Fri 10");
+    expect(screen.getByTestId("timeline-day-Fri-10")).toHaveTextContent("Today");
     expect(screen.queryByText("Pacific/Honolulu")).not.toBeInTheDocument();
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
@@ -237,7 +303,7 @@ describe("SwellDayTimeline", () => {
 
     rerender(<SwellDayTimeline {...createProps({ isExhausted: true })} />);
     expect(screen.getByRole("status")).toHaveTextContent(
-      "Forecast ends Sat 11 — 1 PM HST",
+      "2-day forecast · ends Sat 11 — 1 PM HST",
     );
   });
 

--- a/components/map/swell-field/swell-day-timeline.tsx
+++ b/components/map/swell-field/swell-day-timeline.tsx
@@ -39,6 +39,8 @@ const deltaByKey: Record<string, number> = {
 };
 const PLAYBACK_VISUAL_FRAME_MS = 500;
 const FIELD_UPDATE_INTERVAL_MS = 100;
+// "Mon 17" at 12px bold uppercase plus padding; below this a band shows the date number only.
+const FULL_DAY_LABEL_MIN_PX = 64;
 
 export function advancePlaybackPosition(
   current: number,
@@ -134,6 +136,61 @@ function dayTestId(label: string): string {
 
 export function compactTimelineDayLabel(label: string): string {
   return label.match(/\d+$/)?.[0] ?? label;
+}
+
+export function timelineDayLabelWidthPercent(
+  startIndex: number,
+  endIndex: number,
+  timestampCount: number,
+): number {
+  if (timestampCount <= 0 || endIndex < startIndex) return 0;
+  return ((endIndex - startIndex + 1) / timestampCount) * 100;
+}
+
+function isPartialCurrentDaySegment(
+  segment: TimelineDaySegment,
+  segmentIndex: number,
+  timezone: string,
+  timestamps: string[],
+): boolean {
+  if (segmentIndex !== 0 || segment.startIndex !== 0) return false;
+  return localTimestampParts(timestamps[0], timezone).wallMinutes > 0;
+}
+
+function timelineSegmentLabels(
+  segment: TimelineDaySegment,
+  segmentIndex: number,
+  timestamps: string[],
+  timezone: string,
+): { full: string; compact: string; hint: string | undefined } {
+  const isPartial = isPartialCurrentDaySegment(segment, segmentIndex, timezone, timestamps);
+  if (!isPartial) {
+    return {
+      full: segment.label,
+      compact: compactTimelineDayLabel(segment.label),
+      hint: undefined,
+    };
+  }
+
+  const remainingHours = segment.endIndex - segment.startIndex + 1;
+  return {
+    full: "Today",
+    compact: "Today",
+    hint: `${remainingHours}h left`,
+  };
+}
+
+export function timelineDayLabelClasses(
+  segmentWidthPx: number | null,
+): { full: string; compact: string } {
+  // Unknown width (no layout yet, or jsdom): fall back to the viewport breakpoint.
+  if (segmentWidthPx == null) {
+    return { full: "hidden truncate sm:inline", compact: "tabular-nums sm:hidden" };
+  }
+  if (segmentWidthPx < FULL_DAY_LABEL_MIN_PX) {
+    return { full: "hidden", compact: "inline tabular-nums" };
+  }
+  return { full: "inline truncate", compact: "hidden tabular-nums" };
 }
 
 function TimelineStatus({
@@ -250,7 +307,7 @@ export function SwellDayTimeline({
 }: SwellDayTimelineProps): ReactElement | null {
   const finalTimestamp = timestamps.at(-1);
   const exhaustionLabel = finalTimestamp
-    ? `Forecast ends ${formatTimelineBubble(finalTimestamp, timezone)}`
+    ? `${daySegments.length}-day forecast · ends ${formatTimelineBubble(finalTimestamp, timezone)}`
     : "No forecast hours available";
   const safeIndex = clampIndex(index, timestamps.length);
   const canPlay = timestamps.length > 1;
@@ -259,7 +316,22 @@ export function SwellDayTimeline({
   const visualIndexRef = useRef(safeIndex);
   const controlledIndexRef = useRef(safeIndex);
   const maxIndexRef = useRef(maxIndex);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [trackWidth, setTrackWidth] = useState(0);
   const onPlaybackPositionChangeRef = useRef(onPlaybackPositionChange);
+
+  useLayoutEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    const measure = (): void => {
+      setTrackWidth(track.getBoundingClientRect().width);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(track);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     onPlaybackPositionChangeRef.current = onPlaybackPositionChange;
@@ -372,7 +444,21 @@ export function SwellDayTimeline({
           )}
         </Button>
 
-        <div data-testid="timeline-track" className="relative min-w-0 flex-1 pt-9">
+        <div ref={trackRef} data-testid="timeline-track" className="relative min-w-0 flex-1 pt-9">
+          {error ? null : (
+            <div
+              data-testid="timeline-status-inline"
+              className="pointer-events-none absolute right-0 top-0 max-w-[60%] text-right leading-4 [&>div]:truncate"
+            >
+              <TimelineStatus
+                error={null}
+                isLoadingMore={isLoadingMore}
+                isExhausted={isExhausted}
+                onRetry={onRetry}
+                exhaustionLabel={exhaustionLabel}
+              />
+            </div>
+          )}
           <div
             data-testid="timeline-bubble"
             className="absolute z-10 whitespace-nowrap border border-[var(--swell-timeline-ink)] px-2 py-1 text-xs font-bold tabular-nums shadow-[var(--swell-timeline-sticker-shadow)]"
@@ -430,13 +516,26 @@ export function SwellDayTimeline({
                 if (endIndex < startIndex) return null;
 
                 const left = (startIndex / timestamps.length) * 100;
-                const width = ((endIndex - startIndex + 1) / timestamps.length) * 100;
+                const width = timelineDayLabelWidthPercent(
+                  startIndex,
+                  endIndex,
+                  timestamps.length,
+                );
+                const labels = timelineSegmentLabels(
+                  segment,
+                  segmentIndex,
+                  timestamps,
+                  timezone,
+                );
+                const segmentWidthPx = trackWidth > 0 ? (trackWidth * width) / 100 : null;
+                const labelClasses = timelineDayLabelClasses(segmentWidthPx);
 
                 return (
                   <div
                     key={segment.key}
                     data-testid={dayTestId(segment.label)}
-                    className="absolute bottom-0 top-0 flex min-w-0 items-center justify-center border-r border-[var(--swell-timeline-ink)] px-0.5 text-[10px] font-bold uppercase tracking-[0.04em] last:border-r-0 sm:justify-start sm:px-2 sm:tracking-[0.08em]"
+                    title={labels.hint ? `${labels.full} · ${labels.hint}` : labels.full}
+                    className="absolute bottom-0 top-0 flex min-w-0 items-center justify-center border-r border-[var(--swell-timeline-ink)] px-0.5 text-xs font-bold uppercase tracking-[0.04em] last:border-r-0 sm:justify-start sm:px-2 sm:tracking-[0.08em]"
                     style={{
                       left: `${left}%`,
                       width: `${width}%`,
@@ -445,12 +544,19 @@ export function SwellDayTimeline({
                         : SWELL_MAP_TIMELINE.dayBandAlternate,
                     }}
                   >
-                    <span className="hidden truncate sm:inline">{segment.label}</span>
+                    <span className={labelClasses.full}>
+                      {labels.full}
+                      {labels.hint ? (
+                        <span className="font-medium normal-case tracking-normal">
+                          {` · ${labels.hint}`}
+                        </span>
+                      ) : null}
+                    </span>
                     <span
                       data-testid={`${dayTestId(segment.label)}-compact`}
-                      className="tabular-nums sm:hidden"
+                      className={labelClasses.compact}
                     >
-                      {compactTimelineDayLabel(segment.label)}
+                      {labels.compact}
                     </span>
                   </div>
                 );
@@ -459,16 +565,17 @@ export function SwellDayTimeline({
           </div>
         </div>
       </div>
-
-      <div className="mt-1 min-h-4 pl-14">
-        <TimelineStatus
-          error={error}
-          isLoadingMore={isLoadingMore}
-          isExhausted={isExhausted}
-          onRetry={onRetry}
-          exhaustionLabel={exhaustionLabel}
-        />
-      </div>
+      {error ? (
+        <div className="mt-1 pl-14">
+          <TimelineStatus
+            error={error}
+            isLoadingMore={isLoadingMore}
+            isExhausted={isExhausted}
+            onRetry={onRetry}
+            exhaustionLabel={exhaustionLabel}
+          />
+        </div>
+      ) : null}
     </TimelineShell>
   );
 }


### PR DESCRIPTION
## Summary
- #511: day bands render at 12px; the full label vs date-number variant is chosen from the **measured band width** (ResizeObserver on the track) instead of the viewport breakpoint, so a 10-day horizon on desktop keeps "Mon 17" while genuinely narrow bands fall back to "17". Before the first measurement (and in jsdom) the previous `sm:` breakpoint applies.
- #510: a partial current-day first segment is labelled "Today · 12h left" (also in `title`) without changing its time-proportional width.
- #513: the settled status row is gone; "10-day forecast · ends Mon 17" sits in the bubble strip above the slider, so the panel is one row shorter. Loading/exhaustion use the same slot; the error + Retry row still renders below on error.

Closes #510, closes #511, closes #513.

## Verification
- `yarn test:unit` map suites: 71 tests pass (swell-day-timeline, map-forecast-basic, interactive-map)
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on changed files
- Slider ARIA (`aria-valuetext`), keyboard handling and `role=status` announcements unchanged.

Implementation by Codex (gpt-5.6-luna); review + rework of narrow detection / status placement by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)