### PR TITLE
feat(map): adaptive forecast playback speed (#512)

### DIFF
--- a/__tests__/components/map/swell-day-timeline.test.tsx
+++ b/__tests__/components/map/swell-day-timeline.test.tsx
@@ -4,6 +4,8 @@ import {
   advancePlaybackPosition,
   compactTimelineDayLabel,
   findAdjacentLocalDayIndex,
+  getPlaybackVisualFrameMs,
+  PLAYBACK_TARGET_DURATION_MS,
   timelineDayLabelClasses,
   timelineDayLabelWidthPercent,
   SwellDayTimeline,
@@ -50,6 +52,18 @@ describe("SwellDayTimeline", () => {
     expect(advancePlaybackPosition(2, 125, 10)).toBe(2.25);
     expect(advancePlaybackPosition(2.25, 125, 10)).toBe(2.5);
     expect(advancePlaybackPosition(9.9, 100, 10)).toBe(10);
+  });
+
+  it("adapts playback duration to short and full forecast horizons", () => {
+    const shortHorizonFrameMs = getPlaybackVisualFrameMs(24 + 1);
+    const threeDayHorizonFrameMs = getPlaybackVisualFrameMs(72 + 1);
+    const fullHorizonFrameMs = getPlaybackVisualFrameMs(240 + 1);
+
+    expect(shortHorizonFrameMs * 24).toBe(PLAYBACK_TARGET_DURATION_MS);
+    expect(threeDayHorizonFrameMs * 72).toBe(PLAYBACK_TARGET_DURATION_MS);
+    expect(fullHorizonFrameMs * 240).toBe(PLAYBACK_TARGET_DURATION_MS);
+    expect(advancePlaybackPosition(0, PLAYBACK_TARGET_DURATION_MS, 240, fullHorizonFrameMs))
+      .toBe(240);
   });
 
   it("falls back to the viewport breakpoint for day labels before the track is measured", () => {

--- a/components/map/swell-field/swell-day-timeline.tsx
+++ b/components/map/swell-field/swell-day-timeline.tsx
@@ -37,17 +37,30 @@ const deltaByKey: Record<string, number> = {
   ArrowRight: 1,
   ArrowUp: 1,
 };
-const PLAYBACK_VISUAL_FRAME_MS = 500;
+export const PLAYBACK_TARGET_DURATION_MS = 18_000;
+const DEFAULT_PLAYBACK_VISUAL_FRAME_MS = 500;
+const MIN_PLAYBACK_VISUAL_FRAME_MS = 50;
+const MAX_PLAYBACK_VISUAL_FRAME_MS = 750;
 const FIELD_UPDATE_INTERVAL_MS = 100;
 // "Mon 17" at 12px bold uppercase plus padding; below this a band shows the date number only.
 const FULL_DAY_LABEL_MIN_PX = 64;
+
+export function getPlaybackVisualFrameMs(timestampCount: number): number {
+  const frameCount = Math.max(1, Math.floor(timestampCount) - 1);
+  const targetFrameMs = PLAYBACK_TARGET_DURATION_MS / frameCount;
+  return Math.min(
+    MAX_PLAYBACK_VISUAL_FRAME_MS,
+    Math.max(MIN_PLAYBACK_VISUAL_FRAME_MS, targetFrameMs),
+  );
+}
 
 export function advancePlaybackPosition(
   current: number,
   elapsedMs: number,
   maxIndex: number,
+  visualFrameMs = DEFAULT_PLAYBACK_VISUAL_FRAME_MS,
 ): number {
-  return Math.min(maxIndex, current + elapsedMs / PLAYBACK_VISUAL_FRAME_MS);
+  return Math.min(maxIndex, current + elapsedMs / visualFrameMs);
 }
 
 interface LocalTimestampParts {
@@ -312,6 +325,7 @@ export function SwellDayTimeline({
   const safeIndex = clampIndex(index, timestamps.length);
   const canPlay = timestamps.length > 1;
   const maxIndex = Math.max(0, timestamps.length - 1);
+  const visualFrameMs = getPlaybackVisualFrameMs(timestamps.length);
   const [visualIndex, setVisualIndex] = useState(safeIndex);
   const visualIndexRef = useRef(safeIndex);
   const controlledIndexRef = useRef(safeIndex);
@@ -364,6 +378,7 @@ export function SwellDayTimeline({
           visualIndexRef.current,
           frameTime - lastFrameTime,
           maxIndexRef.current,
+          visualFrameMs,
         );
         visualIndexRef.current = next;
         setVisualIndex(next);
@@ -380,7 +395,7 @@ export function SwellDayTimeline({
     };
     animationFrame = window.requestAnimationFrame(animate);
     return () => window.cancelAnimationFrame(animationFrame);
-  }, [isPlaying]);
+  }, [isPlaying, visualFrameMs]);
 
   if (timestamps.length === 0) {
     if (!error && !isLoadingMore && !isExhausted) return null;


### PR DESCRIPTION
## Summary
Stacked on #591 (includes its commit; rebase/merge after #591 lands).

- Playback advanced one hourly frame every 500ms (~2 min for 10 days). The per-frame visual duration is now `clamp(PLAYBACK_TARGET_DURATION_MS / (frames-1), 50ms, 750ms)` with `PLAYBACK_TARGET_DURATION_MS = 18_000`, so 24h / 72h / 240h horizons all complete in ~18s (short horizons are capped at 750ms/frame so they don't flash).
- Manual hourly scrubbing, reduced-motion handling, missing-frame handling and the 100ms field-update throttle are unchanged; no change to forecast request volume.

Closes #512.

## Verification
- `yarn test:unit` map suites: 72 pass (incl. short/full-horizon duration test)
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on changed files

Implementation by Codex (gpt-5.6-luna); review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)