### PR TITLE
fix(map): embed timeline hour-offset contract, interpolated playback, un-capped span (#501)

### DIFF
--- a/__tests__/app/api/forecasts/bulk/route.test.ts
+++ b/__tests__/app/api/forecasts/bulk/route.test.ts
@@ -4,7 +4,10 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { GET } from "@/app/api/forecasts/bulk/route";
+import {
+  fetchHourlySwellTimelineRows,
+  GET,
+} from "@/app/api/forecasts/bulk/route";
 import { getProfileExperienceLevel } from "@/lib/profile/skill-level";
 import { getBatchSunTimes } from "@/lib/services/discovery";
 import { applyV51DisplayOverrideToForecasts } from "@/lib/services/forecast/v5-display-gate";
@@ -544,6 +547,31 @@ describe("/api/forecasts/bulk", () => {
     mockSupabaseClient.from = jest.fn(() =>
       queryChain({ data: null, error: null }),
     ) as any;
+  });
+
+  it("chunks hourly timeline rows by beach to avoid the PostgREST row cap", async () => {
+    const beachIds = Array.from({ length: 20 }, (_, index) => `beach-${index}`);
+    const { hourlyTimelineChain, nextHourlyTimelineChain } = mockBulkQueries({
+      extensionOnly: true,
+    });
+
+    const result = await fetchHourlySwellTimelineRows(
+      mockSupabaseClient as never,
+      beachIds,
+      new Date("2026-07-10T20:00:00.000Z"),
+      new Date("2026-07-11T20:00:00.000Z"),
+    );
+
+    expect(result).toEqual({ data: [], error: null });
+    expect(mockSupabaseClient.from).toHaveBeenCalledTimes(2);
+    expect(hourlyTimelineChain.in).toHaveBeenCalledWith(
+      "beach_id",
+      beachIds.slice(0, 10),
+    );
+    expect(nextHourlyTimelineChain.in).toHaveBeenCalledWith(
+      "beach_id",
+      beachIds.slice(10),
+    );
   });
 
   afterEach(() => {

--- a/__tests__/components/map/embed-map-timeline.test.ts
+++ b/__tests__/components/map/embed-map-timeline.test.ts
@@ -1,5 +1,6 @@
 import {
   HOURLY_EMBED_TIMELINE_STEPS,
+  embedTimelineArrayPositionForHourOffset,
   forecastAtForEmbedTimelineIndex,
   formatEmbedMapTimelineLabel,
   hourlyEmbedTimelineLabels,
@@ -9,10 +10,10 @@ import {
 describe("embed map hourly timeline", () => {
   const now = new Date(2026, 6, 9, 15, 30);
 
-  it("exposes every hour from now through +42h", () => {
-    expect(HOURLY_EMBED_TIMELINE_STEPS).toHaveLength(43);
+  it("exposes every hour from now through +12 days", () => {
+    expect(HOURLY_EMBED_TIMELINE_STEPS).toHaveLength(12 * 24 + 1);
     expect(HOURLY_EMBED_TIMELINE_STEPS[0]).toBe(0);
-    expect(HOURLY_EMBED_TIMELINE_STEPS[42]).toBe(42);
+    expect(HOURLY_EMBED_TIMELINE_STEPS.at(-1)).toBe(12 * 24);
   });
 
   it("formats same-day and next-day labels for the standalone embed", () => {
@@ -43,9 +44,9 @@ describe("embed map hourly timeline", () => {
 
     const labels = hourlyEmbedTimelineLabels(now, timestamps, "Invalid/Timezone");
 
-    expect(labels).toHaveLength(43);
+    expect(labels).toHaveLength(12 * 24 + 1);
     expect(labels[0]).toBe("Fri 8 PM");
-    expect(labels[1]).toBe("4 PM");
+    expect(labels[1]).toBe("Fri 9 PM");
     expect(labels[2]).toBe("Fri 10 PM");
     expect(labels[3]).toBe("6 PM");
   });
@@ -61,5 +62,32 @@ describe("embed map hourly timeline", () => {
     expect(
       forecastAtForEmbedTimelineIndex(["2026-07-10T20:30:00.000Z"], 0),
     ).toBeUndefined();
+  });
+
+  it("resolves hour offsets from 3-hourly timestamps instead of array indexes", () => {
+    const timestamps = [
+      "2026-07-10T00:00:00.000Z",
+      "2026-07-10T03:00:00.000Z",
+      "2026-07-10T06:00:00.000Z",
+    ];
+
+    expect(forecastAtForEmbedTimelineIndex(timestamps, 3)).toBe(
+      "2026-07-10T03:00:00.000Z",
+    );
+    expect(embedTimelineArrayPositionForHourOffset(timestamps, 1)).toBeCloseTo(1 / 3);
+    expect(embedTimelineArrayPositionForHourOffset(timestamps, 3)).toBe(1);
+  });
+
+  it("resolves hourly timestamps without applying a cadence divisor", () => {
+    const timestamps = [
+      "2026-07-10T00:00:00.000Z",
+      "2026-07-10T01:00:00.000Z",
+      "2026-07-10T02:00:00.000Z",
+    ];
+
+    expect(forecastAtForEmbedTimelineIndex(timestamps, 2)).toBe(
+      "2026-07-10T02:00:00.000Z",
+    );
+    expect(embedTimelineArrayPositionForHourOffset(timestamps, 2)).toBe(2);
   });
 });

--- a/__tests__/components/map/swell-field/field-sampler.test.ts
+++ b/__tests__/components/map/swell-field/field-sampler.test.ts
@@ -421,4 +421,31 @@ describe("maskFieldToWater", () => {
     maskFieldToWater(field, map, { width: 800, height: 600, waterLayerIds: ["water"] });
     expect(queried).toBe(false);
   });
+
+  it("reuses camera-scoped water verdicts for rebuilt fields", () => {
+    const cache = new Map<string, boolean>();
+    let queryCount = 0;
+    const map: WaterMaskMap = {
+      project: () => ({ x: 100, y: 100 }),
+      queryRenderedFeatures: () => {
+        queryCount += 1;
+        return [{}];
+      },
+    };
+
+    maskFieldToWater(makeField(), map, {
+      width: 800,
+      height: 600,
+      waterLayerIds: ["water"],
+      waterMaskCache: cache,
+    });
+    maskFieldToWater(makeField(), map, {
+      width: 800,
+      height: 600,
+      waterLayerIds: ["water"],
+      waterMaskCache: cache,
+    });
+
+    expect(queryCount).toBe(2);
+  });
 });

--- a/app/api/forecasts/bulk/route.ts
+++ b/app/api/forecasts/bulk/route.ts
@@ -534,7 +534,7 @@ function buildHourlySwellTimeline(
   };
 }
 
-async function fetchHourlySwellTimelineRows(
+export async function fetchHourlySwellTimelineRows(
   supabase: SupabaseClient<Database>,
   beachIds: string[],
   start: Date,
@@ -544,20 +544,36 @@ async function fetchHourlySwellTimelineRows(
   error: { message: string } | null;
 }> {
   const anchorTimestamps = timelineAnchorTimestamps(start, end);
-  const { data, error } = await supabase
-    .from("enhanced_forecasts")
-    .select(HOURLY_TIMELINE_SELECT)
-    .in("beach_id", beachIds)
-    .in("forecast_at", anchorTimestamps)
-    .gte("forecast_at", new Date(start.getTime() - HOURLY_SAMPLE_HALO_MS).toISOString())
-    .lt("forecast_at", new Date(end.getTime() + HOURLY_SAMPLE_HALO_MS).toISOString())
-    .order("forecast_at", { ascending: true })
-    .order("beach_id", { ascending: true });
-
-  if (error) return { data: null, error: { message: error.message } };
+  const chunks: string[][] = [];
+  for (let index = 0; index < beachIds.length; index += 10) {
+    chunks.push(beachIds.slice(index, index + 10));
+  }
+  const chunkResults = await Promise.all(
+    chunks.map((chunk) =>
+      supabase
+        .from("enhanced_forecasts")
+        .select(HOURLY_TIMELINE_SELECT)
+        .in("beach_id", chunk)
+        .in("forecast_at", anchorTimestamps)
+        .gte("forecast_at", new Date(start.getTime() - HOURLY_SAMPLE_HALO_MS).toISOString())
+        .lt("forecast_at", new Date(end.getTime() + HOURLY_SAMPLE_HALO_MS).toISOString())
+        .order("forecast_at", { ascending: true })
+        .order("beach_id", { ascending: true }),
+    ),
+  );
+  const rows: unknown[] = [];
+  for (const result of chunkResults) {
+    if (result.error) return { data: null, error: { message: result.error.message } };
+    if (result.data?.length === 1000) {
+      console.warn(
+        "⚠️ [fetchHourlySwellTimelineRows] Chunk returned exactly 1000 rows — possible PostgREST truncation",
+      );
+    }
+    rows.push(...(result.data ?? []));
+  }
 
   return {
-    data: (data ?? []) as unknown as EnhancedForecastEntity[],
+    data: rows as EnhancedForecastEntity[],
     error: null,
   };
 }

--- a/components/map/embed-map-timeline.ts
+++ b/components/map/embed-map-timeline.ts
@@ -9,12 +9,13 @@ export const LEGACY_EMBED_TIMELINE_STEPS = [
   "+21h",
 ] as const;
 
+export const HOURLY_EMBED_TIMELINE_HORIZON_HOURS = 12 * 24;
 export const HOURLY_EMBED_TIMELINE_STEPS = Array.from(
-  { length: 43 },
+  { length: HOURLY_EMBED_TIMELINE_HORIZON_HOURS + 1 },
   (_, hourOffset) => hourOffset,
 ) as number[];
 
-const MAX_HOURLY_EMBED_TIMELINE_INDEX = HOURLY_EMBED_TIMELINE_STEPS.length - 1;
+export const MAX_HOURLY_EMBED_TIMELINE_INDEX = HOURLY_EMBED_TIMELINE_STEPS.length - 1;
 const HOUR_MS = 60 * 60 * 1000;
 
 function validForecastAt(value: unknown): value is string {
@@ -66,12 +67,62 @@ export function forecastAtForEmbedTimelineIndex(
   timestamps: readonly (string | undefined)[],
   index: number,
 ): string | undefined {
-  if (!Number.isInteger(index) || index < 0 || index > MAX_HOURLY_EMBED_TIMELINE_INDEX) {
+  if (
+    !Number.isInteger(index) ||
+    index < 0 ||
+    index > MAX_HOURLY_EMBED_TIMELINE_INDEX
+  ) {
     return undefined;
   }
 
-  const timestamp = timestamps[index];
-  return validForecastAt(timestamp) ? timestamp : undefined;
+  const firstTimestamp = timestamps.find((timestamp) => validForecastAt(timestamp));
+  if (!firstTimestamp) return undefined;
+  const firstEpoch = Date.parse(firstTimestamp);
+  const targetEpoch = firstEpoch + index * HOUR_MS;
+  const lastTimestamp = [...timestamps]
+    .reverse()
+    .find((timestamp) => validForecastAt(timestamp));
+  if (!lastTimestamp || targetEpoch > Date.parse(lastTimestamp)) return undefined;
+
+  return new Date(targetEpoch).toISOString();
+}
+
+export function embedTimelineArrayPositionForHourOffset(
+  timestamps: readonly (string | undefined)[],
+  hourOffset: number,
+): number | undefined {
+  if (
+    !Number.isFinite(hourOffset) ||
+    hourOffset < 0 ||
+    hourOffset > MAX_HOURLY_EMBED_TIMELINE_INDEX
+  ) {
+    return undefined;
+  }
+
+  const validTimestamps = timestamps
+    .map((timestamp, index) => ({
+      epoch: validForecastAt(timestamp) ? Date.parse(timestamp) : NaN,
+      index,
+    }))
+    .filter(({ epoch }) => Number.isFinite(epoch));
+  if (validTimestamps.length === 0) return undefined;
+
+  const targetEpoch = validTimestamps[0].epoch + hourOffset * HOUR_MS;
+  if (targetEpoch < validTimestamps[0].epoch || targetEpoch > validTimestamps.at(-1)!.epoch) {
+    return undefined;
+  }
+
+  for (let index = 0; index < validTimestamps.length - 1; index += 1) {
+    const left = validTimestamps[index];
+    const right = validTimestamps[index + 1];
+    if (targetEpoch === left.epoch) return left.index;
+    if (targetEpoch <= right.epoch) {
+      const progress = (targetEpoch - left.epoch) / (right.epoch - left.epoch);
+      return left.index + progress * (right.index - left.index);
+    }
+  }
+
+  return validTimestamps.at(-1)!.index;
 }
 
 function formatAbsoluteHourlyEmbedTimelineLabel(

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -81,6 +81,7 @@ import {
   type FlowComponentId,
   type FlowField,
 } from "@/components/map/swell-field/field-sampler";
+import { embedTimelineArrayPositionForHourOffset } from "@/components/map/embed-map-timeline";
 import {
   createSwellParticleLayer,
   resolveParticleCount,
@@ -614,6 +615,10 @@ export function InteractiveMap({
     Map<string, SwellPartition[]>
   >(new Map());
   const [hourlyTimelineSeed, setHourlyTimelineSeed] = useState<HourlySwellTimeline | null>(null);
+  const waterMaskCacheRef = useRef<{
+    cameraKey: string;
+    verdicts: Map<string, boolean>;
+  } | null>(null);
   const [hourlyTimelineBeachIds, setHourlyTimelineBeachIds] = useState<string[]>([]);
   // Loader-resolved beaches that partitionsMap is keyed by (the prop may be empty).
   const [swellFieldBeaches, setSwellFieldBeaches] = useState<Beach[]>([]);
@@ -867,12 +872,17 @@ export function InteractiveMap({
   const activeEmbedHourlyPartitionsMap = useMemo(() => {
     const active = new Map<string, SwellPartition>();
     if (!hourlyTimelineSeed) return active;
+    const position = embedTimelineArrayPositionForHourOffset(
+      hourlyTimelineSeed.timestamps,
+      swellTimelineIndex,
+    );
+    if (position === undefined) return active;
 
     for (const beachId of Object.keys(hourlyTimelineSeed.partitionsByBeach)) {
-      const partition = partitionAtAbsoluteTimelineIndex(
+      const partition = partitionAtAbsoluteTimelinePosition(
         hourlyTimelineSeed,
         beachId,
-        swellTimelineIndex,
+        position,
       );
       if (partition) active.set(beachId, partition);
     }
@@ -1597,6 +1607,23 @@ export function InteractiveMap({
       return; // can't read the style yet → leave the field intact
     }
     if (waterLayerIds.length === 0) return;
+    const bounds = map.getBounds();
+    const center = map.getCenter();
+    const cameraKey = JSON.stringify({
+      west: bounds?.getWest() ?? null,
+      south: bounds?.getSouth() ?? null,
+      east: bounds?.getEast() ?? null,
+      north: bounds?.getNorth() ?? null,
+      centerLng: center.lng,
+      centerLat: center.lat,
+      zoom: map.getZoom(),
+      width: map.getCanvas().clientWidth,
+      height: map.getCanvas().clientHeight,
+      waterLayerIds,
+    });
+    if (waterMaskCacheRef.current?.cameraKey !== cameraKey) {
+      waterMaskCacheRef.current = { cameraKey, verdicts: new Map() };
+    }
     const canvas = map.getCanvas();
     for (const component of maskable) {
       const field = flowFieldsRef.current[component];
@@ -1608,6 +1635,7 @@ export function InteractiveMap({
           width: canvas.clientWidth,
           height: canvas.clientHeight,
           waterLayerIds,
+          waterMaskCache: waterMaskCacheRef.current.verdicts,
         }
       );
     }
@@ -1655,6 +1683,12 @@ export function InteractiveMap({
       Math.max(Number.isFinite(swellTimelineIndex) ? swellTimelineIndex : 0, 0),
       Math.max(0, swellTimelineSteps.length - 1)
     );
+    const embedTimelinePosition = isEmbedHourlyTimeline && hourlyTimelineSeed
+      ? embedTimelineArrayPositionForHourOffset(
+          hourlyTimelineSeed.timestamps,
+          swellTimelineIndex,
+        )
+      : undefined;
     // Build a flow field per active component (one for a single layer, three for
     // combined); leave the rest empty so stale fields never render.
     const nextFields: Record<"s1" | "s2" | "wind", FlowField> = {
@@ -1678,7 +1712,13 @@ export function InteractiveMap({
               expandablePlaybackPosition,
             )
           : isEmbedHourlyTimeline
-            ? partitionAtAbsoluteTimelineIndex(hourlyTimelineSeed, beach.id, swellTimelineIndex)
+            ? embedTimelinePosition === undefined
+              ? undefined
+              : partitionAtAbsoluteTimelinePosition(
+                  hourlyTimelineSeed,
+                  beach.id,
+                  embedTimelinePosition,
+                )
           : partitionAtTimelinePosition(
               beach.id,
               timelinePosition,
@@ -1748,6 +1788,7 @@ export function InteractiveMap({
     const map = mapRef.current;
     if (!map || !isMapReady || !showSwellField) return;
     const remask = (): void => {
+      waterMaskCacheRef.current = null;
       applyWaterMask(map);
       map.triggerRepaint();
     };

--- a/components/map/swell-field/field-sampler.ts
+++ b/components/map/swell-field/field-sampler.ts
@@ -117,6 +117,8 @@ export interface WaterMaskOptions {
   height: number;
   /** Basemap layer ids that count as water. */
   waterLayerIds: string[];
+  /** Camera-scoped cell verdicts reused while forecast time changes. */
+  waterMaskCache?: Map<string, boolean>;
 }
 
 /**
@@ -138,6 +140,17 @@ export function maskFieldToWater(
   if (options.waterLayerIds.length === 0) return;
   for (const cell of field.cells) {
     if (cell.speed === 0 && cell.alpha === 0) continue; // already dead
+    const cacheKey = `${cell.lon}:${cell.lat}`;
+    const cachedIsWater = options.waterMaskCache?.get(cacheKey);
+    if (cachedIsWater !== undefined) {
+      if (!cachedIsWater) {
+        cell.speed = 0;
+        cell.alpha = 0;
+        cell.vx = 0;
+        cell.vy = 0;
+      }
+      continue;
+    }
     try {
       const pt = map.project([cell.lon, cell.lat]);
       // Outside the rendered viewport → can't reliably query; leave it alone.
@@ -147,6 +160,7 @@ export function maskFieldToWater(
       const hits = map.queryRenderedFeatures([pt.x, pt.y], {
         layers: options.waterLayerIds,
       });
+      options.waterMaskCache?.set(cacheKey, Boolean(hits && hits.length > 0));
       if (!hits || hits.length === 0) {
         // No water feature here → land → blank the cell.
         cell.speed = 0;


### PR DESCRIPTION
## Summary
- **Index = hours ahead again.** `forecastAtForEmbedTimelineIndex` derives the time from the first timestamp + index hours; new `embedTimelineArrayPositionForHourOffset` maps an hour offset to a fractional array position over 3-hourly or hourly data, so the embed no longer labels +42h while rendering +126h. Span raised to 12 days (`HOURLY_EMBED_TIMELINE_HORIZON_HOURS = 288`); installed binaries clamp at 42 and degrade quietly (decided in the issue).
- **Playback**: the embed flow-field rebuild uses the interpolating `partitionAtAbsoluteTimelinePosition`, and the water mask is cached per camera (cell-verdict map keyed by bounds/zoom/canvas, reset on idle/moveend), so playback no longer issues one `queryRenderedFeatures` per cell per tick.
- **Bulk API**: `fetchHourlySwellTimelineRows` chunks beach ids (10 per query) so the PostgREST 1000-row cap no longer shrinks the step count as beach count grows; warns if a chunk returns exactly 1000 rows.
- `forecastTimeChanged` still carries `forecastAt` (bridge payload unchanged).

Closes #501.

Native follow-ups (separate quiver-native ticket): raise `HOURLY_FORECAST_COUNT`, consume `forecastAt` for the label.

## Verification
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on changed files
- `yarn test:unit`: bulk route, embed-map-timeline, field-sampler, interactive-map, embed-map-bridge — 164 tests pass
- Not device-measured (no device here); the mask cache removes the per-tick `queryRenderedFeatures` cost the issue profiled.

Implementation by Codex (gpt-5.6-luna); review by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)