### PR TITLE
chore(flags): remove the dead GFS shadow flag, centralize ALERTS_DELIVERY_ENABLED

### DIFF
--- a/__tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts
+++ b/__tests__/lib/services/noaa-wavewatch/gfs-wave-shadow.test.ts
@@ -44,24 +44,15 @@ function payload(overrides: Partial<NonNullable<OpenMeteoMarineResponse["hourly"
 }
 
 describe("GFS-Wave shadow capture helpers", () => {
-  const originalEnabled = process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED;
-
-  afterEach(() => {
-    if (originalEnabled === undefined) {
-      delete process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED;
-    } else {
-      process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED = originalEnabled;
-    }
-  });
-
-  it("is hard-disabled even when the legacy env flag is enabled", () => {
+  it("is controlled solely by GFS_WAVE_SHADOW_CAPTURE_DISABLED", () => {
     expect(GFS_WAVE_SHADOW_CAPTURE_DISABLED).toBe(true);
-
-    delete process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED;
     expect(isGfsWaveShadowCaptureEnabled()).toBe(false);
 
+    // No env var can turn capture on: the removed GFS_WAVE_SHADOW_CAPTURE_ENABLED
+    // was always short-circuited by the constant above.
     process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED = "true";
     expect(isGfsWaveShadowCaptureEnabled()).toBe(false);
+    delete process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED;
   });
 
   it("classifies an all-zero wave_height payload as missing-source data", () => {

--- a/app/api/alerts/rules/route.ts
+++ b/app/api/alerts/rules/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { isAlertsDeliveryEnabled } from "@/lib/flags/alerts-delivery";
 import {
   withAuth,
   createSuccessResponse,
@@ -224,7 +225,7 @@ export const POST = withAuth(
       user.id,
       supabase,
       {
-        alertDeliveryPaused: process.env.ALERTS_DELIVERY_ENABLED !== "true",
+        alertDeliveryPaused: !isAlertsDeliveryEnabled(),
         betaAccessRequired:
           process.env.PERSONALIZATION_BETA_REQUIRED === "true" ||
           request.headers.get("x-quiver-beta-access") === "required",

--- a/app/api/cron/condition-alert-deliver/route.ts
+++ b/app/api/cron/condition-alert-deliver/route.ts
@@ -59,6 +59,7 @@ import {
 } from "@/lib/alerts/revalidate-alert-window";
 import type { AlertConditions } from "@/lib/alerts/types";
 import type { MatchingWindow } from "@/lib/alerts/types";
+import { isAlertsDeliveryEnabled } from "@/lib/flags/alerts-delivery";
 import { isForecastAlertDeliveryEnabled } from "@/lib/flags/forecast-alert-delivery";
 import { formatWaveHeightRange } from "@/lib/formatters/surf-data";
 import { parseSkillLevel } from "@/lib/domains/user-preferences/skill-level";
@@ -392,8 +393,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   // Env-driven gates. Default OFF for safety; staged rollout via allowlist.
   const forecastDeliveryEnabled = isForecastAlertDeliveryEnabled();
-  const similarityDeliveryEnabled =
-    process.env.ALERTS_DELIVERY_ENABLED === "true";
+  const similarityDeliveryEnabled = isAlertsDeliveryEnabled();
   const allowlistRaw = process.env.ALERTS_DELIVERY_USER_ALLOWLIST ?? "";
   const allowlist = new Set(
     allowlistRaw

--- a/app/api/cron/similarity-alerts/route.ts
+++ b/app/api/cron/similarity-alerts/route.ts
@@ -44,6 +44,7 @@
 // matches.
 
 import { NextResponse } from "next/server";
+import { isAlertsDeliveryEnabled } from "@/lib/flags/alerts-delivery";
 
 import type { Beach } from "@/types/database";
 import type { EnhancedForecastEntity } from "@/types/forecast";
@@ -312,7 +313,7 @@ async function _GET(req: Request): Promise<Response> {
     return createErrorResponse("Unauthorized", "Invalid cron authentication", 401);
   }
 
-  const deliveryEnabled = process.env.ALERTS_DELIVERY_ENABLED === "true";
+  const deliveryEnabled = isAlertsDeliveryEnabled();
   const allowlistRaw = process.env.ALERTS_DELIVERY_USER_ALLOWLIST ?? "";
   const allowlist = new Set(
     allowlistRaw.split(",").map((s) => s.trim()).filter(Boolean),

--- a/lib/flags/alerts-delivery.ts
+++ b/lib/flags/alerts-delivery.ts
@@ -1,0 +1,13 @@
+export const ALERTS_DELIVERY_ENABLED_FLAG = "ALERTS_DELIVERY_ENABLED";
+
+/**
+ * Legacy similarity-alert send switch, also consulted by the condition-alert
+ * deliver cron and surfaced to the rules API as `alertDeliveryPaused`.
+ *
+ * Unset means OFF. Read it through this helper rather than comparing the env
+ * var inline: the three call sites had drifted into `=== "true"` in the crons
+ * and `!== "true"` in the rules route, which agreed only by accident.
+ */
+export function isAlertsDeliveryEnabled(): boolean {
+  return process.env[ALERTS_DELIVERY_ENABLED_FLAG] === "true";
+}

--- a/lib/services/noaa-wavewatch/gfs-wave-shadow.ts
+++ b/lib/services/noaa-wavewatch/gfs-wave-shadow.ts
@@ -108,8 +108,11 @@ function nullGfsValues(): Pick<
 }
 
 export function isGfsWaveShadowCaptureEnabled(): boolean {
-  if (GFS_WAVE_SHADOW_CAPTURE_DISABLED) return false;
-  return process.env.GFS_WAVE_SHADOW_CAPTURE_ENABLED === "true";
+  // GFS_WAVE_SHADOW_CAPTURE_DISABLED is the only control. A
+  // GFS_WAVE_SHADOW_CAPTURE_ENABLED env var used to be consulted here, but the
+  // constant short-circuited it, so the var could never turn capture on and
+  // reading it only implied a switch that did not exist.
+  return !GFS_WAVE_SHADOW_CAPTURE_DISABLED;
 }
 
 export function isAllZeroWaveHeightPayload(


### PR DESCRIPTION
From the 2026-08-21 flag audit (`handoffs/issues-20260821/FLAG-AUDIT-20260821.md`). Both changes are cleanup; **no behaviour changes**.

## 1. `GFS_WAVE_SHADOW_CAPTURE_ENABLED` — deleted, it could never fire

`isGfsWaveShadowCaptureEnabled()` read the env var *after* the hardcoded `GFS_WAVE_SHADOW_CAPTURE_DISABLED = true` had already returned `false`. So the var was unreachable, while its presence implied a working switch — setting it in an environment would have looked like enabling capture and done nothing.

The constant carries a dated, specific comment ("Disabled 2026-06-18 while mixed-swell promotion is paused. Re-enable only with Seaside's `DEFAULT_PROMOTION_ENABLED` in `mixed_swell_shadow.py`"), so it is clearly the intended control — it stays, and is now the only one.

## 2. `ALERTS_DELIVERY_ENABLED` — one helper instead of three inline comparisons

It was read as `=== "true"` in `similarity-alerts` and `condition-alert-deliver`, but `!== "true"` in `alerts/rules` (to compute `alertDeliveryPaused`). Those agree on "unset means off" only by accident, and the next edit in either direction could have silently split them. All three now use `isAlertsDeliveryEnabled()` in `lib/flags/alerts-delivery.ts`, matching the existing `lib/flags/*` pattern (e.g. `forecast-alert-delivery.ts`).

Left alone deliberately: `ALERTS_DELIVERY_ENABLED` still overlaps `FORECAST_ALERT_DELIVERY_ENABLED` in the deliver cron — collapsing two delivery switches into one is a product decision, not cleanup. `__tests__/lib/services/enhanced-forecast-service.test.ts` still uses the old var name as a *mock* toggle; it is test-local scaffolding and keeps working.

## Verification
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on all changed files
- `yarn test:unit`: gfs-wave-shadow, similarity-alerts, condition-alert-deliver, enhanced-forecast-service — 93 tests pass
- The stale test "is hard-disabled even when the legacy env flag is enabled" was rewritten to assert the constant is the sole control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)