### PR TITLE
fix(map): repair main — getCenter().toArray() breaks the map mount in tests

### DIFF
--- a/__tests__/components/map/map-forecast-basic.test.tsx
+++ b/__tests__/components/map/map-forecast-basic.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { expectConsoleErrors } from "@/__tests__/setup/test-utils";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 const mockAddControl = jest.fn();
@@ -545,15 +546,20 @@ describe("Map Forecast Basic Tests", () => {
 
   it("should handle fetch errors gracefully", async () => {
     mockFetch.mockRejectedValue(new Error("Network error"));
-    
+
     const { InteractiveMap } = await import("@/components/map/interactive-map");
-    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
-    
+
     expect(() => {
       render(<InteractiveMap />);
     }).not.toThrow();
-    
-    consoleSpy.mockRestore();
+
+    // The preload path reports the failed beaches fetch rather than swallowing
+    // it; the point of this test is that the map still mounts. Declared after
+    // the render because expectConsoleErrors inspects what was already logged.
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    expectConsoleErrors([/Public beaches list fetch failed/]);
   });
 
   it("should format wave heights correctly", () => {

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -2281,7 +2281,7 @@ export function InteractiveMap({
         // it once and zoom is the more informative signal.
         const prevZoom = prevZoomRef.current;
         const prevCenter = prevCenterRef.current;
-        const [longitude, latitude] = center.toArray();
+        const { lng: longitude, lat: latitude } = center;
         // First idle after mount has no prior tracked state — seed the refs
         // and skip emission so we don't fire a spurious zoom event for a
         // viewport the user never actually moved.
@@ -2552,7 +2552,7 @@ export function InteractiveMap({
         ).__quiverMapDebugCenter = { lat: center.lat, lon: center.lng };
       }
       const pendingLeashCommand = pendingLeashCommandRef.current;
-      const [longitude, latitude] = map.getCenter().toArray();
+      const { lng: longitude, lat: latitude } = map.getCenter();
       if (
         pendingLeashCommand &&
         cameraCommandContainsCenter(pendingLeashCommand, {
@@ -2683,7 +2683,7 @@ export function InteractiveMap({
       // normalization; a real camera move reconciles through moveend.
       if (lastPopulateKeyRef.current !== null) return;
       const center = mapRef.current.getCenter();
-      const [longitude, latitude] = center.toArray();
+      const { lng: longitude, lat: latitude } = center;
       void populateLocations(latitude, longitude);
     }
   }, [isMapReady, populateLocations]);


### PR DESCRIPTION
**`main` is currently red.** Four tests in `__tests__/components/map/map-forecast-basic.test.tsx` fail on a clean checkout of `origin/main`. Bisected to `4f32f1168 perf(map): preload and parallelize enrichment` — a direct push, which skips Main Gate CI, so nothing caught it. I hit it because it blocked #599.

## Cause
That commit added three `getCenter().toArray()` reads (`interactive-map.tsx:2249, 2520, 2651`). Mapbox returns a `LngLat` instance which has `toArray()`, but:
- every other `getCenter()` read in this same file uses `center.lng` / `center.lat`, and
- the suite's Mapbox mock returns a plain `{ lat, lng }` object.

So the mount effect threw `TypeError: center.toArray is not a function`, the component never rendered, and the other three failures (`swell-day-timeline` missing, no Mapbox markers, null leash) cascaded from that.

## Fix
`const { lng: longitude, lat: latitude } = ...` at all three sites — identical semantics on a real `LngLat` (`toArray()` returns `[lng, lat]`), consistent with the rest of the file, and no longer dependent on a method the mock doesn't provide.

Separately, the new preload path logs `Public beaches list fetch failed`, which the repo's console-error guard treats as a failure. The "should handle fetch errors gracefully" test now declares it with `expectConsoleErrors([...])` — placed *after* the render, since the helper inspects and clears what was already logged.

## Verification
- `yarn test:unit __tests__/components/map` — **27 suites / 350 tests pass** (4 failing before)
- `tsc --noEmit` clean, `eslint --max-warnings=0` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)